### PR TITLE
Ensure that we don't create port names longer than 15 characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: When intercepting `--port` now supports specifying a service port or a service name. Previously, only service name was supported.
 - Feature: Intercepts using `--mechanism=http` now support mTLS.
+- Bugfix: Telepresence no longer generate port names longer than 15 characters.
 
 ### 2.1.5 (TBD)
 - Bugfix: One of the log messages was using the incorrect variable, which led to misleading error messages on telepresence uninstall.

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -925,7 +925,7 @@ func addAgentToWorkload(
 		return nil, nil, fmt.Errorf("unable to add agent to %s %s.%s. The container port cannot be determined", kind, object.GetName(), object.GetNamespace())
 	}
 	if containerPort.Name == "" {
-		containerPort.Name = fmt.Sprintf("tel2px-%d", containerPort.Number)
+		containerPort.Name = fmt.Sprintf("tx-%d", containerPort.Number)
 	}
 
 	// Figure what modifications we need to make.
@@ -970,6 +970,7 @@ func addAgentToWorkload(
 			workloadMod.HideContainerPort = &hideContainerPortAction{
 				ContainerName: container.Name,
 				PortName:      containerPort.Name,
+				ordinal:       0,
 			}
 		}
 	} else {
@@ -977,6 +978,7 @@ func addAgentToWorkload(
 		workloadMod.HideContainerPort = &hideContainerPortAction{
 			ContainerName: container.Name,
 			PortName:      containerPort.Name,
+			ordinal:       0,
 		}
 	}
 

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-initializer.input.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-initializer.input.yaml
@@ -27,16 +27,16 @@ deployment:
             livenessProbe:
               httpGet:
                 path: /health
-                port: http
+                port: someverylongnam
               periodSeconds: 10
             readinessProbe:
               httpGet:
                 path: /health
-                port: http
+                port: someverylongnam
               periodSeconds: 10
             ports:
               - containerPort: 3000
-                name: http
+                name: someverylongnam
         restartPolicy: Always
         securityContext:
           runAsUser: 8888
@@ -51,7 +51,7 @@ service:
   spec:
     ports:
       - port: 80
-        name: http
-        targetPort: http
+        name: someverylongnam
+        targetPort: someverylongnam
     selector:
       service: sample-app

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-initializer.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-initializer.output.yaml
@@ -3,7 +3,7 @@ deployment:
   kind: Deployment
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"sample-app","referenced_service_port":"80","referenced_service_port_name":"http","hide_container_port":{"container_name":"sample-app","port_name":"http","hidden_name":"tel2mv-http"},"add_traffic_agent":{"container_port_name":"http","container_port_proto":"","app_port":3000,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"sample-app","referenced_service_port":"80","referenced_service_port_name":"someverylongnam","hide_container_port":{"container_name":"sample-app","port_name":"someverylongnam","hidden_name":"tm-someverylong"},"add_traffic_agent":{"container_port_name":"someverylongnam","container_port_proto":"","app_port":3000,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: sample-app
     namespace: default
@@ -30,16 +30,16 @@ deployment:
           livenessProbe:
             httpGet:
               path: /health
-              port: tel2mv-http
+              port: tm-someverylong
             periodSeconds: 10
           name: sample-app
           ports:
           - containerPort: 3000
-            name: tel2mv-http
+            name: tm-someverylong
           readinessProbe:
             httpGet:
               path: /health
-              port: tel2mv-http
+              port: tm-someverylong
             periodSeconds: 10
           resources: {}
         - args:
@@ -69,7 +69,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: http
+            name: someverylongnam
           readinessProbe:
             exec:
               command:
@@ -101,9 +101,9 @@ service:
     namespace: default
   spec:
     ports:
-    - name: http
+    - name: someverylongnam
       port: 80
-      targetPort: http
+      targetPort: someverylongnam
     selector:
       service: sample-app
   status:

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-0.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-mp-0","referenced_service_port":"443","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-9090","container_port_proto":"TCP","app_port":9090,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-mp-0","referenced_service_port":"443","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-9090","container_port_proto":"TCP","app_port":9090,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-mp-0
@@ -64,7 +64,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-9090
+            name: tx-9090
             protocol: TCP
           readinessProbe:
             exec:
@@ -111,7 +111,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"https","TargetPort":9090,"SymbolicName":"tel2px-9090"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"https","TargetPort":9090,"SymbolicName":"tx-9090"}}'
     creationTimestamp: null
     labels:
       app: hello-mp-0
@@ -129,7 +129,7 @@ service:
     - name: https
       port: 443
       protocol: TCP
-      targetPort: tel2px-9090
+      targetPort: tx-9090
     selector:
       app: hello-mp-0
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-1.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-1.output.yaml
@@ -3,7 +3,7 @@ deployment:
   kind: Deployment
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -41,7 +41,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
           readinessProbe:
             exec:
               command:
@@ -64,14 +64,14 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
     ports:
     - name: https
       port: 8080
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     - name: grpc
       port: 47555
       targetPort: 0

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-2.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-2.output.yaml
@@ -7,7 +7,7 @@ deployment:
   kind: Deployment
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -45,7 +45,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
           readinessProbe:
             exec:
               command:
@@ -68,14 +68,14 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
     ports:
     - name: https
       port: 8080
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     - name: grpc
       port: 47555
       targetPort: 0

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-3.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-mp-tc-3.output.yaml
@@ -6,7 +6,7 @@ deployment:
   kind: Deployment
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -44,7 +44,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
           readinessProbe:
             exec:
               command:
@@ -67,14 +67,14 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
     ports:
     - name: https
       port: 8080
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     - name: grpc
       port: 47555
       targetPort: 0

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-0.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-0","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-0","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-0
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-0
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-0
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-1.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-1.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-1","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-1","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-1
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-1
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-1
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-10.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-10.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-10","referenced_service_port":"80","referenced_service_port_name":"http","hide_container_port":{"container_name":"echo-server","port_name":"http","hidden_name":"tel2mv-http"},"add_traffic_agent":{"container_port_name":"http","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-10","referenced_service_port":"80","referenced_service_port_name":"http","hide_container_port":{"container_name":"echo-server","port_name":"http","hidden_name":"tm-http"},"add_traffic_agent":{"container_port_name":"http","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-10
@@ -35,7 +35,7 @@ deployment:
           name: echo-server
           ports:
           - containerPort: 8080
-            name: tel2mv-http
+            name: tm-http
             protocol: TCP
           resources: {}
         - args:

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-11.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-11.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-11","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-11","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-11
@@ -67,7 +67,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -114,7 +114,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-11
@@ -127,7 +127,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-11
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-2.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-2.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-2","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-2","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-2
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-2
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-2
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-3.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-3.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-3","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-3","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-3
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-3
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-3
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-4.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-4.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-4","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-4","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-4
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-4
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-4
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-5.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-5.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-5","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-5","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-5
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-5
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-5
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-6.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-6.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-6","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-6","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-6
@@ -59,7 +59,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -106,7 +106,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-6
@@ -119,7 +119,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-6
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-7.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-7.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-7","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-7","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-7
@@ -66,7 +66,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -115,7 +115,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-7
@@ -128,7 +128,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-7
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-8.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-8.output.yaml
@@ -4,7 +4,7 @@ deployment:
   metadata:
     annotations:
       deployment.kubernetes.io/revision: "1"
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-8","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"hello-8","referenced_service_port":"80","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     labels:
       app: hello-8
@@ -91,7 +91,7 @@ deployment:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -138,7 +138,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     labels:
       app: hello-8
@@ -151,7 +151,7 @@ service:
     ports:
     - port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     selector:
       app: hello-8
     sessionAffinity: None

--- a/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-9.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/deployment-tc-9.output.yaml
@@ -6,7 +6,7 @@ deployment:
       deployment.kubernetes.io/revision: "1"
       kubectl.kubernetes.io/last-applied-configuration: |
         {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"with-probes","namespace":"telepresence-5759"},"spec":{"replicas":2,"selector":{"matchLabels":{"service":"with-probes"}},"template":{"metadata":{"annotations":{"consul.hashicorp.com/connect-inject":"false","sidecar.istio.io/inject":"false"},"labels":{"service":"with-probes"}},"spec":{"containers":[{"env":[{"name":"LISTEN_PORT","value":"3000"}],"image":"gcr.io/datawire/k8s-initializer-sample-app:latest","imagePullPolicy":"Always","livenessProbe":{"httpGet":{"path":"/health","port":"http"},"periodSeconds":10},"name":"sample-app","ports":[{"containerPort":3000,"name":"http"}],"readinessProbe":{"httpGet":{"path":"/health","port":"http"},"periodSeconds":10}}]}}}}
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"with-probes","referenced_service_port":"80","referenced_service_port_name":"http","hide_container_port":{"container_name":"sample-app","port_name":"http","hidden_name":"tel2mv-http"},"add_traffic_agent":{"container_port_name":"http","container_port_proto":"TCP","app_port":3000,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"with-probes","referenced_service_port":"80","referenced_service_port_name":"http","hide_container_port":{"container_name":"sample-app","port_name":"http","hidden_name":"tm-http"},"add_traffic_agent":{"container_port_name":"http","container_port_proto":"TCP","app_port":3000,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: with-probes
     namespace: telepresence-5759
@@ -42,7 +42,7 @@ deployment:
             failureThreshold: 3
             httpGet:
               path: /health
-              port: tel2mv-http
+              port: tm-http
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
@@ -50,13 +50,13 @@ deployment:
           name: sample-app
           ports:
           - containerPort: 3000
-            name: tel2mv-http
+            name: tm-http
             protocol: TCP
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /health
-              port: tel2mv-http
+              port: tm-http
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1

--- a/pkg/client/connector/testdata/addAgentToWorkload/replicaset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/replicaset-mp-tc-0.output.yaml
@@ -3,7 +3,7 @@ replicaset:
   kind: ReplicaSet
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -40,7 +40,7 @@ replicaset:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
           readinessProbe:
             exec:
               command:
@@ -64,14 +64,14 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
     ports:
     - name: https
       port: 8080
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     - name: grpc
       port: 47555
       targetPort: 0

--- a/pkg/client/connector/testdata/addAgentToWorkload/replicaset-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/replicaset-tc-0.output.yaml
@@ -3,7 +3,7 @@ replicaset:
   kind: ReplicaSet
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"80","referenced_service_port_name":"http","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"80","referenced_service_port_name":"http","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -40,7 +40,7 @@ replicaset:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:
@@ -65,7 +65,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"http","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"http","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -73,6 +73,6 @@ service:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
   status:
     loadBalancer: {}

--- a/pkg/client/connector/testdata/addAgentToWorkload/statefulset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/statefulset-mp-tc-0.output.yaml
@@ -3,14 +3,14 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","add_symbolic_port":{"PortName":"https","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
     ports:
     - name: https
       port: 8080
-      targetPort: tel2px-8080
+      targetPort: tx-8080
     - name: grpc
       port: 47555
       targetPort: 0
@@ -21,7 +21,7 @@ statefulset:
   kind: StatefulSet
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"8080","referenced_service_port_name":"https","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -59,7 +59,7 @@ statefulset:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
           readinessProbe:
             exec:
               command:

--- a/pkg/client/connector/testdata/addAgentToWorkload/statefulset-tc-0.output.yaml
+++ b/pkg/client/connector/testdata/addAgentToWorkload/statefulset-tc-0.output.yaml
@@ -3,7 +3,7 @@ service:
   kind: Service
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"http","TargetPort":8080,"SymbolicName":"tel2px-8080"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","make_port_symbolic":{"PortName":"http","TargetPort":8080,"SymbolicName":"tx-8080"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -11,7 +11,7 @@ service:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: tel2px-8080
+      targetPort: tx-8080
   status:
     loadBalancer: {}
 statefulset:
@@ -19,7 +19,7 @@ statefulset:
   kind: StatefulSet
   metadata:
     annotations:
-      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"80","referenced_service_port_name":"http","add_traffic_agent":{"container_port_name":"tel2px-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
+      telepresence.getambassador.io/actions: '{"version":"{{.Version}}","ReferencedService":"app","referenced_service_port":"80","referenced_service_port_name":"http","add_traffic_agent":{"container_port_name":"tx-8080","container_port_proto":"TCP","app_port":8080,"image_name":"localhost:5000/tel2:{{.Version}}"}}'
     creationTimestamp: null
     name: app
   spec:
@@ -57,7 +57,7 @@ statefulset:
           name: traffic-agent
           ports:
           - containerPort: 9900
-            name: tel2px-8080
+            name: tx-8080
             protocol: TCP
           readinessProbe:
             exec:


### PR DESCRIPTION
Signed-off-by: Thomas Hallgren <thomas@datawire.io>

## Description

Don't generate port names longer than 15 characters.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 