### PR TITLE
Add env var for remote volume mounts as colon-seperated list

### DIFF
--- a/docs/howto/volumes.md
+++ b/docs/howto/volumes.md
@@ -4,20 +4,22 @@ Volume support requires a small amount of work on your part.
 The root directory where all the volumes can be found will be set to the `TELEPRESENCE_ROOT` environment variable in the shell run by `telepresence`.
 You will then need to use that env variable as the root for volume paths you are opening.
 
-Telepresence will attempt to gather a list of all mount points that exist and put them into
-the `TELEPRESENCE_MOUNTS` variable, seperated by `:` characters.  This allows automated discovery
-of mount-points.  (See below for an example).
+Telepresence will attempt to gather the mount points that exist in the remote pod and list them in the `TELEPRESENCE_MOUNTS` environment variable, separated by `:` characters.
+This allows automated discovery of remote volumes.
 
 For example, all Kubernetes containers have a volume mounted at `/var/run/secrets` with the service account details.
 Those files are accessible from Telepresence:
 
 ```console
-$ telepresence --run-shell
-Starting proxy...
-@minikube|$ echo $TELEPRESENCE_ROOT
-/tmp/tmpk_svwt_5
-@minikube|$ ls $TELEPRESENCE_ROOT/var/run/secrets/kubernetes.io/serviceaccount/
-ca.crt  namespace  token
+$ telepresence
+T: [...]
+T: Setup complete. Launching your command.
+@tel-testing|bash-3.2$ echo $TELEPRESENCE_ROOT
+/tmp/tel-6cjjs3ba/fs
+@tel-testing|bash-3.2$ echo $TELEPRESENCE_MOUNTS
+/var/run/secrets/kubernetes.io/serviceaccount
+@tel-testing|bash-3.2$ ls $TELEPRESENCE_ROOT/var/run/secrets/kubernetes.io/serviceaccount/
+ca.crt          namespace       token
 ```
 
 The files are available at a different path than they are on the actual Kubernetes environment.
@@ -71,21 +73,21 @@ $ ls /var/run/secrets/kubernetes.io/serviceaccount/
 ca.crt  namespace  token
 ```
 
-Using the `TELEPRESENCE_MOUNTS` environment variable allows for automatic discovery and handling of mount
-points.  For example, the following Python code will create sym-links so that any mounted volumes
-appear in their normal locations:
+Using the `TELEPRESENCE_MOUNTS` environment variable allows for automatic discovery and handling of mount points.
+For example, the following Python code will create symlinks so that any mounted volumes appear in their normal locations:
+
 ```python
 def telepresence_remote_mounts():
     mounts = os.environ.get('TELEPRESENCE_MOUNTS')
     if not mounts:
         return
 
-    tele_root = os.environ.get('TELEPRESENCE_ROOT')
+    tel_root = os.environ.get('TELEPRESENCE_ROOT')
 
     for mount in mounts.split(':'):
         dir_name, link_name = os.path.split(mount)
         os.makedirs(dir_name, exist_ok=True)
