### PR TITLE
Fix call to uninstantiated KubeInfo

### DIFF
--- a/newsfragments/781.bugfix
+++ b/newsfragments/781.bugfix
@@ -1,0 +1,1 @@
+fixes #781. Somewhere between 6b793 and 407ba the call to check if in local vm moved from final checks inside KubeInfo instantiation, whereas runner.kubectl is the final output of KubeInfo instantiation.

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -182,7 +182,7 @@ class KubeInfo(object):
                 ip = runner.get_output(["minishift", "ip"]).strip()
             except (OSError, CalledProcessError):
                 return False
-            if ip and ip in runner.kubectl.server:
+            if ip and ip in self.server:
                 return True
         return False
 


### PR DESCRIPTION
fixes #781. Somewhere between 6b793 and 407ba the call to check if in local vm moved from final checks inside KubeInfo instantiation, whereas runner.kubectl is the final output of KubeInfo instantiation.
