### PR TITLE
[v2] Fix hcp error log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.1.5 (TBD)
+- Bugfix: One of the log messages was using the incorrect variable, which led to misleading error messages on telepresence uninstall.
+
 ### 2.1.4 (April 5, 2021)
 
 - Feature: `telepresence status` has been enhanced to provide more information.  In particular, it now provides separate information on the daemon and connector processes, as well as showing login status.

--- a/pkg/client/connector/install_actions.go
+++ b/pkg/client/connector/install_actions.go
@@ -571,7 +571,7 @@ func (hcp *hideContainerPortAction) getPort(obj kates.Object, name string) (*kat
 			}
 		}
 	}
-	return nil, nil, fmt.Errorf("unable to locate port %s in container %s in %s %s.%s", hcp.PortName, hcp.ContainerName, objKind, obj.GetName(), obj.GetNamespace())
+	return nil, nil, fmt.Errorf("unable to locate port %s in container %s in %s %s.%s", name, hcp.ContainerName, objKind, obj.GetName(), obj.GetNamespace())
 }
 
 func swapPortName(cn *kates.Container, p *corev1.ContainerPort, from, to string) {


### PR DESCRIPTION
hcp.PortName was correct when we were adding the agent but it is
hcp.HiddenName when we do an uninstall, so in the error log we should use the
input to be correct in both cases.


---

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.