-        
-        link_src = os.path.join(tele_root, mount[1:])
+
+        link_src = os.path.join(tel_root, mount[1:])
         os.symlink(link_src, mount)
 ```

--- a/k8s-proxy/podinfo.py
+++ b/k8s-proxy/podinfo.py
@@ -18,10 +18,16 @@ Emit information about the pod as a JSON blob
 import json
 import os
 import re
+import sys
 
 IGNORED_MOUNTS = [
-    r'/sys($|/.*)', r'/proc($|/.*)', r'/dev($|/.*)', r'/etc/hostname$',
-    r'/etc/resolv.conf$', r'/etc/hosts$', r'/$'
+    r'/sys($|/.*)',
+    r'/proc($|/.*)',
+    r'/dev($|/.*)',
+    r'/etc/hostname$',
+    r'/etc/resolv.conf$',
+    r'/etc/hosts$',
+    r'/$',
 ]
 
 
@@ -38,7 +44,9 @@ def get_mount_points():
                 mount_point = splitter.split(line)[1]
                 if not ignore.match(mount_point):
                     ret.append(mount_point)
-    except IOError:
+    except Exception as exc:
+        print("//Failed to get mount points: {}".format(exc), file=sys.stderr)
+        print("//Retrieved so far: {}".format(ret), file=sys.stderr)
         return []
 
     return ret

--- a/k8s-proxy/podinfo.py
+++ b/k8s-proxy/podinfo.py
@@ -17,6 +17,32 @@ Emit information about the pod as a JSON blob
 
 import json
 import os
+import re
+
+IGNORED_MOUNTS = [
+    r'/sys($|/.*)', r'/proc($|/.*)', r'/dev($|/.*)', r'/etc/hostname$',
+    r'/etc/resolv.conf$', r'/etc/hosts$', r'/$'
+]
+
+
+def get_mount_points():
+    "Returns a filtered list of mount-points"
+    ret = []
+
+    ignore = re.compile('(' + '|'.join(IGNORED_MOUNTS) + ')')
+    splitter = re.compile(r'\s+')
+
+    try:
+        with open('/proc/mounts', 'r') as mount_fp:
+            for line in mount_fp:
+                mount_point = splitter.split(line)[1]
+                if not ignore.match(mount_point):
+                    ret.append(mount_point)
+    except IOError:
+        return []
+
+    return ret
+
 
 print(
     json.dumps(
@@ -24,6 +50,7 @@ print(
             env=dict(os.environ),
             hostname=open("/etc/hostname").read(),
             resolv=open("/etc/resolv.conf").read(),
+            mountpoints=get_mount_points(),
         )
     )
 )

--- a/newsfragments/917.feature
+++ b/newsfragments/917.feature
@@ -1,0 +1,1 @@
+Add a `TELEPRESENCE_MOUNTS` env var with a automatically generated list of remote mount points.

--- a/telepresence/remote_env.py
+++ b/telepresence/remote_env.py
@@ -41,7 +41,8 @@ def get_remote_env(runner: Runner, ssh: SSH, remote_info: RemoteInfo
         # debugging:
         result = {
             "TELEPRESENCE_POD": remote_info.pod_name,
-            "TELEPRESENCE_CONTAINER": remote_info.container_name
+            "TELEPRESENCE_CONTAINER": remote_info.container_name,
+            "TELEPRESENCE_MOUNTS": ":".join(pod_info["mountpoints"])
         }
         # Alpine, which we use for telepresence-k8s image, automatically sets
         # HOME, PATH, HOSTNAME. The rest are from Kubernetes:

--- a/telepresence/remote_env.py
+++ b/telepresence/remote_env.py
@@ -42,7 +42,7 @@ def get_remote_env(runner: Runner, ssh: SSH, remote_info: RemoteInfo
         result = {
             "TELEPRESENCE_POD": remote_info.pod_name,
             "TELEPRESENCE_CONTAINER": remote_info.container_name,
-            "TELEPRESENCE_MOUNTS": ":".join(pod_info["mountpoints"])
+            "TELEPRESENCE_MOUNTS": ":".join(pod_info["mountpoints"]),
         }
         # Alpine, which we use for telepresence-k8s image, automatically sets
         # HOME, PATH, HOSTNAME. The rest are from Kubernetes:

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -83,6 +83,8 @@ def test_environment_from_deployment(probe):
             )
         )
         assert "TELEPRESENCE_ROOT" in probe_json_env, probe_json_env
+        assert "/podinfo" in probe_json_env["TELEPRESENCE_MOUNTS"], probe_json_env
+        assert "/var/run/secrets/kubernetes.io/serviceaccount" in probe_json_env["TELEPRESENCE_MOUNTS"], probe_json_env
 
         probe_envfile = probe.operation.envfile.read_text()
         for key, value in probe.DESIRED_ENVIRONMENT.items():
@@ -92,6 +94,7 @@ def test_environment_from_deployment(probe):
             else:
                 assert "{}={}\n".format(key, value) in probe_envfile
         assert "TELEPRESENCE_ROOT=" in probe_envfile, probe_envfile
+        assert "TELEPRESENCE_MOUNTS=" in probe_envfile, probe_envfile
 
 
     if probe.method.inherits_client_environment():


### PR DESCRIPTION
Proposed solution to #917.

I've recently discovered telepresence, and quickly got hooked.  I have a whole bunch of micro-services running on k8s, each with a different list of volume mounts.  Instead of having to manually create sym-links or use `proot` to create fake bindings, what I really want is to be able to get a list of mounts from telepresence, which I can then use to automatically handle the mounts.

This pull request adds a `TELEPRESENCE_MOUNTS` environment variable to the local container that holds a colon-separated list of remote mount points, ignoring those that docker automatically creates (`/sys/*`, `/proc/*`, `/dev/*`, `resolv.conf`, `hostname`, `hosts`).

With this in hand, a manually-updated list of locations that must be sym-link'd or bind-mount'd from under `$TELEPRESENCE_ROOT` to their usual locations is no longer required, and can be replaced with something like:

```python
def telepresence_remote_mounts():
    mounts = os.environ.get('TELEPRESENCE_MOUNTS')
    if not mounts:
        return

    tele_root = os.environ.get('TELEPRESENCE_ROOT')

    for mount in mounts.split(':'):
        dir_name, link_name = os.path.split(mount)
        os.makedirs(dir_name, exist_ok=True)
        
        link_src = os.path.join(tele_root, mount[1:])
        os.symlink(link_src, mount)
```

If the container is running locally via telepresence, all the volumes end up where they would normally be, and everything works as expected.  In production, the environment variable is not present and no action occurs.