### PR TITLE
Add --serviceaccount option to set anyuid scc on it separately

### DIFF
--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -270,6 +270,12 @@ def parse_args(args=None) -> argparse.Namespace:
         )
     )
     parser.add_argument(
+        "--serviceaccount",
+        dest="custom_serviceaccount",
+        default=None,
+        help="Service account to set in the proxy pod spec."
+    )
+    parser.add_argument(
         "--expose",
         action='append',
         metavar="PORT[:REMOTE_PORT]",

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -91,9 +91,12 @@ def setup(runner: Runner, args):
             " --new-deployment instead."
         )
 
+    custom_serviceaccount = args.custom_serviceaccount
+
     def start_proxy(runner_: Runner) -> RemoteInfo:
         tel_deployment, run_id = operation(
-            runner_, deployment_arg, args.expose, add_custom_ns
+            runner_, deployment_arg, args.expose, add_custom_ns,
+            custom_serviceaccount
         )
         remote_info = get_remote_info(
             runner,

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -94,7 +94,8 @@ def setup(runner: Runner, args):
     custom_serviceaccount = args.custom_serviceaccount
 
     def start_proxy(runner_: Runner) -> RemoteInfo:
-        tel_deployment, run_id = operation( #pylint: disable-msg=too-many-arguments
+
+        tel_deployment, run_id = operation(
             runner_, deployment_arg, args.expose, add_custom_ns,
             custom_serviceaccount
         )

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -94,7 +94,7 @@ def setup(runner: Runner, args):
     custom_serviceaccount = args.custom_serviceaccount
 
     def start_proxy(runner_: Runner) -> RemoteInfo:
-        tel_deployment, run_id = operation(
+        tel_deployment, run_id = operation( #pylint: disable-msg=too-many-arguments
             runner_, deployment_arg, args.expose, add_custom_ns,
             custom_serviceaccount
         )

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -38,8 +38,11 @@ def get_image_name(expose: PortMapping) -> str:
 
 
 def existing_deployment(
-    runner: Runner, deployment_arg: str, expose: PortMapping,
-    add_custom_nameserver: bool
+    runner: Runner,
+    deployment_arg: str,
+    expose: PortMapping,
+    add_custom_nameserver: bool,
+    custom_serviceaccount: Optional[str] = None
 ) -> Tuple[str, Optional[str]]:
     """
     Handle an existing deployment by doing nothing
@@ -61,8 +64,11 @@ def existing_deployment(
 
 
 def existing_deployment_openshift(
-    runner: Runner, deployment_arg: str, expose: PortMapping,
-    add_custom_nameserver: bool
+    runner: Runner,
+    deployment_arg: str,
+    expose: PortMapping,
+    add_custom_nameserver: bool,
+    custom_serviceaccount: Optional[str] = None
 ) -> Tuple[str, Optional[str]]:
     """
     Handle an existing deploymentconfig by doing nothing


### PR DESCRIPTION
https://github.com/telepresenceio/telepresence/issues/875

https://github.com/telepresenceio/telepresence/issues/875#issuecomment-501257612

We've been running telepresence on local okd kubernetes cluster, so there are security restrictions, such as anyuid, that are breaking telepresence proxy container. So we must to allow serviceaccount, which telepresence uses, anyuid security context. This PR proposes to run telepresence with separate serviceaccount, so privileged mode could be granted not to all apps running in selected namespace.