### PR TITLE
add/patch securityContext runAsUser

### DIFF
--- a/newsfragments/1239.misc
+++ b/newsfragments/1239.misc
@@ -1,2 +1,1 @@
-For the telepresence deployment, the runAsUser will now be set to 0. This is a usefull setting when you
-have a different runAsUser for your deployment or if you have Pod Security Policies defined.
+For the telepresence deployment, the runAsUser will now be set to 0. This is a usefull setting when you have a different runAsUser for your deployment or if you have Pod Security Policies defined.

--- a/newsfragments/1239.misc
+++ b/newsfragments/1239.misc
@@ -1,0 +1,1 @@
+For the telepresence deployment, the runAsUser will now be set to 0.

--- a/newsfragments/1239.misc
+++ b/newsfragments/1239.misc
@@ -1,1 +1,2 @@
-For the telepresence deployment, the runAsUser will now be set to 0.
+For the telepresence deployment, the runAsUser will now be set to 0. This is a usefull setting when you
+have a different runAsUser for your deployment or if you have Pod Security Policies defined.

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -302,7 +302,6 @@ def new_swapped_deployment(
                                                {})["telepresence"] = run_id
     ndj_template = new_deployment_json["spec"]["template"]
     ndj_template["metadata"].setdefault("labels", {})["telepresence"] = run_id
-    ndj_template["spec"]["securityContext"]["runAsUser"] = 0
     if service_account:
         ndj_template["spec"]["serviceAccountName"] = service_account
     for container, old_container in zip(
@@ -319,6 +318,9 @@ def new_swapped_deployment(
             # Not strictly necessary for real use, but tests break without this
             # since we don't upload test images to Docker Hub:
             container["imagePullPolicy"] = "IfNotPresent"
+            # Set runAsUser to 0 because telepresence image requires this. This 
+            # is usefull when PodSecurityPolicy is enabled.
+            container.update({"securityContext": {"runAsUser": 0}})
             # Drop unneeded fields:
             for unneeded in [
                 "args", "livenessProbe", "readinessProbe", "workingDir",

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -318,13 +318,9 @@ def new_swapped_deployment(
             # Not strictly necessary for real use, but tests break without this
             # since we don't upload test images to Docker Hub:
             container["imagePullPolicy"] = "IfNotPresent"
-            # Set runAsUser to 0 because telepresence image requires this. This 
+            # Set runAsUser to 0 because telepresence image requires this. This
             # is usefull when PodSecurityPolicy is enabled.
-            container.update({
-                "securityContext": {
-                    "runAsUser": 0
-                }
-            })
+            container.update({"securityContext": {"runAsUser": 0}})
             # Drop unneeded fields:
             for unneeded in [
                 "args", "livenessProbe", "readinessProbe", "workingDir",

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -320,7 +320,11 @@ def new_swapped_deployment(
             container["imagePullPolicy"] = "IfNotPresent"
             # Set runAsUser to 0 because telepresence image requires this. This 
             # is usefull when PodSecurityPolicy is enabled.
-            container.update({"securityContext": {"runAsUser": 0}})
+            container.update({
+                "securityContext": {
+                    "runAsUser": 0
+                }
+            })
             # Drop unneeded fields:
             for unneeded in [
                 "args", "livenessProbe", "readinessProbe", "workingDir",

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -302,6 +302,7 @@ def new_swapped_deployment(
                                                {})["telepresence"] = run_id
     ndj_template = new_deployment_json["spec"]["template"]
     ndj_template["metadata"].setdefault("labels", {})["telepresence"] = run_id
+    ndj_template["spec"]["securityContext"]["runAsUser"] = 0
     if service_account:
         ndj_template["spec"]["serviceAccountName"] = service_account
     for container, old_container in zip(

--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -178,6 +178,8 @@ spec:
         command: ["/usr/src/app/run.sh"]
         terminationMessagePolicy: "FallbackToLogsOnError"
         imagePullPolicy: "IfNotPresent"
+        securityContext:
+          runAsUser: 0
         ports:
         - containerPort: 80
           name: http-api


### PR DESCRIPTION
The ssh server inside the `datawire/telepresence-k8s` must be run as user `0` because the ssh keys are only readable as root

```shell
➜  ~ docker run --rm docker.io/datawire/telepresence-k8s:0.104 ls -lha /etc/ssh
total 592
drwxr-xr-x    1 root     root        4.0K Jan 23 21:12 .
drwxr-xr-x    1 root     root        4.0K Feb 24 07:48 ..
-rw-r--r--    1 root     root      540.2K Mar  4  2019 moduli
-rw-r--r--    1 root     root        1.6K Mar  4  2019 ssh_config
-rw-r-----    1 root     root         672 Jan 23 21:12 ssh_host_dsa_key
-rw-r--r--    1 root     root         607 Jan 23 21:12 ssh_host_dsa_key.pub
-rw-r-----    1 root     root         227 Jan 23 21:12 ssh_host_ecdsa_key
-rw-r--r--    1 root     root         179 Jan 23 21:12 ssh_host_ecdsa_key.pub
-rw-r-----    1 root     root         411 Jan 23 21:12 ssh_host_ed25519_key
-rw-r--r--    1 root     root          99 Jan 23 21:12 ssh_host_ed25519_key.pub
-rw-r-----    1 root     root        1.6K Jan 23 21:12 ssh_host_rsa_key
-rw-r--r--    1 root     root         399 Jan 23 21:12 ssh_host_rsa_key.pub
-rw-r--r--    1 root     root        3.5K Jan 23 21:12 sshd_config
➜  ~ 
```

If you deployment is configured with a `runAsUser` which is not `0` and you have a `PodSecurityPolicy` with something like

```yaml
  runAsUser:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
```

then the telepresence image will not start. This PR will override or add the rusAsUser to be 0. If you use PSP, then you should supply a PSP which allows `runAsUser: 0`. You can combine this with the telepresence `--serviceaccount` switch and bind this policy to a specific SA

