### PR TITLE
Run testsuite in testbench

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,28 @@ jobs:
           paths:
             - "/opt/circleci/.pyenv"
 
+      - restore_cache:
+          key: "qemu-201711-01-3.0.0"
+      - run:
+          name: "Install QEMU 3.0.0"
+          command: |
+            set -x
+            cd ~
+            curl -OL https://download.qemu.org/qemu-3.0.0.tar.xz
+            tar xf qemu-3.0.0.tar.xz
+            cd qemu-3.0.0
+            ./configure --prefix=$HOME/.local \
+                        --target-list=x86_64-softmmu \
+                        --audio-drv-list='' \
+                        --disable-user
+            make -j$(nproc)
+            make install
+      - save_cache:
+          key: "qemu-201711-01-3.0.0"
+          paths:
+            - "/home/circleci/qemu-3.0.0.tar.xz"
+            - "/home/circleci/qemu-3.0.0"
+
       - run:
           name: "Update APT"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ workflows:
           requires:
             - "build-image"
 
+      - build-testbench:
+          requires:
+            - "build-image"
 jobs:
   lint:
     docker:
@@ -104,6 +107,7 @@ jobs:
     machine:
       enabled: true
       # https://circleci.com/docs/2.0/configuration-reference/#machine
+      # Ubuntu 14.04 + docker 17.11.0-ce + docker-compose 1.17.1
       image: "circleci/classic:201711-01"
 
     environment:
@@ -237,3 +241,130 @@ jobs:
       - store_test_results:
           # https://circleci.com/docs/2.0/collect-test-data/#pytest
           path: test-reports
+
+  build-testbench:
+    # Use the Machine executor for now.
+    #  https://circleci.com/docs/2.0/configuration-reference/#machine
+    #
+    # We use Machine instead of Docker because testbench-mkosi needs
+    # to run privileged Docker containers, which the Docker executor
+    # doesn't support.
+    #  https://circleci.com/docs/2.0/executor-types/
+    #
+    # We may switch to the macOS executor in the future, to enable
+    # testbench to run macOS guests.
+    machine:
+      enabled: true
+      # Ubuntu 14.04 + docker 17.11.0-ce + docker-compose 1.17.1
+      # If you change this be sure to change the restore_cache/save_cache steps below
+      image: "circleci/classic:201711-01"
+
+    steps:
+
+      - restore_cache:
+          key: "pyenv-201711-01-3.6.3"
+      - run:
+          name: "Install Python 3.6"
+          command: |
+            pyenv versions
+            pyenv install --skip-existing 3.6.3
+            pyenv global 2.7.12 3.6.3
+            pyenv versions
+      - save_cache:
+          key: "pyenv-201711-01-3.6.3"
+          paths:
+            - "/opt/circleci/.pyenv"
+
+      - run:
+          name: "Update APT"
+          command: |
+            sudo apt-get --quiet update
+
+      - run:
+          name: "Install testbench"
+          command: |
+            set -x
+            cd ~
+
+            curl -OL http://releases.datawire.io/kubernaut/$(curl http://releases.datawire.io/kubernaut/latest.txt)/linux/amd64/kubernaut
+            sudo install -m755 kubernaut /usr/bin/kubernaut
+            mkdir -p ~/.config/kubernaut
+            # To update:
+            #   1) Get a new token from https://kubernaut.io/token
+            #   2) Update KUBERNAUT_TOKEN in CircleCI "Environment
+            #      Variables" configuration for Telepresence project.
+            #      <https://circleci.com/gh/telepresenceio/telepresence/edit#env-vars>
+            kubernaut config backend create --url="https://next.kubernaut.io" --name="v2" --activate "$KUBERNAUT_TOKEN"
+
+            sudo apt-get install python3-setuptools qemu-system-x86 ovmf curl haveged
+
+            git clone https://github.com/datawire/testbench
+            cd testbench
+            python3 setup.py install --user
+            echo 'PATH=$HOME/.local/bin:$PATH' >> ${BASH_ENV}
+
+      - "checkout"
+
+      - run:
+          name: "decrypt gcloud keys"
+          command: |
+            # To update:
+            #   1) Generate a new key and IV:
+            #      $ dd if=/dev/urandom count=64 bs=1 | md5sum
+            #   2) Update GCLOUD_KEY and GCLOUD_IV in CircleCI "Environment
+            #      Variables" configuration for Telepresence project.
+            #   3) Encrypt the new gcloud key:
+            #      $ ci/encrypt-gcloud-key circleci $GCLOUD_KEY $GCLOUD_IV
+            ci/decrypt-gcloud-key circleci $GCLOUD_KEY $GCLOUD_IV
+
+      - run:
+          name: "setup non-Python environment"
+          command: |
+            # Note hard-coded GNU/Linux platform
+            ./environment-setup.sh datawireio telepresence-testing us-central1-a linux
+            # If we installed kubectl, it was into ${PWD}
+            echo 'PATH=${PWD}:${PATH}' >> ${BASH_ENV}
+            # Magic incantation to make kubectl work, because apparently
+            # gcloud can't do that correctly (see
+            # https://github.com/kubernetes/kubernetes/issues/30617)
+            echo 'export GOOGLE_APPLICATION_CREDENTIALS=${PWD}/gcloud-service-key.json' >> ${BASH_ENV}
+
+      - restore-cache:
+          key: "mkosi.cache-"
+      - run:
+          name: Prepare testbench
+          command: |
+            testbench -j$(nproc) prepare
+            # Remove cache files that weren't accessed in the last 24
+            # hours, to avoid having the the cache keep growing
+            # without bound.
+            sudo find mkosi.cache -atime +0 -type f -delete
+            sudo find mkosi.cache -depth -type d -empty -exec rmdir -- {} \;
+      - save_cache:
+          key: "mkosi.cache-{{ epoch }}"
+          paths:
+            - "mkosi.cache"
+
+      - run:
+          name: "run testbench"
+          command: |
+            make -j$(nproc) testbench-check DOCKER_PUSH='' VERSION_SUFFIX='' PYTEST_ARGS='-m "new and inject_tcp"'
+
+      - run:
+          name: "Delete kubernaut claims"
+          when: always
+          command: |
+            testbench delete-claims
+
+      #- store_test_results:
+      #    path: testbench.junit4.xml
+      - run:
+          name: "Gather testbench report"
+          when: always
+          command: |
+            mkdir -p /tmp/testbench/environments
+            cp -t /tmp/testbench --  testbench.html || true
+            cp -t /tmp/testbench/environments -- environments/*.tap || true
+      - store_artifacts:
+          path: /tmp/testbench
+          destination: testbench-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ jobs:
       - run:
           name: "run testbench"
           command: |
-            make -j$(nproc) testbench-check DOCKER_PUSH='' VERSION_SUFFIX='' PYTEST_ARGS='-m "new and inject_tcp"'
+            DISPLAY='' make -j$(nproc) testbench-check DOCKER_PUSH='' VERSION_SUFFIX='' PYTEST_ARGS='-m "new and inject_tcp"'
 
       - run:
           name: "Delete kubernaut claims"

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,7 @@ docs/.bundle
 virtualenv
 */__pycache__
 *cache*
