### PR TITLE
Handle port-less containers better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+### 2.1.1 (TBD)
+- Bugfix: When looking at the container to intercept, it will check if there's a better match before using a container without containerPorts
 
 ### 2.1.0 (March 8, 2021)
 

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -321,13 +321,17 @@ func findMatchingPort(dep *kates.Deployment, portName string, svcs []*kates.Serv
 			}
 		} else {
 			portNum := port.TargetPort.IntVal
-			for ci := 0; ci < len(cns) && ccn == nil; ci++ {
+			// Here we are using cpi <=0 instead of ccn == nil because if a
+			// container has no ports, we want to use it but we don't want
+			// to break out of the loop looking at containers in case there
+			// is a better fit.  Currently, that is a container where the
+			// ContainerPort matches the targetPort in the service.
+			for ci := 0; ci < len(cns) && cpi <= 0; ci++ {
 				cn := &cns[ci]
 				if len(cn.Ports) == 0 {
 					msp = port
 					ccn = cn
 					cpi = -1
-					break
 				}
 				for pi := range cn.Ports {
 					if cn.Ports[pi].ContainerPort == portNum {

--- a/pkg/client/connector/testdata/addAgentToDeployment/tc-11.input.yaml
+++ b/pkg/client/connector/testdata/addAgentToDeployment/tc-11.input.yaml
@@ -1,0 +1,99 @@
+deployment:
+  apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+    creationTimestamp: "2021-03-10T07:18:54Z"
+    generation: 1
+    labels:
+      app: hello-11
+    name: hello-11
+    namespace: telepresence-5759
+    resourceVersion: "517"
+    selfLink: /apis/extensions/v1beta1/namespaces/telepresence-5759/deployments/hello-11
+    uid: 1ab652ac-41ca-11eb-b40f-0242ac110002
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: hello-11
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: hello-11
+      spec:
+        containers:
+        - image: jmalloc/echo-server:0.1.0
+          imagePullPolicy: IfNotPresent
+          name: echo-server-dont-pick
+          env:
+          - name: PORT
+            value: "9090"
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - image: jmalloc/echo-server:0.1.0
+          imagePullPolicy: IfNotPresent
+          name: echo-server-pick
+          ports:
+          - containerPort: 8080
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-10T07:18:55Z"
+      lastUpdateTime: "2021-03-10T07:18:55Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-10T07:18:00Z"
+      lastUpdateTime: "2021-03-10T07:18:55Z"
+      message: ReplicaSet "hello-11-5c9696799" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: "2021-03-10T07:17:54Z"
+    labels:
+      app: hello-11
+    name: hello-11
+    namespace: telepresence-5759
+    resourceVersion: "219"
+    selfLink: /api/v1/namespaces/telepresence-5759/services/hello-11
+    uid: 423ef12f-41ca-11eb-b40f-0242ac110002
+  spec:
+    clusterIP: 10.43.145.123
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: hello-11
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}

--- a/pkg/client/connector/testdata/addAgentToDeployment/tc-11.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToDeployment/tc-11.output.yaml
@@ -1,0 +1,138 @@
+deployment:
+  apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-11","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+    creationTimestamp: "2021-03-10T07:17:54Z"
+    generation: 2
+    labels:
+      app: hello-11
+    name: hello-11
+    namespace: telepresence-5759
+    resourceVersion: "726"
+    selfLink: /apis/extensions/v1beta1/namespaces/telepresence-5759/deployments/hello-11
+    uid: 1ab652ac-41ca-11eb-b40f-0242ac110002
+  spec:
+    progressDeadlineSeconds: 600
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: hello-11
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: hello-11
+      spec:
+        containers:
+        - image: jmalloc/echo-server:0.1.0
+          imagePullPolicy: IfNotPresent
+          name: echo-server-dont-pick
+          env:
+          - name: PORT
+            value: "9090"
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - image: jmalloc/echo-server:0.1.0
+          imagePullPolicy: IfNotPresent
+          name: echo-server-pick
+          ports:
+          - containerPort: 8080
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        - args:
+          - agent
+          env:
+          - name: TELEPRESENCE_CONTAINER
+            value: echo-server-pick
+          - name: LOG_LEVEL
+            value: debug
+          - name: AGENT_NAME
+            value: hello-11
+          - name: AGENT_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AGENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: APP_PORT
+            value: "8080"
+          - name: MANAGER_HOST
+            value: "traffic-manager.ambassador"
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/stat"
+              - "/tmp/agent/ready"
+          image: localhost:5000/tel2:{{.Version}}
+          imagePullPolicy: IfNotPresent
+          name: traffic-agent
+          ports:
+          - containerPort: 9900
+            name: tel2px-8080
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+  status:
+    availableReplicas: 1
+    conditions:
+    - lastTransitionTime: "2021-03-10T07:18:55Z"
+      lastUpdateTime: "2021-03-10T07:18:55Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2021-03-10T07:18:00Z"
+      lastUpdateTime: "2021-03-10T07:18:55Z"
+      message: ReplicaSet "hello-11-5c9696799" has successfully progressed.
+      reason: NewReplicaSetAvailable
+      status: "True"
+      type: Progressing
+    observedGeneration: 1
+    readyReplicas: 1
+    replicas: 1
+    updatedReplicas: 1
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+    creationTimestamp: "2021-03-10T07:17:54Z"
+    labels:
+      app: hello-11
+    name: hello-11
+    namespace: telepresence-5759
+    resourceVersion: "734"
+    selfLink: /api/v1/namespaces/telepresence-5759/services/hello-11
+    uid: 423ef12f-41ca-11eb-b40f-0242ac110002
+  spec:
+    clusterIP: 10.43.145.123
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: tel2px-8080
+    selector:
+      app: hello-11
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}


### PR DESCRIPTION
## Description
When we are selecting which container the agent for an intercept should be installed on, if we see a container that has no containerPorts, we automatically select that container.  While there are use cases where we do indeed want to select that container, we should make sure there aren't any better fits in the container list by seeing if there's a container where the containerPort matches the targetPort. 

See the test yaml I added for an example of this problem. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
