### PR TITLE
Use correct tmp dir when inside WSL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.py]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/newsfragments/1148.bugfix
+++ b/newsfragments/1148.bugfix
@@ -1,0 +1,1 @@
+When runnning telepresence inside WSL, use a Docker-accessible directory as the TMP dir.


### PR DESCRIPTION
When running tel in WSL on Windows 10, Docker can't access `/tmp`. This adds an exception case for WSL, changing the tmp path.
