### PR TITLE
Translate tp1 commands to tp2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.2.2 (TBD)
+- Feature: Telepresence attempts to translate legacy Telepresence 1 commands into viable Telepresence 2 commands.
+
 ### 2.2.1 (April 29, 2021)
 
 - Bugfix: Improve `ambassador` namespace detection that was trying to create the namespace even when the namespace existed, which was an undesired RBAC escalation for operators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 2.2.2 (TBD)
-- Feature: Telepresence attempts to translate legacy Telepresence 1 commands into viable Telepresence 2 commands.
+- Feature: Telepresence attempts to translate legacy Telepresence commands into viable Telepresence commands.
 
 ### 2.2.1 (April 29, 2021)
 

--- a/go.sum
+++ b/go.sum
@@ -701,7 +701,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/telepresenceio/telepresence v0.0.0-20210504214037-531808c5d7ee h1:F2zAmH9TS32FaX3Ff9DQvBGByFGeQjWN09RK79cy130=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -701,6 +701,7 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/telepresenceio/telepresence v0.0.0-20210504214037-531808c5d7ee h1:F2zAmH9TS32FaX3Ff9DQvBGByFGeQjWN09RK79cy130=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/client/cli/command.go
+++ b/pkg/client/cli/command.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 
@@ -69,7 +68,7 @@ func OnlySubcommands(cmd *cobra.Command, args []string) error {
 	// construct the tp2 command based on their input. If the args passed to
 	// telepresence are one of the flags we recognize, we don't want to error
 	// out here.
-	tp1Flags := []string{"--swap-deployment", "-s", "--run", "--run-shell", "--docker-run"}
+	tp1Flags := []string{"--swap-deployment", "-s", "--run", "--run-shell", "--docker-run", "--help"}
 	for _, v := range args {
 		for _, flag := range tp1Flags {
 			if v == flag {
@@ -120,22 +119,29 @@ func Command(ctx context.Context) *cobra.Command {
 		SilenceUsage:       true, // our FlagErrorFunc will handle it
 		DisableFlagParsing: true, // Bc of the legacyCommand parsing, see legacy_command.go
 	}
-	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		if err == nil {
+
+	// Since we had to DisableFlagParsing so we can parse legacy commands, this
+	// doesn't do anything. Leaving this commented because I don't know if we'll
+	// leave legacy command parsing forever, in which case we'd want to uncomment
+	// this
+	/*
+		rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+			if err == nil {
+				return nil
+			}
+
+			// If the error is multiple lines, include an extra blank line before the "See
+			// --help" line.
+			errStr := strings.TrimRight(err.Error(), "\n")
+			if strings.Contains(errStr, "\n") {
+				errStr += "\n"
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\nSee '%s --help'.\n", cmd.CommandPath(), errStr, cmd.CommandPath())
+			os.Exit(2)
 			return nil
-		}
-
-		// If the error is multiple lines, include an extra blank line before the "See
-		// --help" line.
-		errStr := strings.TrimRight(err.Error(), "\n")
-		if strings.Contains(errStr, "\n") {
-			errStr += "\n"
-		}
-
-		fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\nSee '%s --help'.\n", cmd.CommandPath(), errStr, cmd.CommandPath())
-		os.Exit(2)
-		return nil
-	})
+		})
+	*/
 
 	// Hidden/internal commands. These are called by Telepresence itself from
 	// the correct context and execute in-place immediately.

--- a/pkg/client/cli/command.go
+++ b/pkg/client/cli/command.go
@@ -65,13 +65,16 @@ var kubeFlags *pflag.FlagSet
 // OnlySubcommands is a cobra.PositionalArgs that is similar to cobra.NoArgs, but prints a better
 // error message.
 func OnlySubcommands(cmd *cobra.Command, args []string) error {
-	// If a user is using the `swap-deployment` flag, then that means they
-	// are coming from telepresence 1.  We try to construct the tp2 command
-	// based on their input, which oftentimes has a command as the argument
-	// so we don't want to error out here
+	// If a user is using a flag that is coming from telepresence 1, we try to
+	// construct the tp2 command based on their input. If the args passed to
+	// telepresence are one of the flags we recognize, we don't want to error
+	// out here.
+	tp1Flags := []string{"--swap-deployment", "-s", "--run", "--run-shell", "--docker-run"}
 	for _, v := range args {
-		if v == "--swap-deployment" || v == "-s" {
-			return nil
+		for _, flag := range tp1Flags {
+			if v == flag {
+				return nil
+			}
 		}
 	}
 	if len(args) != 0 {

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Here we handle parsing legacy commands, as well as generating telepresence 2
+// commands from them.  This will make it easier for users to move to
+// telepresence 2.  Note: This isn't exhaustive, but should capture the major
+// flags that were used and have a correlated command in telepresence 2.
+
+type legacyCommand struct {
+	swapDeployment string
+	expose         string
+	run            bool
+	dockerRun      bool
+	processCmd     string
+	mount          string
+	dockerMount    string
+	envFile        string
+	envJSON        string
+
+	// kubectl-related flags
+	context   string
+	namespace string
+
+	unknownFlags []string
+}
+
+// Unfortunately we have to do our own flag parsing if we see legacy telepresence
+// flags because the run command might include something that cobra might detect
+// as a flag e.g. --run python3 -m http.server. In python this was handled by
+// using argparse.REMAINDER and there is not similar functionality with cobra.
+// There is an open ticket to pass unknown flags to the command:
+// https://github.com/spf13/cobra/issues/739
+// but until that is addressed, we'll do the flag parsing ourself (which isn't
+// the worst because it's a legacy command so the flags won't be growing).
+func parseLegacyCommand(args []string) *legacyCommand {
+	lc := &legacyCommand{}
+
+	// We don't want to over-index in case somebody has a command that has a
+	// flag but doesn't put the value after it.  So we have this helper function
+	// to ensure we don't do that.  It may mean the telepresence command at the
+	// end fails, but then they'll see the telepresence 2 error messge and can
+	// fix it from there.
+	getArg := func(i int) string {
+		if len(args) > i {
+			return args[i]
+		}
+		return ""
+	}
+Parsing:
+	for i, v := range args {
+		switch {
+		case v == "--swap-deployment" || v == "-s":
+			lc.swapDeployment = getArg(i + 1)
+		case v == "--expose":
+			lc.expose = getArg(i + 1)
+		case v == "--mount":
+			lc.mount = getArg(i + 1)
+		case v == "--docker-mount":
+			lc.dockerMount = getArg(i + 1)
+		case v == "--env-json":
+			lc.envJSON = getArg(i + 1)
+		case v == "--env-file":
+			lc.envFile = getArg(i + 1)
+		case v == "--namespace":
+			lc.namespace = getArg(i + 1)
+		case v == "--run":
+			lc.run = true
+			if nxtArg := getArg(i + 1); nxtArg != "" {
+				lc.processCmd = strings.Join(args[i+1:], " ")
+			}
+			break Parsing
+		case v == "--docker-run":
+			lc.dockerRun = true
+			if nxtArg := getArg(i + 1); nxtArg != "" {
+				lc.processCmd = strings.Join(args[i+1:], " ")
+			}
+			break Parsing
+		case strings.Contains(v, "--"):
+			lc.unknownFlags = append(lc.unknownFlags, v)
+		}
+	}
+	return lc
+}
+
+// genTP2Command constructs a telepresence 2 command based on
+// the values that are set in the legacyCommand struct
+func (lc *legacyCommand) genTP2Command() (string, error) {
+	cmdSlice := []string{"intercept"}
+	if lc.swapDeployment != "" {
+		cmdSlice = append(cmdSlice, lc.swapDeployment)
+	}
+	if lc.expose != "" {
+		cmdSlice = append(cmdSlice, "--port", lc.expose)
+	}
+
+	if lc.envFile != "" {
+		cmdSlice = append(cmdSlice, "--env-file", lc.envFile)
+	}
+
+	if lc.envJSON != "" {
+		cmdSlice = append(cmdSlice, "--env-json", lc.envJSON)
+	}
+
+	if lc.context != "" {
+		cmdSlice = append(cmdSlice, "--context", lc.context)
+	}
+
+	if lc.namespace != "" {
+		cmdSlice = append(cmdSlice, "--namespace", lc.namespace)
+	}
+
+	if lc.run && lc.dockerRun {
+		return "", errors.New("--run and --docker-run are mutually exclusive")
+	}
+
+	if lc.run {
+		if lc.mount != "" {
+			cmdSlice = append(cmdSlice, "--mount", lc.mount)
+		}
+	}
+
+	if lc.dockerRun {
+		if lc.dockerMount != "" {
+			cmdSlice = append(cmdSlice, "--docker-mount", lc.dockerMount)
+		}
+		cmdSlice = append(cmdSlice, "--docker-run")
+	}
+
+	if lc.processCmd != "" {
+		cmdSlice = append(cmdSlice, "--", lc.processCmd)
+	}
+
+	return strings.Join(cmdSlice, " "), nil
+}
+
+// translateLegacyCmd tries to detect if a telepresence 1 command was used
+// and constructs a telepresence 2 command from that.
+func translateLegacyCmd(args []string) (string, []string, error) {
+	lc := parseLegacyCommand(args)
+	if lc.swapDeployment == "" {
+		return "", nil, nil
+	}
+	tp2Cmd, err := lc.genTP2Command()
+	if err != nil {
+		return "", nil, nil
+	}
+	return tp2Cmd, lc.unknownFlags, nil
+}
+
+// checkLegacyCmd is mostly a wrapper around translateLegacyCmd. The latter
+// is separate to make for easier testing.
+func checkLegacyCmd(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	tp2Cmd, unknownFlags, err := translateLegacyCmd(args)
+	if err != nil {
+		return err
+	}
+	if len(unknownFlags) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "The following flags used don't have a direct translation to tp2 and haven't been translated: %#v", unknownFlags)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nYou used a telepresence 1 command that roughly translates to the following:\ntelepresence %s\n", tp2Cmd)
+	return nil
+}

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 )
 
 // Here we handle parsing legacy commands, as well as generating telepresence 2
@@ -212,6 +214,9 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	scout := client.NewScout(cmd.Context(), "cli")
+	_ = scout.Report(cmd.Context(), "Used legacy syntax")
 
 	if msg != "" {
 		fmt.Fprintln(cmd.OutOrStderr(), msg)

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -214,11 +214,20 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if msg != "" {
-		fmt.Fprintln(cmd.OutOrStdout(), msg)
+		fmt.Fprintln(cmd.OutOrStderr(), msg)
 	}
 
 	if tp2Cmd != "" {
-		fmt.Fprintf(cmd.OutOrStdout(), "\nYou used a telepresence 1 command that roughly translates to the following:\ntelepresence %s\n", tp2Cmd)
+		fmt.Fprintf(cmd.OutOrStderr(), "\nYou used a telepresence 1 command that roughly translates to the following:\ntelepresence %s\n", tp2Cmd)
+		ctx := cmd.Context()
+		fmt.Fprintln(cmd.OutOrStderr(), "running...")
+		newCmd := Command(ctx)
+		newCmd.SetArgs(strings.Split(tp2Cmd, " "))
+		newCmd.SetOut(cmd.OutOrStderr())
+		newCmd.SetErr(cmd.OutOrStderr())
+		if err := newCmd.ExecuteContext(ctx); err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), err)
+		}
 	}
 	return nil
 }

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -191,15 +191,15 @@ func translateLegacyCmd(args []string) (string, string, error) {
 	// about changed behavior.
 	msg := ""
 	if len(lc.unknownFlags) > 0 {
-		msg += fmt.Sprintf("The following flags used don't have a direct translation to tp2: %s",
+		msg += fmt.Sprintf("The following flags used don't have a direct translation to tp2: %s\n",
 			strings.Join(lc.unknownFlags, " "))
 	}
 	if lc.method {
-		msg += "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise tp2 works similarly to vpn-tcp"
+		msg += "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise it works similarly to vpn-tcp\n"
 	}
 
 	if lc.newDeployment {
-		msg += "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace."
+		msg += "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace.\n"
 	}
 	return tp2Cmd, msg, nil
 }
@@ -218,12 +218,15 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	scout := client.NewScout(cmd.Context(), "cli")
 	_ = scout.Report(cmd.Context(), "Used legacy syntax")
 
-	if msg != "" {
-		fmt.Fprintln(cmd.OutOrStderr(), msg)
-	}
-
+	// Separate the help output from the tp1 -> tp2 translation
 	if tp2Cmd != "" {
-		fmt.Fprintf(cmd.OutOrStderr(), "\nYou used a telepresence 1 command that roughly translates to the following:\ntelepresence %s\n", tp2Cmd)
+		fmt.Fprintf(cmd.OutOrStderr(), "\nLegacy telepresence command used\n")
+
+		if msg != "" {
+			fmt.Fprintln(cmd.OutOrStderr(), msg)
+		}
+
+		fmt.Fprintf(cmd.OutOrStderr(), "Command roughly translates to the following in Telepresence 2:\ntelepresence %s\n", tp2Cmd)
 		ctx := cmd.Context()
 		fmt.Fprintln(cmd.OutOrStderr(), "running...")
 		newCmd := Command(ctx)

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -98,6 +98,8 @@ Parsing:
 		case v == "--run-shell":
 			lc.runShell = true
 			break Parsing
+		// this is so telepresence --help returns the help command
+		case v == "--help":
 		case strings.Contains(v, "--"):
 			lc.unknownFlags = append(lc.unknownFlags, v)
 		}
@@ -187,15 +189,15 @@ func translateLegacyCmd(args []string) (string, string, error) {
 	// about changed behavior.
 	msg := ""
 	if len(lc.unknownFlags) > 0 {
-		msg = msg + fmt.Sprintf("The following flags used don't have a direct translation to tp2: %s",
+		msg += fmt.Sprintf("The following flags used don't have a direct translation to tp2: %s",
 			strings.Join(lc.unknownFlags, " "))
 	}
 	if lc.method {
-		msg = msg + "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise tp2 works similarly to vpn-tcp"
+		msg += "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise tp2 works similarly to vpn-tcp"
 	}
 
 	if lc.newDeployment {
-		msg = msg + "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace."
+		msg += "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace."
 	}
 	return tp2Cmd, msg, nil
 }

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -46,9 +46,35 @@ func Test_legacyCommands(t *testing.T) {
 			outputTP2Command:   "intercept myserver --port 9090:80 -- python3 -m http.server 9090",
 		},
 		{
+			name:               "swapDeploymentRunShell",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --run-shell",
+			outputTP2Command:   "intercept myserver -- bash",
+		},
+		{
 			name:               "swapDeploymentBasicDockerRun",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 80 --docker-run -i -t nginx:latest",
 			outputTP2Command:   "intercept myserver --port 80 --docker-run -- -i -t nginx:latest",
+		},
+		{
+			name:               "runCommand",
+			inputLegacyCommand: "telepresence --run curl http://myservice:8080/",
+			outputTP2Command:   "connect -- curl http://myservice:8080/",
+		},
+		{
+			name:               "runShell",
+			inputLegacyCommand: "telepresence --run-shell",
+			outputTP2Command:   "connect -- bash",
+		},
+		{
+			name:               "runShellNewDeployment",
+			inputLegacyCommand: "telepresence --new-deployment myserver --run-shell",
+			outputTP2Command:   "connect -- bash",
+			msg:                "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace.",
+		},
+		{
+			name:               "runShellIgnoreExtraArgs",
+			inputLegacyCommand: "telepresence --expose 8080 --run-shell",
+			outputTP2Command:   "connect -- bash",
 		},
 	}
 

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -12,19 +12,25 @@ func Test_legacyCommands(t *testing.T) {
 		name               string
 		inputLegacyCommand string
 		outputTP2Command   string
-		unknownFlags       []string
+		msg                string
 	}
 	testCases := []testcase{
 		{
-			name:               "basicSwapDeployment",
+			name:               "swapDeploymentBasic",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
+		},
+		{
+			name:               "swapDeploymentMethod",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --method inject-tcp --expose 9090 --run python3 -m http.server 9090",
+			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
+			msg:                "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise tp2 works similarly to vpn-tcp",
 		},
 		{
 			name:               "swapDeploymentUnknownParam",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --not-real-param --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
-			unknownFlags:       []string{"--not-real-param"},
+			msg:                "The following flags used don't have a direct translation to tp2: --not-real-param",
 		},
 		{
 			// This name isn't the greatest but basically, if we have an unknown
@@ -51,11 +57,11 @@ func Test_legacyCommands(t *testing.T) {
 		tc := tc
 		t.Run(tcName, func(t *testing.T) {
 			inputArgs := strings.Split(tc.inputLegacyCommand, " ")
-			genTP2Cmd, unknownFlags, err := translateLegacyCmd(inputArgs)
+			genTP2Cmd, msg, err := translateLegacyCmd(inputArgs)
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.unknownFlags, unknownFlags)
+			assert.Equal(t, tc.msg, msg)
 			assert.Equal(t, tc.outputTP2Command, genTP2Cmd)
 		})
 	}

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -24,13 +24,13 @@ func Test_legacyCommands(t *testing.T) {
 			name:               "swapDeploymentMethod",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --method inject-tcp --expose 9090 --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
-			msg:                "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise tp2 works similarly to vpn-tcp",
+			msg:                "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise it works similarly to vpn-tcp\n",
 		},
 		{
 			name:               "swapDeploymentUnknownParam",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --not-real-param --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
-			msg:                "The following flags used don't have a direct translation to tp2: --not-real-param",
+			msg:                "The following flags used don't have a direct translation to tp2: --not-real-param\n",
 		},
 		{
 			// This name isn't the greatest but basically, if we have an unknown
@@ -69,7 +69,7 @@ func Test_legacyCommands(t *testing.T) {
 			name:               "runShellNewDeployment",
 			inputLegacyCommand: "telepresence --new-deployment myserver --run-shell",
 			outputTP2Command:   "connect -- bash",
-			msg:                "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace.",
+			msg:                "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace.\n",
 		},
 		{
 			name:               "runShellIgnoreExtraArgs",
@@ -87,8 +87,8 @@ func Test_legacyCommands(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, tc.msg, msg)
-			assert.Equal(t, tc.outputTP2Command, genTP2Cmd)
+			assert.Equal(t, msg, tc.msg)
+			assert.Equal(t, genTP2Cmd, tc.outputTP2Command)
 		})
 	}
 }

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_legacyCommands(t *testing.T) {
+	type testcase struct {
+		name               string
+		inputLegacyCommand string
+		outputTP2Command   string
+		unknownFlags       []string
+	}
+	testCases := []testcase{
+		{
+			name:               "basicSwapDeployment",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --run python3 -m http.server 9090",
+			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
+		},
+		{
+			name:               "swapDeploymentUnknownParam",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --not-real-param --run python3 -m http.server 9090",
+			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
+			unknownFlags:       []string{"--not-real-param"},
+		},
+		{
+			// This name isn't the greatest but basically, if we have an unknown
+			// parameter in the process, that's fine because telepresence doesn't
+			// care about parameters associated with a process a user is running.
+			name:               "swapDeploymentUnknownParamInProcess",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --run python3 -m http.server 9090 --not-real-param",
+			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090 --not-real-param",
+		},
+		{
+			name:               "swapDeploymentMappedPort",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090:80 --run python3 -m http.server 9090",
+			outputTP2Command:   "intercept myserver --port 9090:80 -- python3 -m http.server 9090",
+		},
+		{
+			name:               "swapDeploymentBasicDockerRun",
+			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 80 --docker-run -i -t nginx:latest",
+			outputTP2Command:   "intercept myserver --port 80 --docker-run -- -i -t nginx:latest",
+		},
+	}
+
+	for _, tc := range testCases {
+		tcName := tc.name
+		tc := tc
+		t.Run(tcName, func(t *testing.T) {
+			inputArgs := strings.Split(tc.inputLegacyCommand, " ")
+			genTP2Cmd, unknownFlags, err := translateLegacyCmd(inputArgs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tc.unknownFlags, unknownFlags)
+			assert.Equal(t, tc.outputTP2Command, genTP2Cmd)
+		})
+	}
+}

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -24,19 +24,19 @@ func Test_legacyCommands(t *testing.T) {
 			name:               "swapDeploymentMethod",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --method inject-tcp --expose 9090 --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
-			msg:                "Telepresence 2 doesn't have methods. You can use --docker-run for container, otherwise it works similarly to vpn-tcp\n",
+			msg:                "Telepresence doesn't have proxying methods. You can use --docker-run for container, otherwise it works similarly to vpn-tcp\n",
 		},
 		{
-			name:               "swapDeploymentUnknownParam",
+			name:               "swapDeploymentUnsupportedParam",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --not-real-param --run python3 -m http.server 9090",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090",
-			msg:                "The following flags used don't have a direct translation to tp2: --not-real-param\n",
+			msg:                "The following flags used don't have a direct translation to Telepresence: --not-real-param\n",
 		},
 		{
-			// This name isn't the greatest but basically, if we have an unknown
+			// This name isn't the greatest but basically, if we have an unsupported
 			// parameter in the process, that's fine because telepresence doesn't
 			// care about parameters associated with a process a user is running.
-			name:               "swapDeploymentUnknownParamInProcess",
+			name:               "swapDeploymentUnsupportedParamInProcess",
 			inputLegacyCommand: "telepresence --swap-deployment myserver --expose 9090 --run python3 -m http.server 9090 --not-real-param",
 			outputTP2Command:   "intercept myserver --port 9090 -- python3 -m http.server 9090 --not-real-param",
 		},
@@ -69,7 +69,7 @@ func Test_legacyCommands(t *testing.T) {
 			name:               "runShellNewDeployment",
 			inputLegacyCommand: "telepresence --new-deployment myserver --run-shell",
 			outputTP2Command:   "connect -- bash",
-			msg:                "This flag is ignored since Telepresence 2 uses one traffic-manager deployed in the ambassador namespace.\n",
+			msg:                "This flag is ignored since Telepresence uses one traffic-manager deployed in the ambassador namespace.\n",
 		},
 		{
 			name:               "runShellIgnoreExtraArgs",
@@ -83,12 +83,12 @@ func Test_legacyCommands(t *testing.T) {
 		tc := tc
 		t.Run(tcName, func(t *testing.T) {
 			inputArgs := strings.Split(tc.inputLegacyCommand, " ")
-			genTP2Cmd, msg, err := translateLegacyCmd(inputArgs)
+			genTPCmd, msg, _, err := translateLegacyCmd(inputArgs)
 			if err != nil {
 				t.Fatal(err)
 			}
 			assert.Equal(t, msg, tc.msg)
-			assert.Equal(t, genTP2Cmd, tc.outputTP2Command)
+			assert.Equal(t, genTPCmd, tc.outputTP2Command)
 		})
 	}
 }

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -503,6 +503,21 @@ func (cs *connectedSuite) TestK_DockerRun() {
 	cs.Contains(<-stdoutCh, "Using Deployment "+svc)
 }
 
+func (cs *connectedSuite) TestL_LegacySwapDeploymentDoesIntercept() {
+	require := cs.Require()
+
+	// We don't need to defer leaving the intercept because the
+	// intercept is automatically left once the command is finished
+	_, stderr := telepresence(cs.T(), "--swap-deployment", "with-probes", "--expose", "9090", "--namespace", cs.ns(), "--mount", "false", "--run", "sleep", "1")
+	require.Contains(stderr, "You used a telepresence 1 command")
+	require.Contains(stderr, "Using Deployment with-probes")
+
+	// Verify that the intercept no longer exists
+	stdout, stderr := telepresence(cs.T(), "list", "--namespace", cs.ns(), "--intercepts")
+	require.Empty(stderr)
+	require.Contains(stdout, "No Workloads (Deployments, StatefulSets, or ReplicaSets)")
+}
+
 func (cs *connectedSuite) TestZ_Uninstall() {
 	cs.Run("Uninstalls agent on given deployment", func() {
 		require := cs.Require()

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -509,8 +509,13 @@ func (cs *connectedSuite) TestL_LegacySwapDeploymentDoesIntercept() {
 	// We don't need to defer leaving the intercept because the
 	// intercept is automatically left once the command is finished
 	_, stderr := telepresence(cs.T(), "--swap-deployment", "with-probes", "--expose", "9090", "--namespace", cs.ns(), "--mount", "false", "--run", "sleep", "1")
-	require.Contains(stderr, "Legacy telepresence command used")
+	require.Contains(stderr, "Legacy Telepresence command used")
 	require.Contains(stderr, "Using Deployment with-probes")
+
+	// Since legacy Telepresence commands are detected and translated in the
+	// RunSubcommands function, so we ensure that the help text is *not* being
+	// printed out in this case.
+	require.NotContains(stderr, "Telepresence can connect to a cluster and route all outbound traffic")
 
 	// Verify that the intercept no longer exists
 	stdout, stderr := telepresence(cs.T(), "list", "--namespace", cs.ns(), "--intercepts")

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -509,7 +509,7 @@ func (cs *connectedSuite) TestL_LegacySwapDeploymentDoesIntercept() {
 	// We don't need to defer leaving the intercept because the
 	// intercept is automatically left once the command is finished
 	_, stderr := telepresence(cs.T(), "--swap-deployment", "with-probes", "--expose", "9090", "--namespace", cs.ns(), "--mount", "false", "--run", "sleep", "1")
-	require.Contains(stderr, "You used a telepresence 1 command")
+	require.Contains(stderr, "Legacy telepresence command used")
 	require.Contains(stderr, "Using Deployment with-probes")
 
 	// Verify that the intercept no longer exists


### PR DESCRIPTION
Here's my PR for translating tp1 to tp2 commands. It's not exhaustive, but it tries to capture most of the commands (--swap-deployment, --run, --docker-run), as well as the various flags that can be used with those commands.  

---
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - No docs PR for this needed. I do want to make a doc of tp1 -> tp2 but that's a separate work item
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.