### PR TITLE
Add conditional links back to datawire

### DIFF
--- a/docs/_layouts/website/page.html
+++ b/docs/_layouts/website/page.html
@@ -7,3 +7,15 @@
 
 {{ super() }}
 {% endblock %}
+
+{% block page %}
+<a id="datawire-breadcrumb" href="https://datawire.io/learn/open-source-docs">
+    ← Back to Datawire Open Source Documentation
+</a>
+{{ super() }}
+{% endblock %}
+
+{% block javascript %}
+{{ super() }}
+<script src="/js/datawire-breadcrumb.js" type="text/javascript"></script>
+{% endblock %}

--- a/docs/js/datawire-breadcrumb.js
+++ b/docs/js/datawire-breadcrumb.js
@@ -1,0 +1,7 @@
+var url = new URL(window.location.href);
+var utmSource = url.searchParams.get('utm_source');
+var datawireBreadcrumb = document.getElementById('datawire-breadcrumb');
+
+if (utmSource === 'datawire-docs') {
+  datawireBreadcrumb.style.display = 'block';
+}

--- a/docs/styles/website.css
+++ b/docs/styles/website.css
@@ -21,6 +21,10 @@ button.copy-to-clipboard {
     font-size: 11px;
 }
 
+#datawire-breadcrumb {
+    display: none;
+}
+
 
 /*
 *


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
