### PR TITLE
WSL: use a temp dir that exists on Debian/Ubuntu WSL

### DIFF
--- a/newsfragments/1176.bugfix
+++ b/newsfragments/1176.bugfix
@@ -1,0 +1,2 @@
+WSL: use a temp dir that exists on Debian/Ubuntu WSL. It falls back to the old value if `/mnt/c`
+is not available.

--- a/telepresence/runner/runner.py
+++ b/telepresence/runner/runner.py
@@ -129,7 +129,10 @@ class Runner:
         # Docker for Windows can't access /tmp, so use a directory it can
         tmp_dir = "/tmp"
         if self.is_wsl:
-            tmp_dir = "/c/temp"
+            c_drive = "/mnt/c"
+            if not os.path.exists(c_drive):
+                c_drive = "/c"
+            tmp_dir = os.path.join(c_drive, "Temp")
         if not os.path.exists(tmp_dir):
             os.makedirs(tmp_dir)
         self.temp = Path(mkdtemp(prefix="tel-", dir=tmp_dir))


### PR DESCRIPTION
It falls back to the old value if `/mnt/c` is not available.

Fixes #1176
Fixes #1254
Fixes #1335