### PR TITLE
Add fake domain that can be used as varying search-path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.2.0 (TBD)
+
+- Feature: Introduce a fake "tel2-search" domain that gets replaced with a dynamic DNS search when queried (for Docker with no -net host).
+
 ### 2.1.0 (March 8, 2021)
 
 - Bugfix: Environment variables declared with `envFrom` in the app-container are now propagated correctly to the client during intercept.

--- a/pkg/client/daemon/outbound_darwin.go
+++ b/pkg/client/daemon/outbound_darwin.go
@@ -177,6 +177,7 @@ func (o *outbound) dnsServerWorker(c context.Context, onReady func()) error {
 				namespaces[path] = struct{}{}
 			}
 		}
+		namespaces[tel2SubDomain] = struct{}{}
 
 		// On Darwin, we provide resolution of NAME.NAMESPACE by adding one domain
 		// for each namespace in its own domain file under /etc/resolver. Each file

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -69,6 +69,7 @@ func (o *outbound) runOverridingServer(c context.Context, onReady func()) error 
 				namespaces[path] = struct{}{}
 			}
 		}
+		namespaces[tel2SubDomain] = struct{}{}
 		o.domainsLock.Lock()
 		o.namespaces = namespaces
 		o.search = search
@@ -109,17 +110,10 @@ func (o *outbound) resolveWithSearch(query string) []string {
 		// More than just the ending dot, so don't use search-path
 		return o.resolveNoSearch(query)
 	}
-
-	query = strings.ToLower(query)
-	var ips []string
 	o.domainsLock.RLock()
-	for _, suffix := range o.search {
-		if ips = o.domains[query+suffix]; ips != nil {
-			break
-		}
-	}
+	ips := o.resolveWithSearchLocked(query)
 	o.domainsLock.RUnlock()
-	return shuffleIPs(ips)
+	return ips
 }
 
 func (o *outbound) dnsListeners(c context.Context) ([]net.PacketConn, error) {


### PR DESCRIPTION

## Description

This PR addresses the intricate problem that Docker on MacOS (and
possibly on other platforms as well) overrides the the DNS search. It
uses the DNS-resolver and everything else works (including
NAME.NAMESPACE). It's just the DNS search that gets overridden. The
Docker dns-search can however be configured, either by passing options
to the invocation or by modifying the Docker config. Only problem is,
that the Telepresence search path changes dynamically. A fix for
that problem is to introduce a static fake domain (here named
"tel2-search"), which, when queried, will replace itself with the
dynamic search path.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 