### PR TITLE
Add support for attaching a debugger to processes under telepresence

### DIFF
--- a/newsfragments/1003.bugfix
+++ b/newsfragments/1003.bugfix
@@ -1,0 +1,1 @@
+Add support for attaching a debugger to Go services under telepresence

--- a/newsfragments/1003.bugfix
+++ b/newsfragments/1003.bugfix
@@ -1,1 +1,1 @@
-Add support for attaching a debugger to Go services under telepresence
+Add support for attaching a debugger to services under telepresence (tested on Go and Python)

--- a/newsfragments/1003.bugfix
+++ b/newsfragments/1003.bugfix
@@ -1,1 +1,1 @@
-Add support for attaching a debugger to services under telepresence (tested on Go and Python)
+Add support for attaching a debugger to processes under telepresence (tested on Go and Python)

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -679,7 +679,7 @@ class Runner(object):
         self.write("Everything launched. Waiting to exit...")
         main_code = None
         span = self.span()
-        Thread(target=wait_for_process, args=(main_process,))
+        Thread(target=wait_for_process, args=(main_process, ))
         while not self.quitting:
             sleep(0.1)
         span.end()

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -26,13 +26,12 @@ from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree, which
 from subprocess import STDOUT, CalledProcessError, TimeoutExpired, Popen
+from telepresence import TELEPRESENCE_BINARY
+from telepresence.utilities import kill_process, str_command
 from tempfile import mkdtemp
 from threading import Thread
 from time import sleep, time
 
-from telepresence.utilities import kill_process, str_command
-
-from telepresence import TELEPRESENCE_BINARY
 from .cache import Cache
 from .launch import BackgroundProcessCrash, _launch_command, _Logger
 from .output import Output
@@ -670,6 +669,8 @@ class Runner(object):
 
             Note that main_code is defined in the parent function,
             so it is declared as nonlocal
+
+            See https://github.com/telepresenceio/telepresence/issues/1003
             """
             nonlocal main_code
             main_code = p.wait()

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -30,9 +30,9 @@ from tempfile import mkdtemp
 from threading import Thread
 from time import sleep, time
 
+from telepresence import TELEPRESENCE_BINARY
 from telepresence.utilities import kill_process, str_command
 
-from telepresence import TELEPRESENCE_BINARY
 from .cache import Cache
 from .launch import BackgroundProcessCrash, _launch_command, _Logger
 from .output import Output

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -678,7 +678,7 @@ class Runner(object):
         self.write("Everything launched. Waiting to exit...")
         main_code = None
         span = self.span()
-        Thread(target=wait_for_process, args=(p,))
+        Thread(target=wait_for_process, args=(main_process,))
         while not self.quitting:
             sleep(0.1)
         span.end()

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -26,11 +26,12 @@ from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree, which
 from subprocess import STDOUT, CalledProcessError, TimeoutExpired, Popen
-from telepresence import TELEPRESENCE_BINARY
-from telepresence.utilities import kill_process, str_command
 from tempfile import mkdtemp
 from threading import Thread
 from time import sleep, time
+
+from telepresence import TELEPRESENCE_BINARY
+from telepresence.utilities import kill_process, str_command
 
 from .cache import Cache
 from .launch import BackgroundProcessCrash, _launch_command, _Logger


### PR DESCRIPTION
This fixes [bug 1003](https://github.com/telepresenceio/telepresence/issues/1003). 

I added a [detailed comment](https://github.com/telepresenceio/telepresence/issues/1003#issuecomment-485592803) that explains the issue + sample code that demonstrates it.

This change was tested successfully by on macOS by attaching the Goland (delve) debugger to a Go service and the Pycharm debugger to a Python service. Before this change attaching a debugger would cause telepresence to incorrectly assume the process exited and shutdown.
