### PR TITLE
Upgrade to a newer Alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix: Telepresence will now make /var/run/secrets/kubernetes.io available when mounting remote volumes.
 - Bugfix: Hiccups in the connection to the cluster will no longer cause the connector to shut down; it now retries properly.
 - Bugfix: Fix a crash when binary dependencies are missing.
+- Security: Upgrade to a newer OpenSSL, to address OpenSSL CVE-2021-23840.
 
 ### 2.1.2 (March 19, 2021)
 - Bugfix: Uninstalling agents now only happens once per deployment instead of once per agent.

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Datawire. All rights reserved.
+# Copyright 2020-2021 Datawire. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,19 @@
 # limitations under the License.
 
 # Set up sshd. All this can go away once we stop using sshd.
-FROM alpine:3.6 as tel2-base
+FROM alpine:3.13 as tel2-base
 RUN \
   apk add --no-cache openssh ca-certificates && \
   ssh-keygen -A && \
-  echo -e "ClientAliveInterval 1\nGatewayPorts yes\nPermitEmptyPasswords yes\nPort 8022\nClientAliveCountMax 10\nPermitRootLogin yes\n" >> /etc/ssh/sshd_config && \
+  sed -i \
+    -e 's/^AllowTcpForwarding no/AllowTcpForwarding yes/' \
+    -e 's/^GatewayPorts no/GatewayPorts yes/' \
+    -e '$aClientAliveInterval 1' \
+    -e '$aPermitEmptyPasswords yes' \
+    -e '$aPort 8022' \
+    -e '$aClientAliveCountMax 10' \
+    -e '$aPermitRootLogin yes' \
+    /etc/ssh/sshd_config && \
   chmod -R g+r /etc/ssh && \
   mkdir /home/telepresence && \
   mkdir /tel_app_mounts && \


### PR DESCRIPTION
## Description

Addresses https://github.com/datawire/telepresence2-proprietary/issues/53

I built the image locally, `docker exec --rm -it --entrypoint=/bin/sh` it and checked that they have a new OpenSSL:
```console
/ $ for file in /lib/libssl.so.* /lib/libcrypto.so.*; do version=$(grep 'OpenSSL 1' $file); echo "$file: $version"; done
/lib/libssl.so.1.1: OpenSSL 1.1.1k  25 Mar 2021
/lib/libcrypto.so.1.1: OpenSSL 1.1.1k  25 Mar 2021
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - yes
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no applicable change
 - [x] My change is adequately tested. - ci should do it, see version check above
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
