### PR TITLE
Move the flags after the environmnet setup stuff so the usage is less…

### DIFF
--- a/environment-setup.sh
+++ b/environment-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh
 
 # Prepare a development environment for running telepresence and its test
 # suite.  These steps should typically only be required once to prepare the
@@ -9,6 +9,8 @@ if [ "$#" -ne 4 ]; then
     echo "  (See .circleci/config.yml for sample values)"
     exit 1
 fi
+
+set -ex
 
 PROJECT_NAME=$1
 CLUSTER_NAME=$2


### PR DESCRIPTION
… confusing.



---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
