### PR TITLE
Only add docker args without env-file

### DIFF
--- a/docs/reference/proxying.md
+++ b/docs/reference/proxying.md
@@ -144,3 +144,14 @@ Currently unsupported:
 
 * Fully qualified Kubernetes DNS names that end with `.local`, e.g. `redis-master.default.svc.cluster.local`, won't work on Linux (see [the relevant ticket](https://github.com/datawire/telepresence/issues/161) for details.)
 * UDP messages in any direction.
+
+### Docker and Kubernetes in clusters with severall services
+
+There is a kubernetes configuration `EnableServiceLinks` that by default is set to `true` if not defined.
+If enabled this flag will instruct kubernetes to inject environment variables with service information into the pods.
+This behaviour can bring problems in clusters that have many services, having negative impact in the number of environment variables that are defined for a pod and effectivelly invalidating the successfull start of a docker container through passing the variables by adding multiple entries of the argument `-e VAR=VALUE`.
+To avoid that the docker container can be initiallized to load the environment variables from a file with the parameter `--env-file` instead of from a list of arguments, more info [in docker documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
+
+To use it you should use the `---env-file filepath` pointing to a file where the environment variables are defined.
+
+

--- a/telepresence/outbound/container.py
+++ b/telepresence/outbound/container.py
@@ -229,7 +229,15 @@ def run_docker_command(
     )
 
     # Prepare container environment
-    if not "--env-file" in docker_args:
+    if "--env-file" in docker_args:
+        if runner.chatty:
+            runner.show(
+                "Not proxying cluster environment variables to your container "
+                "because you are passing '--env-file' to 'docker run'. See "
+                "https://www.telepresence.io/reference/proxying#environment-variables "  # noqa: E501
+                "for more information"
+            )
+    else:
         for key in remote_env:
             docker_command.append("-e={}".format(key))
     docker_env = os.environ.copy()

--- a/telepresence/outbound/container.py
+++ b/telepresence/outbound/container.py
@@ -229,8 +229,9 @@ def run_docker_command(
     )
 
     # Prepare container environment
-    for key in remote_env:
-        docker_command.append("-e={}".format(key))
+    if not "--env-file" in docker_args:
+        for key in remote_env:
+            docker_command.append("-e={}".format(key))
     docker_env = os.environ.copy()
     docker_env.update(remote_env)
 


### PR DESCRIPTION
Hello and thanks for the great work on this tool.
I've created a workaround that could help starting telepresence in a cluster with several services, mainly it leverage the docker cli to use the environment variables from a file instead of from parameters.

It would be good if it could incorporated into telepresence to ease the start in clusters with lot of services.
Is it something that worth to be incorporated?

---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
