### PR TITLE
version split allows for private registries

### DIFF
--- a/newsfragments/967.bugfix
+++ b/newsfragments/967.bugfix
@@ -1,0 +1,1 @@
+Telepresence should be able to handle private repositories as sources for expected images

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -57,7 +57,9 @@ class RemoteInfo(object):
 
     def remote_telepresence_version(self) -> str:
         """Return the version used by the remote Telepresence container."""
-        name, version = self.container_config["image"].split(":")
+        arrs = self.container_config["image"].split(":")
+        name = arrs[1][::-1]
+        version = arrs[0][::-1]
         if name.endswith("telepresence-proxy"):
             return image_version
         return version

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -57,7 +57,7 @@ class RemoteInfo(object):
 
     def remote_telepresence_version(self) -> str:
         """Return the version used by the remote Telepresence container."""
-        arrs = self.container_config["image"].split(":", 1)
+        arrs = self.container_config["image"][::-1].split(":", 1)
         name = arrs[1][::-1]
         version = arrs[0][::-1]
         if name.endswith("telepresence-proxy"):

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -57,9 +57,7 @@ class RemoteInfo(object):
 
     def remote_telepresence_version(self) -> str:
         """Return the version used by the remote Telepresence container."""
-        arrs = self.container_config["image"][::-1].split(":", 1)
-        name = arrs[1][::-1]
-        version = arrs[0][::-1]
+        name, version = self.container_config["image"].rsplit(":", 1)
         if name.endswith("telepresence-proxy"):
             return image_version
         return version

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -57,7 +57,7 @@ class RemoteInfo(object):
 
     def remote_telepresence_version(self) -> str:
         """Return the version used by the remote Telepresence container."""
-        arrs = self.container_config["image"].split(":")
+        arrs = self.container_config["image"].split(":", 1)
         name = arrs[1][::-1]
         version = arrs[0][::-1]
         if name.endswith("telepresence-proxy"):


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
