### PR TITLE
Fix broken virtualenv install on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ virtualenv: dev-requirements.txt k8s-proxy/requirements.txt  ## Set up Python3 v
 	$(PIP) install -U pip || $(DIRFAIL)
 	$(PIP) install -r dev-requirements.txt || $(DIRFAIL)
 	$(PIP) install -r k8s-proxy/requirements.txt || $(DIRFAIL)
+	$(PIP) install setuptools_scm || $(DIRFAIL) # Ensure subsequent line executes without error on macos
 	$(PIP) install git+https://github.com/datawire/sshuttle.git@telepresence || $(DIRFAIL)
 	$(PIP) install --no-use-pep517 -e . || $(DIRFAIL)
 


### PR DESCRIPTION
When running `make virtualenv` on macos (10.14.6, python3 installed via homebrew), the install of sshuttle from source results in the following error when it attempts to install setuptools_scm:

```
 [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to
 get local issuer certificate (_ssl.c:1076) -- Some packages may not
 be found!
```

Full failure in a gist: https://gist.github.com/marun/4c2ff72b3b6db9db235e39f01b77b79e

Installing setuptools_scm in the virtualenv before attempting to install sshuttle works around the issue. Is there a less hacky way to fix this?