### PR TITLE
connector: Don't keep retrying if the access/refresh tokens are expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ### 2.2.1 (TBD)
-- Bugfix: Improve ambassador namespace detection that was trying to create the namespace even when the namespace existed, which was an undesired rbac escalation for operators.
+
+- Bugfix: Improve `ambassador` namespace detection that was trying to create the namespace even when the namespace existed, which was an undesired RBAC escalation for operators.
+- Bugfix: Telepresence will now no longer generate excessive traffic trying repeatedly to exchange auth tokens with Ambassador Cloud.  This could happen when upgrading from <2.1.4 if you had an expired `telepresence login` from before upgrading.
 
 ### 2.2.0 (April 19, 2021)
 

--- a/pkg/client/connector/auth/refresh.go
+++ b/pkg/client/connector/auth/refresh.go
@@ -6,21 +6,31 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// cbTokenSource is an oauth2.TokenSource that calls a callback whenever a new token is issued or a
+// new token fails to be issued.
 type cbTokenSource struct {
+	// Static
 	inner oauth2.TokenSource
-	cb    func(context.Context, *oauth2.Token) error
-	ctx   context.Context
+	ctx   context.Context // to pass to the callbacks
+	tokCB func(context.Context, *oauth2.Token) error
+	errCB func(context.Context, error) error
 
+	// Stateful
 	lastToken string
 }
 
+// Token implements oauth2.TokenSource.
 func (ts *cbTokenSource) Token() (*oauth2.Token, error) {
 	ret, err := ts.inner.Token()
+	if (ret != nil) == (err != nil) {
+		panic("TokenSource is broken")
+	}
 	if err != nil {
+		err = ts.errCB(ts.ctx, err)
 		return nil, err
 	}
 	if ret.AccessToken != ts.lastToken {
-		if err := ts.cb(ts.ctx, ret); err != nil {
+		if err := ts.tokCB(ts.ctx, ret); err != nil {
 			return nil, err
 		}
 	}
@@ -28,11 +38,21 @@ func (ts *cbTokenSource) Token() (*oauth2.Token, error) {
 	return ret, nil
 }
 
-func newTokenSource(ctx context.Context, cfg oauth2.Config, cur *oauth2.Token, cb func(context.Context, *oauth2.Token) error) oauth2.TokenSource {
+// newTokenSource returns a new cbTokenSource.
+func newTokenSource(
+	// Static
+	ctx context.Context,
+	cfg oauth2.Config,
+	tokCB func(context.Context, *oauth2.Token) error,
+	errCB func(context.Context, error) error,
+	// The initial token, must not be nil
+	cur *oauth2.Token,
+) oauth2.TokenSource {
 	return &cbTokenSource{
 		inner: cfg.TokenSource(ctx, cur),
-		cb:    cb,
 		ctx:   ctx,
+		tokCB: tokCB,
+		errCB: errCB,
 
 		lastToken: cur.AccessToken,
 	}


### PR DESCRIPTION
## Description

Occasionally, Telepresence decides to hammer the Ambassador Cloud auth server.  This fixes that.  I have tested it manually, but did not write an automated test yet.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - yes
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no applicable changes
 - [ ] My change is adequately tested. - no, testing isn't automated yet, but I think we can land it anyway
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
