### PR TITLE
Improve sync subprocesses

### DIFF
--- a/newsfragments/966.bugfix
+++ b/newsfragments/966.bugfix
@@ -1,0 +1,1 @@
+Telepresence no longer crashes when used with kubectl 1.14.

--- a/telepresence/connect/connect.py
+++ b/telepresence/connect/connect.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from subprocess import STDOUT, CalledProcessError
+from subprocess import CalledProcessError
 from typing import Tuple
 
 from telepresence.cli import PortMapping
@@ -90,7 +90,7 @@ def setup(runner: Runner, args):
     # Make sure we can run openssh:
     runner.require(["ssh"], "Please install the OpenSSH client")
     try:
-        version = runner.get_output(["ssh", "-V"], stderr=STDOUT)
+        version = runner.get_output(["ssh", "-V"], stderr_to_stdout=True)
         if not version.startswith("OpenSSH"):
             raise runner.fail("'ssh' is not the OpenSSH client, apparently.")
     except (CalledProcessError, OSError, IOError) as e:

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from subprocess import CalledProcessError, STDOUT
+from subprocess import CalledProcessError
 
 from telepresence import (
     TELEPRESENCE_REMOTE_IMAGE, TELEPRESENCE_REMOTE_IMAGE_PRIV
@@ -54,19 +54,17 @@ def setup(runner: Runner, args):
         # OpenShift Origin might be using DeploymentConfig instead
         if args.swap_deployment:
             try:
-                runner.get_output(
+                runner.check_call(
                     runner.kubectl(
                         "get", "dc/{}".format(args.swap_deployment)
                     ),
-                    reveal=True,
-                    stderr=STDOUT
                 )
                 deployment_type = "deploymentconfig"
             except CalledProcessError as exc:
                 runner.show(
                     "Failed to find OpenShift deploymentconfig {}. "
                     "Will try regular k8s deployment. Reason:\n{}".format(
-                        deployment_arg, exc.stdout
+                        deployment_arg, exc.stderr
                     )
                 )
 

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -14,7 +14,7 @@
 
 import json
 from copy import deepcopy
-from subprocess import STDOUT, CalledProcessError
+from subprocess import CalledProcessError
 from typing import Dict, Optional, Tuple
 
 from telepresence.cli import PortMapping
@@ -36,15 +36,11 @@ def existing_deployment(
         "Deployment {}".format(deployment_arg)
     )
     try:
-        runner.get_output(
-            runner.kubectl("get", "deployment", deployment_arg),
-            reveal=True,
-            stderr=STDOUT
-        )
+        runner.check_call(runner.kubectl("get", "deployment", deployment_arg))
     except CalledProcessError as exc:
         raise runner.fail(
             "Failed to find deployment {}:\n{}".format(
-                deployment_arg, exc.stdout
+                deployment_arg, exc.stderr
             )
         )
     run_id = None
@@ -68,7 +64,7 @@ def create_new_deployment(
     def remove_existing_deployment(quiet=False):
         if not quiet:
             runner.show("Cleaning up Deployment {}".format(deployment_arg))
-        runner.get_output(
+        runner.check_call(
             runner.kubectl(
                 "delete",
                 "--ignore-not-found",
@@ -102,11 +98,11 @@ def create_new_deployment(
             "--env=TELEPRESENCE_NAMESERVER=" + get_alternate_nameserver()
         )
     try:
-        runner.get_output(runner.kubectl(command), reveal=True, stderr=STDOUT)
+        runner.check_call(runner.kubectl(command))
     except CalledProcessError as exc:
         raise runner.fail(
             "Failed to create deployment {}:\n{}".format(
-                deployment_arg, exc.stdout
+                deployment_arg, exc.stderr
             )
         )
     span.end()

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -82,7 +82,6 @@ def get_deployment_json(
             deployment_type,
             "-o",
             "json",
-            "--export",
         ]
         if run_id is None:
             return json.loads(
@@ -160,7 +159,7 @@ def get_remote_info(
     runner.write("  with name {}-*".format(deployment_name))
     runner.write("  with labels {}".format(expected_labels))
 
-    cmd = "get pod -o json --export".split()
+    cmd = "get pod -o json".split()
     if run_id:
         cmd.append("--selector=telepresence={}".format(run_id))
 

--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from subprocess import STDOUT, CalledProcessError
+from subprocess import CalledProcessError
 from typing import Dict, Optional
 
 from telepresence import image_version
@@ -87,8 +87,7 @@ def get_deployment_json(
         if run_id is None:
             return json.loads(
                 runner.get_output(
-                    runner.kubectl(get_deployment + [deployment_name]),
-                    stderr=STDOUT
+                    runner.kubectl(get_deployment + [deployment_name])
                 )
             )
         else:
@@ -97,8 +96,7 @@ def get_deployment_json(
                 runner.get_output(
                     runner.kubectl(
                         get_deployment + ["--selector=telepresence=" + run_id]
-                    ),
-                    stderr=STDOUT
+                    )
                 )
             )["items"][0]
     except CalledProcessError as e:

--- a/telepresence/runner/launch.py
+++ b/telepresence/runner/launch.py
@@ -62,7 +62,7 @@ def _launch_command(
     out_logger: _Logger,
     err_logger: _Logger,
     done: typing.Optional[typing.Callable[[Popen], None]] = None,
-    **kwargs: typing.Any,
+    **kwargs: typing.Any
 ) -> Popen:
     """
     Launch subprocess with args, kwargs.

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -129,7 +129,10 @@ class Runner(object):
         for additional in "/usr/sbin", "/sbin":
             if additional not in path_elements:
                 path += ":" + additional
-        libexec = TELEPRESENCE_BINARY.parents[1] / "libexec"
+        try:
+            libexec = TELEPRESENCE_BINARY.parents[1] / "libexec"
+        except IndexError:
+            libexec = TELEPRESENCE_BINARY / "does_not_exist_please"
         if libexec.exists():
             path = "{}:{}".format(libexec, path)
         os.environ["PATH"] = path

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -17,7 +17,7 @@ import os
 import ssl
 import sys
 from shutil import which
-from subprocess import STDOUT, CalledProcessError
+from subprocess import CalledProcessError
 from typing import List, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
@@ -101,10 +101,9 @@ class KubeInfo(object):
         # in kubeconfig:
         if args.context is None:
             try:
-                args.context = runner.get_output(
-                    [prelim_command, "config", "current-context"],
-                    stderr=STDOUT,
-                )
+                args.context = runner.get_output([
+                    prelim_command, "config", "current-context"
+                ])
             except CalledProcessError:
                 sudo_used = ""
                 if os.geteuid() == 0:
@@ -255,17 +254,16 @@ def final_checks(runner: Runner, args):
 
     # Make sure we can access Kubernetes:
     try:
-        runner.get_output(
+        runner.check_call(
             runner.kubectl(
                 "get", "pods", "telepresence-connectivity-check",
                 "--ignore-not-found"
-            ),
-            stderr=STDOUT,
+            )
         )
     except CalledProcessError as exc:
         sys.stderr.write("Error accessing Kubernetes: {}\n".format(exc))
-        if exc.output:
-            sys.stderr.write("{}\n".format(exc.output.strip()))
+        if exc.stderr:
+            sys.stderr.write("{}\n".format(exc.stderr.strip()))
         raise runner.fail("Cluster access failed")
     except (OSError, IOError) as exc:
         raise runner.fail(


### PR DESCRIPTION
Now synchronous subprocess calls (`runner.get_output(...)` and `runner.check_call(...)`) use almost the same code. They always capture stderr and have it available for reporting to the user upon failure. There is no longer any need to use get_output and throw away the answer just to have stderr around for error reporting.

Fixes #966 