+
+environments
+mkosi.cache
+.mkosi*

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ gcloud-service-key.json
 .idea
 .vscode
 
+# testbench
+/mkosi.cache/
+/testbench.html
+*.tap
+.mkosi*
+
 # --- Docs ---
 docs/book.json
 docs/_book

--- a/Makefile
+++ b/Makefile
@@ -88,14 +88,15 @@ VIRTUALENV = PATH=$$PWD/virtualenv/bin:$$PATH
 # to write the wrong #! line.  Only expected to be set on OS X.
 # https://bugs.python.org/issue22490
 PIP = $(VIRTUALENV) env -u __PYENV_LAUNCHER__ pip
+DIRFAIL = { r=$$?; rm -rf $@; exit $$r; }
 virtualenv: dev-requirements.txt k8s-proxy/requirements.txt  ## Set up Python3 virtual environment for development
 	rm -rf $@ || true
-	virtualenv --python=python3 $@
-	$(PIP) install flake8
-	$(PIP) install -r dev-requirements.txt
-	$(PIP) install -r k8s-proxy/requirements.txt
-	$(PIP) install git+https://github.com/datawire/sshuttle.git@telepresence
-	$(PIP) install -e .
+	virtualenv --python=python3 $@ || $(DIRFAIL)
+	$(PIP) install flake8 || $(DIRFAIL)
+	$(PIP) install -r dev-requirements.txt || $(DIRFAIL)
+	$(PIP) install -r k8s-proxy/requirements.txt || $(DIRFAIL)
+	$(PIP) install git+https://github.com/datawire/sshuttle.git@telepresence || $(DIRFAIL)
+	$(PIP) install -e . || $(DIRFAIL)
 
 lint: virtualenv  ## Run the linters used by CI (implies 'virtualenv')
 	./tools/license-check

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ _testbench_vars += TELEPRESENCE_VERSION=$(TELEPRESENCE_VERSION)
 _testbench_vars += DOCKER_PUSH=''
 _testbench_vars += PYTEST_ARGS='$(call escape_squotes,--tap-combined $(PYTEST_ARGS))'
 testbench-check: $(DOCKER_PUSH)  ## Run the test suite in testbench (implies '$(DOCKER_PUSH)')
