### PR TITLE
fix(openshift): waits for original deployment config to be available

### DIFF
--- a/newsfragments/929.bugfix
+++ b/newsfragments/929.bugfix
@@ -1,0 +1,1 @@
+Telepresence will wait until deployment config on Openshift is successfully rolled back to its original state (pre Telepresence session)

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -357,6 +357,10 @@ def swap_deployment_openshift(
             runner.kubectl("rollout", "latest", "dc/{}".format(deployment))
         )
 
+        runner.check_call(
+            runner.kubectl("rollout", "status", "-w", "dc/{}".format(deployment))
+        )
+
     runner.add_cleanup(
         "Restore original deployment config", apply_json, dc_json_with_triggers
     )


### PR DESCRIPTION
By using `oc rollout status -w dc/name` we can wait during cleanup process until original deployment config is restored, finishing Telepresence process at the right moment.

Fixes #929 