### PR TITLE
Don't hardcode the kubernetes.default FQDN in local-docker

### DIFF
--- a/local-docker/entrypoint.py
+++ b/local-docker/entrypoint.py
@@ -115,7 +115,7 @@ def wait():
     start = time()
     while time() - start < 30:
         try:
-            gethostbyname("kubernetes.default.svc.cluster.local")
+            gethostbyname("kubernetes.default")
             sleep(1)  # just in case there's more to startup
             sys.exit(100)
         except gaierror:


### PR DESCRIPTION
The default search domain for clusters can be changed and
kubernetes.default.svc.cluster.local may not respond leading to
telepresence timing out when starting the local container.

So I propose to not use a FQDN.


---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
