### PR TITLE
WIP Allow the default remote image to be used with ocp via env var

### DIFF
--- a/telepresence/__init__.py
+++ b/telepresence/__init__.py
@@ -46,9 +46,15 @@ TELEPRESENCE_REMOTE_IMAGE = "{}/telepresence-k8s:{}".format(
 TELEPRESENCE_REMOTE_IMAGE_PRIV = "{}/telepresence-k8s-priv:{}".format(
     REGISTRY, image_version
 )
-TELEPRESENCE_REMOTE_IMAGE_OCP = "{}/telepresence-ocp:{}".format(
-    REGISTRY, image_version
-)
+# Use the default remote image if TELEPRESENCE_OCP_USE_DEFAULT_IMAGE
+# is non-empty. This ensures that ocp users have a well-tested
+# alternative to the centos image should they desire it.
+if os.environ.get("TELEPRESENCE_OCP_USE_DEFAULT_IMAGE", ""):
+    TELEPRESENCE_REMOTE_IMAGE_OCP = TELEPRESENCE_REMOTE_IMAGE
+else:
+    TELEPRESENCE_REMOTE_IMAGE_OCP = "{}/telepresence-ocp:{}".format(
+        REGISTRY, image_version
+    )
 
 # This path points to one of
 # - the telepresence executable zip file, for an installed telepresence


### PR DESCRIPTION
The default remote image is lightweight compared to the centos-based ocp image and compatible with ocp when invoked with sufficient privilege. This change allows the use of the default remote image on ocp when `TELEPRESENCE_OCP_USE_DEFAULT_IMAGE` is set to a non-empty value.

Marking WIP because I have no attachment to the proposed implementation. I just want to allow use of the default image on ocp. For me the centos image [doesn't work](https://github.com/telepresenceio/telepresence/issues/1305) due to password-less sudo not being configured correctly. While the centos image can and should be fixed, but I don't think everyone using ocp wants or needs the less-supported option that the centos image represents.

