### PR TITLE
Add experimental `--method teleproxy`

### DIFF
--- a/docs/discussion/overview.md
+++ b/docs/discussion/overview.md
@@ -17,7 +17,7 @@ Telepresence deploys a two-way network proxy in a pod running in your Kubernetes
 This approach gives:
 
 * your local service full access to other services in the remote cluster
-* your local service full access to Kubernetes environment variables, secrets, and ConfigMap
+* your local service full access to Kubernetes environment variables, secrets, and ConfigMaps
 * your remote services full access to your local service
 
 How Telepresence works is discussed in more detail [here](/discussion/how-it-works.html).
@@ -35,4 +35,4 @@ Typical alternatives to Telepresence include:
 Telepresence offers a broad set of [proxying options](/reference/methods.html) which have different strengths and weaknesses. Generally speaking, we recommend you:
 
 * Start with the container method, which provides the most consistent environment for your code. Here is a [container quick start](/tutorials/docker.html).
-* Use the VPN method, which lets you use an IDE or debugger with your code. Here is a [quick start that uses the VPN method](/tutorials/kubernetes-rapid.html)
+* Use the vpn-tcp method, which lets you use an IDE or debugger with your code. Here is a [quick start that uses the vpn-tcp method](/tutorials/kubernetes-rapid.html)

--- a/docs/reference/install.md
+++ b/docs/reference/install.md
@@ -3,9 +3,9 @@
 {% import "../macros.html" as macros %}
 {{ macros.installSpecific("reference-page") }}
 
-### Dependencies
+## Dependencies
 
-If you install Telepresence using a pre-built package, dependencies other than [`kubectl`][k] are handled by the package manager. If you install from source, you will also need to install the following software.
+If you install Telepresence using a pre-built package, dependencies other than [`kubectl`][k] and Edge Control (FIXME: link) are handled by the package manager. If you install from source, you will also need to install the following software.
 
 [k]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
