### PR TITLE
Remove file.txt query when back to normal

### DIFF
--- a/docs/macros.html
+++ b/docs/macros.html
@@ -204,7 +204,7 @@ $ {{ command }} get pod | grep hello-world
 When the new pod is back to `Running` state you can see that everything is back to normal:
 
 ```console
-$ curl $HELLOWORLD/file.txt
+$ curl $HELLOWORLD/
 Hello, world!
 ```
 


### PR DESCRIPTION
original **hello-world** service does not have the `file.txt` in the cluster