### PR TITLE
website: Add <link rel="canonical"> tags

### DIFF
--- a/docs/_layouts/website/page.html
+++ b/docs/_layouts/website/page.html
@@ -2,6 +2,7 @@
 
 {% block head %}
     {{ super() }}
+    <link rel="canonical" href="https://www.telepresence.io/{{ file.path | replace('.md', '.html') | replace('/index.html', '/') }}"/>
     <link rel="stylesheet" href="/styles/home.css">
 {% endblock %}
 

--- a/docs/_layouts/website/page.html
+++ b/docs/_layouts/website/page.html
@@ -1,24 +1,24 @@
 {% extends template.self %}
 
-{% block book_sidebar %}
-<a href="/" class="logo__link">
-    <img class="logo" src="/images/telepresence-logo.png" alt="logo">
-</a>
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" href="/styles/home.css">
+{% endblock %}
 
-{{ super() }}
+{% block book_sidebar %}
+    <a href="/" class="logo__link">
+        <img class="logo" src="/images/telepresence-logo.png" alt="logo">
+    </a>
+    {{ super() }}
 {% endblock %}
 
 {% block page %}
-
-<link rel="stylesheet" href="/styles/home.css">
-
-<section class="banner">
-    <div class="banner__text banner__text--docs">
-        Telepresence 2 is open source and available to preview now! 
-        <a href="https://www.getambassador.io/docs/latest/telepresence/quick-start" target="_blank" class="banner__link banner__link--docs">Learn more</a> 
-        <img alt="" class="banner__icon" src="/images/arrow.inline.svg">
-    </div>
-</section>
-
-{{ super() }}
+    <section class="banner">
+        <div class="banner__text banner__text--docs">
+            Telepresence 2 is open source and available to preview now!
+            <a href="https://www.getambassador.io/docs/latest/telepresence/quick-start" target="_blank" class="banner__link banner__link--docs">Learn more</a> 
+            <img alt="" class="banner__icon" src="/images/arrow.inline.svg">
+        </div>
+    </section>
+    {{ super() }}
 {% endblock %}

--- a/docs/about.html
+++ b/docs/about.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>About - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/about.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/announcing-telepresence-2.html
+++ b/docs/announcing-telepresence-2.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Announcing Telepresence 2!</title>
+    <link rel="canonical" href="https://www.telepresence.io/announcing-telepresence-2.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/bitnami.html
+++ b/docs/case-studies/bitnami.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Bitnami Case Study - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/bitnami.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/engel-volkers.html
+++ b/docs/case-studies/engel-volkers.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Verloop Case Study - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/engel-volkers.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/index.html
+++ b/docs/case-studies/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Case Studies - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/iris-tv.html
+++ b/docs/case-studies/iris-tv.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>IRIS.TV Case Study - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/iris-tv.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/sight-machine.html
+++ b/docs/case-studies/sight-machine.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Sight Machine Case Study - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/sight-machine.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/case-studies/verloop.html
+++ b/docs/case-studies/verloop.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Verloop Case Study - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/case-studies/verloop.html"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">

--- a/docs/community.html
+++ b/docs/community.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <title>Telepresence community</title>
+    <link rel="canonical" href="https://www.telepresence.io/community.html"/>
     <meta
       name="description"
       content="Get involved and collaborate with our outstanding community of adopters and contributors on the Telepresence project"

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Home - Telepresence</title>
+    <link rel="canonical" href="https://www.telepresence.io/"/>
     <meta name="description" content="Telepresence: a local development environment for a remote Kubernetes cluster">
     <meta name="keywords" content="Telepresence, Kubernetes, microservices">
     <meta name="author" content="Ambassador Labs">


### PR DESCRIPTION
This is solving the same thing as https://github.com/telepresenceio/telepresence/pull/1414 :

> As it stands, search engines are currently crawling our deploy previews from GitHub and indexing them, making the published telepresence.io website less valuable in their eyes due to the content duplication.

But is solving it in a different way: Adding `<link rel="canonical">` tags, so that Google knows which one is the non-duplicate.  This is the same solution as we use for getambassador.io previews.