### PR TITLE
[v2] Add support for StatefulSets 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 2.1.4 (TBD)
 
 - Feature: `telepresence status` has been enhanced to provide more information.  In particular, it now provides separate information on the daemon and connector processes, as well as showing login status.
+- Feature: Telepresence now supports intercepting StatefulSets
+- Change: Telepresence necessary RBAC has been refined to support StatefulSets and now requires "get,list,update" for StatefulSets
 - Change: Telepresence no longer requires that port 1080 must be available.
 - Change: Telepresence now makes use of refresh tokens to avoid requiring the user to manually log in so often.
 - Bugfix: Fix race condition that occurred when intercepting a ReplicaSet while another pod was terminating in the same namespace (this fixes a transient test failure)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/datawire/ambassador v1.12.2-0.20210325164646-9d653a4f2cfa
+	github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977
 	github.com/datawire/dlib v1.2.1
 	github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/blang/semver v3.5.0+incompatible
-	github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977
+	github.com/datawire/ambassador v1.12.3-0.20210401195424-3d91930ec3fd
 	github.com/datawire/dlib v1.2.1
 	github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
-github.com/datawire/ambassador v1.12.2-0.20210325164646-9d653a4f2cfa h1:sd5jtI+QMQQRghLh2zsEMTnp+iqnSc3jcbjkkh6hZ0U=
-github.com/datawire/ambassador v1.12.2-0.20210325164646-9d653a4f2cfa/go.mod h1:2grBLdYgILzrgTpenDMB5OeyhObIUaT+KwkLkZI1KDE=
+github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977 h1:w5AavQPFbXbLSIBn2OLkbI65aVi44PJsVHRvUWfDxa0=
+github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977/go.mod h1:2grBLdYgILzrgTpenDMB5OeyhObIUaT+KwkLkZI1KDE=
 github.com/datawire/dlib v1.2.0/go.mod h1:t0upKFHApJskdVFH/gyksG5+vMCl0GCKeEZIEJBBv4g=
 github.com/datawire/dlib v1.2.1 h1:a5YOsQfzlzpcAkRvNOL4xY4r6c1jyixZSJF0iz3kS3M=
 github.com/datawire/dlib v1.2.1/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
-github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977 h1:w5AavQPFbXbLSIBn2OLkbI65aVi44PJsVHRvUWfDxa0=
-github.com/datawire/ambassador v1.12.2-0.20210329195933-976e68296977/go.mod h1:2grBLdYgILzrgTpenDMB5OeyhObIUaT+KwkLkZI1KDE=
+github.com/datawire/ambassador v1.12.3-0.20210401195424-3d91930ec3fd h1:yt9n2dnenlvOeTyOHuMKQRrFjFJNlMAURVrCiTUJjCM=
+github.com/datawire/ambassador v1.12.3-0.20210401195424-3d91930ec3fd/go.mod h1:2grBLdYgILzrgTpenDMB5OeyhObIUaT+KwkLkZI1KDE=
 github.com/datawire/dlib v1.2.0/go.mod h1:t0upKFHApJskdVFH/gyksG5+vMCl0GCKeEZIEJBBv4g=
 github.com/datawire/dlib v1.2.1 h1:a5YOsQfzlzpcAkRvNOL4xY4r6c1jyixZSJF0iz3kS3M=
 github.com/datawire/dlib v1.2.1/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=

