### PR TITLE
Update Docker tutorial, add hello-world manifest

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -1,8 +1,8 @@
 # Fast development workflow with Docker and Kubernetes
 
-Keeping development environments in sync is a constant pain. Containerizing your development environment enables your service to run in the exact same environment everywhere: from your laptop to production (for more details on the benefits of a container native development workflow, see [this post by Matt Butcher](https://open.microsoft.com/2018/04/23/5-reasons-you-should-be-doing-container-native-development/).)
+Keeping development environments in sync is a constant pain. Containerizing your development environment enables your service to run in the exact same environment everywhere, from your laptop to production (for more details on the benefits of a container native development workflow, see [this post by Matt Butcher](https://open.microsoft.com/2018/04/23/5-reasons-you-should-be-doing-container-native-development/).)
 
-Telepresence, in conjunction with a containerized development environment, gives the developer a fast development workflow in developing a multi-container application on Kubernetes.  Telepresence lets you run a Docker container locally, while proxying it to your Kubernetes cluster.
+Telepresence, in conjunction with a containerized development environment, gives the developer a fast development workflow in developing a multi-container application on Kubernetes.  Telepresence lets you run a Docker container locally while proxying it to your Kubernetes cluster.
 
 In this HOWTO, we'll walk through how to use Telepresence with a containerized Docker environment to build a fast development workflow.
 
@@ -11,21 +11,27 @@ In this HOWTO, we'll walk through how to use Telepresence with a containerized D
 
 ## Quick example
 
-We'll start with a quick example. Start by running a service in the cluster:
+We'll start with a quick example. Apply the following 
+[manifest](https://github.com/telepresenceio/telepresence/blob/master/docs/tutorials/hello-world.yaml)
+to create a deployment and service both named hello-world, exposed on port 8000.
+Then confirm that the deployment becomes ready:
 
 ```console
-$ kubectl create deployment hello-world --image=datawire/hello-world
+$ kubectl apply -f https://raw.githubusercontent.com/telepresenceio/telepresence/master/docs/tutorials/hello-world.yaml
 deployment.apps/hello-world created
-$ kubectl expose deployment hello-world --port=8000
 service/hello-world created
-$ kubectl get service hello-world
-NAME          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
-hello-world   ClusterIP   10.111.122.25   <none>        8000/TCP   45s
+
+$ kubectl get deployments
+NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/hello-world   1/1     1            1           6s
 ```
 
-It may take a minute or two for the pod running the server to be up and running, depending on how fast your cluster is.
+It may take a minute or two for the pod running the server to be up and running,
+depending on how fast your cluster is.
 
-You can now run a Docker container using Telepresence that can access that service, even though the process is local but the service is running in the Kubernetes cluster:
+You can now run a Docker container using Telepresence that can access that 
+service, even though the process is local but the service is running in the 
+Kubernetes cluster:
 
 ```console
 $ telepresence --docker-run --rm -it pstauffer/curl curl http://hello-world:8000/
@@ -36,7 +42,6 @@ T: Your process has exited.
 [...]
 ```
 
-(This will not work if the hello-world pod hasn't started yet... If so, try again.)
 
 ## Setting up a development environment in Docker
 
@@ -121,7 +126,7 @@ Greetings, world!
 / #
 ```
 
-And notice how the code has changed, live. Congratulations! You've now:
+Notice how the output has updated in realtime. Congratulations! You've now:
 
 * Routed the hello-world service to the Docker container running locally
 * Configured your Docker service to pick up changes from your local filesystem
@@ -129,7 +134,7 @@ And notice how the code has changed, live. Congratulations! You've now:
 
 ## How it works
 
-Telepresence will start a new proxy container, and then call `docker run` with whatever arguments you pass to `--docker-run` to start a container that will have its networking proxied. All networking is proxied:
+Telepresence will start a new proxy container and then call `docker run` with whatever arguments you pass to `--docker-run` to start a container that will have its networking proxied. All networking is proxied:
 
 * Outgoing to Kubernetes.
 * Outgoing to cloud resources outside the cluster

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -11,8 +11,7 @@ In this HOWTO, we'll walk through how to use Telepresence with a containerized D
 
 ## Quick example
 
-We'll start with a quick example. Apply the following 
-[manifest](https://github.com/telepresenceio/telepresence/blob/master/docs/tutorials/hello-world.yaml)
+We'll start with a quick example. Apply [this manifest](https://github.com/telepresenceio/telepresence/blob/master/docs/tutorials/hello-world.yaml)
 to create a deployment and service both named hello-world, exposed on port 8000.
 Then confirm that the deployment becomes ready:
 

--- a/docs/tutorials/hello-world.yaml
+++ b/docs/tutorials/hello-world.yaml
@@ -1,0 +1,39 @@
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world
+  template:
+    metadata:
+      labels:
+        app: hello-world
+    spec:
+      containers:
+      - image: datawire/hello-world
+        name: hello-world
+        ports:
+        - containerPort: 8000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-world
+  name: hello-world
+spec:
+  ports:
+  - port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: hello-world


### PR DESCRIPTION
resolves #1409

- Replaced `kubectl create` and `kubectl expose` commands with a manifest that creates the deployment and service, with port info included in the deployment, the lack of which broke the tutorial.

- Made a few minor revisions across the doc

- After this is merged I'll go back and review the other tutorials, assuming they all need to be updated to use this manifest.