### PR TITLE
fix: remove startupProbe from swapped deployment

### DIFF
--- a/newsfragments/1536.bugfix
+++ b/newsfragments/1536.bugfix
@@ -1,0 +1,1 @@
+Using a startup probe no longer crashes the Telepresence client.

--- a/telepresence/proxy/deployment.py
+++ b/telepresence/proxy/deployment.py
@@ -392,7 +392,8 @@ def new_swapped_deployment(
     Makes the following changes:
 
     1. Changes to single replica.
-    2. Disables command, args, livenessProbe, readinessProbe, workingDir.
+    2. Disables command, args, livenessProbe, readinessProbe,
+       startupProbe, workingDir.
     3. Adds labels.
     4. Adds environment variables.
     5. Runs as root, if requested.
@@ -428,7 +429,7 @@ def new_swapped_deployment(
             # Drop unneeded fields:
             for unneeded in [
                 "args", "startupProbe", "livenessProbe", "readinessProbe",
-                "workingDir", "lifecycle"
+                "startupProbe", "workingDir", "lifecycle"
             ]:
                 try:
                     container.pop(unneeded)

--- a/telepresence/proxy/operation.py
+++ b/telepresence/proxy/operation.py
@@ -228,7 +228,7 @@ class Swap(ProxyOperation):
 
         for unneeded in [
             "args", "livenessProbe", "startupProbe", "readinessProbe",
-            "workingDir", "lifecycle"
+            "startupProbe", "workingDir", "lifecycle"
         ]:
             try:
                 container.pop(unneeded)


### PR DESCRIPTION
Related issue : #1536

Prevent a timeout on the client when a `startupProbe` is defined in the original Kubernetes deployment with `swap-deployment` option set on Telepresence. 

Startup probes documentation: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes

 