### PR TITLE
[v2] Upgrade dlib, consistently use dlib/dexec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,8 +27,10 @@ issues:
 linters-settings:
   depguard:
     list-type: blacklist
+    include-go-root: true
     packages-with-error-message:
-      - github.com/golang/protobuf: "Use google.golang.org/protobuf instead of github.com/golang/protobuf"
+      - os/exec:                    "Use `github.com/datawire/dlib/dexec` instead of `os/exec`"
+      - github.com/golang/protobuf: "Use `google.golang.org/protobuf` instead of `github.com/golang/protobuf`"
 
   gocyclo:
     min-complexity: 35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Connects to Minikube/Hyperkit no longer fails intermittently.
 - Bugfix: Telepresence will now make /var/run/secrets/kubernetes.io available when mounting remote volumes.
 - Bugfix: Hiccups in the connection to the cluster will no longer cause the connector to shut down; it now retries properly.
+- Bugfix: Fix a crash when binary dependencies are missing.
 
 ### 2.1.2 (March 19, 2021)
 - Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/datawire/ambassador v1.11.1
-	github.com/datawire/dlib v1.2.0
+	github.com/datawire/dlib v1.2.1
 	github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/godbus/dbus/v5 v5.0.4-0.20201218172701-b3768b321399
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/telepresenceio/telepresence/rpc/v2 v2.1.2
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2
 github.com/datawire/ambassador v1.11.1 h1:2TbJKxb5Q1j/HH78ry4hjqOMKisEyIGfYzBy0OstYKQ=
 github.com/datawire/ambassador v1.11.1/go.mod h1:V7hZ5338X79YZ4Gr1jNStqZhDsY/HFSiypimmOdq688=
 github.com/datawire/dlib v1.1.0/go.mod h1:aCzh74rJ3kOireYbg4gH0CuD48/xA4G+LuHhkpcqo1s=
-github.com/datawire/dlib v1.2.0 h1:ZeUvQHfwm+PycuSl/wH3Dz/jQt/c94kHpy7hdmK93E4=
-github.com/datawire/dlib v1.2.0/go.mod h1:t0upKFHApJskdVFH/gyksG5+vMCl0GCKeEZIEJBBv4g=
+github.com/datawire/dlib v1.2.1 h1:a5YOsQfzlzpcAkRvNOL4xY4r6c1jyixZSJF0iz3kS3M=
+github.com/datawire/dlib v1.2.1/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a h1:VHPuM0sSTEHfjtSX86XQqZKJNUWTWVu2BuV6X8SdGUk=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a/go.mod h1:H8uUmE8qqo7z9u30MYB9riLyRckPHOPBk9ZdCuH+dQQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -815,8 +815,8 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
-golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/client/cli/run.go
+++ b/pkg/client/cli/run.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	// nolint:depguard // TODO: switch this stuff over to dexec
+	"os/exec"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
 )

--- a/pkg/client/cmd_error.go
+++ b/pkg/client/cmd_error.go
@@ -2,13 +2,14 @@ package client
 
 import (
 	"fmt"
-	"os/exec"
+
+	"github.com/datawire/dlib/dexec"
 )
 
 // RunError checks if the given err is a *exit.ExitError, and if so, extracts
 // Stderr and the ExitCode from it.
 func RunError(err error) error {
-	if ee, ok := err.(*exec.ExitError); ok {
+	if ee, ok := err.(*dexec.ExitError); ok {
 		if len(ee.Stderr) > 0 {
 			err = fmt.Errorf("%s, exit code %d", string(ee.Stderr), ee.ExitCode())
 		} else {

--- a/pkg/client/connector/install_test.go
+++ b/pkg/client/connector/install_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -67,7 +66,12 @@ func showArgs(exe string, args []string) {
 
 func capture(t *testing.T, exe string, args ...string) string {
 	showArgs(exe, args)
-	cmd := exec.Command(exe, args...)
+	ctx := context.Background()
+	if t != nil {
+		ctx = dlog.NewTestContext(t, false)
+	}
+	cmd := dexec.CommandContext(ctx, exe, args...)
+	cmd.DisableLogging = true
 	out, err := cmd.CombinedOutput()
 	sout := string(out)
 	if err != nil {

--- a/pkg/client/daemon/dns/flush_linux.go
+++ b/pkg/client/daemon/dns/flush_linux.go
@@ -2,14 +2,15 @@ package dns
 
 import (
 	"context"
-	"os/exec"
+
+	"github.com/datawire/dlib/dexec"
 )
 
 // Flush makes an attempt to flush the host's DNS cache
-func Flush(c context.Context) {
+func Flush(ctx context.Context) {
 	// GNU libc Name Service Cache Daemon
-	_ = exec.Command("nscd", "--invalidate=hosts").Run()
+	_ = dexec.CommandContext(ctx, "nscd", "--invalidate=hosts").Run()
 
 	// systemd-resolved
-	_ = exec.Command("resolvectl", "flush-caches").Run()
+	_ = dexec.CommandContext(ctx, "resolvectl", "flush-caches").Run()
 }

--- a/pkg/client/daemon/nat/route.go
+++ b/pkg/client/daemon/nat/route.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // FirewallRouter is an interface to what is essentially a routing table, but implemented in the
@@ -93,3 +94,12 @@ type routingTableCommon struct {
 	// an IP, we route to a localhost port number.
 	mappings map[Destination]*Route
 }
+
+type withoutCancel struct {
+	context.Context
+}
+
+func (withoutCancel) Deadline() (deadline time.Time, ok bool) { return }
+func (withoutCancel) Done() <-chan struct{}                   { return nil }
+func (withoutCancel) Err() error                              { return nil }
+func (c withoutCancel) String() string                        { return fmt.Sprintf("%v.WithoutCancel", c.Context) }

--- a/pkg/client/daemon/nat/route_darwin.go
+++ b/pkg/client/daemon/nat/route_darwin.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	"golang.org/x/net/route"
 	"golang.org/x/sys/unix"
@@ -45,15 +44,6 @@ func newRouter(name string, localIPv4, localIPv6 net.IP) *pfRouter {
 		localIPv6: localIPv6,
 	}
 }
-
-type withoutCancel struct {
-	context.Context
-}
-
-func (withoutCancel) Deadline() (deadline time.Time, ok bool) { return }
-func (withoutCancel) Done() <-chan struct{}                   { return nil }
-func (withoutCancel) Err() error                              { return nil }
-func (c withoutCancel) String() string                        { return fmt.Sprintf("%v.WithoutCancel", c.Context) }
 
 func pfCmd(ctx context.Context, args []string) *dexec.Cmd {
 	// We specifically don't want to use the cancellation of 'ctx' for pfctl, because


### PR DESCRIPTION
## Description

We got a report of the https://github.com/datawire/dlib/pull/14 crash happening in a real telepresence install on CentOS 7, so pull in the fix from dlib.

And while we're at it, now that the bug is fixed, switch (most) everything over to dexec instead of os/exec.  I left `run.go` alone though, because it's pretty hairy.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - yes
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no applicable changes
 - [x] My change is adequately tested. - CI should do it
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks