### PR TITLE
Better detect presence of ambassador namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.2.1 (TBD)
+- Bugfix: Improve ambassador namespace detection that was trying to create the namespace even when the namespace existed, which was an undesired rbac escalation for operators.
+
 ### 2.2.0 (April 19, 2021)
 
 - Feature: `telepresence intercept` now has the option `--docker-run` which will start a docker container with intercepted environment and volume mounts.

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -96,6 +96,9 @@ func (ki *installer) createManagerSvc(c context.Context) (*kates.Service, error)
 	// Ensure that the managerNamespace exists
 	_, err := ki.findNamespace(c, managerNamespace)
 	if err != nil {
+		if !errors2.IsNotFound(err) {
+			return nil, err
+		}
 		ns := &kates.Namespace{
 			TypeMeta:   kates.TypeMeta{Kind: "Namespace"},
 			ObjectMeta: kates.ObjectMeta{Name: managerNamespace},

--- a/pkg/client/connector/k8s_cluster.go
+++ b/pkg/client/connector/k8s_cluster.go
@@ -264,7 +264,7 @@ func (kc *k8sCluster) findPod(c context.Context, namespace, name string) (*kates
 }
 
 // findSecret returns a secret with the given name in the given namespace or nil
-// if no suchs secret could be found.
+// if no such secret could be found.
 func (kc *k8sCluster) findSecret(c context.Context, namespace, name string) (*kates.Secret, error) {
 	sec := &kates.Secret{
 		TypeMeta:   kates.TypeMeta{Kind: "Secret"},
@@ -274,6 +274,19 @@ func (kc *k8sCluster) findSecret(c context.Context, namespace, name string) (*ka
 		return nil, err
 	}
 	return sec, nil
+}
+
+// findNamespace returns a namespace with the given name or nil
+// if no such namespace could be found.
+func (kc *k8sCluster) findNamespace(c context.Context, name string) (*kates.Namespace, error) {
+	ns := &kates.Namespace{
+		TypeMeta:   kates.TypeMeta{Kind: "Namespace"},
+		ObjectMeta: kates.ObjectMeta{Name: name},
+	}
+	if err := kc.client.Get(c, ns, ns); err != nil {
+		return nil, err
+	}
+	return ns, nil
 }
 
 // findObjectKind returns a workload for the given name and namespace. We


### PR DESCRIPTION
There was a race condition in determining presence of the ambassador
namespace that was dependent on trying to create the namespace and
ignoring the error if the namespace existed.  This is an unneccesary
rbac escalation, so I have fixed that here.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.