### PR TITLE
Prevent iptables --list from hanging on reverse lookup

### DIFF
--- a/newsfragments/1476.bugfix
+++ b/newsfragments/1476.bugfix
@@ -1,0 +1,1 @@
+> unprivileged container check via iptables will not hang on DNS lookups

--- a/telepresence/outbound/setup.py
+++ b/telepresence/outbound/setup.py
@@ -81,7 +81,7 @@ def setup_vpn(runner: Runner, args: Namespace) -> LaunchType:
     if runner.platform == "linux":
         # Do a quick iptables sanity check, post sudo
         try:
-            ipt_command = ["sudo", "iptables", "--list"]
+            ipt_command = ["sudo", "iptables", "--list", "--numeric"]
             runner.get_output(ipt_command, stderr_to_stdout=True)
         except subprocess.CalledProcessError as exc:
             runner.show("Quick test of iptables failed:")


### PR DESCRIPTION
[`iptables --list` will occasionally hang](https://serverfault.com/questions/286422/iptables-hangs-when-listing-rules) while performing a reverse lookup for IP addresses. As it's just a sanity check, the lookup isn't needed.