### PR TITLE
Add no-global-proxy flag to stop proxying all traffic

### DIFF
--- a/telepresence/cli.py
+++ b/telepresence/cli.py
@@ -358,6 +358,18 @@ def parse_args(in_args: Optional[List[str]] = None) -> argparse.Namespace:
         )
     )
     parser.add_argument(
+        "--no-global-proxy",
+        dest="no_global_proxy",
+        action='store_true',
+        help=(
+            "By default, container method proxies all traffic through the "
+            "remote Kubernetes cluster. This option disable the default "
+            "behavior by only proxying the remote Kubernetes cluster CIDR. "
+            "It is possible to use --also-proxy with --no-global-proxy "
+            "to specify additionnal CIDRs to proxy through the clusters."
+        )
+    )
+    parser.add_argument(
         "--local-cluster",
         action='store_true',
         help=(

--- a/telepresence/outbound/container.py
+++ b/telepresence/outbound/container.py
@@ -23,6 +23,7 @@ from telepresence import TELEPRESENCE_LOCAL_IMAGE
 from telepresence.cli import PortMapping
 from telepresence.connect import SSH
 from telepresence.proxy import RemoteInfo
+from telepresence.outbound.cidr import get_proxy_cidrs
 from telepresence.runner import Runner
 from telepresence.utilities import find_free_port, random_name
 
@@ -110,6 +111,7 @@ def run_docker_command(
     to_pod: List[int],
     from_pod: List[int],
     container_to_host: PortMapping,
+    no_global_proxy: bool,
     remote_env: Dict[str, str],
     ssh: SSH,
     mount_dir: Optional[str],
@@ -148,6 +150,10 @@ def run_docker_command(
         "to_pod": to_pod,
         "from_pod": from_pod,
     }
+
+    if no_global_proxy:
+        config["cidrs"] = get_proxy_cidrs(runner, remote_info)
+
     dns_args = []
     if "hostname" in pod_info:
         dns_args.append("--hostname={}".format(pod_info["hostname"].strip()))

--- a/telepresence/outbound/setup.py
+++ b/telepresence/outbound/setup.py
@@ -117,10 +117,11 @@ def setup_vpn(runner: Runner, args: Namespace) -> LaunchType:
 
 def setup_container(runner: Runner, args: Namespace) -> LaunchType:
     runner.require_docker()
-    if args.also_proxy:
+    if not args.no_global_proxy and args.also_proxy:
         runner.show(
             "Note: --also-proxy is no longer required with --docker-run. "
-            "The container method sends all network traffic to the cluster."
+            "By default, the container method sends all network traffic "
+            "to the cluster."
         )
 
     # Check for non-local docker
@@ -162,6 +163,7 @@ def setup_container(runner: Runner, args: Namespace) -> LaunchType:
             args.to_pod,
             args.from_pod,
             args.container_to_host,
+            args.no_global_proxy,
             env,
             ssh,
             mount_dir,


### PR DESCRIPTION
Workaround added after reading #1371 

* Add no-global-proxy flag to avoid proxying all traffic. Otherwise, everything works as expected.