### PR TITLE
Fix the `bash--norc` typo introduced in 0.91

### DIFF
--- a/newsfragments/738.bugfix
+++ b/newsfragments/738.bugfix
@@ -1,0 +1,1 @@
+Fixed the `bash--norc` typo introduced in 0.91.

--- a/telepresence/outbound/__init__.py
+++ b/telepresence/outbound/__init__.py
@@ -26,7 +26,7 @@ def setup_inject(runner: Runner, args):
             "method limitations see "
             "https://telepresence.io/reference/methods.html"
         )
-    command = ["torsocks"] + (args.run or ["bash" "--norc"])
+    command = ["torsocks"] + (args.run or ["bash", "--norc"])
 
     def launch(runner_, _remote_info, env, socks_port, _ssh, _mount_dir):
         return launch_inject(runner_, command, socks_port, env)
@@ -53,7 +53,7 @@ def setup_vpn(runner: Runner, args):
             "a full list of method limitations see "
             "https://telepresence.io/reference/methods.html"
         )
-    command = args.run or ["bash" "--norc"]
+    command = args.run or ["bash", "--norc"]
 
     def launch(runner_, remote_info, env, _socks_port, ssh, _mount_dir):
         return launch_vpn(


### PR DESCRIPTION
Fixes #738
