### PR TITLE
1245 users want to use a kubernetes client in a swapped container

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
 * [Rapid development with Kubernetes](tutorials/kubernetes-rapid.md)
 * [Get started with OpenShift](tutorials/openshift.md)
 * [Minikube VPN access](tutorials/minikube-vpn.md)
+* [Using Telepresence with Golang](tutorials/kubernetes-client-libs.md)
 * [Using Telepresence with Golang](howto/golang.md)
 * [Local Java development](tutorials/java.md)
 * [Using Telepresence with IntelliJ](tutorials/intellij.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,7 +18,7 @@
 * [Rapid development with Kubernetes](tutorials/kubernetes-rapid.md)
 * [Get started with OpenShift](tutorials/openshift.md)
 * [Minikube VPN access](tutorials/minikube-vpn.md)
-* [Using Telepresence with Golang](tutorials/kubernetes-client-libs.md)
+* [Using a Kubernetes Client Library](tutorials/kubernetes-client-libs.md)
 * [Using Telepresence with Golang](howto/golang.md)
 * [Local Java development](tutorials/java.md)
 * [Using Telepresence with IntelliJ](tutorials/intellij.md)

--- a/docs/tutorials/java.md
+++ b/docs/tutorials/java.md
@@ -51,22 +51,7 @@ And that's it! You can easily create a `telepresence.sh` file in the root of you
 
 ### Kubernetes Client
 
-If you are using a Kubernetes client like this [one](https://github.com/fabric8io/kubernetes-client), you need to make sure the client can access service account information. This can be done with the `--mount` command introduced in `Telepresence 0.85`.
-
-We need to add the following to the command:
-
-* `--mount /tmp/known` Tells `Telepresence` to mount `TELEPRESENCE_ROOT` to a known folder
-* `-v=/tmp/known/var/run/secrets:/var/run/secrets` This is another Docker mounting command to mount the known folder to `/var/run/secrets` in the local container. The [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) can find the secrets there as it would inside Kubernetes
-
-So our `telepresense.sh` file would look like that
-
-> telepresence.sh
-> ```bash
-> telepresence --mount /tmp/known --swap-deployment foo --docker-run --rm -v$(pwd):/build -v $HOME/.m2/repository:/m2 -v=/tmp/known/var/run/secrets:/var/run/secrets -p 8080:8080 maven-build:jdk8 mvn -Dmaven.repo.local=/m2 -f /build spring-boot:run
->
-> ```
-
-For more details about the `mount` command check the [documentation](/howto/volumes.html)
+For more details about how to connect Kubernetes using Kubernetes client library and a service account, check the [documentation](/tutorials/kubernetes-client-libs.html)
 
 ### Debugging your code
 

--- a/docs/tutorials/kubernetes-client-libs.md
+++ b/docs/tutorials/kubernetes-client-libs.md
@@ -4,6 +4,14 @@
 {% import "../macros.html" as macros %}
 {{ macros.install("https://kubernetes.io/docs/tasks/tools/install-kubectl/", "kubectl", "Kubernetes", "top") }}
 
+### Intro
+
+Kubernetes has client libraries in many different languages. It is not rare to have situations that require connecting Kubernetes API from your cluster and getting resources/creating new pods & deployments, ... While the list goes on, Kubernetes provide ServiceAccount objects in its RBAC to fill up this need. Still, development from local computers, testing, and debugging become a pain due to lack of direct access to the cluster API using token.
+
+Using Telepresence, it becomes an easy task to access ServiceAccount token seamlessly with your libraries. Here are the links for jumping:
+
+- [Java Kubernetes Client Local Connection](#java-kubernetes-client)
+- [Python Kubernetes Client Local Connection](#python-kubernetes-client)
 
 ### Java Kubernetes Client
 
@@ -24,3 +32,25 @@ So our `telepresense.sh` file would look like that
 
 For more details about the `mount` command check the [documentation](/howto/volumes.html)
 
+### Python Kubernetes Client
+
+If you are using a Python Kubernetes client like [the officially supported one](https://github.com/kubernetes-client/python/), you need to make sure the client can access service account information. This can be done with the `--mount` command introduced in `Telepresence 0.85`.
+
+We need to add the following to the command:
+
+* `--mount /tmp/known` Tells `Telepresence` to mount `TELEPRESENCE_ROOT` to a known folder
+* `-v=/tmp/known/var/run/secrets:/var/run/secrets` This is another Docker mounting command to mount the known folder to `/var/run/secrets` in the local container. The [Kubernetes Python client](https://github.com/kubernetes-client/python) can find the secrets there as it would inside Kubernetes.
+
+> telepresence.sh
+> ```bash
+> telepresence --mount /tmp/known --swap-deployment myapp --docker-run --rm -v$(pwd):/code -v=/tmp/known/var/run/secrets:/var/run/secrets -p 8080:8080 guray/podstatus:1.0
+>
+> ```
+
+The example is an API which returns list of pods in the desired namespace(*if serviceaccount is authorized*), to try it from your laptop: `curl localhost:8080/pods/default`.
+
+#### How it works?
+
+The container is running on your laptop and gets serviceaccount information like it is on the Kubernetes cluster. Afterwards if authorized, get list of the pods and returns with their status as JSON.
+
+For more details about the `mount` command check the [documentation](/howto/volumes.html)

--- a/docs/tutorials/kubernetes-client-libs.md
+++ b/docs/tutorials/kubernetes-client-libs.md
@@ -1,0 +1,26 @@
+# Local Connection to Kubernetes Client Libraries
+*Author: Guray Yildirim ([@gurayyildirim](https://twitter.com/gurayyildirim))*
+
+{% import "../macros.html" as macros %}
+{{ macros.install("https://kubernetes.io/docs/tasks/tools/install-kubectl/", "kubectl", "Kubernetes", "top") }}
+
+
+### Java Kubernetes Client
+
+If you are using a Kubernetes client like this [one](https://github.com/fabric8io/kubernetes-client), you need to make sure the client can access service account information. This can be done with the `--mount` command introduced in `Telepresence 0.85`.
+
+We need to add the following to the command:
+
+* `--mount /tmp/known` Tells `Telepresence` to mount `TELEPRESENCE_ROOT` to a known folder
+* `-v=/tmp/known/var/run/secrets:/var/run/secrets` This is another Docker mounting command to mount the known folder to `/var/run/secrets` in the local container. The [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) can find the secrets there as it would inside Kubernetes
+
+So our `telepresense.sh` file would look like that
+
+> telepresence.sh
+> ```bash
+> telepresence --mount /tmp/known --swap-deployment foo --docker-run --rm -v$(pwd):/build -v $HOME/.m2/repository:/m2 -v=/tmp/known/var/run/secrets:/var/run/secrets -p 8080:8080 maven-build:jdk8 mvn -Dmaven.repo.local=/m2 -f /build spring-boot:run
+>
+> ```
+
+For more details about the `mount` command check the [documentation](/howto/volumes.html)
+

--- a/newsfragments/1245.misc
+++ b/newsfragments/1245.misc
@@ -1,0 +1,1 @@
+Kubernetes client libs are now in a separate page with existing Java and newly added Python examples.


### PR DESCRIPTION
Hi!

I created a separate page for client libraries and moved Java example to there. Also prepared a Python example with officially supported Kubernetes Python library and documented the process.

The image I have used as an example is based on a [repo](https://github.com/gurayyildirim/python-kubernetes-get-info/) I created for this example.

Related to #1245 