### PR TITLE
Add Fedora 33 to packaging

### DIFF
--- a/packaging/distros.py
+++ b/packaging/distros.py
@@ -40,4 +40,5 @@ distros = [
     ("fedora", "30", "rpm", fedora_deps, install_rpm),  # EOL 2020-05-26
     ("fedora", "31", "rpm", fedora_deps, install_rpm),
     ("fedora", "32", "rpm", fedora_deps, install_rpm),
+    ("fedora", "33", "rpm", fedora_deps, install_rpm),
 ]


### PR DESCRIPTION
The builds for Fedora 33, which has been out for a couple of months, are missing. Hopefully this pull request will nudge things forward. :smile: 