### PR TITLE
fix: Crash on `sudo telepresence`

### DIFF
--- a/newsfragments/460.misc
+++ b/newsfragments/460.misc
@@ -1,0 +1,1 @@
+Detect that telepresence is running as root and suggest the user not launch Telepresence under sudo

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -14,6 +14,7 @@
 
 import ssl
 import sys
+import os
 
 import json
 from subprocess import CalledProcessError, STDOUT
@@ -89,10 +90,18 @@ class KubeInfo(object):
                     stderr=STDOUT,
                 )
             except CalledProcessError:
+                sudo_used = ""
+                if os.geteuid() == 0:
+                    sudo_used = "Sudo user detected. " + \
+                        "We can't find a context " + \
+                        "and maybe that's because we're running as root. " + \
+                        "Try running without sudo."
+
                 raise runner.fail(
                     "No current-context set. "
                     "Please use the --context option to explicitly set the "
                     "context."
+                    "\n{}".format(sudo_used)
                 )
         self.context = args.context
 


### PR DESCRIPTION
This is a fix for #460

Previously while running `sudo telepresence` gave the following output
```
T: No current-context set. Please use the --context option to explicitly set the context.
```
which did not mention that `kubectl` subprocess is looking at root's Kubernetes configuration instead of that of the user.

So after this enhancement, it will detect we are running as root and will suggest user to not use sudo

Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>



---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
