### PR TITLE
Fixes containerPort bug when intercepting RS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.1.4 (TBD)
 
 - Bugfix: Fix race condition that occurred when intercepting a ReplicaSet while another pod was terminating in the same namespace (this fixes a transient test failure)
+- Bugfix: Fix error when intercepting a ReplicaSet requires the containerPort to be hidden.
 
 ### 2.1.3 (March 29, 2021)
 

--- a/pkg/client/connector/install_actions.go
+++ b/pkg/client/connector/install_actions.go
@@ -164,7 +164,7 @@ func GetPodTemplateFromObject(obj kates.Object) (*kates.PodTemplateSpec, string,
 }
 
 // A makePortSymbolicAction replaces the numeric TargetPort of a ServicePort with a generated
-// symbolic name so that an traffic-agent in a designated Deployment can reference the symbol
+// symbolic name so that an traffic-agent in a designated Workload can reference the symbol
 // and then use the original port number as the port to forward to when it is not intercepting.
 type makePortSymbolicAction struct {
 	PortName     string
@@ -586,13 +586,13 @@ func swapPortName(cn *kates.Container, p *corev1.ContainerPort, from, to string)
 	p.Name = to
 }
 
-func (hcp *hideContainerPortAction) Do(dep kates.Object) error {
-	return hcp.do(dep.(*kates.Deployment))
+func (hcp *hideContainerPortAction) Do(obj kates.Object) error {
+	return hcp.do(obj)
 }
 
-func (hcp *hideContainerPortAction) do(dep *kates.Deployment) error {
+func (hcp *hideContainerPortAction) do(obj kates.Object) error {
 	// New name must be max 15 characters long
-	cn, p, err := hcp.getPort(dep, hcp.PortName)
+	cn, p, err := hcp.getPort(obj, hcp.PortName)
 	if err != nil {
 		return err
 	}
@@ -611,17 +611,17 @@ func (hcp *hideContainerPortAction) ExplainUndo(_ kates.Object, out io.Writer) {
 		hcp.HiddenName, hcp.ContainerName, hcp.PortName)
 }
 
-func (hcp *hideContainerPortAction) IsDone(dep kates.Object) bool {
-	_, _, err := hcp.getPort(dep.(*kates.Deployment), hcp.HiddenName)
+func (hcp *hideContainerPortAction) IsDone(obj kates.Object) bool {
+	_, _, err := hcp.getPort(obj, hcp.HiddenName)
 	return err == nil
 }
 
-func (hcp *hideContainerPortAction) Undo(dep kates.Object) error {
-	return hcp.undo(dep.(*kates.Deployment))
+func (hcp *hideContainerPortAction) Undo(obj kates.Object) error {
+	return hcp.undo(obj)
 }
 
-func (hcp *hideContainerPortAction) undo(dep *kates.Deployment) error {
-	cn, p, err := hcp.getPort(dep, hcp.HiddenName)
+func (hcp *hideContainerPortAction) undo(obj kates.Object) error {
+	cn, p, err := hcp.getPort(obj, hcp.HiddenName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I was testing some other workloads and noticed that I had not fully finished the install_actions.go changes to work with all types of ReplicaSets 🤦‍♂️  This fixes that.

The error:
```
(⎈ |donnyyung-0:stateful)➜  ~/go/telepresenceio git:(donnyyung/fix-rs-containerport) ✗ telepresence intercept rs-echo --port 3000
telepresence: error: rpc error: code = Unknown desc = PANIC: interface conversion: kates.Object is *v1.ReplicaSet, not *v1.Deployment
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.