### PR TITLE
Allow running telepresence without any network

### DIFF
--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -196,7 +196,7 @@ def parse_args(args=None) -> argparse.Namespace:
     parser.add_argument(
         "--method",
         "-m",
-        choices=["inject-tcp", "vpn-tcp", "container"],
+        choices=["inject-tcp", "vpn-tcp", "container", "none"],
         help=(
             "'inject-tcp': inject process-specific shared "
             "library that proxies TCP to the remote cluster.\n"

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -203,6 +203,7 @@ def parse_args(args=None) -> argparse.Namespace:
             "'vpn-tcp': all local processes can route TCP "
             "traffic to the remote cluster. Requires root.\n"
             "'container': used with --docker-run.\n"
+            "'none': traffic routing is not handled by this process.\n"
             "\n"
             "Default is 'vpn-tcp', or 'container' when --docker-run is used.\n"
             "\nFor more details see "

--- a/telepresence/outbound/__init__.py
+++ b/telepresence/outbound/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from telepresence.outbound.container import SUDO_FOR_DOCKER, run_docker_command
-from telepresence.outbound.local import launch_inject, launch_vpn
+from telepresence.outbound.local import launch_inject, launch_vpn, launch_none
 from telepresence.runner import Runner
 
 
@@ -91,6 +91,24 @@ def setup_container(runner: Runner, args):
     return launch
 
 
+def setup_none(runner: Runner, args):
+    if runner.chatty:
+        runner.show(
+            "Starting proxy with method 'none', which has the following "
+            "limitations: No network connections are made. "
+            "It assumes you're managing network independent of telepresence. "
+            "For a full list of method limitations see "
+            "https://telepresence.io/reference/methods.html"
+        )
+    command = args.run or ["bash", "--norc"]
+
+    def launch(runner_, _remote_info, env, _socks_port, _ssh, _mount_dir):
+        return launch_none(
+            runner_, command, env
+        )
+    return launch
+
+
 def setup(runner: Runner, args):
     if args.method == "inject-tcp":
         return setup_inject(runner, args)
@@ -100,5 +118,8 @@ def setup(runner: Runner, args):
 
     if args.method == "container":
         return setup_container(runner, args)
+
+    if args.method == "none":
+        return setup_none(runner, args)
 
     assert False, args.method

--- a/telepresence/outbound/local.py
+++ b/telepresence/outbound/local.py
@@ -124,3 +124,15 @@ def launch_vpn(
         "Terminate local process", terminate_local_process, runner, process
     )
     return process
+
+
+def launch_none(
+        runner: Runner,
+        command: List[str],
+        env_overrides: Dict[str, str]):
+    env = get_local_env(runner, env_overrides, False)
+    process = Popen(command, env=env)
+    runner.add_cleanup(
+        "Terminate local process", terminate_local_process, runner, process
+    )
+    return process


### PR DESCRIPTION
WRT: #289, comment on #363 

Waiting for @ark3 to move things around.
<details><summary>Original comment</summary><p>

I am not entirely sure if this is the correct way to achieve that goal.

Please advise



### What this PR does

* This PR adds a method called "none"
* When selected, no attempt of forwarding connections/DNS is made.

### Why?
* If I have the a VPN setup with my cluster, I have to switch it off for telepresence.
* When I had to work on a feature across multiple dependent go programs, I had no way of proxying all of them without risking network issues.

### The fix
If I already have a VPN, I can run all telepresence instances with this method.

If I don't, I  can run 1 telepresence instance locally with `vpn-tcp` and other instances with `none` to allow multiple shells for multiple deployments.

</p></details>