### PR TITLE
Add check for docker-desktop (MacOS) in startup

### DIFF
--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -194,7 +194,8 @@ class KubeInfo(object):
 
     def _check_if_in_local_vm(self, runner: Runner) -> bool:
         # Running Docker Desktop on macOS (or maybe Windows?)
-        if (self.context == "docker-for-desktop") or (self.context == "docker-desktop"):
+        if (self.context == "docker-for-desktop"
+            ) or (self.context == "docker-desktop"):
             return True
         # kind (kube-in-docker) has complex context name, so check by cluster
         if self.cluster == "kind":

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -194,7 +194,7 @@ class KubeInfo(object):
 
     def _check_if_in_local_vm(self, runner: Runner) -> bool:
         # Running Docker Desktop on macOS (or maybe Windows?)
-        if self.context == "docker-for-desktop":
+        if (self.context == "docker-for-desktop") or (self.context == "docker-desktop"):
             return True
         # kind (kube-in-docker) has complex context name, so check by cluster
         if self.cluster == "kind":


### PR DESCRIPTION
Docker Desktop for Mac has changed the context name it uses. I added a check for this new context name next to docker-for-desktop in startup.py. I wonder if there is a better way to check if telepresence is running locally. Thanks!
