### PR TITLE
container method: better CIDR guessing

### DIFF
--- a/newsfragments/1220.bugfix
+++ b/newsfragments/1220.bugfix
@@ -1,0 +1,2 @@
+Setup sshuttle in Container method to only route cluster CIDR like the VPN
+method.

--- a/telepresence/outbound/container.py
+++ b/telepresence/outbound/container.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from telepresence import TELEPRESENCE_LOCAL_IMAGE
 from telepresence.cli import PortMapping
 from telepresence.connect import SSH
+from telepresence.outbound.cidr import get_proxy_cidrs
 from telepresence.proxy import RemoteInfo
 from telepresence.runner import Runner
 from telepresence.utilities import find_free_port, random_name
@@ -143,7 +144,7 @@ def run_docker_command(
     # Start the network (sshuttle) container:
     name = random_name()
     config = {
-        "cidrs": ["0/0"],
+        "cidrs": get_proxy_cidrs(runner, remote_info),
         "expose_ports": list(expose.local_to_remote()),
         "to_pod": to_pod,
         "from_pod": from_pod,


### PR DESCRIPTION
This was originally submitted as part of https://github.com/telepresenceio/telepresence/pull/1371 along with other improvements. However it looks like it was forgotten (or never rebased).

Submitting it again.

This improves the CIDR guessing when using the container method and fixes #1220 in a good number of cases.

It would also be useful to merge https://github.com/telepresenceio/telepresence/pull/1456