### PR TITLE
Adding StartupProbe to probes to be deleted

### DIFF
--- a/telepresence/proxy/operation.py
+++ b/telepresence/proxy/operation.py
@@ -227,7 +227,7 @@ class Swap(ProxyOperation):
         })
 
         for unneeded in [
-            "args", "livenessProbe", "readinessProbe", "workingDir",
+            "args", "livenessProbe", "startupProbe", "readinessProbe", "workingDir",
             "lifecycle"
         ]:
             try:

--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -69,6 +69,12 @@ spec:
         ports:
         - containerPort: 443
         - containerPort: 80
+        startupProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /index.html
@@ -97,6 +103,12 @@ spec:
         - containerPort: 80
           name: http-api
           protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /index.html
@@ -158,6 +170,12 @@ spec:
         ports:
         - containerPort: 443
         - containerPort: 80
+        startupProbe:
+          httpGet:
+            path: /index.html
+            port: 80
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
         livenessProbe:
           httpGet:
             path: /index.html

--- a/tests/local/test_unit.py
+++ b/tests/local/test_unit.py
@@ -102,13 +102,7 @@ spec:
         ports:
         - containerPort: 80
           name: http-api
-          protocol: TCP
-        startupProbe:
-          httpGet:
-            path: /index.html
-            port: 80
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
+          protocol: TCP      
         livenessProbe:
           httpGet:
             path: /index.html
@@ -169,19 +163,7 @@ spec:
         workingDir: "/somewhere/over/the/rainbow"
         ports:
         - containerPort: 443
-        - containerPort: 80
-        startupProbe:
-          httpGet:
-            path: /index.html
-            port: 80
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
-        livenessProbe:
-          httpGet:
-            path: /index.html
-            port: 80
-          initialDelaySeconds: 30
-          timeoutSeconds: 1
+        - containerPort: 80               
         readinessProbe:
           httpGet:
             path: /index.html


### PR DESCRIPTION
Swap Deplyment fails on Deployments using startupProbes. This PR removes the startup Probe from swapped deployment as well 
---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
