### PR TITLE
Fix doc compatibility with kubectl >= 1.18

### DIFF
--- a/docs/howto/golang.md
+++ b/docs/howto/golang.md
@@ -5,10 +5,11 @@ Because of the way Go is implemented you will need to use `--method vpn-tcp` wit
 
 ### A Go program talking to Kubernetes
 
-First, start a web server inside Kubernetes:
+First, start a web server inside Kubernetes and expose it via a service:
 
 ```console
-$ kubectl run hello-world --image=datawire/hello-world --port=8000 --expose
+$ kubectl create deployment hello-world --image=datawire/hello-world
+$ kubectl expose deployment hello-world --port=8000
 ```
 
 Next, install a neat little Go program called [wuzz](https://github.com/asciimoo/wuzz), an interactive HTTP client.

--- a/docs/internal/demo-script.txt
+++ b/docs/internal/demo-script.txt
@@ -1,9 +1,10 @@
 # Let's say I have an nginx server running in Kubernetes:
-kubectl run --expose --port 80 mynginx --image=nginx
+kubectl create deployment mynginx --image=nginx
+kubectl expose deployment nginx --port=80
 # I'll start a Telepresence proxy in the Kubernetes cluster:
-kubectl run --port 8080 myserver --image=datawire/telepresence-k8s:0.41
+kubectl create deployment myserver --image=datawire/telepresence-k8s:0.41
 # I'll expose it to the Internet:
-kubectl expose deployment myserver --type=LoadBalancer --name=myserver
+kubectl expose deployment myserver --type=LoadBalancer --name=myserver --port=8080
 # Next, I'll start a shell session whose contents will be proxied to Kubernetes:
 telepresence --method inject-tcp --deployment myserver --expose 8080 --run-shell
 # I will start a local web server on port 8080:

--- a/docs/reference/proxying.md
+++ b/docs/reference/proxying.md
@@ -29,7 +29,7 @@ This limitation is the default on OpenShift.
 The locally running process wrapped by `telepresence` has access to everything that a normal Kubernetes pod would have access to.
 That means `Service` instances, their corresponding DNS entries, and any cloud resources you can normally access from Kubernetes.
 
-To see this in action, let's start a `Service` and `Deployment` called `"helloworld"` in Kubernetes in the default namespace `"default"`, and wait until it's up and running.
+To see this in action, let's start a `Service` and `Pod` called `"helloworld"` in Kubernetes in the default namespace `"default"`, and wait until it's up and running.
 The resulting `Service` will have three DNS records you can use:
 
 1. `helloworld`, from a pod in the `default` namespace.
@@ -46,9 +46,9 @@ $ kubectl run --expose helloworld --image=nginx:alpine --port=80
 Wait 30 seconds and make sure a new pod is available in `Running` state:
 
 ```console
-$ kubectl get pod --selector=run=helloworld
+$ kubectl get pod helloworld
 NAME                          READY     STATUS    RESTARTS   AGE
-helloworld-1333052153-63kkw   1/1       Running   0          33s
+helloworld                    1/1       Running   0          33s
 ```
 
 Now you can send queries to the new `Service` as if you were running inside Kubernetes:

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -14,10 +14,10 @@ In this HOWTO, we'll walk through how to use Telepresence with a containerized D
 We'll start with a quick example. Start by running a service in the cluster:
 
 ```console
-$ kubectl run hello-world --image=datawire/hello-world --port 8000 --expose
-[...]
-service/hello-world created
+$ kubectl create deployment hello-world --image=datawire/hello-world
 deployment.apps/hello-world created
+$ kubectl expose deployment hello-world --port=8000
+service/hello-world created
 $ kubectl get service hello-world
 NAME          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
 hello-world   ClusterIP   10.111.122.25   <none>        8000/TCP   45s

--- a/docs/tutorials/kubernetes-client.md
+++ b/docs/tutorials/kubernetes-client.md
@@ -11,7 +11,8 @@ This allows you to use your local tools on your laptop to communicate with proce
 You should start by running a service in the cluster:
 
 ```console
-$ kubectl run myservice --image=datawire/hello-world --port=8000 --expose
+$ kubectl create deployment myservice --image=datawire/hello-world
+$ kubectl expose deployment myservice --port=8000
 $ kubectl get service myservice
 NAME        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
 myservice   10.0.0.12    <none>        8000/TCP   1m

--- a/docs/tutorials/kubernetes.md
+++ b/docs/tutorials/kubernetes.md
@@ -8,8 +8,8 @@
 You should start a `Deployment` and publicly exposed `Service` like this:
 
 ```console
-$ kubectl run hello-world --image=datawire/hello-world --port=8000
-$ kubectl expose deployment hello-world --type=LoadBalancer --name=hello-world
+$ kubectl create deployment hello-world --image=datawire/hello-world
+$ kubectl expose deployment hello-world --type=LoadBalancer --port=8000
 ```
 
 > **If your cluster is in the cloud** you can find the address of the resulting `Service` like this:


### PR DESCRIPTION
As of 1.18, `kubectl run` only creates pods. Rather than document the different behavior between versions, update the docs to always create deployments with `kubectl create deployment` which is compatible with all versions of `kubectl`.

Intended to address #1297 from a docs perspective 

TODO
 - [ ] - Figure out how best to update the [transcript](https://github.com/telepresenceio/telepresence/blob/master/docs/internal/transcript.json) to reflect the changes in `demo-script.txt`

