### PR TITLE
WIP: Make failures quicker in end-to-end tests

### DIFF
--- a/tests/parameterize_utils.py
+++ b/tests/parameterize_utils.py
@@ -945,6 +945,7 @@ class Probe(object):
                 self.HTTP_SERVER_DIFFERENT_PORT,
                 self.HTTP_SERVER_LOW_PORT,
             ]
+            self._result = "FAILED"
             self._result = run_telepresence_probe(
                 self._request,
                 self.method,
@@ -959,6 +960,7 @@ class Probe(object):
             )
             self._cleanup.append(self.ensure_dead)
             self._cleanup.append(self.cleanup_resources)
+        assert self._result != "FAILED"
         return self._result
 
 
@@ -978,6 +980,8 @@ class Probe(object):
         """
         if self._result is None:
             raise Exception("Probe never launched")
+        if self._result == "FAILED":
+            raise Exception("Probe has failed")
 
         _cleanup_process(self._result.telepresence)
 


### PR DESCRIPTION
Each probe runs telepresence once, then communicates with that process
to make assertions about what telepresence has done. The first test in
each probe sequence is what prompts the test system to run telepresence.
If that first attempt fails, each subsequent test in the same probe
fruitlessly tries to run telepresence again. This change makes those
subsequent tests fails immediately.

Fixes #653



---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
