### PR TITLE
[v2] OpenRotatingLogFile: Fix the os.MkdirAll call

### DIFF
--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -158,11 +158,11 @@ func (ts *telepresenceSuite) SetupSuite() {
 	}()
 	wg.Wait()
 
-	// Ensure that no telepresence is running when the tests start
-	_, _ = telepresence(ts.T(), "quit")
-
 	// Also ensure that telepresence is not logged in
 	_, _ = telepresence(ts.T(), "logout")
+
+	// Ensure that no telepresence is running when the tests start
+	_, _ = telepresence(ts.T(), "quit")
 }
 
 func (ts *telepresenceSuite) TearDownSuite() {

--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
@@ -27,7 +28,7 @@ func InitContext(ctx context.Context, name string) (context.Context, error) {
 		if err != nil {
 			return ctx, err
 		}
-		rf, err := OpenRotatingFile(dir, name+".log", "20060102T150405", true, true, 0600, NewRotateOnce(), 5)
+		rf, err := OpenRotatingFile(filepath.Join(dir, name+".log"), "20060102T150405", true, true, 0600, NewRotateOnce(), 5)
 		if err != nil {
 			return ctx, err
 		}

--- a/pkg/client/logging/rotatingfile.go
+++ b/pkg/client/logging/rotatingfile.go
@@ -115,7 +115,6 @@ func OpenRotatingFile(
 	strategy RotationStrategy,
 	maxFiles uint16,
 ) (*RotatingFile, error) {
-
 	logfileDir, logfileBase := filepath.Split(logfilePath)
 
 	if err := os.MkdirAll(logfileDir, 0755); err != nil {

--- a/pkg/client/logging/rotatingfile.go
+++ b/pkg/client/logging/rotatingfile.go
@@ -107,23 +107,24 @@ type RotatingFile struct {
 // - maxFiles: maximum number of files in rotation, including the currently active logfile. A value of zero means
 // unlimited
 func OpenRotatingFile(
-	dirName,
-	fileName,
+	logfilePath string,
 	timeFormat string,
-	localTime,
+	localTime bool,
 	captureStd bool,
 	fileMode os.FileMode,
 	strategy RotationStrategy,
-	maxFiles uint16) (*RotatingFile, error) {
-	dir := filepath.Dir(fileName)
-	err := os.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create directory %s: %v", dir, err)
+	maxFiles uint16,
+) (*RotatingFile, error) {
+
+	logfileDir, logfileBase := filepath.Split(logfilePath)
+
+	if err := os.MkdirAll(logfileDir, 0755); err != nil {
+		return nil, err
 	}
 
 	rf := &RotatingFile{
-		dirName:    dirName,
-		fileName:   fileName,
+		dirName:    logfileDir,
+		fileName:   logfileBase,
 		fileMode:   fileMode,
 		strategy:   strategy,
 		localTime:  localTime,
@@ -132,9 +133,9 @@ func OpenRotatingFile(
 		maxFiles:   maxFiles,
 	}
 
-	fullPath := filepath.Join(dirName, fileName)
 	var info os.FileInfo
-	if info, err = os.Stat(fullPath); err != nil {
+	var err error
+	if info, err = os.Stat(logfilePath); err != nil {
 		if os.IsNotExist(err) {
 			if err = rf.openNew(); err == nil {
 				return rf, nil
@@ -147,7 +148,7 @@ func OpenRotatingFile(
 	rf.size = info.Size()
 
 	// Open existing file for append
-	if rf.file, err = os.OpenFile(fullPath, os.O_WRONLY|os.O_APPEND, rf.fileMode); err != nil {
+	if rf.file, err = os.OpenFile(logfilePath, os.O_WRONLY|os.O_APPEND, rf.fileMode); err != nil {
 		return nil, err
 	}
 	rf.afterOpen()


### PR DESCRIPTION
## Description

It was calling os.MkdirAll with the filepath.Dir of `fileName`, which is
*already* the basename, so the filepath.Dir of it was *always* just ".".

So rename the variables to hopefully make this clearer:

- fullPath → logfilePath
- dirName  → logfileDir
- fileName → logfileBase

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
