### PR TITLE
fix(docs): cleans up Telepresence 2 announcement

### DIFF
--- a/docs/announcing-telepresence-2.html
+++ b/docs/announcing-telepresence-2.html
@@ -80,9 +80,9 @@
         <h1 class="text-lg">Announcing Telepresence 2!</h1>
         <p>We’re excited to announce that a new version of Telepresence is coming soon. Among other new features, we are currently rewriting Telepresence in Go (from Python) in order to:</p>
         <ul>
-            <li>•  Make it even faster!</li>
-            <li>•  Better serve our awesome open source community and make it easier for more community members to contribute</li>
-            <li>•  Make Telepresence easier to integrate with other cloud native tools in your tech stack</li>
+            <li>Make it even faster!</li>
+            <li>Better serve our awesome open source community and make it easier for more community members to contribute</li>
+            <li>Make Telepresence easier to integrate with other cloud native tools in your tech stack</li>
         </ul>
 
         <div class="bg-white content-box text-center">


### PR DESCRIPTION
This commit removes unneeded bullet points, as they are rendered double (because of `<li>`).

![image](https://user-images.githubusercontent.com/719616/99514008-8f854180-298b-11eb-8149-b01be6cc5f91.png)

I'm super excited about this announcement! Is the code already open? I would love to contribute!