### PR TITLE
Update OpenShift tutorial

### DIFF
--- a/docs/macros.html
+++ b/docs/macros.html
@@ -93,7 +93,7 @@ Telepresence will then forward traffic from {{ cluster }} to the local process.
 
 {% endmacro %}
 
-{% macro gettingStartedPart2(deployment, command, cluster) %}
+{% macro gettingStartedPart2(command, cluster) %}
 
 Once you know the address you can store its value (don't forget to replace this with the real address!):
 

--- a/docs/tutorials/kubernetes.md
+++ b/docs/tutorials/kubernetes.md
@@ -30,7 +30,7 @@ $ kubectl expose deployment hello-world --type=LoadBalancer --name=hello-world
 > http://192.168.99.100:12345/
 > ```
 
-{{ macros.gettingStartedPart2("Deployment", "kubectl", "Kubernetes") }}
+{{ macros.gettingStartedPart2("kubectl", "Kubernetes") }}
 
 ```console
 $ kubectl delete deployment,service hello-world

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -6,7 +6,8 @@
 2. Run a service in the cluster:
 
    ```console
-   $ oc run myservice --image=datawire/hello-world --port=8000 --expose
+   $ oc create deployment myservice --image=datawire/hello-world
+   $ oc expose deployment/myservice --type="ClusterIP" --port 8000
    $ oc get service myservice
    NAME        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
    myservice   10.0.0.12    <none>        8000/TCP   1m
@@ -36,7 +37,8 @@ In the more extended tutorial that follows you'll see how you can also route tra
 You should start a new application and publicly expose it:
 
 ```console
-$ oc new-app --docker-image=datawire/hello-world --name=hello-world
+$ oc create deployment hello-world --image=datawire/hello-world
+$ oc expose deployment/hello-world --type="ClusterIP" --port 8000
 $ oc expose service hello-world
 ```
 
@@ -67,10 +69,10 @@ In the above output the address is `http://example.openshiftsapps.com`, but you 
 It may take a few minutes before this route will be live; in the interim you will get an error page.
 If you do wait a minute and try again.
 
-{{ macros.gettingStartedPart2("DeploymentConfig", "oc", "OpenShift") }}
+{{ macros.gettingStartedPart2("oc", "OpenShift") }}
 
 ```console
-$ oc delete dc,service,route,imagestream hello-world
+$ oc delete deploy,service,route hello-world
 ```
 
 Telepresence can do much more than this: see the reference section of the documentation, on the top-left, for details.

--- a/docs/tutorials/openshift.md
+++ b/docs/tutorials/openshift.md
@@ -69,6 +69,13 @@ In the above output the address is `http://example.openshiftsapps.com`, but you 
 It may take a few minutes before this route will be live; in the interim you will get an error page.
 If you do wait a minute and try again.
 
+**Important:** When running Telepresence with `vpn-tcp` proxying, all DNS queries for the host will be routed to
+cluster DNS. This can break `oc` if the cluster is running in AWS and a request to resolve the name of a cluster's API
+endpoint returns an address internal to AWS. Manually updating `KUBECONFIG` with the resolved address may work around
+this issue, but if the API endpoint is behind a virtualhost proxy (e.g. if the cluster was deployed with
+`try.openshift.com`) it may be necessary to leave the host name in `KUBECONFIG` and add an entry to `/etc/hosts`
+instead.
+
 {{ macros.gettingStartedPart2("oc", "OpenShift") }}
 
 ```console


### PR DESCRIPTION
- Replace DeploymentConfig with Deployment
   - Otherwise the use of `--swap-deployment=<name>` will fail with error:
      
```
T: Failed to find deployment <name>:
```

- Document workaround for [API endpoint DNS issue](https://github.com/telepresenceio/telepresence/issues/320#issuecomment-537757455)
