### PR TITLE
[v2] Make /var/run/secrets/kubenetes.io available to mount remotely.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.1.3 (TBD)
 - Bugfix: Connects to Minikube/Hyperkit no longer fails intermittently.
+- Bugfix: Telepresence will now make /var/run/secrets/kubernetes.io available when mounting remote volumes.
 
 ### 2.1.2 (March 19, 2021)
 - Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -20,6 +20,8 @@ RUN \
   echo -e "ClientAliveInterval 1\nGatewayPorts yes\nPermitEmptyPasswords yes\nPort 8022\nClientAliveCountMax 10\nPermitRootLogin yes\n" >> /etc/ssh/sshd_config && \
   chmod -R g+r /etc/ssh && \
   mkdir /home/telepresence && \
+  mkdir /tel_app_mounts && \
+  chmod 0770 /tel_app_mounts && \
   chmod g+w /run && \
   echo "telepresence::1000:0:Telepresence User:/home/telepresence:/bin/ash" >> /etc/passwd
 

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -157,6 +157,7 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 			}
 			if err = ki.undoDeploymentMods(c, agent); err != nil {
 				addError(err)
+				return
 			}
 			if err = ki.waitForApply(c, ai.Namespace, ai.Name, agent); err != nil {
 				addError(err)
@@ -609,8 +610,11 @@ func (ki *installer) undoDeploymentMods(c context.Context, dep *kates.Deployment
 func undoDeploymentMods(c context.Context, dep *kates.Deployment) (string, error) {
 	var actions deploymentActions
 	ok, err := getAnnotation(dep, &actions)
-	if !ok {
+	if err != nil {
 		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("deployment %s.%s has no agent installed", dep.Name, dep.Namespace)
 	}
 
 	if err = actions.undo(dep); err != nil {

--- a/pkg/client/connector/intercept.go
+++ b/pkg/client/connector/intercept.go
@@ -497,10 +497,10 @@ func (tm *trafficManager) workerMountForwardIntercept(ctx context.Context, mf mo
 				"-oConnectTimeout=10",
 				"-oStrictHostKeyChecking=no",     // don't bother checking the host key...
 				"-oUserKnownHostsFile=/dev/null", // and since we're not checking it, don't bother remembering it either
-
-				"-p", localPort, // port to connect to
+				"-p", localPort,                  // port to connect to
 
 				// mount directives
+				"-o", "follow_symlinks",
 				"telepresence@localhost:" + telAppMountPoint, // remote user and what to mount
 				mountPoint, // where to mount it
 			}


### PR DESCRIPTION
## Description

Kubernetes puts things in the `/var/run/secrets/kubenetes.io` folder that are essential to get
access to when doing intercepts. So this folder must be available as a remote mount point
even though no `mountPoints` entry exists in the pod spec.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 