### PR TITLE
fix: calls /users endpoint to determine if oc should be used

### DIFF
--- a/newsfragments/1139.bugfix
+++ b/newsfragments/1139.bugfix
@@ -1,0 +1,1 @@
+Changing strategy to determine if `oc` (Openshift) cli tool should be used for a given telepresence session. Previously called `/apis` endpoint can be secured making `telepresence` defaulting to `kubectl` where the actual cluster is Openshift and uses `DeploymentConfig`s.

--- a/telepresence/startup.py
+++ b/telepresence/startup.py
@@ -24,10 +24,6 @@ from urllib.request import urlopen
 
 from telepresence.runner import Runner
 
-KUBECTL = "kubectl"
-
-OC = "oc"
-
 
 def kubectl_or_oc(server: str) -> str:
     """
@@ -35,8 +31,11 @@ def kubectl_or_oc(server: str) -> str:
 
     :param server: The URL of the cluster API server.
     """
-    if which(OC) is None:
-        return KUBECTL
+    kubectl = "kubectl"
+    oc = "oc"
+
+    if which(oc) is None:
+        return kubectl
     # We've got oc, and possibly kubectl as well. We only want oc for OpenShift
     # servers, so check for an OpenShift API endpoint exposing users
     # (it's also used by oc whoami command):
@@ -50,16 +49,16 @@ def kubectl_or_oc(server: str) -> str:
             api_group_list = str(response.read())
     except HTTPError as err:
         if err.code == 403:
-            return OC
+            return oc
         else:
-            return KUBECTL
+            return kubectl
     except URLError:
-        return KUBECTL
+        return kubectl
 
     if "openshift" in api_group_list:
-        return OC
+        return oc
     else:
-        return KUBECTL
+        return kubectl
 
 
 def _parse_version_component(comp: str) -> int:


### PR DESCRIPTION
Previously called `/apis` endpoint which lists all resources in the cluster can be secured making it impossible to determine if the actual cluster is Openshift. In such a case Telepresence rolls back to `kubectl` and assumes `Deployment` is used rather than `DeploymentConfig` which is commonly used in Openshift.

The proposed solution calls Openshift-specific endpoint and based on the
response decides which cli tool to use.

Fixes #1139
