### PR TITLE
Testable crash handling

### DIFF
--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -15,14 +15,14 @@
 import argparse
 import sys
 import webbrowser
-from traceback import print_exc
-from urllib.parse import quote_plus
-
-from io import StringIO
-from subprocess import check_output
-from typing import List, Set, Tuple, Union
-from pathlib import Path
+from contextlib import contextmanager
 from functools import wraps
+from io import StringIO
+from pathlib import Path
+from subprocess import check_output
+from traceback import print_exc, format_exc
+from typing import List, Set, Tuple, Union
+from urllib.parse import quote_plus
 
 import telepresence
 from telepresence.utilities import random_name
@@ -67,6 +67,74 @@ class PortMapping(object):
         return set(self._mapping.items())
 
 
+def safe_output(args: List[str]) -> str:
+    """
+    Capture output from a command but try to avoid crashing
+    :param args: Command to run
+    :return: Output from the command
+    """
+    try:
+        return str(check_output(args), "utf-8").strip().replace("\n", " // ")
+    except Exception as e:
+        return "(error: {})".format(e)
+
+
+def report_crash(error, log_path, logs):
+    print(
+        "\nLooks like there's a bug in our code. Sorry about that!\n\n"
+        "Here's the traceback:\n\n" + error + "\n"
+    )
+    if log_path != "-":
+        log_ref = " (see {} for the complete logs):".format(log_path)
+    else:
+        log_ref = ""
+    if "\n" in logs:
+        print(
+            "And here are the last few lines of the logfile" + log_ref +
+            "\n\n" + "\n".join(logs.splitlines()[-20:]) + "\n"
+        )
+    if sys.stdout.isatty() and input(
+        "Would you like to file an issue in our issue tracker?"
+        " You'll be able to review and edit before anything is"
+        " posted to the public."
+        " We'd really appreciate the help improving our product. [Y/n]: ",
+    ).lower() in ("y", ""):
+        url = "https://github.com/datawire/telepresence/issues/new?body="
+        body = quote_plus(
+            BUG_REPORT_TEMPLATE.format(
+                sys.argv,
+                telepresence.__version__,
+                sys.version,
+                safe_output(["kubectl", "version", "--short"]),
+                safe_output(["oc", "version"]),
+                safe_output(["uname", "-a"]),
+                error,
+                logs[-1000:],
+            )[:4000]
+        )  # Overly long URLs won't work
+        webbrowser.open_new(url + body)
+
+
+@contextmanager
+def crash_reporting(runner=None):
+    """
+    Decorator that catches unexpected errors
+    """
+    try:
+        yield
+    except KeyboardInterrupt:
+        print("Keyboard interrupt (Ctrl-C/Ctrl-Break) pressed")
+        raise SystemExit(0)
+    except Exception:
+        error = format_exc()
+        logs = "Not available"
+        log_path = "-"
+        if runner is not None:
+            logs = runner.output.read_logs()
+            log_path = runner.output.logfile_path
+        report_crash(error, log_path, logs)
+
+
 class handle_unexpected_errors(object):
     """Decorator that catches unexpected errors."""
 
@@ -74,13 +142,6 @@ class handle_unexpected_errors(object):
         self.session = session
 
     def __call__(self, f):
-        def safe_output(args):
-            try:
-                return str(check_output(args),
-                           "utf-8").strip().replace("\n", " // ")
-            except Exception as e:
-                return "(error: {})".format(e)
-
         @wraps(f)
         def call_f(*args, **kwargs):
             try:
@@ -98,47 +159,7 @@ class handle_unexpected_errors(object):
                 errorf = StringIO()
                 print_exc(file=errorf)
                 error = errorf.getvalue()
-                print(
-                    "\nLooks like there's a bug in our code. Sorry about that!"
-                    "\n\n"
-                    "Here's the traceback:\n\n" + error + "\n"
-                )
-                if log_path != "-":
-                    log_ref = " (see {} for the complete logs):".format(
-                        log_path
-                    )
-                else:
-                    log_ref = ""
-                if "\n" in logs:
-                    print(
-                        "And here are the last few lines of the logfile" +
-                        log_ref + "\n\n" + "\n".join(logs.splitlines()[-20:]) +
-                        "\n"
-                    )
-
-                if sys.stdout.isatty() and input(
-                    "Would you like to file an issue in our issue tracker?"
-                    " You'll be able to review and edit before anything is"
-                    " posted to the public."
-                    " We'd really appreciate the help improving our "
-                    "product. [Y/n]: ",
-                ).lower() in ("y", ""):
-                    url = (
-                        "https://github.com/datawire/telepresence/issues/" +
-                        "new?body="
-                    )
-                    body = quote_plus(
-                        # Overly long URLs won't work:
-                        BUG_REPORT_TEMPLATE.format(
-                            sys.argv, telepresence.__version__, sys.version,
-                            safe_output(["kubectl", "version", "--short"]),
-                            safe_output(["oc", "version"]),
-                            safe_output(["uname", "-a"]), error, logs[-1000:]
-                        )[:4000]
-                    )
-                    webbrowser.open_new(url + body)
-                else:
-                    raise SystemExit(1)
+                report_crash(error, log_path, logs)
 
         return call_f
 

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -16,11 +16,9 @@ import argparse
 import sys
 import webbrowser
 from contextlib import contextmanager
-from functools import wraps
-from io import StringIO
 from pathlib import Path
 from subprocess import check_output
-from traceback import print_exc, format_exc
+from traceback import format_exc
 from typing import List, Set, Tuple, Union
 from urllib.parse import quote_plus
 