--- a/k8s/client_rbac.yaml
+++ b/k8s/client_rbac.yaml
@@ -1,0 +1,57 @@
+# This should be the minium RBAC that is needed for users (not operators) to
+# use telepresence.  These objects are used in a portion of our tests to
+# determine if we have changed the minimal rbac profile. If you need to change
+# this file, you must also change it in the docs.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: telepresence-test-developer
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: telepresence-role
+rules:
+- apiGroups:
+  - ""
+  resources: ["pods"]
+  verbs: ["get", "list", "create", "watch", "delete"]
+- apiGroups:
+  - ""
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups:
+  - ""
+  resources: ["pods/portforward"]
+  verbs: ["create"]
+- apiGroups:
+  - "apps"
+  resources: ["deployments", "replicasets", "statefulsets"]
+  verbs: ["get", "list", "update"]
+- apiGroups:
+  - "getambassador.io"
+  resources: ["hosts", "mappings"]
+  verbs: ["*"]
+- apiGroups:
+  - ""
+  resources: ["endpoints"]
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - ""
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telepresence-clusterrolebinding
+subjects:
+- name: telepresence-test-developer
+  kind: ServiceAccount
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: telepresence-role
+  kind: ClusterRole

--- a/k8s/echo-easy.yaml
+++ b/k8s/echo-easy.yaml
@@ -34,3 +34,7 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/k8s/echo-w-agent.yaml
+++ b/k8s/echo-w-agent.yaml
@@ -46,3 +46,7 @@ spec:
               value: echo-w-agent
             - name: APP_PORT
               value: "8080"
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/k8s/echo-w-subdomain.yaml
+++ b/k8s/echo-w-subdomain.yaml
@@ -36,3 +36,7 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/k8s/rs-echo.yaml
+++ b/k8s/rs-echo.yaml
@@ -33,3 +33,7 @@ spec:
           image: jmalloc/echo-server
           ports:
             - containerPort: 8080
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/k8s/ss-echo.yaml
+++ b/k8s/ss-echo.yaml
@@ -34,3 +34,7 @@ spec:
           image: jmalloc/echo-server
           ports:
             - containerPort: 8080
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/k8s/ss-echo.yaml
+++ b/k8s/ss-echo.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ss-echo
+spec:
+  type: ClusterIP
+  selector:
+    service: ss-echo
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ss-echo
+  labels:
+    service: ss-echo
+spec:
+  serviceName: "ss-echo"
+  replicas: 2
+  selector:
+    matchLabels:
+      service: ss-echo
+  template:
+    metadata:
+      labels:
+        service: ss-echo
+    spec:
+      containers:
+        - name: ss-echo
+          image: jmalloc/echo-server
+          ports:
+            - containerPort: 8080

