### PR TITLE
Print a happy little error msg instead of traceback

### DIFF
--- a/newsfragments/330.bugfix
+++ b/newsfragments/330.bugfix
@@ -1,0 +1,1 @@
+Print a happy little error message instead of a traceback when the namespace cannot be found.

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -115,10 +115,13 @@ class KubeInfo(object):
 
         # Check if the requested namespace exists
         try:
-            runner.get_output([prelim_command, "get", "ns", args.namespace]).split("\n")
+            runner.get_output([prelim_command, "get", "ns",
+                               args.namespace]).split("\n")
             self.namespace = args.namespace
         except CalledProcessError:
-            raise runner.fail("Error: Namespace '{}' does not exist".format(args.namespace))
+            raise runner.fail(
+                "Error: Namespace '{}' does not exist".format(args.namespace)
+            )
 
         for cluster_setting in kubectl_config["clusters"]:
             if cluster_setting["name"] == self.cluster:

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -112,7 +112,13 @@ class KubeInfo(object):
                 break
         else:
             raise runner.fail("Error: Unable to find cluster information")
-        self.namespace = args.namespace
+
+        # Check if the requested namespace exists
+        try:
+            runner.get_output([prelim_command, "get", "ns", args.namespace]).split("\n")
+            self.namespace = args.namespace
+        except CalledProcessError:
+            raise runner.fail("Error: Namespace '{}' does not exist".format(args.namespace))
 
         for cluster_setting in kubectl_config["clusters"]:
             if cluster_setting["name"] == self.cluster:


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