@@ -135,35 +133,6 @@ def crash_reporting(runner=None):
         report_crash(error, log_path, logs)
 
 
-class handle_unexpected_errors(object):
-    """Decorator that catches unexpected errors."""
-
-    def __init__(self, session):
-        self.session = session
-
-    def __call__(self, f):
-        @wraps(f)
-        def call_f(*args, **kwargs):
-            try:
-                return f(*args, **kwargs)
-            except KeyboardInterrupt:
-                raise SystemExit(0)
-            except Exception as e:
-                try:
-                    logs = self.session.output.read_logs()
-                    log_path = self.session.output.logfile_path
-                except AttributeError:
-                    # No session or no output
-                    logs = "Not available"
-                    log_path = "-"
-                errorf = StringIO()
-                print_exc(file=errorf)
-                error = errorf.getvalue()
-                report_crash(error, log_path, logs)
-
-        return call_f
-
-
 def path_or_bool(value: str) -> Union[Path, bool]:
     """Parse value as a Path or a boolean"""
     path = Path(value)
@@ -179,7 +148,6 @@ def path_or_bool(value: str) -> Union[Path, bool]:
     )
 
 
-@handle_unexpected_errors("-")
 def parse_args(args=None) -> argparse.Namespace:
     """Create a new ArgumentParser and parse sys.argv."""
     parser = argparse.ArgumentParser(

--- a/telepresence/main.py
+++ b/telepresence/main.py
@@ -19,7 +19,9 @@ import sys
 from types import SimpleNamespace
 
 from telepresence.cleanup import wait_for_exit
-from telepresence.cli import parse_args, handle_unexpected_errors
+from telepresence.cli import (
+    parse_args, handle_unexpected_errors, crash_reporting
+)
 from telepresence.container import run_docker_command
 from telepresence.local import run_local_command
 from telepresence.output import Output
@@ -52,7 +54,7 @@ def main(session):
     call_scout(session)
 
     # Set up exit handling
-    with session.runner.cleanup_handling():
+    with session.runner.cleanup_handling(), crash_reporting(session.runner):
         ########################################
         # Now it's okay to change things
 

--- a/telepresence/runner.py
+++ b/telepresence/runner.py
@@ -17,7 +17,7 @@ import textwrap
 from subprocess import Popen, PIPE, DEVNULL, CalledProcessError, check_output
 from threading import Thread
 from time import time, sleep
-from typing import List, Optional
+import typing
 
 from inspect import getframeinfo, currentframe
 import os
@@ -44,8 +44,7 @@ class Runner(object):
         self.kubectl_cmd = kubectl_cmd
         self.verbose = verbose
         self.start_time = time()
-        Optional  # Avoid Pyflakes F401
-        self.current_span = None  # type: Optional[Span]
+        self.current_span = None  # type: typing.Optional[Span]
         self.counter = 0
 
         if sys.stderr.isatty():
@@ -194,7 +193,7 @@ class Runner(object):
     def get_output(self, args, reveal=False, **kwargs) -> str:
         """Return (stripped) command result as unicode string."""
         self.counter = track = self.counter + 1
-        capture = []  # type: List[str]
+        capture = []  # type: typing.List[str]
         if reveal or self.verbose:
             out_cb = self.make_logger(track, capture=capture)
         else:
@@ -238,7 +237,7 @@ class Runner(object):
             self.output.write("[{}] exit {}".format(track, retcode))
 
     def kubectl(self, context: str, namespace: str,
-                args: List[str]) -> List[str]:
+                args: typing.List[str]) -> typing.List[str]:
         """Return command-line for running kubectl."""
         result = [self.kubectl_cmd]
         if self.verbose:
@@ -249,7 +248,11 @@ class Runner(object):
         return result
 
     def get_kubectl(
-        self, context: str, namespace: str, args: List[str], stderr=None
+        self,
+        context: str,
+        namespace: str,
+        args: typing.List[str],
+        stderr=None
     ) -> str:
         """Return output of running kubectl."""
         return self.get_output(
@@ -257,7 +260,8 @@ class Runner(object):
         )
 
     def check_kubectl(
-        self, context: str, namespace: str, kubectl_args: List[str], **kwargs
+        self, context: str, namespace: str, kubectl_args: typing.List[str],
+        **kwargs
     ) -> None:
         """Check exit code of running kubectl."""
         self.check_call(

--- a/telepresence/runner.py
+++ b/telepresence/runner.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import atexit
+import os
 import sys
 import textwrap
-from subprocess import Popen, PIPE, DEVNULL, CalledProcessError, check_output
-from threading import Thread
-from time import time, sleep
 import typing
-
-from inspect import getframeinfo, currentframe
-import os
+from inspect import currentframe, getframeinfo
+from subprocess import CalledProcessError, DEVNULL, PIPE, Popen, check_output
+from threading import Thread
+from time import sleep, time
 
 from telepresence.cache import Cache
 from telepresence.output import Output

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -399,7 +399,13 @@ def httpbin_ip():
 def probe_also_proxy(probe_result, hostname):
     probe_result.write("probe-also-proxy {}".format(hostname))
     success, request_ip = loads(probe_result.read())
-    return success, IPv4Address(request_ip)
+    try:
+        address = IPv4Address(request_ip)
+    except ValueError as exc:
+        print("Request IP: {}".format(request_ip))
+        assert not success, (request_ip, exc)
+        address = None
+    return success, address
 
 
 def _get_swap_result(probe):


### PR DESCRIPTION
Make cleanup and crash reporting go through context managers instead of using decorator and atexit magic.
In service of #628.