### PR TITLE
stalebot: Don't close issues or PRs, just mark them stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ daysUntilStale: 700
 # Number of days of inactivity before an Issue or Pull Request with the stale
 # label is closed. Set to false to disable. If disabled, issues still need to be
 # closed manually, but will remain marked as stale.
-daysUntilClose: 30
+daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are check if stale.
 # Defaults to `[]` (disabled)


### PR DESCRIPTION
I was looking for an outside-contributor PR, and none existed.  That didn't seem right!

Having stalebot close issues and PRs is just a jerk move.  Have it flag them stale, but don't close them.