### PR TITLE
[v2] Make FindMatchingServices namespace-bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: `telepresence quit` no longer starts the daemon process just to shut it down.
 - Bugfix: Telepresence no longer hangs the next time it's run after getting killed.
 - Bugfix: Telepresence now does a better job of automatically logging in as necessary, especially with regard to expired logins.
+- Bugfix: Telepresence was incorrectly looking across all namespaces for services when intercepting, but now it only looks in the given namespace.  This should prevent people from running into "Found multiple services" errors when services with the same selectors existed in other namespaces.
 
 ### 2.1.3 (March 29, 2021)
 

--- a/pkg/client/connector/traffic_manager.go
+++ b/pkg/client/connector/traffic_manager.go
@@ -277,7 +277,7 @@ func (tm *trafficManager) getInfosForWorkflow(
 				continue
 			}
 
-			matchingSvcs := tm.findMatchingServices("", "", labels)
+			matchingSvcs := tm.findMatchingServices("", "", namespace, labels)
 			if len(matchingSvcs) == 0 {
 				reason = "No service with matching selector"
 			}


### PR DESCRIPTION
This fixes the bug mentioned in https://github.com/telepresenceio/telepresence/issues/1625 . Pretty self-explanatory fix, but findMatchingServices should have _only_ been looking at the namespace we were trying to intercept in instead of looking at all namespaces (which caused collisions with services that shouldn't have been collisions). 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.