### PR TITLE
PR for prev. solution in #389 (no google.com)

### DIFF
--- a/telepresence/outbound/local.py
+++ b/telepresence/outbound/local.py
@@ -55,7 +55,7 @@ def set_up_torsocks(runner: Runner, socks_port: int) -> Dict[str, str]:
     # https://github.com/telepresenceio/telepresence/issues/389
     test_proxying_cmd = [
         "torsocks", "python3", "-c",
-        "import socket; socket.socket().connect(('google.com', 80))"
+        "import socket; socket.socket().connect(('kubernetes.default.svc', 443))"
     ]
     launch_env = os.environ.copy()
     launch_env.update(torsocks_env)


### PR DESCRIPTION
It seems more are facing the same "google.com" problem, starting with #389 ( #1071 and others).
It's understood that it takes more time to make test network connection optional, or more configurable.
This a PR for an already suggested option, which might solve most (if not all) current real case scenarios where there is no internet connection.
While there might be some network policies blocking kubernetes.default.svc:443, those cases most probably won't have internet access either, therefore this proposal can be seen as a small first step in fix direction.
PS: It us agnostic to k8s flavour, therefore good also for OCP.