@@ -16,6 +16,7 @@ If you install Telepresence using a pre-built package, dependencies other than [
 - `conntrack` and `iptables` on Linux for the vpn-tcp method
 - `torsocks` for the inject-tcp method
 - Docker for the container method
+- Edge Control (`edgectl`) for the Teleproxy method
 - `sudo` to allow Telepresence to
   - modify the local network (via `sshuttle` and `pf`/`iptables`) for the vpn-tcp method
   - run the `docker` command in some configurations on Linux

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -1,17 +1,17 @@
 # Troubleshooting & Workarounds
 
-### Method-specific limitations
+## Method-specific limitations
 
 For method-specific limitations see the documentation on the [available proxying methods](/reference/methods.html).
 
-### General limitations & workarounds
+## General limitations & workarounds
 
-#### Docker containers
+### Docker containers
 
 When using `--method vpn-tcp` or `--method inject-tcp` a container run via `docker run` will not inherit the outgoing functionality of the Telepresence shell.
 If you want to use Telepresence to proxy a containerized application you should use [`--method container`](/tutorials/docker.html).
 
-#### `localhost` and the pod
+### `localhost` and the pod
 
 `localhost` and `127.0.0.1` will access the host machine, i.e. the machine where you ran `telepresence`.
 If you're using the container method, `localhost` will refer to your local container.
@@ -40,24 +40,25 @@ spec:
               fieldPath: status.podIP
 </code></pre>
 
-#### EC2
+### EC2
 
 Amazon EC2 instances inside a VPC use a custom DNS setup that resolves internal names. This will prevent Telepresence from working properly. To resolve this issue, override the default name servers, e.g.,
 
-```
+```shell
 sudo echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf
 sudo dhclient
+
 ```
 
 For more details see [issue # 462](https://github.com/datawire/telepresence/issues/462).
 
-#### Fedora 18+/CentOS 7+/RHEL 7+ and `--docker-run`
+### Fedora 18+/CentOS 7+/RHEL 7+ and `--docker-run`
 
 Fedora 18+/CentOS 7+/RHEL 7+ ship with firewalld enabled and running by default. In its default configuration this will drop traffic on unknown ports originating from Docker's default bridge network - usually `172.17.0.0/16`. 
 
 To resolve this issue, instruct firewalld to trust traffic from `172.17.0.0/16`:
 
-```
+```shell
 sudo firewall-cmd --permanent --zone=trusted --add-source=172.17.0.0/16
 sudo firewall-cmd --reload
 ```

--- a/docs/reference/proxying.md
+++ b/docs/reference/proxying.md
@@ -1,6 +1,6 @@
 # What gets proxied
 
-### Networking access from the cluster
+## Networking access from the cluster
 
 If you use the `--expose` option for `telepresence` with a given port the pod will forward traffic it receives on that port to your local process.
 This allows the Kubernetes or OpenShift cluster to talk to your local process as if it was running in the pod.
@@ -24,7 +24,7 @@ $ telepresence --expose 8080:80 --new-deployment example2 \
 You can't expose ports <1024 on clusters that don't support running images as `root`.
 This limitation is the default on OpenShift.
 
-### Networking access to the cluster
+## Networking access to the cluster
 
 The locally running process wrapped by `telepresence` has access to everything that a normal Kubernetes pod would have access to.
 That means `Service` instances, their corresponding DNS entries, and any cloud resources you can normally access from Kubernetes.
@@ -41,6 +41,7 @@ We'll check the current Kubernetes context and then start a new pod:
 
 ```console
 $ kubectl run --expose helloworld --image=nginx:alpine --port=80
+[...]
 ```
 
 Wait 30 seconds and make sure a new pod is available in `Running` state:
@@ -64,17 +65,20 @@ $ telepresence --run curl http://helloworld.default
 
 > **Having trouble?** Ask us a question in our [Slack chatroom](https://d6e.co/slack).
 
-### Networking access to cloud resources
+## Networking access to cloud resources
 
 When using `--method=inject-tcp`, the subprocess run by `telepresence` will have *all* of its traffic routed via the cluster.
 That means transparent access to cloud resources like databases that are accessible from the Kubernetes cluster's private network or VPC.
 It also means public servers like `google.com` will be routed via the cluster, but again only for the subprocess run by `telepresence` via `--run` or `--run-shell`.
+The same is true when using `--method=container`: all traffic from a container launched via `--docker-run` is routed via the cluster.
 
 When using `--method=vpn-tcp` *all* processes on the machine running `telepresence` will have access to the Kubernetes cluster.
 Cloud resources will only be routed via the cluster if you explicitly specify them using `--also-proxy <ip | ip range | hostname>`.
 Access to public websites should not be affected or changed in any way.
 
-### Environment variables
+Using `--method=teleproxy` is similar except `--also-proxy` is not yet supported.
+
+## Environment variables
 
 Environment variables set in the `Deployment` pod template will be available to your local process.
 You also have access to all the environment variables Kubernetes sets automatically.
@@ -91,7 +95,7 @@ KUBERNETES_PORT_443_TCP=tcp://10.0.0.1:443
 KUBERNETES_SERVICE_HOST=10.0.0.1
 ```
 
-### Volumes
+## Volumes
 
 Volumes configured in the `Deployment` pod template will also be made available to your local process.
 This will work better with read-only volumes with small files like `Secret` and `ConfigMap`; a local database server writing to a remote volume will be slow.
@@ -102,19 +106,19 @@ You will then need to use that env variable as the root for volume paths you are
 
 You can see an example of this in the [Volumes Howto](../howto/volumes.html).
 
-### The complete list: what Telepresence proxies
+## The complete list: what Telepresence proxies
 
-#### `--method inject-tcp`
+### `--method inject-tcp`
 
 When using `--method inject-tcp`, Telepresence currently proxies the following:
 
 * The [special environment variables](https://kubernetes.io/docs/user-guide/services/#environment-variables) that expose the addresses of `Service` instances.
   E.g. `REDIS_MASTER_SERVICE_HOST`.
+* Any environment variables that the `Deployment` explicitly configured for the pod.
 * The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
   E.g. `redis-master` and `redis-master.default.svc.cluster.local` will resolve to a working IP address.
   These will work regardless of whether they existed when the proxy started.
 * TCP connections to other `Service` instances, regardless of whether they existed when the proxy was started.
-* Any environment variables that the `Deployment` explicitly configured for the pod.
 * TCP connections to any hostname/port; all but `localhost` will be routed via Kubernetes.
   Typically this is useful for accessing cloud resources, e.g. a AWS RDS database.
 * TCP connections *from* Kubernetes to your local machine, for ports specified on the command line using `--expose`
@@ -126,15 +130,15 @@ Currently unsupported:
 * SRV DNS records matching `Services`, e.g. `_http._tcp.redis-master.default`.
 * UDP messages in any direction.
 
-#### `--method vpn-tcp`
+### `--method vpn-tcp`
 
 When using `--method vpn-tcp`, Telepresence currently proxies the following:
 
 * The [special environment variables](https://kubernetes.io/docs/user-guide/services/#environment-variables) that expose the addresses of `Service` instances.
   E.g. `REDIS_MASTER_SERVICE_HOST`.
-* The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
-  E.g. `redis-master` and `redis-master.default`, but not those ending with `.local`. 
 * Any environment variables that the `Deployment` explicitly configured for the pod.
+* The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
+  E.g. `redis-master` and `redis-master.default`, but not those ending with `.local`.
 * TCP connections to any `Service` in the cluster regardless of when they were started, as well as to any hosts or ranges explicitly listed with `--also-proxy`.
 * TCP connections *from* Kubernetes to your local machine, for ports specified on the command line using `--expose`.
 * Access to volumes, including those for `Secret` and `ConfigMap` Kubernetes objects.
@@ -143,4 +147,46 @@ When using `--method vpn-tcp`, Telepresence currently proxies the following:
 Currently unsupported:
 
 * Fully qualified Kubernetes DNS names that end with `.local`, e.g. `redis-master.default.svc.cluster.local`, won't work on Linux (see [the relevant ticket](https://github.com/datawire/telepresence/issues/161) for details.)
+* UDP messages in any direction.
+
+### `--method teleproxy`
+
+When using `--method teleproxy`, Telepresence currently proxies the following:
+
+* The [special environment variables](https://kubernetes.io/docs/user-guide/services/#environment-variables) that expose the addresses of `Service` instances.
+  E.g. `REDIS_MASTER_SERVICE_HOST`.
+* The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
+  E.g. `redis-master` and `redis-master.default`, but not those ending with `.local`.
+* Any environment variables that the `Deployment` explicitly configured for the pod.
+* TCP connections to any `Service` in the cluster regardless of when they were started.
+* TCP connections *from* Kubernetes to your local machine, for ports specified on the command line using `--expose`.
+* Access to volumes, including those for `Secret` and `ConfigMap` Kubernetes objects.
+* `/var/run/secrets/kubernetes.io` credentials (used to the [access the Kubernetes( API](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod)).
+
+Currently unsupported:
+
+* Fully qualified Kubernetes DNS names that end with `.local`, e.g. `redis-master.default.svc.cluster.local`, won't work on Linux (see [the relevant ticket](https://github.com/datawire/telepresence/issues/161) for details.)
+* TCP connections to hosts or ranges in the cluster that are not associated with a `Service`.
+  Explicitly forwarding hosts/ranges with `--also-proxy` is coming soon.
+* UDP messages in any direction.
+
+### `--method container`
+
+When using `--method container` (or `--docker-run`), Telepresence currently proxies the following:
+
+* The [special environment variables](https://kubernetes.io/docs/user-guide/services/#environment-variables) that expose the addresses of `Service` instances.
+  E.g. `REDIS_MASTER_SERVICE_HOST`.
+* Any environment variables that the `Deployment` explicitly configured for the pod.
+* The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
+  E.g. `redis-master` and `redis-master.default.svc.cluster.local` will resolve to a working IP address.
+  These will work regardless of whether they existed when the proxy started.
+* TCP connections to other `Service` instances, regardless of whether they existed when the proxy was started.
+* TCP connections to any hostname/port; all but `localhost` will be routed via Kubernetes.
+  Typically this is useful for accessing cloud resources, e.g. a AWS RDS database.
+* TCP connections *from* Kubernetes to your local machine, for ports specified on the command line using `--expose`
+* Access to volumes, including those for `Secret` and `ConfigMap` Kubernetes objects.
+* `/var/run/secrets/kubernetes.io` credentials (used to the [access the Kubernetes( API](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod)).
+
+Currently unsupported:
+
 * UDP messages in any direction.

--- a/environment-setup.sh
+++ b/environment-setup.sh
@@ -24,12 +24,17 @@ case "${OS}" in
         brew cask install osxfuse
         brew install sshfs
         pip3 install virtualenv
+        curl -Ls -o /usr/local/bin/edgectl https://metriton.datawire.io/downloads/darwin/edgectl
+        chmod a+x /usr/local/bin/edgectl
         ;;
 
     linux)
         sudo apt-get install \
              sshfs conntrack \
              lsb-release
+        curl -Ls -o /tmp/edgectl https://metriton.datawire.io/downloads/linux/edgectl
+        sudo mv /tmp/edgectl /usr/bin/edgectl
+        sudo chmod a+x /usr/bin/edgectl
         ;;
 
     *)
@@ -43,6 +48,9 @@ python2 --version || true
 python3 --version
 ruby --version || true
 docker version || true
+
+sudo edgectl daemon
+edgectl version || true
 
 # Make sure gcloud is installed.  This includes kubectl.
 ./ci/setup-gcloud.sh "${PROJECT_NAME}" "${CLUSTER_NAME}" "${CLOUDSDK_COMPUTE_ZONE}" "${OS}"

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -216,12 +216,13 @@ def parse_args(in_args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--method",
         "-m",
-        choices=["inject-tcp", "vpn-tcp", "container"],
+        choices=["inject-tcp", "vpn-tcp", "container", "teleproxy"],
         help=(
             "'inject-tcp': inject process-specific shared "
             "library that proxies TCP to the remote cluster.\n"
             "'vpn-tcp': all local processes can route TCP "
             "traffic to the remote cluster. Requires root.\n"
+            "'teleproxy': experimental, like `vpn-tcp`.\n"
             "'container': used with --docker-run.\n"
             "\n"
             "Default is 'vpn-tcp', or 'container' when --docker-run is used.\n"

--- a/telepresence/main.py
+++ b/telepresence/main.py
@@ -92,5 +92,5 @@ def run_telepresence():
     main()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_telepresence()

--- a/telepresence/outbound/edgectl.py
+++ b/telepresence/outbound/edgectl.py
@@ -1,0 +1,114 @@
+# Copyright 2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import subprocess
+import typing
+
+from telepresence.runner import Runner
+
+ECResult = typing.Dict[str, str]
+
+
+def run(runner: Runner, *args: str) -> ECResult:
+    """
+    Call Edge Control in batch mode. Accumulate the key/value results into a
+    dictionary. Show error information on failure.
+    """
+    result = {}  # type: ECResult
+    try:
+        output = runner.get_output(["edgectl", "--batch"] + list(args))
+    except subprocess.CalledProcessError as exc:
+        runner.show("Call to Edge Control failed:")
+        runner.report_subprocess_failure(exc)
+        output = ""
+    for line in output.splitlines():
+        result.update(json.loads(line))  # JSONDecodeError or TypeError
+    return result
+
+
+def net_overrides_ok(status: ECResult) -> bool:
+    return bool(status.get("net_overrides"))
+
+
+def is_connected(status: ECResult) -> bool:
+    """Return False if Edge Control is connecting or disconnected"""
+    return bool(status.get("cluster.connected"))
+
+
+def is_disconnected(status: ECResult) -> bool:
+    """Return False if Edge Control is connecting or connected"""
+    return "cluster.connected" not in status
+
+
+def bridge_ok(status: ECResult) -> bool:
+    return bool(status.get("bridge"))
+
+
+def what_cluster(status: ECResult) -> typing.Tuple[str, str]:
+    """
+    Return the context and server to which Edge Control is connecting or
+    connected
+    """
+    return status["cluster.context"], status["cluster.server"]
+
+
+NET_OVERRIDES_MESSAGE = """
+The Edge Control Daemon's network overrides are not ready. This may occur on
+startup and when the network configuration changes. Please try again once
+'edgectl status' does not report 'Network overrides NOT established'.
+"""
+
+WRONG_CLUSTER_MESSAGE = """
+Edge Control is connected to a different cluster. Use 'edgectl disconnect' to
+disconnect -- this will effect all processes -- then try again.
+"""
+
+
+def connect_teleproxy(runner: Runner) -> None:
+    """Connect to Kubernetes using teleproxy via Edge Control."""
+    span = runner.span()
+    for _ in runner.loop_until(45, 0.5):
+        status = run(runner, "status")
+        if not status:
+            raise runner.fail("Error: Failed to get status")
+
+        if is_disconnected(status):
+            # Try to connect
+            connect_args = [
+                "connect", "--", "--context", runner.kubectl.context
+            ]
+            connect = run(runner, *connect_args)
+            if not connect:
+                raise runner.fail("Error: Failed to connect")
+            runner.add_cleanup(
+                "edgectl disconnect",
+                run,  # type: ignore
+                runner,
+                "disconnect",
+            )
+        else:  # Connecting or connected
+            # Make sure we're talking to the right cluster
+            connected_to = what_cluster(status)
+            if connected_to != (runner.kubectl.context, runner.kubectl.server):
+                runner.show(WRONG_CLUSTER_MESSAGE)
+                runner.show("This is probably a bug...")
+                raise runner.fail("Error: Connected to another cluster")
+
+        if is_connected(status) and bridge_ok(status):
+            break
+    else:
+        # runner.add_cleanup("Diagnose vpn-tcp", log_info_vpn_crash, runner)
+        raise RuntimeError("Edge Control did not connect")
+    span.end()

--- a/telepresence/outbound/edgectl.py
+++ b/telepresence/outbound/edgectl.py
@@ -116,3 +116,17 @@ def connect_teleproxy(runner: Runner) -> None:
         # runner.add_cleanup("Diagnose vpn-tcp", log_info_vpn_crash, runner)
         raise RuntimeError("Edge Control did not connect")
     span.end()
+
+
+def is_running_quiet(runner: Runner) -> bool:
+    """
+    Determines whether the Edge Control Daemon is running without notifying the
+    user that an edgectl command has failed. This is useful for vpn-tcp to check
+    for a conflict between sshuttle and a running Edge Control Daemon.
+    """
+    # Check whether "edgectl status" succeeds
+    try:
+        runner.check_call(["edgectl", "status"], )
+        return True
+    except (OSError, subprocess.CalledProcessError):
+        return False

--- a/telepresence/outbound/edgectl.py
+++ b/telepresence/outbound/edgectl.py
@@ -121,8 +121,8 @@ def connect_teleproxy(runner: Runner) -> None:
 def is_running_quiet(runner: Runner) -> bool:
     """
     Determines whether the Edge Control Daemon is running without notifying the
-    user that an edgectl command has failed. This is useful for vpn-tcp to check
-    for a conflict between sshuttle and a running Edge Control Daemon.
+    user that an edgectl command has failed. This is useful for vpn-tcp to
+    check for a conflict between sshuttle and a running Edge Control Daemon.
     """
     # Check whether "edgectl status" succeeds
     try:

--- a/telepresence/outbound/edgectl.py
+++ b/telepresence/outbound/edgectl.py
@@ -87,7 +87,11 @@ def connect_teleproxy(runner: Runner) -> None:
         if is_disconnected(status):
             # Try to connect
             connect_args = [
-                "connect", "--", "--context", runner.kubectl.context
+                "connect",
+                "--context",
+                runner.kubectl.context,
+                "--namespace",
+                runner.kubectl.namespace,
             ]
             connect = run(runner, *connect_args)
             if not connect:

--- a/telepresence/outbound/local.py
+++ b/telepresence/outbound/local.py
@@ -21,6 +21,7 @@ from telepresence.proxy import RemoteInfo
 from telepresence.runner import Runner
 from telepresence.utilities import kill_process
 
+from .edgectl import connect_teleproxy
 from .vpn import connect_sshuttle
 from .workarounds import apply_workarounds
 
@@ -135,11 +136,10 @@ def launch_vpn(
     """
     connect_sshuttle(runner, remote_info, also_proxy, ssh)
     _flush_dns_cache(runner)
-
     return launch_local(runner, command, env_overrides, False)
 
 
-def _flush_dns_cache(runner: Runner):
+def _flush_dns_cache(runner: Runner) -> None:
     if runner.platform == "darwin":
         runner.show("Connected. Flushing DNS cache.")
         pkill_cmd = ["sudo", "-n", "/usr/bin/pkill", "-HUP", "mDNSResponder"]
@@ -147,3 +147,15 @@ def _flush_dns_cache(runner: Runner):
             runner.check_call(pkill_cmd)
         except (OSError, CalledProcessError):
             pass
+
+
+def launch_teleproxy(
+    runner: Runner,
+    remote_info: RemoteInfo,
+    command: List[str],
+    also_proxy: List[str],
+    env_overrides: Dict[str, str],
+    ssh: SSH,
+) -> Popen:
+    connect_teleproxy(runner)
+    return launch_local(runner, command, env_overrides, False)

--- a/telepresence/outbound/setup.py
+++ b/telepresence/outbound/setup.py
@@ -78,6 +78,13 @@ def setup_vpn(runner: Runner, args: Namespace) -> LaunchType:
                        "Required for the vpn-tcp method")
     if runner.platform == "darwin":
         runner.require(["pfctl"], "Required for the vpn-tcp method")
+    if edgectl.is_running_quiet(runner):
+        runner.show(
+            "Edge Control Daemon is running. At present, the vpn-tcp method "
+            "conflicts with Edge Control Daemon. Please quit the daemon using "
+            "'edgectl quit' to use the vpn-tcp method. We will fix this soon!"
+        )
+        raise runner.fail("Error: Edge Control Daemon is running")
     runner.require_sudo()
     if runner.platform == "linux":
         # Do a quick iptables sanity check, post sudo

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -454,7 +454,7 @@ class Runner:
         self._run_command_sync(
             ("Running", "ran"),
             True,
-            False,
+            True,
             args,
             10,  # limited capture, only used for error reporting
             timeout,
@@ -483,6 +483,31 @@ class Runner:
             env,
         )
         return output
+
+    def report_subprocess_failure(
+        self, exc: typing.Union[CalledProcessError, TimeoutExpired]
+    ) -> None:
+        if isinstance(exc, TimeoutExpired):
+            command = exc.cmd
+            message = "Timed out after {:.2f} seconds)".format(exc.timeout)
+            if exc.output:
+                output = exc.output
+            else:
+                output = "[no output]"
+        elif isinstance(exc, CalledProcessError):
+            command = exc.cmd
+            message = "Exited with return code {}".format(exc.returncode)
+            if exc.output:
+                output = exc.output
+            else:
+                output = "[no output]"
+        else:
+            raise exc  # i.e. crash
+        indent = "  "
+        output = indent + ("\n" + indent).join(output.splitlines())
+        self.show("{}$ {}".format(indent, str_command(command)))
+        self.show_raw(output)
+        self.show(indent + "--> " + message)
 
     def launch(
         self,


### PR DESCRIPTION
To do before landing
- [x] Update `--method vpn-tcp`: Make sure Edge Control is not running. Sshuttle and Teleproxy stomp on each other in bad ways
- [x] Update the documentation to explain the benefits and limitations of `--method teleproxy`
  - [x] discussion/overview
  - [x] discussion/how-it-works
  - [x] reference/install
  - [x] reference/methods
  - [x] reference/limitations
  - [x] reference/proxying ?
- [x] Grab a copy of `edgectl` in CI so that `--method teleproxy` is tested
- [ ] Handle testing both teleproxy and vpn methods in CI _somehow_
- [ ] Add information about how to get a copy of `edgectl` if it's not found
- [ ] Add appropriate changelog entry