--- a/pkg/client/cli/list.go
+++ b/pkg/client/cli/list.go
@@ -63,7 +63,7 @@ func (s *listInfo) list(cmd *cobra.Command, _ []string) error {
 	}
 	stdout := cmd.OutOrStdout()
 	if len(r.Workloads) == 0 {
-		fmt.Fprintln(stdout, "No Workloads (Deployments or ReplicaSets)")
+		fmt.Fprintln(stdout, "No Workloads (Deployments, StatefulSets, or ReplicaSets)")
 		return nil
 	}
 

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -662,7 +662,7 @@ func (ts *telepresenceSuite) applyEchoService(c context.Context, name string) er
 }
 
 func (ts *telepresenceSuite) waitForService(c context.Context, name string, port int) error {
-	c, cancel := context.WithTimeout(c, 30*time.Second)
+	c, cancel := context.WithTimeout(c, 60*time.Second)
 	defer cancel()
 
 	// Since this function can be called multiple times in parallel
@@ -672,7 +672,7 @@ func (ts *telepresenceSuite) waitForService(c context.Context, name string, port
 	reg := regexp.MustCompile("[^a-zA-Z0-9-]+")
 	k8sSafeName := reg.ReplaceAllString(name, "")
 	containerName := fmt.Sprintf("curl-%s-from-cluster", k8sSafeName)
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 60; i++ {
 		time.Sleep(time.Second)
 		err := ts.kubectl(c, "run", containerName, "--context", "default", "--rm", "-it",
 			"--image=docker.io/pstauffer/curl", "--restart=Never", "--",

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -391,7 +391,7 @@ func (cs *connectedSuite) TestI_ListOnlyMapped() {
 
 	stdout, stderr = telepresence(cs.T(), "list", "--namespace", cs.ns())
 	require.Empty(stderr)
-	require.Contains(stdout, "No Workloads (Deployments or ReplicaSets)")
+	require.Contains(stdout, "No Workloads (Deployments, StatefulSets, or ReplicaSets)")
 
 	stdout, stderr = telepresence(cs.T(), "connect", "--mapped-namespaces", "all")
 	require.Empty(stderr)
@@ -399,7 +399,7 @@ func (cs *connectedSuite) TestI_ListOnlyMapped() {
 
 	stdout, stderr = telepresence(cs.T(), "list", "--namespace", cs.ns())
 	require.Empty(stderr)
-	require.NotContains(stdout, "No Workloads (Deployments or ReplicaSets)")
+	require.NotContains(stdout, "No Workloads (Deployments, StatefulSets, or ReplicaSets)")
 }
 
 func (cs *connectedSuite) TestJ_Uninstall() {
@@ -449,7 +449,7 @@ func (cs *connectedSuite) TestJ_Uninstall() {
 		require.Eventually(
 			func() bool {
 				stdout, _ := telepresence(cs.T(), "list", "--namespace", cs.ns(), "--agents")
-				return stdout == "No Workloads (Deployments or ReplicaSets)"
+				return stdout == "No Workloads (Deployments, StatefulSets, or ReplicaSets)"
 			},
 			30*time.Second,     // waitFor
 			2*time.Millisecond, // polling interval

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -831,6 +831,12 @@ func addAgentToWorkload(
 	if err != nil {
 		return nil, nil, err
 	}
+	if matchingService.Spec.ClusterIP == "None" {
+		dlog.Debugf(c,
+			"Intercepts of headless service: %s likely won't work as expected "+
+				"see https://github.com/telepresenceio/telepresence/issues/1632",
+			matchingService.Name)
+	}
 	dlog.Debugf(c, "using service %q port %q when intercepting %s %q",
 		matchingService.Name,
 		func() string {

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -309,8 +308,9 @@ func (ki *installer) findMatchingServices(portName, svcName, namespace string, l
 	return matching
 }
 
-func findMatchingPort(obj kates.Object, portName string, svcs []*kates.Service) (
-	service *kates.Service,
+// findMathingPort find the matching container associated with portName in
+// the given service.
+func findMatchingPort(obj kates.Object, portName string, svc *kates.Service) (
 	sPort *kates.ServicePort,
 	cn *kates.Container,
 	cPortIndex int,
@@ -318,111 +318,73 @@ func findMatchingPort(obj kates.Object, portName string, svcs []*kates.Service) 
 ) {
 	podTemplate, objType, err := GetPodTemplateFromObject(obj)
 	if err != nil {
-		return nil, nil, nil, 0, err
+		return nil, nil, 0, err
 	}
-	// Sort slice of services so that the ones in the same namespace get prioritized.
-	sort.Slice(svcs, func(i, j int) bool {
-		a := svcs[i]
-		b := svcs[j]
-		objNamespace := obj.GetNamespace()
-		if a.Namespace != b.Namespace {
-			if a.Namespace == objNamespace {
-				return true
-			}
-			if b.Namespace == objNamespace {
-				return false
-			}
-			return a.Namespace < b.Namespace
-		}
-		return a.Name < b.Name
-	})
 
 	cns := podTemplate.Spec.Containers
-	for _, svc := range svcs {
-		// For now, we only support intercepting one port on a given service.
-		ports := svcPortByName(svc, portName)
-		if len(ports) == 0 {
-			// this may happen when portName is specified but none of the ports match
-			continue
-		}
-		if len(ports) > 1 {
-			return nil, nil, nil, 0, fmt.Errorf(`
+	// For now, we only support intercepting one port on a given service.
+	ports := svcPortByName(svc, portName)
+	switch numPorts := len(ports); {
+	case numPorts == 0:
+		// this may happen when portName is specified but none of the ports match
+		return nil, nil, 0, fmt.Errorf(`
+found no services with a port that matches a container in %s %s.%s`,
+			objType, obj.GetName(), obj.GetNamespace())
+
+	case numPorts > 1:
+		return nil, nil, 0, fmt.Errorf(`
 found matching service with multiple ports for %s %s.%s. Please specify the
 service port you want to intercept like so --port local:svcPortName`,
-				objType, obj.GetName(), obj.GetNamespace())
-		}
-		port := ports[0]
-		var msp *corev1.ServicePort
-		var ccn *corev1.Container
-		var cpi int
+			objType, obj.GetName(), obj.GetNamespace())
+	default:
+	}
+	port := ports[0]
+	var matchingServicePort *corev1.ServicePort
+	var matchingContainer *corev1.Container
+	var containerPortIndex int
 
-		if port.TargetPort.Type == intstr.String {
-			portName := port.TargetPort.StrVal
-			for ci := 0; ci < len(cns) && ccn == nil; ci++ {
-				cn := &cns[ci]
-				for pi := range cn.Ports {
-					if cn.Ports[pi].Name == portName {
-						msp = port
-						ccn = cn
-						cpi = pi
-						break
-					}
-				}
-			}
-		} else {
-			portNum := port.TargetPort.IntVal
-			// Here we are using cpi <=0 instead of ccn == nil because if a
-			// container has no ports, we want to use it but we don't want
-			// to break out of the loop looking at containers in case there
-			// is a better fit.  Currently, that is a container where the
-			// ContainerPort matches the targetPort in the service.
-			for ci := 0; ci < len(cns) && cpi <= 0; ci++ {
-				cn := &cns[ci]
-				if len(cn.Ports) == 0 {
-					msp = port
-					ccn = cn
-					cpi = -1
-				}
-				for pi := range cn.Ports {
-					if cn.Ports[pi].ContainerPort == portNum {
-						msp = port
-						ccn = cn
-						cpi = pi
-						break
-					}
+	if port.TargetPort.Type == intstr.String {
+		portName := port.TargetPort.StrVal
+		for ci := 0; ci < len(cns) && matchingContainer == nil; ci++ {
+			cn := &cns[ci]
+			for pi := range cn.Ports {
+				if cn.Ports[pi].Name == portName {
+					matchingServicePort = port
+					matchingContainer = cn
+					containerPortIndex = pi
+					break
 				}
 			}
 		}
-
-		switch {
-		case msp == nil:
-			continue
-		case sPort == nil:
-			service = svc
-			sPort = msp
-			cPortIndex = cpi
-			cn = ccn
-		case sPort.TargetPort == msp.TargetPort:
-			// Keep the chosen one
-		case sPort.TargetPort.Type == intstr.String && msp.TargetPort.Type == intstr.Int:
-			// Keep the chosen one
-		case sPort.TargetPort.Type == intstr.Int && msp.TargetPort.Type == intstr.String:
-			// Prefer targetPort in string format
-			service = svc
-			sPort = msp
-			cPortIndex = cpi
-			cn = ccn
-		default:
-			// Conflict
-			return nil, nil, nil, 0, fmt.Errorf(
-				"found services with conflicting port mappings to %s %s.%s. Please use --service to specify", objType, obj.GetName(), obj.GetNamespace())
+	} else {
+		portNum := port.TargetPort.IntVal
+		// Here we are using containerPortIndex <=0 instead of matchingContainer == nil because if a
+		// container has no ports, we want to use it but we don't want
+		// to break out of the loop looking at containers in case there
+		// is a better fit.  Currently, that is a container where the
+		// ContainerPort matches the targetPort in the service.
+		for ci := 0; ci < len(cns) && containerPortIndex <= 0; ci++ {
+			cn := &cns[ci]
+			if len(cn.Ports) == 0 {
+				matchingServicePort = port
+				matchingContainer = cn
+				containerPortIndex = -1
+			}
+			for pi := range cn.Ports {
+				if cn.Ports[pi].ContainerPort == portNum {
+					matchingServicePort = port
+					matchingContainer = cn
+					containerPortIndex = pi
+					break
+				}
+			}
 		}
 	}
 
-	if sPort == nil {
-		return nil, nil, nil, 0, fmt.Errorf("found no services with a port that matches a container in %s %s.%s", objType, obj.GetName(), obj.GetNamespace())
+	if matchingServicePort == nil {
+		return nil, nil, 0, fmt.Errorf("found no services with a port that matches a container in %s %s.%s", objType, obj.GetName(), obj.GetNamespace())
 	}
-	return service, sPort, cn, cPortIndex, nil
+	return matchingServicePort, matchingContainer, containerPortIndex, nil
 }
 
 // Finds the Referenced Service in an objects' annotations
@@ -560,7 +522,7 @@ already exist for this service`, kind, obj.GetName())
 		}
 
 		var err error
-		obj, svc, err = addAgentToDeployment(c, portName, agentImageName, obj, matchingSvcs)
+		obj, svc, err = addAgentToWorkload(c, portName, agentImageName, obj, matchingSvcs[0])
 		if err != nil {
 			return "", "", err
 		}
@@ -848,11 +810,14 @@ func undoServiceMods(c context.Context, svc *kates.Service) error {
 	return nil
 }
 
-func addAgentToDeployment(
+// addAgentToWorkload takes a given workload object and a service and
+// determines which container + port to use for an intercept. It also
+// prepares and performs modifications to the obj and/or service.
+func addAgentToWorkload(
 	c context.Context,
 	portName string,
 	agentImageName string,
-	object kates.Object, matchingServices []*kates.Service,
+	object kates.Object, matchingService *kates.Service,
 ) (
 	kates.Object,
 	*kates.Service,
@@ -862,12 +827,12 @@ func addAgentToDeployment(
 	if err != nil {
 		return nil, nil, err
 	}
-	service, servicePort, container, containerPortIndex, err := findMatchingPort(object, portName, matchingServices)
+	servicePort, container, containerPortIndex, err := findMatchingPort(object, portName, matchingService)
 	if err != nil {
 		return nil, nil, err
 	}
 	dlog.Debugf(c, "using service %q port %q when intercepting %s %q",
-		service.Name,
+		matchingService.Name,
 		func() string {
 			if servicePort.Name != "" {
 				return servicePort.Name
@@ -924,9 +889,9 @@ func addAgentToDeployment(
 	}
 
 	// Figure what modifications we need to make.
-	deploymentMod := &workloadActions{
+	workloadMod := &workloadActions{
 		Version:                   version,
-		ReferencedService:         service.Name,
+		ReferencedService:         matchingService.Name,
 		ReferencedServicePortName: portName,
 		AddTrafficAgent: &addTrafficAgentAction{
 			containerName:       container.Name,
@@ -961,52 +926,52 @@ func addAgentToDeployment(
 		// if that value came from the container, then we need to hide it
 		// since the service is using the targetPort's int.
 		if usedContainerName {
-			deploymentMod.HideContainerPort = &hideContainerPortAction{
+			workloadMod.HideContainerPort = &hideContainerPortAction{
 				ContainerName: container.Name,
 				PortName:      containerPort.Name,
 			}
 		}
 	} else {
 		// Hijack the port name in the Deployment.
-		deploymentMod.HideContainerPort = &hideContainerPortAction{
+		workloadMod.HideContainerPort = &hideContainerPortAction{
 			ContainerName: container.Name,
 			PortName:      containerPort.Name,
 		}
 	}
 
-	// Apply the actions on the Deployment.
-	if err = deploymentMod.Do(object); err != nil {
+	// Apply the actions on the workload.
+	if err = workloadMod.Do(object); err != nil {
 		return nil, nil, err
 	}
 	annotations := object.GetAnnotations()
 	if object.GetAnnotations() == nil {
 		annotations = make(map[string]string)
 	}
-	annotations[annTelepresenceActions], err = deploymentMod.MarshalAnnotation()
+	annotations[annTelepresenceActions], err = workloadMod.MarshalAnnotation()
 	if err != nil {
 		return nil, nil, err
 	}
 	object.SetAnnotations(annotations)
-	explainDo(c, deploymentMod, object)
+	explainDo(c, workloadMod, object)
 
 	// Apply the actions on the Service.
 	if serviceMod != nil {
-		if err = serviceMod.Do(service); err != nil {
+		if err = serviceMod.Do(matchingService); err != nil {
 			return nil, nil, err
 		}
-		if service.Annotations == nil {
-			service.Annotations = make(map[string]string)
+		if matchingService.Annotations == nil {
+			matchingService.Annotations = make(map[string]string)
 		}
-		service.Annotations[annTelepresenceActions], err = serviceMod.MarshalAnnotation()
+		matchingService.Annotations[annTelepresenceActions], err = serviceMod.MarshalAnnotation()
 		if err != nil {
 			return nil, nil, err
 		}
-		explainDo(c, serviceMod, service)
+		explainDo(c, serviceMod, matchingService)
 	} else {
-		service = nil
+		matchingService = nil
 	}
 
-	return object, service, nil
+	return object, matchingService, nil
 }
 
 func (ki *installer) managerDeployment(env client.Env) *kates.Deployment {

--- a/pkg/client/connector/install_actions.go
+++ b/pkg/client/connector/install_actions.go
@@ -156,6 +156,9 @@ func GetPodTemplateFromObject(obj kates.Object) (*kates.PodTemplateSpec, string,
 	case "Deployment":
 		dep := obj.(*kates.Deployment)
 		tplSpec = &dep.Spec.Template
+	case "StatefulSet":
+		statefulSet := obj.(*kates.StatefulSet)
+		tplSpec = &statefulSet.Spec.Template
 	default:
 		return nil, "", fmt.Errorf("Unsupported workload kind: %s", kind)
 	}

--- a/pkg/client/connector/install_test.go
+++ b/pkg/client/connector/install_test.go
@@ -350,11 +350,11 @@ func TestAddAgentToDeployment(t *testing.T) {
 			expectedSvc := tc.OutputService.DeepCopy()
 			sanitizeService(expectedSvc)
 
-			actualDep, actualSvc, actualErr := addAgentToDeployment(ctx,
+			actualDep, actualSvc, actualErr := addAgentToWorkload(ctx,
 				tc.InputPortName,
 				managerImageName(env), // ignore extensions
 				tc.InputDeployment.DeepCopy(),
-				[]*kates.Service{tc.InputService.DeepCopy()},
+				tc.InputService.DeepCopy(),
 			)
 			if !assert.NoError(t, actualErr) {
 				return
@@ -393,7 +393,7 @@ func TestAddAgentToDeployment(t *testing.T) {
 	}
 }
 
-// I (Donny) would like to unify this w/ the "TestAddAgentToDeployment
+// I (Donny) would like to unify this w/ the "TestAddAgentToWorkload
 // since this is a lot of copy pasta, I will likely do that when I move
 // onto adding StatefulSets
 func TestAddAgentToReplicaSet(t *testing.T) {
@@ -480,11 +480,11 @@ func TestAddAgentToReplicaSet(t *testing.T) {
 			expectedSvc := tc.OutputService.DeepCopy()
 			sanitizeService(expectedSvc)
 
-			actualDep, actualSvc, actualErr := addAgentToDeployment(ctx,
+			actualDep, actualSvc, actualErr := addAgentToWorkload(ctx,
 				tc.InputPortName,
 				managerImageName(env), // ignore extensions
 				tc.InputReplicaSet.DeepCopy(),
-				[]*kates.Service{tc.InputService.DeepCopy()},
+				tc.InputService.DeepCopy(),
 			)
 			if !assert.NoError(t, actualErr) {
 				return

--- a/pkg/client/connector/k8s_cluster.go
+++ b/pkg/client/connector/k8s_cluster.go
@@ -201,6 +201,11 @@ func (kc *k8sCluster) replicaSetNames(c context.Context, namespace string) ([]st
 	return kc.kindNames(c, "ReplicaSet", namespace)
 }
 
+// statefulSetNames returns the names of all replica sets found in the given Namespace
+func (kc *k8sCluster) statefulSetNames(c context.Context, namespace string) ([]string, error) {
+	return kc.kindNames(c, "StatefulSet", namespace)
+}
+
 // PodSetNames returns the names of all replica sets found in the given Namespace
 func (kc *k8sCluster) podNames(c context.Context, namespace string) ([]string, error) {
 	return kc.kindNames(c, "Pod", namespace)
@@ -217,6 +222,19 @@ func (kc *k8sCluster) findDeployment(c context.Context, namespace, name string) 
 		return nil, err
 	}
 	return dep, nil
+}
+
+// findStatefulSet returns a statefulSet with the given name in the given namespace or nil
+// if no such statefulSet could be found.
+func (kc *k8sCluster) findStatefulSet(c context.Context, namespace, name string) (*kates.StatefulSet, error) {
+	statefulSet := &kates.StatefulSet{
+		TypeMeta:   kates.TypeMeta{Kind: "StatefulSet"},
+		ObjectMeta: kates.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	if err := kc.client.Get(c, statefulSet, statefulSet); err != nil {
+		return nil, err
+	}
+	return statefulSet, nil
 }
 
 // findReplicaSet returns a replica set with the given name in the given namespace or nil

--- a/pkg/client/connector/k8s_cluster.go
+++ b/pkg/client/connector/k8s_cluster.go
@@ -267,6 +267,7 @@ func (kc *k8sCluster) findPod(c context.Context, namespace, name string) (*kates
 // search in a specific order based on how we prefer workload objects:
 // 1. Deployments
 // 2. ReplicaSets
+// 3. StatefulSets
 // And return the kind as soon as we find one that matches
 func (kc *k8sCluster) findObjectKind(c context.Context, namespace, name string) (string, error) {
 	depNames, err := kc.deploymentNames(c, namespace)
@@ -288,6 +289,18 @@ func (kc *k8sCluster) findObjectKind(c context.Context, namespace, name string) 
 	for _, rsName := range rsNames {
 		if rsName == name {
 			return "ReplicaSet", nil
+		}
+	}
+
+	// Like ReplicaSets, StatefulSets only manage pods so we check for
+	// them next
+	statefulSetNames, err := kc.statefulSetNames(c, namespace)
+	if err != nil {
+		return "", err
+	}
+	for _, statefulSetName := range statefulSetNames {
+		if statefulSetName == name {
+			return "StatefulSet", nil
 		}
 	}
 	return "", errors.New("No supported Object Kind Found")

--- a/pkg/client/connector/testdata/addAgentToStatefulSet/mp-ss-tc-0.input.yaml
+++ b/pkg/client/connector/testdata/addAgentToStatefulSet/mp-ss-tc-0.input.yaml
@@ -1,0 +1,22 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+  spec:
+    ports:
+      - name: https
+        port: 8080
+      - name: grpc
+        port: 47555
+statefulset:
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: app
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always

--- a/pkg/client/connector/testdata/addAgentToStatefulSet/mp-ss-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToStatefulSet/mp-ss-tc-0.output.yaml
@@ -1,0 +1,62 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+  spec:
+    ports:
+      - name: https
+        port: 8080
+        targetPort: tel2px-8080
+      - name: grpc
+        port: 47555
+statefulset:
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: app
+    annotations:
+        telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always
+          - args:
+              - agent
+            env:
+              - name: TELEPRESENCE_CONTAINER
+                value: app
+              - name: LOG_LEVEL
+                value: debug
+              - name: AGENT_NAME
+                value: app
+              - name: AGENT_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: AGENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: APP_PORT
+                value: "8080"
+              - name: MANAGER_HOST
+                value: "traffic-manager.ambassador"
+            readinessProbe:
+              exec:
+                command:
+                  - "/bin/stat"
+                  - "/tmp/agent/ready"
+            image: localhost:5000/tel2:{{.Version}}
+            imagePullPolicy: IfNotPresent
+            name: traffic-agent
+            ports:
+              - containerPort: 9900
+                name: tel2px-8080
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File

--- a/pkg/client/connector/testdata/addAgentToStatefulSet/ss-tc-0.input.yaml
+++ b/pkg/client/connector/testdata/addAgentToStatefulSet/ss-tc-0.input.yaml
@@ -1,0 +1,25 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+  spec:
+    ports:
+      - name: http
+        port: 80
+        protocol: TCP
+        targetPort: 8080
+statefulset:
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: app
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP

--- a/pkg/client/connector/testdata/addAgentToStatefulSet/ss-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToStatefulSet/ss-tc-0.output.yaml
@@ -1,0 +1,62 @@
+service:
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: app
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"http","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+  spec:
+    ports:
+      - name: http
+        port: 80
+        protocol: TCP
+        targetPort: tel2px-8080
+statefulset:
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: app
+    annotations:
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+  spec:
+    template:
+      spec:
+        containers:
+          - name: app
+            imagePullPolicy: Always
+          - args:
+              - agent
+            env:
+              - name: TELEPRESENCE_CONTAINER
+                value: app
+              - name: LOG_LEVEL
+                value: debug
+              - name: AGENT_NAME
+                value: app
+              - name: AGENT_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: AGENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: APP_PORT
+                value: "8080"
+              - name: MANAGER_HOST
+                value: "traffic-manager.ambassador"
+            readinessProbe:
+              exec:
+                command:
+                  - "/bin/stat"
+                  - "/tmp/agent/ready"
+            image: localhost:5000/tel2:{{.Version}}
+            imagePullPolicy: IfNotPresent
+            name: traffic-agent
+            ports:
+              - containerPort: 9900
+                name: tel2px-8080
+                protocol: TCP
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File

--- a/rpc/connector/connector.pb.go
+++ b/rpc/connector/connector.pb.go
@@ -751,7 +751,7 @@ type WorkloadInfo struct {
 	AgentInfo *manager.AgentInfo `protobuf:"bytes,3,opt,name=agent_info,json=agentInfo,proto3" json:"agent_info,omitempty"`
 	// InterceptInfo reported from the traffic manager in case the workload is currently intercepted
 	InterceptInfo *manager.InterceptInfo `protobuf:"bytes,4,opt,name=intercept_info,json=interceptInfo,proto3" json:"intercept_info,omitempty"`
-	// Workload Resource type (e.g. Deployment, ReplicaSet)
+	// Workload Resource type (e.g. Deployment, ReplicaSet, StatefulSet)
 	WorkloadResourceType string `protobuf:"bytes,5,opt,name=workload_resource_type,json=workloadResourceType,proto3" json:"workload_resource_type,omitempty"`
 }
 

--- a/rpc/connector/connector.proto
+++ b/rpc/connector/connector.proto
@@ -177,7 +177,7 @@ message WorkloadInfo {
   // InterceptInfo reported from the traffic manager in case the workload is currently intercepted
   telepresence.manager.InterceptInfo intercept_info = 4;
 
-  // Workload Resource type (e.g. Deployment, ReplicaSet)
+  // Workload Resource type (e.g. Deployment, ReplicaSet, StatefulSet)
   string workload_resource_type = 5;
 }
 


### PR DESCRIPTION
This will enable users to intercept StatefulSet services, and largely builds on top of the ReplicaSet PR I merged last week, I've also cleaned up some functions + names that I introduced in that PR that weren't the best.  Would recommend a commit-by-commit review. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. -- will do this in the morning, should just be rbac changes in the docs
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.