### PR TITLE
Update __init__.py

### DIFF
--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -31,7 +31,7 @@ def _dc_exists(runner: Runner, name: str) -> bool:
     if runner.kubectl.command != "oc":
         return False
     if ":" in name:
-        name, container = name.split(":",1)
+        name, container = name.split(":", 1)
     try:
         runner.check_call(runner.kubectl("get", "dc/{}".format(name)))
         return True

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -30,6 +30,8 @@ def _dc_exists(runner: Runner, name: str) -> bool:
     """
     if runner.kubectl.command != "oc":
         return False
+    if ":" in name:
+        name, container = name.split(":",1)
     try:
         runner.check_call(runner.kubectl("get", "dc/{}".format(name)))
         return True
@@ -53,14 +55,15 @@ def setup(runner: Runner, args):
 
     # Figure out which operation the user wants
     # Handle --deployment case
-    deployment_arg = args.deployment
-    if _dc_exists(runner, deployment_arg):
-        operation = existing_deployment_openshift
-        deployment_type = "deploymentconfig"
-    else:
-        operation = existing_deployment
-        deployment_type = "deployment"
-    args.operation = "deployment"
+    if args.deployment is not None:
+        deployment_arg = args.deployment
+        if _dc_exists(runner, deployment_arg):
+            operation = existing_deployment_openshift
+            deployment_type = "deploymentconfig"
+        else:
+            operation = existing_deployment
+            deployment_type = "deployment"
+        args.operation = "deployment"
 
     if args.new_deployment is not None:
         # This implies --new-deployment


### PR DESCRIPTION
Added verification if parameter --Deployment or -d has been provided. Without that verification an error is printed that the deploymentconfig NONE can not be found if the user has installed the oc tool. Furthermore added code in _dc_exists to use only the DeploymentConfig name and not the container name.



---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