-	+testbench CMD='rm -rf virtualenv; make check $(call escape_squotes,$(_testbench_vars)) >&2; cat testresults.tap'
+	+testbench CMD='make check $(call escape_squotes,$(_testbench_vars)) >&2; cat testresults.tap'
 .PHONY: testbench-check
 
 docker-build:  ## Build Docker images

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ _testbench_vars  = TELEPRESENCE_REGISTRY=$(TELEPRESENCE_REGISTRY)
 _testbench_vars += TELEPRESENCE_VERSION=$(TELEPRESENCE_VERSION)
 _testbench_vars += DOCKER_PUSH=''
 _testbench_vars += PYTEST_ARGS='$(call escape_squotes,--tap-combined $(PYTEST_ARGS))'
-testbench-check: virtualenv $(DOCKER_PUSH)  ## Run the test suite in testbench (implies 'virtualenv' and '$(DOCKER_PUSH)')
-	+testbench CMD='make check $(call escape_squotes,$(_testbench_vars)) >&2; cat testresults.tap'
+testbench-check: $(DOCKER_PUSH)  ## Run the test suite in testbench (implies '$(DOCKER_PUSH)')
+	+testbench CMD='rm -rf virtualenv; make check $(call escape_squotes,$(_testbench_vars)) >&2; cat testresults.tap'
 .PHONY: testbench-check
 
 docker-build:  ## Build Docker images
@@ -90,8 +90,7 @@ VIRTUALENV = PATH=$$PWD/virtualenv/bin:$$PATH
 PIP = $(VIRTUALENV) env -u __PYENV_LAUNCHER__ pip
 virtualenv: dev-requirements.txt k8s-proxy/requirements.txt  ## Set up Python3 virtual environment for development
 	rm -rf $@ || true
-	virtualenv --python=python3 --always-copy $@
-	if [ ! -d virtualenv/lib64 ]; then ln -s lib virtualenv/lib64; fi
+	virtualenv --python=python3 $@
 	$(PIP) install flake8
 	$(PIP) install -r dev-requirements.txt
 	$(PIP) install -r k8s-proxy/requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ mypy
 pytest
 pytest-xdist
 pytest-timeout
+pytest-tap
 pyyaml
 yapf
 pylint

