### PR TITLE
Switch to telepresence user if unpriv running as root

### DIFF
--- a/k8s-proxy/Dockerfile
+++ b/k8s-proxy/Dockerfile
@@ -46,7 +46,7 @@ RUN chmod -R g+r /etc/ssh && \
     echo "telepresence::1000:0:Telepresence User:/usr/src/app:/bin/ash" >> /etc/passwd
 USER 1000:0
 
-CMD /usr/src/app/run.sh
+CMD /usr/src/app/pre-run.sh
 
 #
 # The privileged (running-as-root) image

--- a/k8s-proxy/pre-run.sh
+++ b/k8s-proxy/pre-run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+if [ $(id -u) = 0 ]; then
+    echo "root -> telepresence"
+    exec su telepresence ./run.sh
+fi
+exec ./run.sh

--- a/newsfragments/1013.bugfix
+++ b/newsfragments/1013.bugfix
@@ -1,0 +1,1 @@
+The unprivileged proxy image switches to the intended UID when unexpectedly running as root.


### PR DESCRIPTION
This an attempt to address #1013, at least in the common cases.