### PR TITLE
Create deployments with `kubectl create` for compatibility with kubectl 1.18

### DIFF
--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -74,11 +74,7 @@ def setup(runner: Runner, args):
     if args.new_deployment is not None:
         # This implies --new-deployment
         deployment_arg = args.new_deployment
-        if runner.kubectl.cluster_is_openshift:
-            # FIXME: This will not clean up the new dc
-            deployment_type = "deploymentconfig"
-        else:
-            deployment_type = "deployment"
+        deployment_type = "deployment"
         operation = create_new_deployment
         args.operation = "new_deployment"
 


### PR DESCRIPTION
As of kube 1.18, `kubectl run` is no longer capable of creating a deployment. This commit switches to supplying deployment yaml to `kubectl create -f` to ensure compatibility with all supported versions of kubectl. If `--expose` is specified, `kubectl expose` will be used to create a service.

Note that the yaml specifies `apiVersion: apps/v1`, which is compatible with kube >= 1.9.

Fixes #1297