### PR TITLE
remove cpu resource limit

### DIFF
--- a/newsfragments/1120.bugfix
+++ b/newsfragments/1120.bugfix
@@ -1,0 +1,1 @@
+increase telepresence pod CPU limit to 1, fixing performance degrading caused by CPU time throttling, more information can be found here https://github.com/kubernetes/kubernetes/issues/67577 and https://github.com/kubernetes/kubernetes/issues/51135

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -118,7 +118,7 @@ def create_new_deployment(
     command = [
         "run",  # This will result in using Deployment:
         "--restart=Always",
-        "--limits=cpu=100m,memory=256Mi",
+        "--limits=cpu=1000m,memory=256Mi",
         "--requests=cpu=25m,memory=64Mi",
         deployment_arg,
         "--image=" + get_image_name(expose),


### PR DESCRIPTION
Thanks for this wonderful tool! enjoying it so far :), but found a problem

Having CPU limit on telepresence pod causes noticeable latency increasing when there is a lot of simultaneously connections being proxied by telepresense. I observed almost 4X faster with my case( proxying a lot of connections) by disabling CPU limit. 

For latency sensitive applications, turning off CPU limit is sort of what's being suggested give the current kubernetes status. Thinking telepresense is one of the type. 


