### PR TITLE
Fix checkSvcSame when portNameOrNumber empty

### DIFF
--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -460,10 +460,12 @@ func checkSvcSame(c context.Context, obj kates.Object, svcName, portNameOrNumber
 		// If the portNameOrNumber passed in doesn't match the referenced service
 		// port name or number in the annotation, then the servicePort to be intercepted
 		// has changed.
-		curSvcPortName := actions.ReferencedServicePortName
-		curSvcPort := actions.ReferencedServicePort
-		if curSvcPortName != portNameOrNumber && curSvcPort != portNameOrNumber {
-			return fmt.Errorf("Port for %s changed from %s -> %s", obj.GetName(), curSvcPort, portNameOrNumber)
+		if portNameOrNumber != "" {
+			curSvcPortName := actions.ReferencedServicePortName
+			curSvcPort := actions.ReferencedServicePort
+			if curSvcPortName != portNameOrNumber && curSvcPort != portNameOrNumber {
+				return fmt.Errorf("Port for %s changed from %s -> %s", obj.GetName(), curSvcPort, portNameOrNumber)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
When introducing portNameOrNumber instead of just portName, I made an
error in the logic and it was checking if the annotations matched the
value of portNameOrNumber, even when that value is empty.  This fixes
the logic so that we only validate portNameOrNumber with the annotations
when it is non-empty

Signed-off-by: Donny Yung <donaldyung@datawire.io>



---
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - bugfix for new feature that hasn't been released yet so omitted from changelog
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.