### PR TITLE
Change IndexError to meaningful error message

### DIFF
--- a/telepresence/proxy/remote.py
+++ b/telepresence/proxy/remote.py
@@ -87,15 +87,18 @@ def get_deployment_json(
                 )
             )
         else:
-            # When using a selector we get a list of objects, not just one:
-            return json.loads(
-                runner.get_output(
-                    runner.kubectl(
-                        get_deployment + ["--selector=telepresence=" + run_id]
-                    ),
-                    stderr=STDOUT
-                )
-            )["items"][0]
+            try:
+                # When using a selector we get a list of objects, not just one:
+                return json.loads(
+                    runner.get_output(
+                        runner.kubectl(
+                            get_deployment + ["--selector=telepresence=" + run_id]
+                        ),
+                        stderr=STDOUT
+                    )
+                )["items"][0]
+            except IndexError:
+                raise SystemExit('No deployements found!')
     except CalledProcessError as e:
         raise runner.fail(
             "Failed to find Deployment '{}':\n{}".format(


### PR DESCRIPTION
When telepresence doesn't find any deployements it crashes with IndexError. This commit only changes the error message to "No Deployements Found"

also referenced at https://github.com/telepresenceio/telepresence/issues/949

Changelog:
1. Put a section in `remote.py` in a try-catch block
