### PR TITLE
Make it possible to hide the Telepresence proxy output

### DIFF
--- a/k8s-proxy/run-ocp.sh
+++ b/k8s-proxy/run-ocp.sh
@@ -3,4 +3,8 @@ set -e
 echo -e ",s/1000/`id -u`/g\\012 w" | ed -s /etc/passwd
 ssh-keygen -A
 /usr/sbin/sshd -e
-exec env PYTHONPATH=/usr/src/app twistd --pidfile= -n -y ./forwarder.py
+if [ "$TELEPRESENCE_SUPPRESS_PROXY_OUTPUT" = "1" ]; then
+    exec env PYTHONPATH=/usr/src/app twistd -l=- --pidfile= -n -y ./forwarder.py 2>&1 >/dev/null
+else
+    exec env PYTHONPATH=/usr/src/app twistd --pidfile= -n -y ./forwarder.py
+fi;

--- a/k8s-proxy/run-priv.sh
+++ b/k8s-proxy/run-priv.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 set -e
 /usr/sbin/sshd -e
-exec env PYTHONPATH=/usr/src/app twistd --pidfile= -n -y ./forwarder.py
+if [ "$TELEPRESENCE_SUPPRESS_PROXY_OUTPUT" = "1" ]; then
+    exec env PYTHONPATH=/usr/src/app twistd -l=- --pidfile= -n -y ./forwarder.py 2>&1 >/dev/null
+else
+    exec env PYTHONPATH=/usr/src/app twistd --pidfile= -n -y ./forwarder.py
+fi;

--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -214,6 +214,11 @@ def parse_args(in_args: Optional[List[str]] = None) -> argparse.Namespace:
         )
     )
     parser.add_argument(
+        "--suppress-proxy-output",
+        action='store_true',
+        help=("Hides the output of the Telepresence proxy")
+    )
+    parser.add_argument(
         "--method",
         "-m",
         choices=["inject-tcp", "vpn-tcp", "container"],

--- a/telepresence/proxy/__init__.py
+++ b/telepresence/proxy/__init__.py
@@ -125,7 +125,7 @@ def setup(runner: Runner, args):
                 )
         tel_deployment, run_id = operation(
             runner_, deployment_arg, args.expose, custom_nameserver,
-            args.service_account
+            args.suppress_proxy_output, args.service_account
         )
         remote_info = get_remote_info(
             runner,

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -62,6 +62,7 @@ def existing_deployment(
     deployment_arg: str,
     expose: PortMapping,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
     service_account: str,
 ) -> Tuple[str, Optional[str]]:
     """
@@ -88,6 +89,7 @@ def existing_deployment_openshift(
     deployment_arg: str,
     expose: PortMapping,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
     service_account: str,
 ) -> Tuple[str, Optional[str]]:
     """
@@ -174,6 +176,7 @@ def create_new_deployment(
     deployment_arg: str,
     expose: PortMapping,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
     service_account: str,
 ) -> Tuple[str, str]:
     """
@@ -206,6 +209,9 @@ def create_new_deployment(
         # If we're on local VM we need to use different nameserver to prevent
         # infinite loops caused by sshuttle:
         env["TELEPRESENCE_NAMESERVER"] = custom_nameserver
+    if suppress_proxy_output:
+        # Pass an environment variable to the proxy so it hides its output.
+        env["TELEPRESENCE_SUPPRESS_PROXY_OUTPUT"] = "1"
     # Create the deployment via yaml
     deployment_yaml = _get_deployment_yaml(
         deployment_arg,
@@ -270,6 +276,7 @@ def supplant_deployment(
     deployment_arg: str,
     expose: PortMapping,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
     service_account: str,
 ) -> Tuple[str, str]:
     """
@@ -304,6 +311,7 @@ def supplant_deployment(
         expose,
         service_account,
         custom_nameserver,
+        suppress_proxy_output,
     )
 
     # Compute a new name that isn't too long, i.e. up to 63 characters.
@@ -368,6 +376,7 @@ def new_swapped_deployment(
     expose: PortMapping,
     service_account: str,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
 ) -> Dict:
     """
     Create a new Deployment that uses telepresence-k8s image.
@@ -427,6 +436,12 @@ def new_swapped_deployment(
                     "name": "TELEPRESENCE_NAMESERVER",
                     "value": custom_nameserver,
                 })
+            # Pass an environment variable to the proxy so it hides its output.
+            if suppress_proxy_output:
+                container.setdefault("env", []).append({
+                    "name": "TELEPRESENCE_SUPPRESS_PROXY_OUTPUT",
+                    "value": "1",
+                })
             # Add namespace environment variable to support deployments using
             # automountServiceAccountToken: false. To be used by forwarder.py
             # in the k8s-proxy.
@@ -451,6 +466,7 @@ def swap_deployment_openshift(
     deployment_arg: str,
     expose: PortMapping,
     custom_nameserver: Optional[str],
+    suppress_proxy_output: Optional[bool],
     service_account: str,
 ) -> Tuple[str, str]:
     """
@@ -520,6 +536,7 @@ def swap_deployment_openshift(
         expose,
         service_account,
         custom_nameserver,
+        suppress_proxy_output,
     )
 
     apply_json(new_dc_json)

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -495,7 +495,7 @@ class Runner:
         bufsize: int = -1,
         is_critical: bool = True,
     ) -> None:
-        """Asyncrounously run a process.
+        """Asynchronously run a process.
 
         :param name: A human-friendly name to describe the process.
 
@@ -516,7 +516,7 @@ class Runner:
         a new session breaks sudo if it is configured to ask for a
         password.
 
-        :parmam bufsize: See ``subprocess.Popen()`.
+        :param bufsize: See ``subprocess.Popen()`.
 
         :param is_critical: Whether this process quitting should end this
         Telepresence session. Default is True because that used to be the

--- a/tests/cluster/conftest.py
+++ b/tests/cluster/conftest.py
@@ -46,7 +46,7 @@ def _get_marks(items):
 def _probe_parametrize(fixture_name):
     """
     Create a "parametrized" pytest fixture which will supply Probes (one for
-    each coordinate in the cartesion space defined by METHODS and OPERATIONS)
+    each coordinate in the cartesian space defined by METHODS and OPERATIONS)
     to test functions which use it.
     """
     return pytest.mark.parametrize(


### PR DESCRIPTION
- Adds the flag `--suppress-proxy-output` (may reconsider its name, maybe an env var is sufficient) to hide the output of the proxy Pod.
- An attempt to address: https://github.com/telepresenceio/telepresence/issues/1226
- I have some questions here: https://github.com/telepresenceio/telepresence/issues/1226#issuecomment-576449777
- I think we can add an e2e test that checks the `kubectl logs` of the proxy pod, can we set the flag for `_ExistingDeploymentOperation` e.g., so we don't have to add another dimension to the tests parameters (probe) ? 