### PR TITLE
fix: OpenShift Deployment/DeploymentConfig support

### DIFF
--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -312,21 +312,21 @@ def swap_deployment_openshift(
     dc_json_with_triggers = json.loads(
         runner.get_output(
             runner.kubectl(
-                "get", 'dc/%s' % deployment, "-o", "json", "--export"
+                "get", "dc/{}".format(deployment), "-o", "json", "--export"
             )
         )
     )
 
     runner.check_call(
         runner.kubectl(
-            "set", "triggers", "dc/%s" % deployment, "--remove-all"
+            "set", "triggers", "dc/{}".format(deployment), "--remove-all"
         )
     )
 
     dc_json = json.loads(
         runner.get_output(
             runner.kubectl(
-                "get", 'dc/%s' % deployment, "-o", "json", "--export"
+                "get", "dc/{}".format(deployment), "-o", "json", "--export"
             )
         )
     )
@@ -339,7 +339,7 @@ def swap_deployment_openshift(
         # Now that we've updated the replication controller, delete pods to
         # make sure changes get applied:
         runner.check_call(
-            runner.kubectl("rollout", "latest", "dc/%s" % deployment)
+            runner.kubectl("rollout", "latest", "dc/{}".format(deployment))
         )
 
     runner.add_cleanup(


### PR DESCRIPTION
This PR improves usage of Telepresence with OpenShift. 

Potentially fixes: #299 #581 #582 #663 #666 #793 #825 

While using telepresence with Openshift (v3.11.0) I came across several problems.

#### Checks if cluster is openshift by inspecting api groups

Current version calls `server + '/version/openshift'` which returns 404 thus the code concludes it needs to use `kubectl` instead of `oc`. 

See d1817c1.

#### Checks if openshift is using `DeploymentConfig` or k8s deployment

As OpenShift support both `DeploymentConfig` and `Deployment` resources we have to check which is used in the current namespace for `--swap-deployment` mode before proceeding.  

See 1b12fc5.

#### Swaps deployment config instead of replication controller

Current implementation attempts to swap `ReplicationController`, but if deployment config has `ImageStream` trigger this will result with discarding telepresence deployment and roll back to original one.

See b48ff8a.