--- a/environments/.gitignore
+++ b/environments/.gitignore
@@ -1,0 +1,4 @@
+/*.knaut
+/*.knaut.claim
+/*.mk
+/*.osi

--- a/environments/archlinux.mkosi
+++ b/environments/archlinux.mkosi
@@ -1,0 +1,27 @@
+[Distribution]
+Distribution=arch
+
+[Output]
+Bootable=yes
+
+[Partitions]
+RootSize=4G
+
+[Packages]
+Packages=
+	# Base OS
+	base
+	base-devel
+	networkmanager
+
+	# For AUR and for tests/utils.py
+	git
+
+	# For Telepresence
+	conntrack-tools
+	docker
+	fuse2
+	python-setuptools
+	sshfs
+	torsocks
+WithNetwork=yes

--- a/environments/archlinux.mkosi
+++ b/environments/archlinux.mkosi
@@ -17,11 +17,14 @@ Packages=
 	# For AUR and for tests/utils.py
 	git
 
+	# Python
+	python-setuptools
+	python-virtualenv
+
 	# For Telepresence
 	conntrack-tools
 	docker
 	fuse2
-	python-setuptools
 	sshfs
 	torsocks
 WithNetwork=yes

--- a/environments/archlinux.mkosi
+++ b/environments/archlinux.mkosi
@@ -3,6 +3,8 @@ Distribution=arch
 
 [Output]
 Bootable=yes
+Cache=
+	/home/testbench/.cache/pip
 
 [Partitions]
 RootSize=4G

--- a/environments/archlinux.postinst
+++ b/environments/archlinux.postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+gpasswd -a testbench docker
+systemctl enable docker
+sudo -u testbench sh -c 'cd ~ && git clone https://aur.archlinux.org/kubectl-bin.git && cd kubectl-bin && makepkg --syncdeps --install --noconfirm --rmdeps'

--- a/environments/archlinux.pre-run
+++ b/environments/archlinux.pre-run
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -rf virtualenv
+make virtualenv

--- a/environments/debian.mkosi
+++ b/environments/debian.mkosi
@@ -1,0 +1,29 @@
+[Distribution]
+Distribution=debian
+
+[Output]
+Bootable=yes
+
+[Partitions]
+RootSize=4G
+
+[Packages]
+Packages=
+	# Base OS
+	ca-certificates
+	make
+	network-manager
+	sudo
+
+	# For tests/utils.py
+	git
+
+	# For Telepresence
+	conntrack
+	docker.io
+	kubernetes-client
+	libpython3.7
+	python3-setuptools
+	sshfs
+	torsocks
+WithNetwork=yes

--- a/environments/debian.mkosi
+++ b/environments/debian.mkosi
@@ -3,6 +3,8 @@ Distribution=debian
 
 [Output]
 Bootable=yes
+Cache=
+	/home/testbench/.cache/pip
 
 [Partitions]
 RootSize=4G
@@ -12,6 +14,7 @@ Packages=
 	# Base OS
 	build-essential
 	ca-certificates
+	haveged
 	network-manager
 	sudo
 

--- a/environments/debian.mkosi
+++ b/environments/debian.mkosi
@@ -10,20 +10,23 @@ RootSize=4G
 [Packages]
 Packages=
 	# Base OS
+	build-essential
 	ca-certificates
-	make
 	network-manager
 	sudo
 
 	# For tests/utils.py
 	git
 
+	# Python
+	libpython3-dev
+	python3-setuptools
+	virtualenv
+
 	# For Telepresence
 	conntrack
 	docker.io
 	kubernetes-client
-	libpython3.7
-	python3-setuptools
 	sshfs
 	torsocks
 WithNetwork=yes

--- a/environments/debian.mkosi
+++ b/environments/debian.mkosi
@@ -25,6 +25,7 @@ Packages=
 	libpython3-dev
 	python3-setuptools
 	virtualenv
+	wget
 
 	# For Telepresence
 	conntrack

--- a/environments/debian.postinst
+++ b/environments/debian.postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+gpasswd -a testbench docker
+systemctl enable NetworkManager

--- a/environments/debian.postinst
+++ b/environments/debian.postinst
@@ -1,3 +1,9 @@
 #!/bin/sh
+
+# On 2018-12-03, Debian Sid updated pip 9->18, but didn't update
+# virtualenv 15->16.  The pip update breaks virtualenv.
+wget -c http://ftp.us.debian.org/debian/pool/main/p/python-pip/python-pip-whl_9.0.1-2.3_all.deb
+dpkg -i python-pip-whl_9.0.1-2.3_all.deb
+
 gpasswd -a testbench docker
 systemctl enable NetworkManager

--- a/environments/debian.pre-run
+++ b/environments/debian.pre-run
@@ -1,0 +1,1 @@
+archlinux.pre-run

--- a/environments/fedora.mkosi
+++ b/environments/fedora.mkosi
@@ -1,0 +1,28 @@
+[Distribution]
+Distribution=fedora
+
+[Output]
+Bootable=yes
+
+[Partitions]
+RootSize=4G
+
+[Packages]
+Packages=
+	# Base OS
+	@core
+	@standard
+	make
+
+	# For tests/utils.py
+	git
+
+	# For Telepresence
+	conntrack-tools
+	docker
+	fuse
+	kubernetes-client
+	python3-setuptools
+	sshfs
+	torsocks
+WithNetwork=yes

--- a/environments/fedora.mkosi
+++ b/environments/fedora.mkosi
@@ -3,6 +3,8 @@ Distribution=fedora
 
 [Output]
 Bootable=yes
+Cache=
+	/home/testbench/.cache/pip
 
 [Partitions]
 RootSize=4G

--- a/environments/fedora.mkosi
+++ b/environments/fedora.mkosi
@@ -12,17 +12,20 @@ Packages=
 	# Base OS
 	@core
 	@standard
-	make
+	@development-tools
 
 	# For tests/utils.py
 	git
+
+	# Python
+	python3-setuptools
+	python3-virtualenv
 
 	# For Telepresence
 	conntrack-tools
 	docker
 	fuse
 	kubernetes-client
-	python3-setuptools
 	sshfs
 	torsocks
 WithNetwork=yes

--- a/environments/fedora.postinst
+++ b/environments/fedora.postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+sudo groupadd docker
+gpasswd -a testbench docker
+systemctl enable NetworkManager
+systemctl enable docker

--- a/environments/fedora.pre-run
+++ b/environments/fedora.pre-run
@@ -1,0 +1,1 @@
+archlinux.pre-run


### PR DESCRIPTION
This PR
 - Adds the `make testbench-check` target, which is like `make check`, but runs `make check` in [testbench](https://github.com/datawire/testbench)
 - Adds several simple testbench environments
 - Adds a CircleCI job to run `make testbench-check`

At this time, I 100% expect CI to come back and tell me I did everything wrong, hence [WIP].