### PR TITLE
 Make kubectl logs a non-critical subprocess 

### DIFF
--- a/newsfragments/598.bugfix
+++ b/newsfragments/598.bugfix
@@ -1,0 +1,1 @@
+Telepresence no longer quits if its `kubectl logs` subprocess quits.

--- a/telepresence/connect/connect.py
+++ b/telepresence/connect/connect.py
@@ -34,7 +34,8 @@ def connect(
     Return (local port of SOCKS proxying tunnel, SSH instance).
     """
     span = runner.span()
-    # Keep local copy of pod logs, for debugging purposes:
+    # Keep local copy of pod logs, for debugging purposes. Set is_critical to
+    # False so logs failing doesn't bring down the Telepresence session.
     runner.launch(
         "kubectl logs",
         runner.kubectl(
@@ -42,6 +43,7 @@ def connect(
             remote_info.container_name, "--tail=10"
         ),
         bufsize=0,
+        is_critical=False,
     )
 
     ssh = SSH(runner, find_free_port())


### PR DESCRIPTION
so that Telepresence no longer quits if its `kubectl logs` subprocess quits.

Fixes #598 
Fixes #916 
Fixes #969 
