### PR TITLE
Disable tracking by default and make it opt in

### DIFF
--- a/docs/reference/usage_reporting.md
+++ b/docs/reference/usage_reporting.md
@@ -29,8 +29,8 @@ The reporting code can be found in [`telepresence/usage_tracking.py`][1].
 
 Telepresence collects and reports usage every time a session is launched.
 
-## Can it be disabled?
+## Can it be enabled?
 
 Yes. Set the environment variable `SCOUT_DISABLE`.
 
-    export SCOUT_DISABLE=1
+    export SCOUT_DISABLE=0

--- a/telepresence/usage_tracking.py
+++ b/telepresence/usage_tracking.py
@@ -107,7 +107,7 @@ class Scout:
         if str(os.getenv("TRAVIS_REPO_SLUG")).startswith("datawire/"):
             return True
 
-        return os.getenv("SCOUT_DISABLE", "0").lower() in {"1", "true", "yes"}
+        return os.getenv("SCOUT_DISABLE", "1").lower() in {"1", "true", "yes"}
 
 
 def call_scout(runner, args):


### PR DESCRIPTION
I had no idea the TP was collecting data. How come it is not mentioned in the main `README`? I had look into `docs/reference/usage_reporting.md`. I am really disappointed that such default/opt-out behaviour is not made obvious.

Second, it should be opt in, not opt out. 