### PR TITLE
[v2] Fix `telepresence login` when there's an expired login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Improve `ambassador` namespace detection that was trying to create the namespace even when the namespace existed, which was an undesired RBAC escalation for operators.
 - Bugfix: Telepresence will now no longer generate excessive traffic trying repeatedly to exchange auth tokens with Ambassador Cloud.  This could happen when upgrading from <2.1.4 if you had an expired `telepresence login` from before upgrading.
+- Bugfix: `telepresence login` now correctly handles expired logins, just like all of the other subcommands.
 
 ### 2.2.0 (April 19, 2021)
 

--- a/pkg/client/connector/auth/login.go
+++ b/pkg/client/connector/auth/login.go
@@ -22,7 +22,6 @@ import (
 	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
-	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/connector/auth/authdata"
@@ -106,19 +105,6 @@ func NewLoginExecutor(
 	ret.loginMu.Lock()
 	ret.resetRefreshTimerUnlocked(0)
 	return ret
-}
-
-// EnsureLoggedIn will check if the user is logged in and if not initiate the login flow.
-func EnsureLoggedIn(ctx context.Context, executor LoginExecutor) (connector.LoginResult_Code, error) {
-	if token, _ := authdata.LoadTokenFromUserCache(ctx); token != nil {
-		return connector.LoginResult_OLD_LOGIN_REUSED, nil
-	}
-
-	if err := executor.Login(ctx); err != nil {
-		return connector.LoginResult_UNSPECIFIED, err
-	}
-
-	return connector.LoginResult_NEW_LOGIN_SUCCEEDED, nil
 }
 
 func NewStandardLoginExecutor(env client.Env, stdout io.Writer, scout chan<- scout.ScoutReport) LoginExecutor {

--- a/pkg/client/connector/service.go
+++ b/pkg/client/connector/service.go
@@ -237,11 +237,13 @@ func (s *service) UserNotifications(_ *empty.Empty, stream rpc.Connector_UserNot
 
 func (s *service) Login(ctx context.Context, _ *empty.Empty) (*rpc.LoginResult, error) {
 	ctx = s.callCtx(ctx, "Login")
-	resultCode, err := auth.EnsureLoggedIn(ctx, s.loginExecutor)
-	if err != nil {
+	if _, err := s.loginExecutor.GetToken(ctx); err == nil {
+		return &rpc.LoginResult{Code: rpc.LoginResult_OLD_LOGIN_REUSED}, nil
+	}
+	if err := s.loginExecutor.Login(ctx); err != nil {
 		return nil, err
 	}
-	return &rpc.LoginResult{Code: resultCode}, nil
+	return &rpc.LoginResult{Code: rpc.LoginResult_NEW_LOGIN_SUCCEEDED}, nil
 }
 
 func (s *service) Logout(ctx context.Context, _ *empty.Empty) (*empty.Empty, error) {


### PR DESCRIPTION
This came up during smoke-testing of 2.2.1-rc.0.