### PR TITLE
Testable exit

### DIFF
--- a/telepresence/cleanup.py
+++ b/telepresence/cleanup.py
@@ -124,4 +124,4 @@ def wait_for_exit(
                     file=sys.stderr
                 )
             span.end()
-            raise SystemExit(3)
+            raise runner.fail("Exiting...", code=3)

--- a/telepresence/mount.py
+++ b/telepresence/mount.py
@@ -106,7 +106,9 @@ def mount_remote(session):
             try:
                 args.mount.mkdir(parents=True, exist_ok=True)
             except OSError as exc:
-                exit("Unable to use mount path: {}".format(exc))
+                raise session.runner.fail(
+                    "Unable to use mount path: {}".format(exc)
+                )
             mount_dir = str(args.mount)
         # We allow all users if we're using Docker because we don't know
         # what uid the Docker container will use.

--- a/telepresence/proxy.py
+++ b/telepresence/proxy.py
@@ -88,10 +88,10 @@ def connect(
                     runner.get_output(["ifconfig", "docker0"])
                 )
             else:
-                raise SystemExit("'ip addr' nor 'ifconfig' available")
+                raise runner.fail("'ip addr' nor 'ifconfig' available")
 
             if len(docker_interfaces) == 0:
-                raise SystemExit("No interface for docker found")
+                raise runner.fail("No interface for docker found")
 
             docker_interface = docker_interfaces[0]
 

--- a/telepresence/remote.py
+++ b/telepresence/remote.py
@@ -108,7 +108,7 @@ def get_deployment_json(
                 )
             )["items"][0]
     except CalledProcessError as e:
-        raise SystemExit(
+        raise runner.fail(
             "Failed to find Deployment '{}':\n{}".format(
                 deployment_name, e.stdout
             )
@@ -223,7 +223,7 @@ def get_remote_info(
             remote_version = remote_info.remote_telepresence_version()
             if remote_version != image_version:
                 runner.write("Pod is running Tel {}".format(remote_version))
-                raise SystemExit((
+                raise runner.fail((
                     "The remote datawire/telepresence-k8s container is " +
                     "running version {}, but this tool is version {}. " +
                     "Please make sure both are running the same version."

--- a/telepresence/remote_env.py
+++ b/telepresence/remote_env.py
@@ -78,7 +78,7 @@ def get_remote_env(
         except CalledProcessError:
             sleep(0.25)
     else:
-        return exit("Error: Failed to get environment variables")
+        raise runner.fail("Error: Failed to get environment variables")
     return env
 
 

--- a/telepresence/runner.py
+++ b/telepresence/runner.py
@@ -245,11 +245,44 @@ class Runner(object):
     # Cleanup
 
     def add_cleanup(self, name: str, callback, *args, **kwargs) -> None:
+        """
+        Set up callback to be called during cleanup processing on exit.
+
+        :param name: Logged for debugging
+        :param callback: What to call during cleanup
+        """
+
         def cleanup():
             self.output.write("(Cleanup) {}".format(name))
             callback(*args, **kwargs)
 
         atexit.register(cleanup)
+
+    # Exit
+
+    def fail(self, message: str, code=1) -> SystemExit:
+        """
+        Report failure to the user and exit. Does not return. Cleanup will run
+        before the process ends. This does not invoke the crash reporter; an
+        uncaught exception will achieve that, e.g., RuntimeError.
+
+        :param message: So the user knows what happened
+        :param code: Process exit code
+        """
+        self.write("FAILING: {}".format(message))
+        print(message, file=sys.stderr)
+        self.write("EXITING with status code {}".format(code))
+        exit(code)
+        return SystemExit(code)  # Not reached; just here for the linters
+
+    def exit(self) -> SystemExit:
+        """
+        Exit after a successful session. Does not return. Cleanup will run
+        before the process ends.
+        """
+        self.write("EXITING successful session.")
+        exit(0)
+        return SystemExit(0)  # Not reached; just here for the linters
 
 
 def launch_command(args, out_cb, err_cb, done=None, **kwargs):

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -42,7 +42,7 @@ def require_command(
             "See the documentation at https://telepresence.io "
             "for more details.\n"
         )
-        raise SystemExit(1)
+        raise runner.fail("Missing required command: {}".format(command))
 
 
 def kubectl_or_oc(server: str) -> str:
@@ -182,7 +182,7 @@ def analyze_args(session):
         args.in_local_vm and args.method == "vpn-tcp"
         and args.new_deployment is None and args.swap_deployment is None
     ):
-        raise SystemExit(
+        raise runner.fail(
             "vpn-tcp method doesn't work with minikube/minishift when"
             " using --deployment. Use --swap-deployment or"
             " --new-deployment instead."
@@ -202,7 +202,7 @@ def analyze_args(session):
         sys.stderr.write("Error accessing Kubernetes: {}\n".format(exc))
         if exc.output:
             sys.stderr.write("{}\n".format(exc.output.strip()))
-        raise SystemExit(1)
+        raise runner.fail("Cluster access failed")
 
     # Make sure we can run openssh:
     try:
@@ -210,10 +210,9 @@ def analyze_args(session):
                                     stdin=DEVNULL,
                                     stderr=STDOUT)
         if not version.startswith("OpenSSH"):
-            raise SystemExit("'ssh' is not the OpenSSH client, apparently.")
+            raise runner.fail("'ssh' is not the OpenSSH client, apparently.")
     except (CalledProcessError, OSError, IOError) as e:
-        sys.stderr.write("Error running ssh: {}\n".format(e))
-        raise SystemExit(1)
+        raise runner.fail("Error running ssh: {}\n".format(e))
 
     # Other requirements:
     require_command(

--- a/telepresence/vpn.py
+++ b/telepresence/vpn.py
@@ -108,8 +108,7 @@ def k8s_resolve(
     """
     Resolve a list of host and/or ip addresses inside the cluster
     using the context, namespace, and remote_info supplied. Note that
-    if any hostname fails to resolve this will raise a SystemExit
-    exception.
+    if any hostname fails to resolve this will fail Telepresence.
     """
     # Separate hostnames from IPs and IP ranges
     hostnames = []
@@ -145,7 +144,7 @@ def k8s_resolve(
             )
         except CalledProcessError as e:
             runner.write(str(e))
-            raise SystemExit(
+            raise runner.fail(
                 "We failed to do a DNS lookup inside Kubernetes for the "
                 "hostname(s) you listed in "
                 "--also-proxy ({}). Maybe you mistyped one of them?".format(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -174,6 +174,7 @@ def query_from_cluster(url, namespace, tries=10, retries_on_empty=0):
         # separate all that stuff from the response body which comes next.
         echo {delimiter}
         [ -e output ] && cat output
+        echo {delimiter}
         """).format(tries=tries, url=url, delimiter=delimiter)
     print("Querying {url} (tries={tries} empty-retries={empty})".format(
         url=url, tries=tries, empty=retries_on_empty,
@@ -189,7 +190,7 @@ def query_from_cluster(url, namespace, tries=10, retries_on_empty=0):
         print("query output:")
         print(_indent(res))
         if res:
-            debug, res = res.split(delimiter + "\n")
+            before, res, after = res.split(delimiter + "\n")
             return res
         print("... empty response")
     return res


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
