### PR TITLE
[v2] Add ability to configure timeouts (and future other things)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix: IPv6 routes now work + don't prevent other pfctl rules being written in MacOS
 - Bugfix: Pods with `hostname` and/or `subdomain` are now get correct DNS-names and routes.
 - Change: Service UID was added to InterceptSpec to better link intercepts and services.
+- Feature: All timeouts can now be configured in a <user-config-dir>/telepresence/config.yml file
 
 ### 2.1.1 (March 12, 2021)
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,0 +1,209 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+const configFile = "config.yml"
+
+type Config struct {
+	Timeouts Timeouts `json:"timeouts,omitempty"`
+}
+
+// merge merges this instance with the non-zero values of the given argument. The argument values take priority.
+func (c *Config) merge(o *Config) {
+	c.Timeouts.merge(&o.Timeouts)
+}
+
+type Timeouts struct {
+	// AgentInstall is how long to wait for an agent to be installed (i.e. apply of service and deploy manifests)
+	AgentInstall time.Duration `json:"agentInstall,omitempty"`
+	// Apply is how long to wait for a k8s manifest to be applied
+	Apply time.Duration `json:"apply,omitempty"`
+	// ClusterConnect is the maximum time to wait for a connection to the cluster to be established
+	ClusterConnect time.Duration `json:"clusterConnect,omitempty"`
+	// Intercept is the time to wait for an intercept after the agents has been installed
+	Intercept time.Duration `json:"intercept,omitempty"`
+	// ProxyDial is how long to wait for the proxy to establish an outbound connection
+	ProxyDial time.Duration `json:"proxyDial,omitempty"`
+	// TrafficManagerConnect is how long to wait for the traffic-manager API to connect
+	TrafficManagerConnect time.Duration `json:"trafficManagerConnect,omitempty"`
+}
+
+func CheckTimeout(c context.Context, which *time.Duration, err error) error {
+	cErr := c.Err()
+	if cErr != context.DeadlineExceeded {
+		if cErr != nil {
+			return cErr
+		}
+		return err
+	}
+	var name, text string
+	timeouts := &config.Timeouts
+	switch which {
+	case &timeouts.AgentInstall:
+		name = "agentInstall"
+		text = "agent install"
+	case &timeouts.Apply:
+		name = "apply"
+		text = "apply"
+	case &timeouts.ClusterConnect:
+		name = "clusterConnect"
+		text = "cluster connect"
+	case &timeouts.Intercept:
+		name = "intercept"
+		text = "intercept"
+	case &timeouts.ProxyDial:
+		name = "proxyDial"
+		text = "proxy dial"
+	case &timeouts.TrafficManagerConnect:
+		name = "trafficManagerConnect"
+		text = "traffic manager connect"
+	default:
+		name = "unknown timer"
+		text = "unknown timer"
+	}
+	dir, _ := filelocation.AppUserConfigDir(c)
+	return fmt.Errorf("the %s timed out. The current timeout %s can be configured as timeout.%s in %s",
+		text, *which, name, filepath.Join(dir, configFile))
+}
+
+// UnmarshalYAML caters for the unfortunate fact that time.Duration doesn't do YAML or JSON at all.
+func (d *Timeouts) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
+	var fields map[string]interface{}
+	if err = unmarshal(&fields); err != nil {
+		return err
+	}
+	get := func(key string) (value time.Duration, err error) {
+		if jv, ok := fields[key]; ok {
+			switch jv := jv.(type) {
+			case string:
+				if value, err = time.ParseDuration(jv); err != nil {
+					err = fmt.Errorf("timeouts.%s: %q is not a valid duration", key, jv)
+				}
+			case float64:
+				value = time.Duration(jv * float64(time.Second))
+			case int:
+				value = time.Duration(jv) * time.Second
+			default:
+				err = fmt.Errorf("timeouts.%s: %v is not a valid duration", key, jv)
+			}
+		}
+		return value, err
+	}
+	if d.AgentInstall, err = get("agentInstall"); err != nil {
+		return err
+	}
+	if d.Apply, err = get("apply"); err != nil {
+		return err
+	}
+	if d.ClusterConnect, err = get("clusterConnect"); err != nil {
+		return err
+	}
+	if d.Intercept, err = get("intercept"); err != nil {
+		return err
+	}
+	if d.ProxyDial, err = get("proxyDial"); err != nil {
+		return err
+	}
+	d.TrafficManagerConnect, err = get("trafficManagerConnect")
+	return err
+}
+
+// merge merges this instance with the non-zero values of the given argument. The argument values take priority.
+func (d *Timeouts) merge(o *Timeouts) {
+	if o.AgentInstall != 0 {
+		d.AgentInstall = o.AgentInstall
+	}
+	if o.Apply != 0 {
+		d.Apply = o.Apply
+	}
+	if o.ClusterConnect != 0 {
+		d.ClusterConnect = o.ClusterConnect
+	}
+	if o.Intercept != 0 {
+		d.Intercept = o.Intercept
+	}
+	if o.ProxyDial != 0 {
+		d.ProxyDial = o.ProxyDial
+	}
+	if o.TrafficManagerConnect != 0 {
+		d.TrafficManagerConnect = o.TrafficManagerConnect
+	}
+}
+
+var defaultConfig = Config{Timeouts: Timeouts{
+	ClusterConnect:        20 * time.Second,
+	TrafficManagerConnect: 20 * time.Second,
+	Apply:                 1 * time.Minute,
+	Intercept:             5 * time.Second,
+	AgentInstall:          120 * time.Second,
+	ProxyDial:             5 * time.Second,
+}}
+
+var config *Config
+
+var configOnce = sync.Once{}
+
+// GetConfig returns the Telepresence configuration as stored in filelocation.AppUserConfigDir
+// or filelocation.AppSystemConfigDirs
+//
+func GetConfig(c context.Context) *Config {
+	configOnce.Do(func() {
+		var err error
+		config, err = loadConfig(c)
+		if err != nil {
+			config = &defaultConfig
+		}
+	})
+	return config
+}
+
+func loadConfig(c context.Context) (*Config, error) {
+	dirs, err := filelocation.AppSystemConfigDirs(c)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := defaultConfig // start with a by value copy of the default
+
+	readMerge := func(dir string) error {
+		bs, err := ioutil.ReadFile(filepath.Join(dir, configFile))
+		if err != nil {
+			if err == os.ErrNotExist {
+				err = nil
+			}
+			return err
+		}
+		fileConfig := Config{}
+		if err = yaml.Unmarshal(bs, &fileConfig); err != nil {
+			return err
+		}
+		cfg.merge(&fileConfig)
+		return nil
+	}
+
+	for _, dir := range dirs {
+		if err = readMerge(dir); err != nil {
+			return nil, err
+		}
+	}
+	appDir, err := filelocation.AppUserConfigDir(c)
+	if err != nil {
+		return nil, err
+	}
+	if err = readMerge(appDir); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+func TestGetConfig(t *testing.T) {
+	configs := []string{
+		/* sys1 */ `
+timeouts:
+  agentInstall: 2m10s
+`,
+		/* sys2 */ `
+timeouts:
+  apply: 33s
+`,
+		/* user */ `
+timeouts:
+  clusterConnect: 25
+  proxyDial: 17.0
+`,
+	}
+
+	tmp := t.TempDir()
+	sys1 := filepath.Join(tmp, "sys1")
+	sys2 := filepath.Join(tmp, "sys2")
+	user := filepath.Join(tmp, "user")
+	for i, dir := range []string{sys1, sys2, user} {
+		require.NoError(t, os.MkdirAll(dir, 0700))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(dir, configFile), []byte(configs[i]), 0600))
+	}
+
+	c := dlog.NewTestContext(t, false)
+	c = filelocation.WithAppSystemConfigDirs(c, []string{sys1, sys2})
+	c = filelocation.WithAppUserConfigDir(c, user)
+
+	cfg := GetConfig(c)
+	to := &cfg.Timeouts
+	assert.Equal(t, 2*time.Minute+10*time.Second, to.AgentInstall) // from sys1
+	assert.Equal(t, 33*time.Second, to.Apply)                      // from sys2
+	assert.Equal(t, 25*time.Second, to.ClusterConnect)             // from user
+	assert.Equal(t, 17*time.Second, to.ProxyDial)                  // from user
+	assert.Equal(t, defaultConfig.Timeouts.Intercept, to.Intercept)
+	assert.Equal(t, defaultConfig.Timeouts.TrafficManagerConnect, to.TrafficManagerConnect)
+}

