### PR TITLE
Simplify env fetch code and add other pod info

### DIFF
--- a/k8s-proxy/podinfo.py
+++ b/k8s-proxy/podinfo.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Emit information about the pod as a JSON blob
+"""
+
+import json
+import os
+
+print(
+    json.dumps(
+        dict(
+            env=dict(os.environ),
+            hostname=open("/etc/hostname").read(),
+            resolv=open("/etc/resolv.conf").read(),
+        )
+    )
+)

--- a/telepresence/main.py
+++ b/telepresence/main.py
@@ -70,7 +70,7 @@ def main():
         socks_port, ssh = do_connect(runner, remote_info)
 
         # Capture remote environment information (ssh object -> env info)
-        env = get_remote_env(runner, remote_info)
+        env, pod_info = get_remote_env(runner, ssh, remote_info)
 
         # Handle filesystem stuff
         mount_dir = mount_remote(runner, env, ssh)


### PR DESCRIPTION
- Use a script present in the remote image
- Use ssh rather than kubectl exec
- Other pod info is ignore/thrown away for now
