### PR TITLE
Allow to set timeout for pod ready status

### DIFF
--- a/newsfragments/777.feature
+++ b/newsfragments/777.feature
@@ -1,0 +1,1 @@
+Telepresence allows to set a timeout for the pod to become ready.

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -327,6 +327,15 @@ def parse_args(args=None) -> argparse.Namespace:
         )
     )
 
+    parser.add_argument(
+        "--timeout",
+        default=120,
+        type=float,
+        help=(
+            "Number of seconds to wait for the Telepresence pod to become ready."
+        )
+    )
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--run-shell",

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -101,6 +101,7 @@ def setup(runner: Runner, args):
             runner,
             tel_deployment,
             deployment_type,
+            args.timeout,
             run_id=run_id,
         )
         return remote_info

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -142,6 +142,7 @@ def get_remote_info(
     runner: Runner,
     deployment_name: str,
     deployment_type: str,
+    timeout: float,
     run_id: Optional[str] = None,
 ) -> RemoteInfo:
     """
@@ -166,7 +167,7 @@ def get_remote_info(
     if run_id:
         cmd.append("--selector=telepresence={}".format(run_id))
 
-    for _ in runner.loop_until(120, 1):
+    for _ in runner.loop_until(timeout, 1):
         pods = json.loads(runner.get_output(runner.kubectl(cmd)))["items"]
         for pod in pods:
             name = pod["metadata"]["name"]


### PR DESCRIPTION
Add a new cli flag `timeout` which allows the user to set the timeout telepresence waits for its pod to become ready.

Fixes #777 