### PR TITLE
[v2] Uninstall once per deployment instead of per agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.1.2 (TBD)
+- Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.
+
 ### 2.1.1 (March 12, 2021)
 
 - Bugfix: When looking at the container to intercept, it will check if there's a better match before using a container without containerPorts.

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -158,6 +158,9 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 			if err = ki.undoDeploymentMods(c, agent); err != nil {
 				addError(err)
 			}
+			if err = ki.waitForApply(c, ai.Namespace, ai.Name, agent); err != nil {
+				addError(err)
+			}
 		}()
 	}
 	// wait for all agents to be removed


### PR DESCRIPTION
## Checklist
This is a fix I believe for the error we have been seeing transiently in our tests that looks something like this: 
```   
 --- FAIL: TestTelepresence/TestC_Uninstall (18.77s)
        --- FAIL: TestTelepresence/TestC_Uninstall/Uninstalls_all_agents (6.97s)
...
            multi.go:60: level="info" msg="multiple errors:\n  Operation cannot be fulfilled on deployments.apps \"with-probes\": the object has been modified; please apply your changes to the latest version and try again\n  Operation cannot be fulfilled on deployments.apps \"with-probes\": the object has been modified; please apply your changes to the latest version and try again\n" stream="stderr"
            telepresence_test.go:589: level="info" msg="command terminated [\"telepresence\" \"uninstall\" \"--namespace\" \"telepresence-17500\" \"--all-agents\"]"
            telepresence_test.go:220: 
                	Error Trace:	telepresence_test.go:220
                	            				suite.go:77
                	Error:      	Should be empty, but was multiple errors:
                	            	  Operation cannot be fulfilled on deployments.apps "with-probes": the object has been modified; please apply your changes to the latest version and try again
                	            	  Operation cannot be fulfilled on deployments.apps "with-probes": the object has been modified; please apply your changes to the latest version and try again
                	Test:       	TestTelepresence/TestC_Uninstall/Uninstalls_all_agents
            telepresence_test.go:568: level="info" msg="running command: [\"telepresence\" \"quit\"]"
            telepresence_test.go:589: level="info" msg="command terminated [\"telepresence\" \"quit\"]"
FAIL
```
The root cause is that the `with-probes` service has more than 1 replica, so when we do the `uninstall --all-agents`, the `with-probes` service has up to 2 pods still running and in the uninstall `--all-agents` code we try to remove the agent from the deployment per agent (which is 2 since there are two replicas).  So there's a race condition where we are updating the deployment up to n times (where n is the number of replicas), which I believe is why we are seeing this "the object has been modified" error.  

So my suggested fix is to remove the agent from the deployment once per deployment instead of once per agent (which is what our algorithm was already doing in the `telepresence uninstall --agent <svcName>` case).  


<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.