### PR TITLE
Fix pod CIDR detection when falling back to using pod IPs

### DIFF
--- a/telepresence/outbound/vpn.py
+++ b/telepresence/outbound/vpn.py
@@ -170,7 +170,11 @@ def podCIDRs(runner: Runner):
     if len(cidrs) == 0:
         # Fallback to using pod IPs:
         pods = json.loads(
-            runner.get_output(runner.kubectl("get", "pods", "-o", "json"))
+            runner.get_output(
+                runner.kubectl(
+                    "get", "pods", "--all-namespaces", "-o", "json"
+                )
+            )
         )["items"]
         pod_ips = []
         for pod in pods:


### PR DESCRIPTION
If the pod CIDR can not be determined by looking at node configuration, an attempt will be made to collect pod ips and find a CIDR that covers them. Previously only pods in the current namespace were collected which may not result in an accurate CIDR. This change ensures that the IPs of pods from all namespaces are considered.