### PR TITLE
[v2] Fix ReplicaSet intercept race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.1.4 (TBD)
+
+- Bugfix: Fix race condition that occurred when intercepting a ReplicaSet while another pod was terminating in the same namespace (this fixes a transient test failure)
+
 ### 2.1.3 (March 29, 2021)
 
 - Feature: Telepresence now supports intercepting ReplicaSets (that aren't owned by a Deployment)

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -676,6 +676,11 @@ func (ki *installer) refreshReplicaSet(c context.Context, name, namespace string
 	}
 
 	for _, podName := range podNames {
+		// We only care about pods that are associated with the ReplicaSet
+		// so we filter them out here
+		if !strings.Contains(podName, name) {
+			continue
+		}
 		podInfo, err := ki.findPod(c, namespace, podName)
 		if err != nil {
 			return err


### PR DESCRIPTION
When refreshing the ReplicaSet pods, it was looking at all pods in the
namespace so if we had a pod that was terminating, the ki.findPod call
would error when it got to that pod. This has been fixed by only calling
findPod on pods that have the ReplicaSet name in their name.  This was
causing
TestTelepresence/TestB_Connected/TestG_SuccessfullyInterceptsReplicaSet
to be a little flakey.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.