### PR TITLE
Fix error when running telepresence to swap a non-root deployment

### DIFF
--- a/newsfragments/1413.bugfix
+++ b/newsfragments/1413.bugfix
@@ -1,0 +1,1 @@
+Swapping a deployment with a securityContext.runAsUser other than root no longer fail.

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -436,6 +436,8 @@ def new_swapped_deployment(
                     pass
             # Set running command explicitly
             container["command"] = ["/usr/src/app/run.sh"]
+            # Run the container as root. Required by telepresence images.
+            container.setdefault("securityContext", {})["runAsUser"] = 0
             # We don't write out termination file:
             container["terminationMessagePolicy"] = "FallbackToLogsOnError"
             # Use custom name server if necessary:

--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -178,6 +178,8 @@ spec:
       - name: nginxhttps
         image: ___replace___me___
         command: ["/usr/src/app/run.sh"]
+        securityContext:
+          runAsUser: 0
         terminationMessagePolicy: "FallbackToLogsOnError"
         imagePullPolicy: "IfNotPresent"
         ports:


### PR DESCRIPTION
Fixes https://github.com/telepresenceio/telepresence/issues/1413

Run the telepresence container as root, since the images assume so and drop privilege if needed.