### PR TITLE
Fix outbound network access with Docker Desktop

### DIFF
--- a/docs/discussion/how-it-works.md
+++ b/docs/discussion/how-it-works.md
@@ -71,10 +71,10 @@ inside a Telepresence-proxied shell.
 5. The custom Telepresence DNS server hands this back, `sshuttle` forwards it back, and eventually `curl` gets the Service IP.
 6. `curl` opens connection to that IP, `sshuttle` forwards it to the Kubernetes cluster.
 
-#### minikube/minishift
+#### minikube/minishift and Docker Desktop
 
-When using minikube or minishift to run a cluster locally in a VM there is an additional complication.
-Let's say you lookup `google.com`.
+There is an additional complication when running a cluster locally in a VM, using
+something like minikube, minishift, or Docker Desktop. Let's say you lookup `google.com`:
 
 1. `sshuttle` forwards `google.com` to Kubernetes (via Telepresence DNS server).
 2. Kubernetes DNS server doesn't know about any such Service, so it does normal DNS lookup.
@@ -82,8 +82,10 @@ Let's say you lookup `google.com`.
 4. `sshuttle` captures all DNS lookups going from the host machine.
 5. Your DNS lookup is now in an infinite loop.
 
-To solve this Telepresence will detect minikube and minishift, and when it does the Telepresence DNS server will forward DNS requests that aren't Kubernetes-specific to an external DNS server that is different than the ones your host machine is using.
-E.g. it might use Google's public DNS if your host isn't.
+To solve this Telepresence will detect minikube, minishift, and Docker Dekstop.
+When it does, the Telepresence DNS server will forward DNS requests that aren't Kubernetes-specific to an external DNS server
+that is different than the ones your host machine is using. For example, it might use Google's public DNS if your host isn't.
+
 As a result these DNS lookups aren't captured by `sshuttle` and the infinite loop is prevented.
  
 ### inject-tcp method in detail

--- a/newsfragments/736.bugfix
+++ b/newsfragments/736.bugfix
@@ -1,0 +1,1 @@
+Telepresence no longer breaks all outbound network access when running on macOS with Docker Desktop.

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -190,6 +190,9 @@ class KubeInfo(object):
         return result
 
     def _check_if_in_local_vm(self, runner: Runner) -> bool:
+        # Running Docker Desktop on macOS (or maybe Windows?)
+        if self.context == "docker-for-desktop":
+            return True
         # Minikube just has 'minikube' as context'
         if self.context == "minikube":
             return True


### PR DESCRIPTION
Docker Desktop has the same issue as minikube/minishift, so we need to
detect and handle it the same way.

Fixes #736.
