### PR TITLE
Don't auto-skip mapping of kube-* and ambassador namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ### 2.1.1 (TBD)
 - Bugfix: When looking at the container to intercept, it will check if there's a better match before using a container without containerPorts
+- Bugfix: Telepresence will now map `kube-*` and `ambassador` namespaces by default.
 
 ### 2.2.0 (TBD)
 

--- a/pkg/client/connector/outbound.go
+++ b/pkg/client/connector/outbound.go
@@ -154,7 +154,7 @@ func (kc *k8sCluster) refreshNamespaces(c context.Context, accWait chan<- struct
 
 func (kc *k8sCluster) shouldBeWatched(namespace string) bool {
 	if len(kc.mappedNamespaces) == 0 {
-		return !(namespace == managerNamespace || strings.HasPrefix(namespace, "kube-"))
+		return true
 	}
 	for _, n := range kc.mappedNamespaces {
 		if n == namespace {


### PR DESCRIPTION
Signed-off-by: Thomas Hallgren <thomas@datawire.io>