--- a/pkg/client/connector/service.go
+++ b/pkg/client/connector/service.go
@@ -290,13 +290,13 @@ func (s *service) connectWorker(c context.Context, cr *rpc.ConnectRequest, k8sCo
 
 	dlog.Info(c, "Connecting to k8s cluster...")
 	cluster, err := func() (*k8sCluster, error) {
+		c, cancel := context.WithTimeout(c, client.GetConfig(c).Timeouts.ClusterConnect)
+		defer cancel()
 		cluster, err := newKCluster(c, k8sConfig, mappedNamespaces, s.daemon)
 		if err != nil {
 			return nil, err
 		}
 		s.clusterRequest <- cluster
-		c, cancel := context.WithTimeout(c, 10*time.Second)
-		defer cancel()
 		if err := cluster.waitUntilReady(c); err != nil {
 			return nil, err
 		}

--- a/pkg/filelocation/app.go
+++ b/pkg/filelocation/app.go
@@ -63,6 +63,9 @@ func AppUserCacheDir(ctx context.Context) (string, error) {
 // If the location cannot be determined (for example, $HOME is not defined),
 // then it will return an error.
 func AppUserConfigDir(ctx context.Context) (string, error) {
+	if untyped := ctx.Value(configCtxKey{}); untyped != nil {
+		return untyped.(string), nil
+	}
 	userDir, err := UserConfigDir(ctx)
 	if err != nil {
 		return "", err
@@ -79,6 +82,9 @@ func AppUserConfigDir(ctx context.Context) (string, error) {
 //
 // If the location cannot be determined, then it will return an error.
 func AppSystemConfigDirs(ctx context.Context) ([]string, error) {
+	if untyped := ctx.Value(sysConfigsCtxKey{}); untyped != nil {
+		return untyped.([]string), nil
+	}
 	dirs, err := systemConfigDirs(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/filelocation/ctx.go
+++ b/pkg/filelocation/ctx.go
@@ -32,8 +32,22 @@ func WithUserHomeDir(ctx context.Context, home string) context.Context {
 
 type logCtxKey struct{}
 
-// WithAppUserLogdir spoofs the AppUserLogDir.  This is useful for testing, or for when logging to a
+// WithAppUserLogDir spoofs the AppUserLogDir.  This is useful for testing, or for when logging to a
 // normal user's logs as root.
 func WithAppUserLogDir(ctx context.Context, logdir string) context.Context {
 	return context.WithValue(ctx, logCtxKey{}, logdir)
+}
+
+type configCtxKey struct{}
+
+// WithAppUserConfigDir spoofs the AppUserConfigDir.  This is useful for testing
+func WithAppUserConfigDir(ctx context.Context, configDir string) context.Context {
+	return context.WithValue(ctx, configCtxKey{}, configDir)
+}
+
+type sysConfigsCtxKey struct{}
+
+// WithAppSystemConfigDirs spoofs the AppSystemConfigDirs.  This is useful for testing
+func WithAppSystemConfigDirs(ctx context.Context, configDirs []string) context.Context {
+	return context.WithValue(ctx, sysConfigsCtxKey{}, configDirs)
 }


### PR DESCRIPTION
## Description

Adds a generic configuration ability which reads a `config.yml` file
stored under the users config directory. Files under the system config
directories will also be considered on platforms that supports this.

The config contains only timeouts at present but it's expected to grow.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 