### PR TITLE
Fix hubspot embed form

### DIFF
--- a/docs/styles/home.css
+++ b/docs/styles/home.css
@@ -603,11 +603,16 @@ header {
         flex-direction: row;
     }
 }
-.mailing-list-signup .hbspt-form > form > .hs_email {
+
+.mailing-list-signup .hbspt-form > form > div:first-child{
+    width: 100%;
+}
+
+.mailing-list-signup .hbspt-form > form .hs_email {
     flex: 1;
     margin-bottom: 10px;
 }
-.mailing-list-signup .hbspt-form > form > .hs_email input {
+.mailing-list-signup .hbspt-form > form .hs_email input {
     width: 100%;
     border-radius: 0;
     border: 1px solid #F9634E;
@@ -617,7 +622,7 @@ header {
     color: #9B9B9B;
     font-weight: 400;
 }
-.mailing-list-signup .hbspt-form > form > .hs_email > label {
+.mailing-list-signup .hbspt-form > form .hs_email > label {
     display: none;
 }
 .mailing-list-signup .hbspt-form .hs-error-msgs {


### PR DESCRIPTION
Hubspot changed their dom structure on embedded forms, this pr addresses the broken styling because of the change.
---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
