### PR TITLE
Handle services that have ports declared without a TargetPort field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: When looking at the container to intercept, it will check if there's a better match before using a container without containerPorts.
 - Bugfix: Telepresence will now map `kube-*` and `ambassador` namespaces by default.
+- Bugfix: Service port declarations that lack a TargetPort field will now correctly default to using the Port field instead.
 - Bugfix: Several DNS fixes.  Notably, introduce a fake "tel2-search" domain that gets replaced with a dynamic DNS search when queried, which fixes DNS for Docker with no `-net host`.
 - Change: Improvements to how we report the requirements for volume mounts; notably, if the requirements are not met then it defaults to `--mount=false`.
 - Change: There has been substantial code cleanup in the "connector" process.

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -297,6 +297,10 @@ func findMatchingPort(dep *kates.Deployment, portName string, svcs []*kates.Serv
 	for _, svc := range svcs {
 		// For now, we only support intercepting one port on a given service.
 		ports := svcPortByName(svc, portName)
+		if len(ports) == 0 {
+			// this may happen when portName is specified but non of the ports match
+			continue
+		}
 		if len(ports) > 1 {
 			return nil, nil, nil, 0, fmt.Errorf(
 				"found matching service with multiple ports for deployment %s. Please specify the service port you want to intercept like so --port local:svcPortName", dep.Name)

--- a/pkg/client/connector/install_test.go
+++ b/pkg/client/connector/install_test.go
@@ -351,6 +351,27 @@ func TestAddAgentToDeployment(t *testing.T) {
 
 			assert.Equal(t, expectedDep, actualDep)
 			assert.Equal(t, expectedSvc, actualSvc)
+
+			expectedDep = tc.InputDeployment.DeepCopy()
+			sanitizeDeployment(expectedDep)
+
+			expectedSvc = tc.InputService.DeepCopy()
+			sanitizeService(expectedSvc)
+
+			_, actualErr = undoDeploymentMods(ctx, actualDep)
+			if !assert.NoError(t, actualErr) {
+				return
+			}
+			sanitizeDeployment(actualDep)
+
+			actualErr = undoServiceMods(ctx, actualSvc)
+			if !assert.NoError(t, actualErr) {
+				return
+			}
+			sanitizeDeployment(actualDep)
+
+			assert.Equal(t, expectedDep, actualDep)
+			assert.Equal(t, expectedSvc, actualSvc)
 		})
 	}
 }

--- a/pkg/client/connector/testdata/addAgentToDeployment/mp-tc-1.input.yaml
+++ b/pkg/client/connector/testdata/addAgentToDeployment/mp-tc-1.input.yaml
@@ -1,0 +1,22 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+  spec:
+    ports:
+      - name: https
+        port: 8080
+      - name: grpc
+        port: 47555
+deployment:
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always

--- a/pkg/client/connector/testdata/addAgentToDeployment/mp-tc-1.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToDeployment/mp-tc-1.output.yaml
@@ -1,0 +1,62 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+  spec:
+    ports:
+      - name: https
+        port: 8080
+        targetPort: tel2px-8080
+      - name: grpc
+        port: 47555
+deployment:
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: app
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always
+          - args:
+              - agent
+            env:
+              - name: TELEPRESENCE_CONTAINER
+                value: app
+              - name: LOG_LEVEL
+                value: debug
+              - name: AGENT_NAME
+                value: app
+              - name: AGENT_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: AGENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: APP_PORT
+                value: "8080"
+              - name: MANAGER_HOST
+                value: "traffic-manager.ambassador"
+            readinessProbe:
+              exec:
+                command:
+                  - "/bin/stat"
+                  - "/tmp/agent/ready"
+            image: localhost:5000/tel2:{{.Version}}
+            imagePullPolicy: IfNotPresent
+            name: traffic-agent
+            ports:
+              - containerPort: 9900
+                name: tel2px-8080
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File


### PR DESCRIPTION
## Description

When a TargetPort field is missing, the target port defaults to the
value of the Port field. This commit ensures that this case is handled
correctly.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 