### PR TITLE
Do not proxy local cluster external IP

### DIFF
--- a/newsfragments/1380.bugfix
+++ b/newsfragments/1380.bugfix
@@ -1,0 +1,1 @@
+Do not proxy local cluster external IP

--- a/telepresence/outbound/vpn.py
+++ b/telepresence/outbound/vpn.py
@@ -184,7 +184,10 @@ def podCIDRs(runner: Runner):
         pod_ips = []
         for pod in pods:
             try:
-                pod_ips.append(pod["status"]["podIP"])
+                ip = pod["status"]["podIP"]
+                if runner.kubectl.in_local_vm and ip in runner.kubectl.server:
+                    continue
+                pod_ips.append(ip)
             except KeyError:
                 # Apparently a problem on OpenShift
                 pass


### PR DESCRIPTION
With minikube some of the system pods (e.g. etcd) are configured to have the same IP as minikube external endpoint. This results in podCIDRs=128.0.0.0/1 which breaks network.

Fixes #1380