### PR TITLE
Make Telepresence development a little cleaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,12 @@ DIRFAIL = { r=$$?; rm -rf $@; exit $$r; }
 virtualenv: dev-requirements.txt k8s-proxy/requirements.txt  ## Set up Python3 virtual environment for development
 	rm -rf $@ || true
 	python3 -m venv $@ || $(DIRFAIL)
-	$(PIP) install -U pip || $(DIRFAIL)
-	$(PIP) install -r dev-requirements.txt || $(DIRFAIL)
-	$(PIP) install -r k8s-proxy/requirements.txt || $(DIRFAIL)
-	$(PIP) install setuptools_scm || $(DIRFAIL) # Ensure subsequent line executes without error on macos
-	$(PIP) install git+https://github.com/datawire/sshuttle.git@telepresence || $(DIRFAIL)
-	$(PIP) install --no-use-pep517 -e . || $(DIRFAIL)
+	$(PIP) install -q -U pip || $(DIRFAIL)
+	$(PIP) install -q -r dev-requirements.txt || $(DIRFAIL)
+	$(PIP) install -q -r k8s-proxy/requirements.txt || $(DIRFAIL)
+	$(PIP) install -q setuptools_scm || $(DIRFAIL) # Ensure subsequent line executes without error on macos
+	$(PIP) install -q git+https://github.com/datawire/sshuttle.git@telepresence || $(DIRFAIL)
+	$(PIP) install -q --no-use-pep517 -e . || $(DIRFAIL)
 
 lint: virtualenv  ## Run the linters used by CI (implies 'virtualenv')
 	./tools/license-check

--- a/tests/cluster/parameterize_utils.py
+++ b/tests/cluster/parameterize_utils.py
@@ -13,6 +13,7 @@ from subprocess import (
 from sys import executable, stdout
 from time import sleep
 
+import pytest
 from telepresence.utilities import find_free_port
 
 from .utils import (
@@ -980,7 +981,8 @@ class Probe(object):
             )
             self._cleanup.append(self.ensure_dead)
             self._cleanup.append(self.cleanup_resources)
-        assert self._result != "FAILED"
+        if self._result == "FAILED":
+            pytest.skip("Probe has failed.")
         return self._result
 
     def cleanup(self):

--- a/tests/cluster/test_endtoend.py
+++ b/tests/cluster/test_endtoend.py
@@ -18,6 +18,8 @@ from .utils import DEPLOYMENT_TYPE, KUBECTL, query_from_cluster
 
 @pytest.fixture(scope="session")
 def origin_ip():
+    if the_cluster_ip == the_origin_ip:  # local cluster
+        return None
     return the_origin_ip
 
 
@@ -241,6 +243,9 @@ def test_network_routing_also_proxy_hostname(probe, origin_ip):
     if probe.method.name != "vpn-tcp":
         pytest.skip("Test only applies to --method vpn-tcp usage.")
 
+    if origin_ip is None:  # Local cluster
+        pytest.skip("Test does not work with local clusters.")
+
     probe_result = probe.result()
 
     (success, request_ip) = probe_also_proxy(
@@ -260,6 +265,9 @@ def test_network_routing_also_proxy_ip_literal(probe, origin_ip):
     if probe.method.name != "vpn-tcp":
         pytest.skip("Test only applies to --method vpn-tcp usage.")
 
+    if origin_ip is None:  # Local cluster
+        pytest.skip("Test does not work with local clusters.")
+
     probe_result = probe.result()
 
     (success, request_ip) = probe_also_proxy(
@@ -278,6 +286,9 @@ def test_network_routing_also_proxy_ip_cidr(probe, origin_ip):
     """
     if probe.method.name != "vpn-tcp":
         pytest.skip("Test only applies to --method vpn-tcp usage.")
+
+    if origin_ip is None:  # Local cluster
+        pytest.skip("Test does not work with local clusters.")
 
     probe_result = probe.result()
 
@@ -399,7 +410,14 @@ def httpbin_ip():
     return origin
 
 
+def get_cluster_ip():
+    result = query_from_cluster("http://httpbin.org/ip", "default")
+    return fix_httpbin_ip(loads(result)["origin"])
+
+
 the_origin_ip = IPv4Address(httpbin_ip())
+
+the_cluster_ip = IPv4Address(get_cluster_ip())
 
 
 def probe_also_proxy(probe_result, hostname):


### PR DESCRIPTION
- Skip also-proxy cluster tests for local clusters. We should test
  `--also-proxy` in a less end-to-end manner elsewhere, e.g., by
  seeing what arguments we're passing to `sshuttle`.
- Skip a probe's remaining tests when the probe fails. Don't fail those
  tests, as that generates a lot of noise from `pytest` that gets in the
  way of debugging the real failure.
- Make the virtualenv more quietly. Avoid lots of noise in CI.
