### PR TITLE
PR for CI

### DIFF
--- a/newsfragments/1356.bugfix
+++ b/newsfragments/1356.bugfix
@@ -1,0 +1,1 @@
+Auto expose containerPorts as defined in the Deployment/DeploymentConfig when using existing Deployments

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -72,7 +72,15 @@ def existing_deployment(
         "Deployment {}".format(deployment_arg)
     )
     try:
-        runner.check_call(runner.kubectl("get", "deployment", deployment_arg))
+        d_json = json.loads(
+            runner.get_output(
+                runner.kubectl(
+                    "get", "deployment", deployment_arg, "-o", "json"
+                )
+            )
+        )
+
+        _set_expose_ports(expose, deployment_arg, d_json)
     except CalledProcessError as exc:
         raise runner.fail(
             "Failed to find deployment {}:\n{}".format(
@@ -98,11 +106,15 @@ def existing_deployment_openshift(
         "DeploymentConfig {}".format(deployment_arg)
     )
     try:
-        # FIXME: This call is redundant, as we already check for an existing dc
-        # just to get to this code path in the first place.
-        runner.check_call(
-            runner.kubectl("get", "deploymentconfig", deployment_arg)
+        d_json = json.loads(
+            runner.get_output(
+                runner.kubectl(
+                    "get", "deploymentconfig", deployment_arg, "-o", "json"
+                )
+            )
         )
+
+        _set_expose_ports(expose, deployment_arg, d_json)
     except CalledProcessError as exc:
         raise runner.fail(
             "Failed to find deploymentconfig {}:\n{}".format(
@@ -111,6 +123,19 @@ def existing_deployment_openshift(
         )
     run_id = None
     return deployment_arg, run_id
+
+
+def _set_expose_ports(expose, deployment_arg, d_json):
+    deployment, container = _split_deployment_container(deployment_arg)
+    container_to_update = _get_container_name(container, d_json)
+
+    for container in d_json["spec"]["template"]["spec"]["containers"]:
+        if container["name"] == container_to_update:
+            # Merge container ports into the expose list
+            expose.merge_automatic_ports([
+                port["containerPort"] for port in container.get("ports", [])
+                if port["protocol"] == "TCP"
+            ])
 
 
 _deployment_template = """apiVersion: apps/v1

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -136,6 +136,7 @@ def _set_expose_ports(expose, deployment_arg, d_json):
                 port["containerPort"] for port in container.get("ports", [])
                 if port["protocol"] == "TCP"
             ])
+            break
 
 
 _deployment_template = """apiVersion: apps/v1

--- a/tests/cluster/parameterize_utils.py
+++ b/tests/cluster/parameterize_utils.py
@@ -190,26 +190,6 @@ class _ExistingDeploymentOperation(object):
             # command is restored after Telepresence swaps the original
             # deployment back in.
             self.container_args = ["/hello-openshift"]
-            self.http_server_auto_expose_same = HTTPServer(
-                random_port(),
-                None,
-                random_name("auto-same"),
-            )
-            print(
-                "HTTP Server auto-expose same-port: {}".format(
-                    self.http_server_auto_expose_same.remote_port,
-                )
-            )
-            self.http_server_auto_expose_diff = HTTPServer(
-                12330,
-                random_port(),
-                random_name("auto-diff"),
-            )
-            print(
-                "HTTP Server auto-expose diff-port: {}".format(
-                    self.http_server_auto_expose_diff.remote_port,
-                )
-            )
         else:
             self.name = "existing"
             self.image = "{}/telepresence-k8s:{}".format(
@@ -219,25 +199,43 @@ class _ExistingDeploymentOperation(object):
             self.replicas = 1
             self.container_args = None
 
+        self.http_server_auto_expose_same = HTTPServer(
+            random_port(),
+            None,
+            random_name("auto-same"),
+        )
+        print(
+            "HTTP Server auto-expose same-port: {}".format(
+                self.http_server_auto_expose_same.remote_port,
+            )
+        )
+        self.http_server_auto_expose_diff = HTTPServer(
+            12330,
+            random_port(),
+            random_name("auto-diff"),
+        )
+        print(
+            "HTTP Server auto-expose diff-port: {}".format(
+                self.http_server_auto_expose_diff.remote_port,
+            )
+        )
+
     def inherits_deployment_environment(self):
         return True
 
     def prepare_deployment(self, deployment_ident, environ):
-        if self.swap:
-            ports = [
-                {
-                    "containerPort": self.http_server_auto_expose_same.
-                    local_port,
-                    "hostPort": self.http_server_auto_expose_same.remote_port,
-                },
-                {
-                    "containerPort": self.http_server_auto_expose_diff.
-                    local_port,
-                    "hostPort": self.http_server_auto_expose_diff.remote_port,
-                },
-            ]
-        else:
-            ports = []
+        ports = [
+            {
+                "name": "samehttp",
+                "containerPort": self.http_server_auto_expose_same.local_port,
+                "hostPort": self.http_server_auto_expose_same.remote_port,
+            },
+            {
+                "name": "diffhttp",
+                "containerPort": self.http_server_auto_expose_diff.local_port,
+                "hostPort": self.http_server_auto_expose_diff.remote_port,
+            },
+        ]
 
         create_deployment(
             deployment_ident,
@@ -259,12 +257,10 @@ class _ExistingDeploymentOperation(object):
             self.envfile.unlink()
 
     def auto_http_servers(self):
-        if self.swap:
-            return [
-                self.http_server_auto_expose_same,
-                self.http_server_auto_expose_diff,
-            ]
-        return []
+        return [
+            self.http_server_auto_expose_same,
+            self.http_server_auto_expose_diff,
+        ]
 
     def prepare_service(self, deployment_ident, ports):
         create_service(deployment_ident, ports)
@@ -904,7 +900,7 @@ class Probe(object):
     )
     print(
         "HTTP Server diff-port: {}".format(
-            HTTP_SERVER_SAME_PORT.remote_port,
+            HTTP_SERVER_DIFFERENT_PORT.remote_port,
         )
     )
     HTTP_SERVER_LOW_PORT = HTTPServer(

--- a/tests/cluster/test_endtoend.py
+++ b/tests/cluster/test_endtoend.py
@@ -335,8 +335,8 @@ def test_network_routing_from_cluster_auto_expose_same(probe):
     otherwise we will miss bugs where a Telepresence proxy container is added
     rather than being swapped.
     """
-    if probe.operation.name != "swap":
-        pytest.skip("Test only applies to --swap-deployment usage.")
+    if probe.operation.name not in ("swap", "existing"):
+        pytest.skip("Test only applies to --swap-deployment and --deployment usage.")
 
     result = probe.result()
     http = probe.operation.http_server_auto_expose_same
@@ -351,8 +351,8 @@ def test_network_routing_from_cluster_auto_expose_diff(probe):
     Like ``test_network_routing_from_cluster_auto_expose_same`` but for the
     case where the exposed port and the container port are different.
     """
-    if probe.operation.name != "swap":
-        pytest.skip("Test only applies to --swap-deployment usage.")
+    if probe.operation.name not in ("swap", "existing"):
+        pytest.skip("Test only applies to --swap-deployment and --deployment usage.")
 
     result = probe.result()
     http = probe.operation.http_server_auto_expose_diff

--- a/tests/cluster/test_endtoend.py
+++ b/tests/cluster/test_endtoend.py
@@ -336,7 +336,9 @@ def test_network_routing_from_cluster_auto_expose_same(probe):
     rather than being swapped.
     """
     if probe.operation.name not in ("swap", "existing"):
-        pytest.skip("Test only applies to --swap-deployment and --deployment usage.")
+        pytest.skip(
+            "Test only applies to --swap-deployment and --deployment usage."
+        )
 
     result = probe.result()
     http = probe.operation.http_server_auto_expose_same
@@ -352,7 +354,9 @@ def test_network_routing_from_cluster_auto_expose_diff(probe):
     case where the exposed port and the container port are different.
     """
     if probe.operation.name not in ("swap", "existing"):
-        pytest.skip("Test only applies to --swap-deployment and --deployment usage.")
+        pytest.skip(
+            "Test only applies to --swap-deployment and --deployment usage."
+        )
 
     result = probe.result()
     http = probe.operation.http_server_auto_expose_diff


### PR DESCRIPTION


---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
