### PR TITLE
added documentation for specifying multiple hosts to also-proxy

### DIFF
--- a/docs/reference/methods.md
+++ b/docs/reference/methods.md
@@ -27,7 +27,7 @@ This method does have some limitations of its own, however:
   instances with other proxying methods concurrently is possible.
 * VPNs may interfere with `telepresence`, and vice-versa: don't use both at once.
 * Cloud resources like AWS RDS will not be routed automatically via cluster.
-  You'll need to specify the hosts manually using `--also-proxy`, e.g. `--also-proxy mydatabase.somewhere.vpc.aws.amazon.com` to route traffic to that host via the Kubernetes cluster..
+  You'll need to specify the hosts manually using `--also-proxy`, e.g. `--also-proxy mydatabase.somewhere.vpc.aws.amazon.com` to route traffic to that host via the Kubernetes cluster. Specify multiple hosts to `--also-proxy` like `--also-proxy example1.com --also-proxy example2.com --also-proxy example3.com`. 
 
 ### Limitations: `--method inject-tcp`
 

--- a/docs/reference/proxying.md
+++ b/docs/reference/proxying.md
@@ -135,7 +135,7 @@ When using `--method vpn-tcp`, Telepresence currently proxies the following:
 * The standard [DNS entries for services](https://kubernetes.io/docs/user-guide/services/#dns).
   E.g. `redis-master` and `redis-master.default`, but not those ending with `.local`. 
 * Any environment variables that the `Deployment` explicitly configured for the pod.
-* TCP connections to any `Service` in the cluster regardless of when they were started, as well as to any hosts or ranges explicitly listed with `--also-proxy`.
+* TCP connections to any `Service` in the cluster regardless of when they were started, as well as to any hosts or ranges explicitly listed with `--also-proxy`. It is possible to specify multiple hosts to `--also-proxy` like so: `--also-proxy example1.com --also-proxy example2.com --also-proxy example3.com`.
 * TCP connections *from* Kubernetes to your local machine, for ports specified on the command line using `--expose`.
 * Access to volumes, including those for `Secret` and `ConfigMap` Kubernetes objects.
 * `/var/run/secrets/kubernetes.io` credentials (used to the [access the Kubernetes( API](https://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod)).

--- a/newsfragments/1440.misc
+++ b/newsfragments/1440.misc
@@ -1,2 +1,0 @@
-Updated the "Proxying methods" section of the docs with a line specifying how
-to use --also-proxy with multiple hosts.

--- a/newsfragments/1440.misc
+++ b/newsfragments/1440.misc
@@ -1,0 +1,2 @@
+Updated the "Proxying methods" section of the docs with a line specifying how
+to use --also-proxy with multiple hosts.


### PR DESCRIPTION
Updated the "Proxying methods" section of the docs with a line specifying how to use --also-proxy with multiple hosts.

Closes #1440 