### PR TITLE
Openshift docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,16 @@ format: virtualenv  ## Format source code in-place
 
 #
 
+docs: ## Builds documentation
+	@exec docs/build-website.sh
+.PHONY: docs
+
+docs-serve: docs ## Serves documentation under localhost for easy editing with preview
+	@exec npm start --prefix docs/
+.PHONY: docs
+
+#
+
 help:  ## Show this message
 	@echo 'usage: make [TARGETS...] [VARIABLES...]'
 	@echo

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,7 +37,7 @@
 
 ## Community
 
-* [Development info](reference/developing.md)
+* [Development Guide](reference/developing.md)
 * [Community](reference/community.md)
 * [Related Projects](reference/related-projects.md)
 * [Case Studies](https://www.telepresence.io/case-studies)

--- a/docs/reference/developing.md
+++ b/docs/reference/developing.md
@@ -1,4 +1,4 @@
-# Development info
+# Development Guide
 
 ### Known issues
 
@@ -55,6 +55,14 @@ You can also build images and push them to a registry without running any tests:
 ```console
 $ make docker-push TELEPRESENCE_REGISTRY=<Docker registry for tag and push>
 ```
+
+If you want to push images to the local registry, start the container first:
+
+```console
+$ docker run -d -p 5000:5000 --restart=always --name docker-local-registry registry
+```
+
+and then simply use `TELEPRESENCE_REGISTRY=localhost:5000`.
 
 Or if you want to build images using minikube (untested):
 
@@ -230,7 +238,7 @@ A single end-to-end test to verify a gross code path combined with many unit tes
 Formatting is enforced by the installed `yapf` tool; to reformat the code, you can do:
 
 ```console
-$ virtualenv/bin/yapf -r -i telepresence
+$ make format
 ```
 
 ### Releasing Telepresence

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -40,6 +40,14 @@ $ oc new-app --docker-image=datawire/hello-world --name=hello-world
 $ oc expose service hello-world
 ```
 
+**Important:** It might be necessary to define security context constraint in order for Telepresence to run privileged
+containers. Execute following using an account with sufficient permission (i.e. for local cluster login first as `system:admin`):
+
+```console
+$ oc adm policy add-scc-to-user anyuid -z default -n hello-world
+$ oc adm policy add-scc-to-user privileged -z default -n hello-world
+```
+
 The service will be running once the following shows a pod with `Running` status that *doesn't* have "deploy" in its name:
 
 ```console


### PR DESCRIPTION
* mentions adding security context constraints for the user when using OpenShift
* creates doc-related targets in Makefile
* minor polishing in dev guide with mention how to run docker registry locally (useful when building)
