### PR TITLE
.gitattributes: Mark *.min.js files as "binary"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 telepresence/_version.py export-subst
+*.min.js binary


### PR DESCRIPTION
 - No one will ever want to use a regular text diff on them
 - No one will ever want them to show up in `git grep`

I'm tired of having to type `-- ':!*.min.js'` to exclude these every time I run `git grep`.