### PR TITLE
Fixes #1161

### DIFF
--- a/newsfragments/1161.bugfix
+++ b/newsfragments/1161.bugfix
@@ -1,0 +1,1 @@
+Change the test hostname from `kubernetes.default.svc.cluster.local` to `kubernetes.default`.

--- a/telepresence/outbound/local.py
+++ b/telepresence/outbound/local.py
@@ -54,7 +54,7 @@ def set_up_torsocks(runner: Runner, socks_port: int) -> Dict[str, str]:
     # FIXME: Make this lookup externally configurable
     # https://github.com/telepresenceio/telepresence/issues/389
     # https://github.com/telepresenceio/telepresence/issues/985
-    test_hostname = "kubernetes.default.svc.cluster.local"
+    test_hostname = "kubernetes.default"
     test_proxying_cmd = [
         "torsocks", "python3", "-c",
         "import socket; socket.socket().connect(('%s', 443))" % test_hostname


### PR DESCRIPTION
Adds the `TELEPRESENCE_TEST_HOSTNAME` environment variable so that `test_hostname` can be changed as needed.
Also changes the default value of `test_hostname` to `kubernetes.default`.