### PR TITLE
Replace references to Datawire.io with Ambassador Labs

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -9,7 +9,7 @@
     <title>About - Telepresence</title>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
-    <meta name="author" content="Datawire.io">
+    <meta name="author" content="Ambassador Labs">
 
     <link rel="shortcut icon" href="/favicon.ico">
 
@@ -82,7 +82,7 @@
             service to a remote Kubernetes cluster.</p>
         <p>
             Telepresence was originally built by the team at
-            <a target="_blank" href="https://www.datawire.io/">Datawire</a>, which builds open source development tools
+            <a target="_blank" href="https://www.getambassador.io/">Ambassador Labs</a>, which builds open source development tools
             for Kubernetes, including <a target="_blank" href="https://forge.sh/">Forge</a> and
             <a target="_blank" href="https://www.getambassador.io">Ambassador</a>. The current list of maintainers of
             Telepresence are listed in the

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,7 +250,7 @@
                 </p>
             </div>
             <p class="text-md">
-                Telepresence was originally created by <a href="https://www.datawire.io" target="_blank">Datawire, Inc.</a>
+                Telepresence was originally created by <a href="https://www.getambassador.io" target="_blank">Ambassador Labs</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION


---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
