### PR TITLE
Avoid teleproxy startup race

### DIFF
--- a/packaging/retrieve-teleproxy.py
+++ b/packaging/retrieve-teleproxy.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 import sys
 
 TELEPROXY_BASE = "https://s3.amazonaws.com/datawire-static-files/teleproxy/"
-TELEPROXY_VERSION = "0.2.0"
+TELEPROXY_VERSION = "0.3.6"
 
 
 def retrieve_teleproxy(version, go_os, go_arch, output):

--- a/telepresence/outbound/command.py
+++ b/telepresence/outbound/command.py
@@ -32,9 +32,13 @@ def command(runner):
         runner.show("Setting up outbound connectivity...")
         runner.launch(
             "teleproxy intercept",
-            ["sudo", "teleproxy", "-mode", "intercept"],
+            [
+                "sh", "-c", 'exec sudo NOTIFY_SOCKET="$NOTIFY_SOCKET" "$@"',
+                "--", "teleproxy", "-mode", "intercept"
+            ],
             killer=kill_intercept,
             keep_session=True,  # Avoid trouble with interactive sudo
+            notify=True,
         )
         runner.launch(
             "teleproxy bridge",
@@ -42,6 +46,7 @@ def command(runner):
                 "teleproxy", "-mode", "bridge", "-context",
                 runner.kubectl.context, "-namespace", runner.kubectl.namespace
             ],
+            notify=True,
         )
         runner.show("Outbound is running. Press Ctrl-C/Ctrl-Break to quit.")
         user_process = Popen(["cat"], stdout=DEVNULL)


### PR DESCRIPTION
This modifies `telepresence outbound` to wait for teleproxy to send READY=1 over the sd_notify(3) interface during start-up.  It assumes that https://github.com/datawire/teleproxy/pull/33 will be present in teleproxy 0.3.6, and that 0.3.6 will be released by the time the next telepresence release is cut.

This has been tested on Parabola, and on macOS 10.13.6.