### PR TITLE
[#955] Add Maven Option of Local Java Deployment Tutorial for JDK under 9

### DIFF
--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -72,9 +72,7 @@ For more details about the `mount` command check the [documentation](/howto/volu
 
 If you need to debug your code with your favourite IDE that's super easy too. You only need to pass a JVM argument and forward the remote port:
 
-* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` Creates a
-* Docker environment variable that Maven will use to set a JVM argument and awaits for a remote
-* connection on port `5005`. This is for Java 9+.
+* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` Creates a Docker environment variable that Maven will use to set a JVM argument and awaits for a remote connection on port `5005`. This is for Java 9+.
   * `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` Should be used for JDK 5-8.
 * `-p 5005:5005` Tells docker to forward that ports from your local machine.
 

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -72,8 +72,9 @@ For more details about the `mount` command check the [documentation](/howto/volu
 
 If you need to debug your code with your favourite IDE that's super easy too. You only need to pass a JVM argument and forward the remote port:
 
-* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` Creates a Docker environment variable that Maven will use to set a JVM argument and awaits for a remote connection on port `5005`. This is for Java 9+.
-  * `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` Should be used for JDK 5-8.
+* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` (JDK 9+)  
+  `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` (JDK 5-8)  
+  Creates a Docker environment variable that Maven will use to set a JVM argument and awaits for a remote connection on port `5005`.
 * `-p 5005:5005` Tells docker to forward that ports from your local machine.
 
 Then you can use your IDE to start a debug remote session on your local port `5005`

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -72,7 +72,10 @@ For more details about the `mount` command check the [documentation](/howto/volu
 
 If you need to debug your code with your favourite IDE that's super easy too. You only need to pass a JVM argument and forward the remote port:
 
-* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` Creates a Docker environment variable that Maven will use to set a JVM argument and awaits for a remote connection on port `5005`. This is for Java 8+, check the Java documentation if you are running a lower version.
+* `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005` Creates a
+* Docker environment variable that Maven will use to set a JVM argument and awaits for a remote
+* connection on port `5005`. This is for Java 9+.
+  * `-e MAVEN_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` Should be used for JDK 5-8.
 * `-p 5005:5005` Tells docker to forward that ports from your local machine.
 
 Then you can use your IDE to start a debug remote session on your local port `5005`

--- a/newsfragments/955.misc
+++ b/newsfragments/955.misc
@@ -1,0 +1,1 @@
+Add a substitute Maven debug option for JDK 5-8.


### PR DESCRIPTION
The Maven option in current doc only works for JDK 9+.
I added a substitute option for JDK 5-8. (Thanks for @ark3)

Closed #955