### PR TITLE
Fix: crash if --new-deployment names an existing deployment

### DIFF
--- a/newsfragments/756.bugfix
+++ b/newsfragments/756.bugfix
@@ -1,0 +1,1 @@
+Fix Telepresence crashes if --new-deployment names an existing deployment.


### PR DESCRIPTION
This is a fix for #756 

Previously when running the following command, and the deployment `qotm` being present in the cluster, Telepresence would crash
```console
telepresence --new-deployment qotm
```

So, after this fix, Telepresence will give an error message stating that deployment already exists in the cluster.

Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>



---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
