### PR TITLE
[v2] Defer startup of k8s watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.1.3 (TBD)
+- Bugfix: Connects to Minikube/Hyperkit no longer fails intermittently.
+
 ### 2.1.2 (March 19, 2021)
 - Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.
 - Bugfix: The list command no longer shows agents from namespaces that aren't mapped.

--- a/pkg/client/connector/k8s_cluster.go
+++ b/pkg/client/connector/k8s_cluster.go
@@ -103,8 +103,8 @@ func (kc *k8sCluster) portForwardAndThen(
 
 	sc := bufio.NewScanner(out)
 
-	// Give port-forward 10 seconds to produce the correct output and spawn the next process
-	timer := time.AfterFunc(10*time.Second, func() {
+	// Give port-forward at least the port-forward timeout to produce the correct output and spawn the next process
+	timer := time.AfterFunc(client.GetConfig(c).Timeouts.TrafficManagerConnect, func() {
 		cancel()
 	})
 


### PR DESCRIPTION
## Description

Starting the k8s watchers in parallel with the kubectl port-forward
creates intermittent problems on some platforms (most notably
Minikube with Hyperkit). Deferring until the traffic-manager is
fully connected lessens the concurrency at connect time and that
makes the intermittent problem go away.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 