### PR TITLE
[v2] Fix bug where IPv6 routes broke all pfctl rule writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.1.2 (TBD)
 - Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.
 - Bugfix: The list command no longer shows agents from namespaces that aren't mapped.
+- Bugfix: IPv6 routes now work + don't prevent other pfctl rules being written in MacOS
 - Change: Service UID was added to InterceptSpec to better link intercepts and services.
 
 ### 2.1.1 (March 12, 2021)

--- a/pkg/client/daemon/nat/route.go
+++ b/pkg/client/daemon/nat/route.go
@@ -34,9 +34,9 @@ type FirewallRouter interface {
 	GetOriginalDst(conn *net.TCPConn) (host string, err error)
 }
 
-func NewRouter(name string, localIP net.IP) FirewallRouter {
+func NewRouter(name string, localIPv4, localIPv6 net.IP) FirewallRouter {
 	// newRouter is implemented in platform-specific files.
-	return newRouter(name, localIP)
+	return newRouter(name, localIPv4, localIPv6)
 }
 
 type Table struct {

--- a/pkg/client/daemon/nat/route_darwin_test.go
+++ b/pkg/client/daemon/nat/route_darwin_test.go
@@ -88,7 +88,7 @@ func TestSorted(t *testing.T) {
 	c := dlog.NewTestContext(t, false)
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{DisableLogging: true})
 	g.Go("sorted-test", func(c context.Context) (err error) {
-		tr := newRouter("test-table", net.IP{127, 0, 1, 2})
+		tr := newRouter("test-table", net.IP{127, 0, 1, 2}, net.IPv6loopback)
 		if err = tr.Enable(c); err != nil {
 			return err
 		}

--- a/pkg/client/daemon/nat/route_linux.go
+++ b/pkg/client/daemon/nat/route_linux.go
@@ -17,7 +17,7 @@ type iptablesRouter struct {
 	routingTableCommon
 }
 
-func newRouter(name string, _ net.IP) FirewallRouter {
+func newRouter(name string, _, _ net.IP) FirewallRouter {
 	return &iptablesRouter{
 		routingTableCommon: routingTableCommon{
 			Name:     name,

--- a/pkg/client/daemon/nat/route_test.go
+++ b/pkg/client/daemon/nat/route_test.go
@@ -206,7 +206,7 @@ func testMapping(c context.Context, network string, mappings []*mapping, t *test
 		require.NoError(t, checkNoForwardTCP(fmt.Sprintf("%s.%s", network, mapping.from), mapping.forwarded))
 	}
 
-	tr := NewRouter("test-table", net.IP{127, 0, 1, 2})
+	tr := NewRouter("test-table", net.IP{127, 0, 1, 2}, net.IPv6loopback)
 	require.NoError(t, tr.Enable(c))
 	defer func() {
 		_ = tr.Disable(c)

--- a/pkg/client/daemon/outbound.go
+++ b/pkg/client/daemon/outbound.go
@@ -94,7 +94,7 @@ func newOutbound(c context.Context, name string, dnsIP, fallbackIP string, noSea
 		fallbackIP:  fallbackIP,
 		noSearch:    noSearch,
 		tables:      make(map[string]*nat.Table),
-		translator:  nat.NewRouter(name, net.IP{127, 0, 0, 1}),
+		translator:  nat.NewRouter(name, net.IP{127, 0, 0, 1}, net.IPv6loopback),
 		namespaces:  make(map[string]struct{}),
 		domains:     make(map[string][]string),
 		search:      []string{""},


### PR DESCRIPTION
So I think this issue only affects us when people use externalNames where the lookupIP includes an IPv6 address.  This results in routes that have an IP that is IPv6 but our newRouteMessage only supported an IPv4 RTAX_GATEWAY and similarly our pfctl rules only worked for IPv4.  This adds support for both of those.

example of what some pfctl rules look like after they are written:
```
rdr pass on lo0 inet proto tcp from any to 10.43.223.167 port = 80 -> 127.0.0.1 port 62772
rdr pass on lo0 inet proto tcp from any to 10.43.223.167 port = 443 -> 127.0.0.1 port 62772
rdr pass on lo0 inet proto tcp from any to 10.43.233.56 port = 443 -> 127.0.0.1 port 62772
rdr pass on lo0 inet proto tcp from any to 10.43.244.24 port = 8080 -> 127.0.0.1 port 62772
rdr pass on lo0 inet proto tcp from any to 10.43.249.54 port = 2746 -> 127.0.0.1 port 62772
rdr pass on lo0 inet proto tcp from any to 172.217.11.46 -> 127.0.0.1 port 62772
rdr pass on lo0 inet6 proto tcp from any to 2607:f8b0:4006:803::200e -> ::1 port 62772
``` 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested. - I tested it locally but since the firewall is going away and likely the need for this patch very soon, I didn't try to write more exhaustive tests.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.