### PR TITLE
Add Helm Chart for Server Components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ traffic
 tst-manager
 tst-systema
 !/cmd/*/
+
+# The Chart directory
+!/charts/telepresence

--- a/charts/telepresence/.helmignore
+++ b/charts/telepresence/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/telepresence/CHANGELOG.md
+++ b/charts/telepresence/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## v0.1.0
+
+- Feature: Add support for installing the Traffic Manager with Helm

--- a/charts/telepresence/Chart.yaml
+++ b/charts/telepresence/Chart.yaml
@@ -1,23 +1,11 @@
 apiVersion: v2
 name: telepresence
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+description: A chart for deploying the server-side components of Telepresence
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+# Note: This is the version of the Traffic Manager that will be installed by 
+# this chart. The telepresence CLI will always attempt to update the Traffic 
+# Manager if it is not the same version as the CLI so ensure you are keeping
+# these in sync.
 appVersion: 2.2.2

--- a/charts/telepresence/Chart.yaml
+++ b/charts/telepresence/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: telepresence
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 2.2.2

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -1,0 +1,73 @@
+# Telepresence
+
+[Telepresence](https://www.getambassador.io/products/telepresence/) is a tool 
+that allows for local development of microservices running in a remote 
+Kubernetes cluster.
+
+This chart manages the server-side components of Telepresence so that an
+operations team can give limited access to the cluster for developers to work on
+their services.
+
+## Install
+
+```sh
+helm repo add datawire https://getambassador.io
+helm install traffic-manager -n ambassador datawire/telepresence --create-namespace
+```
+
+## Changelog
+
+Notable chart changes are listed in the [CHANGELOG](./CHANGELOG.md)
+
+## Configuration
+
+The following tables lists the configurable parameters of the Ambassador chart and their default values.
+
+| Parameter                | Description                                                                                                             | Default                                                                                           |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| image.repository         | The repository to download the image from. Set `TELEPRESENCE_REGISTRY=image.repository` locally if changing this value. | `docker.io/datawire/tel2`                                                                         |
+| image.pullPolicy         | How the `Pod` will attempt to pull the image.                                                                           | `IfNotPresent`                                                                                    |
+| image.tag                | Override the version of the Traffic Manager to be installed.                                                            | `""` (Defined in `appVersion` Chart.yaml)                                                         |
+| image.imagePullSecrets   | The `Secret` storing any credentials needed to access the image in a private registry.                                  | `[]`                                                                                              |
+| podAnnotations           | Annotations for the Traffic Manager `Pod`                                                                               | `{}`                                                                                              |
+| podSecurityContext       | The Kubernetes SecurityContext for the `Pod`                                                                            | `{}`                                                                                              |
+| securityContext          | The Kubernetes SecurityContext for the `Deployment`                                                                     | `{"readOnlyRootFilesystem": true, "runAsNonRoot": true, "runAsUser": 1000}`                       |
+| service.type             | The type of `Service` for the Traffic Manager.                                                                          | `ClusterIP`                                                                                       |
+| service.ports            | The ports the Traffic Manager `Service` will listen on and forward to. **Do not change.**                               | `[{"name":"sshd","port":8022,"targetPort":"sshd"},{"name":"api","port":8081,"targetPort":"api"}]` |
+| resources                | Define resource requests and limits for the Traffic Manger.                                                             | `{}`                                                                                              |
+| nodeSelector             | Define which `Node`s you want to the Traffic Manager to be deployed to.                                                 | `{}`                                                                                              |
+| tolerations              | Define tolerations for the Traffic Manager to ignore `Node` taints.                                                     | `[]`                                                                                              |
+| affinity                 | Define the `Node` Affinity and Anti-Affinity for the Traffic Manager.                                                   | `{}`                                                                                              |
+| licenseKey.create        | Create the license key `volume` and `volumeMount`. **Only required for clusters without access to the internet.**       | `false`                                                                                           |
+| licenseKey.value         | The value of the license key.                                                                                           | `""`                                                                                              |
+| licenseKey.secret.create | Define whether you want the license key `Secret` to be managed by the release or not.                                   | `true`                                                                                            |
+| licenseKey.secret.name   | The name of the `Secret` that Traffic Manager will look for.                                                            | `systema-license`                                                                                 |
+
+## License Key 
+
+Telepresence can create TCP intercepts without a license key. Creating 
+intercepts based on HTTP headers requires a license key from the Ambassador
+Cloud.
+
+In normal environments that have access to the public internet, the Traffic
+Manager will automatically connect to the Ambassador Cloud to retrieve a license
+key. If you are working in one of these environments, you can safely ignore
+these settings in the chart.
+
+If you are running in an [air gapped cluster](https://www.getambassador.io/docs/telepresence/latest/reference/cluster-config/#air-gapped-cluster),
+you will need to configure the Traffic Manager to use a license key you manually
+deploy to the cluster.
+
+These notes should help clarify your options for enabling this.
+
+* `licenseKey.create` will **always** create the `volume` and `volumeMount` for
+mounting the `Secret` in the Traffic Managed
+
+* `licenseKey.secret.name` will define the name of the `Secret` that is
+mounted in the Traffic Manager, regardless of it it is created by the chart
+
+* `licenseKey.secret.create` will create a `Secret` with
+   ```
+   data:
+     license: {{.licenseKey.value}}
+   ```

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -12,7 +12,9 @@ their services.
 
 ```sh
 helm repo add datawire https://getambassador.io
-helm install traffic-manager -n ambassador datawire/telepresence --create-namespace
+helm install traffic-manager -n ambassador datawire/telepresence \
+--create-namespace \
+--set clusterID=$(kubectl get ns default -o jsonpath='{.metadata.uid}')
 ```
 
 ## Changelog
@@ -32,12 +34,14 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | podAnnotations           | Annotations for the Traffic Manager `Pod`                                                                               | `{}`                                                                                              |
 | podSecurityContext       | The Kubernetes SecurityContext for the `Pod`                                                                            | `{}`                                                                                              |
 | securityContext          | The Kubernetes SecurityContext for the `Deployment`                                                                     | `{"readOnlyRootFilesystem": true, "runAsNonRoot": true, "runAsUser": 1000}`                       |
-| service.type             | The type of `Service` for the Traffic Manager.                                                                          | `ClusterIP`                                                                                       |
-| service.ports            | The ports the Traffic Manager `Service` will listen on and forward to. **Do not change.**                               | `[{"name":"sshd","port":8022,"targetPort":"sshd"},{"name":"api","port":8081,"targetPort":"api"}]` |
-| resources                | Define resource requests and limits for the Traffic Manger.                                                             | `{}`                                                                                              |
 | nodeSelector             | Define which `Node`s you want to the Traffic Manager to be deployed to.                                                 | `{}`                                                                                              |
 | tolerations              | Define tolerations for the Traffic Manager to ignore `Node` taints.                                                     | `[]`                                                                                              |
 | affinity                 | Define the `Node` Affinity and Anti-Affinity for the Traffic Manager.                                                   | `{}`                                                                                              |
+| service.type             | The type of `Service` for the Traffic Manager.                                                                          | `ClusterIP`                                                                                       |
+| service.ports            | The ports the Traffic Manager `Service` will listen on and forward to. **Do not change.**                               | `[{"name":"sshd","port":8022,"targetPort":"sshd"},{"name":"api","port":8081,"targetPort":"api"}]` |
+| resources                | Define resource requests and limits for the Traffic Manger.                                                             | `{}`                                                                                              |
+| logLevel                 | Define the logging level of the Traffic Manager                                                                         | `debug`                                                                                           |
+| clusterID                | The ID the Traffic Manager uses to identify itself. This is just the UID of the default namespace.                      | `""`                                                                                              |
 | licenseKey.create        | Create the license key `volume` and `volumeMount`. **Only required for clusters without access to the internet.**       | `false`                                                                                           |
 | licenseKey.value         | The value of the license key.                                                                                           | `""`                                                                                              |
 | licenseKey.secret.create | Define whether you want the license key `Secret` to be managed by the release or not.                                   | `true`                                                                                            |

--- a/charts/telepresence/templates/NOTES.txt
+++ b/charts/telepresence/templates/NOTES.txt
@@ -1,0 +1,19 @@
+--------------------------------------------------------------------------------
+Congratulations!
+
+
+You have successfully installed the Traffic Manager component of Telepresence!
+Now your users will be able to `telepresence connect` to this Cluster and create
+intercepts for their services!
+
+--------------------------------------------------------------------------------
+Next Steps
+--------------------------------------------------------------------------------
+
+- Take a look at our RBAC documentation for setting up the minimal required RBAC
+roles for your users at
+https://www.getambassador.io/docs/telepresence/latest/reference/rbac/
+
+- Ensure that you are keeping up to date with Telepresence releases 
+https://github.com/telepresenceio/telepresence/releases so that your Traffic
+Manager is the same version as the telepresence client your users are running!

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -32,6 +32,16 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Traffic Manager Namespace
+*/}}
+{{- define "telepresence.namespace" -}}
+{{- if ne "ambassador" .Release.Namespace}}
+{{- fail "The Traffic Manager MUST BE deployed to the namespace named Ambassador" }}
+{{- end }}
+{{- printf "%s" .Release.Namespace }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "telepresence.chart" -}}

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "telepresence.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+{{- define "telepresence.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+*/}}
+
+{{- define "telepresence.fullname" -}}
+{{- $name := default "traffic-manager" }}
+{{- if ne $name .Release.Name }}
+{{- fail "The name of the release MUST BE traffic-manager" }}
+{{- end }}
+{{- printf "%s" .Release.Name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "telepresence.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "telepresence.labels" -}}
+{{ include "telepresence.selectorLabels" . }}
+helm.sh/chart: {{ include "telepresence.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "telepresence.selectorLabels" -}}
+app: traffic-manager
+telepresence: manager
+{{- end }}

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -39,6 +39,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.licenseKey.create }}
+          volumeMounts:
+          - name: license
+            mountPath: /home/telepresence
+            readOnly: true
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -50,4 +56,11 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.licenseKey.create }}
+      volumes:
+      - name: license
+        secret: 
+          defaultMode: 420
+          secretName: {{ .Values.licenseKey.secret.name }}
       {{- end }}

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "telepresence.fullname" . }}
+  namespace: {{ include "telepresence.namespace" . }}
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 spec:

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "telepresence.fullname" . }}
+  labels:
+    {{- include "telepresence.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "telepresence.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "telepresence.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: sshd
+            containerPort: 8022
+          - name: api
+            containerPort: 8081
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -31,6 +31,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel }}
+          - name: SYSTEMA_HOST
+            value: app.getambassador.io
+          - name: SYSTEMA_PORT
+            value: "443"
+          - name: CLUSTER_ID
+            value: {{ .Values.clusterID }}
           ports:
           - name: sshd
             containerPort: 8022

--- a/charts/telepresence/templates/licenseSecret.yaml
+++ b/charts/telepresence/templates/licenseSecret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.licenseKey.secret.name }}
+  namespace: {{ include "telepresence.namespace" . }}
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:

--- a/charts/telepresence/templates/licenseSecret.yaml
+++ b/charts/telepresence/templates/licenseSecret.yaml
@@ -3,8 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.licenseKey.secret.name }}
+  labels:
+    {{- include "telepresence.labels" . | nindent 4 }}
 data:
   hostDomain: {{ printf "auth.datawire.io" | b64enc }}
-  license: {{ .Values.licenseKey.value | b64enc }}
-
+  license: {{ .Values.licenseKey.value | quote | b64enc }}
 {{- end }}

--- a/charts/telepresence/templates/licenseSecret.yaml
+++ b/charts/telepresence/templates/licenseSecret.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.licenseKey.create .Values.licenseKey.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.licenseKey.secret.name }}
+data:
+  hostDomain: {{ printf "auth.datawire.io" | b64enc }}
+  license: {{ .Values.licenseKey.value | b64enc }}
+
+{{- end }}

--- a/charts/telepresence/templates/licenseSecret.yaml
+++ b/charts/telepresence/templates/licenseSecret.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
-  hostDomain: {{ printf "auth.datawire.io" | b64enc }}
-  license: {{ .Values.licenseKey.value | quote | b64enc }}
+  hostDomain: {{ printf "auth.datawire.io" | b64enc | quote }}
+  license: {{ .Values.licenseKey.value | quote | b64enc | quote }}
 {{- end }}

--- a/charts/telepresence/templates/licenseSecret.yaml
+++ b/charts/telepresence/templates/licenseSecret.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
   hostDomain: {{ printf "auth.datawire.io" | b64enc | quote }}
-  license: {{ .Values.licenseKey.value | quote | b64enc | quote }}
+  license: {{ .Values.licenseKey.value | b64enc | quote }}
 {{- end }}

--- a/charts/telepresence/templates/service.yaml
+++ b/charts/telepresence/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "telepresence.fullname" . }}
+  labels:
+    {{- include "telepresence.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: None
+  {{- with .Values.service.ports }}
+  ports:
+  {{- toYaml . | nindent 2}}
+  {{- end }}
+  selector:
+    {{- include "telepresence.selectorLabels" . | nindent 4 }}

--- a/charts/telepresence/templates/service.yaml
+++ b/charts/telepresence/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "telepresence.fullname" . }}
+  namespace: {{ include "telepresence.namespace" . }}
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 spec:

--- a/charts/telepresence/templates/tests/test-connection.yaml
+++ b/charts/telepresence/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "telepresence.fullname" . }}-test-connection"
+  labels:
+    {{- include "telepresence.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "telepresence.fullname" . }}:8081']
+  restartPolicy: Never

--- a/charts/telepresence/templates/tests/test-connection.yaml
+++ b/charts/telepresence/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "telepresence.fullname" . }}-test-connection"
+  namespace: {{ include "telepresence.namespace" . }}
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
   annotations:

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -1,3 +1,7 @@
+################################################################################
+## Deployment Configuration
+################################################################################
+
 # The Traffic Manager only support running with one replica at the moment.
 # Configuring the replicaCount will be added in future versions of Telepresence
 
@@ -28,16 +32,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-service:
-  type: ClusterIP
-  ports:
-  - name: sshd
-    port: 8022
-    targetPort: sshd
-  - name: api
-    port: 8081
-    targetPort: api
-
 resources: {}
   # limits:
   #   cpu: 100m
@@ -51,6 +45,37 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+################################################################################
+## Service Configuration
+################################################################################
+
+service:
+  type: ClusterIP
+  ports:
+  - name: sshd
+    port: 8022
+    targetPort: sshd
+  - name: api
+    port: 8081
+    targetPort: api
+
+################################################################################
+## Traffic Manager Configuration
+################################################################################
+
+# The log level of the Traffic Manager.
+#
+# Default: debug
+logLevel: debug
+
+# Telepresence requires a clusterID for identifying itself.
+# This cluster ID is just the UID of the default namespace. You can get this by
+# running `kubectl get ns default -o jsonpath='{.metadata.uid}'`
+# Telepresence will not be able to request a license without this.
+#
+# Default: ""
+clusterID: ""
 
 # Telepresence requires a license key for creating selective intercepts. In
 # normal clusters with access to the public internet, this license is managed

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -1,6 +1,14 @@
 # The Traffic Manager only support running with one replica at the moment.
 # Configuring the replicaCount will be added in future versions of Telepresence
+
 # replicaCount: 1
+
+# The Telepresence client will try to ensure that the Traffic Manager image is
+# up to date and from the right registry. If you are changing the value below,
+# ensure that the tag is the same as the client version and that the 
+# TELEPRESENCE_REGISTRY environment variable is equal to image.repository.
+# 
+# The client will default to docker.io/datawire/tel2:{{CLIENT_VERSION}}
 
 image:
   repository: docker.io/datawire/tel2
@@ -43,3 +51,37 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Telepresence requires a license key for creating selective intercepts. In
+# normal clusters with access to the public internet, this license is managed
+# automatically by the Ambassador Cloud. In air-gapped environments however, 
+# you need to get a license and add it to your cluster manually.
+# https://www.getambassador.io/docs/telepresence/latest/reference/cluster-config/#air-gapped-cluster
+#
+# Leave this unset unless you are running in an air-gapped environment.
+licenseKey:
+
+  # Creates the Volume and VolumeMounts for reading and managing the license key.
+  # 
+  # Default: false
+  create: false
+
+  # Value of the licence you get from the Ambassador cloud
+  #
+  # Default: ""
+  value: 
+  
+  # Configure the Helm Chart to manage the Secret the Traffic Manager will use 
+  # to read the license key. 
+  secret:
+
+    # Create the Secret with the Helm release create
+    #
+    # Default: true
+    create: true
+
+    # Name of the Secret created (if create is true) and the Secret that will be
+    # mounted as a Volume for the Traffic Manager to read
+    #
+    # Default: systema-license
+    name: systema-license

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -69,7 +69,7 @@ licenseKey:
   # Value of the licence you get from the Ambassador cloud
   #
   # Default: ""
-  value: 
+  value: ""
   
   # Configure the Helm Chart to manage the Secret the Traffic Manager will use 
   # to read the license key. 

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -1,0 +1,45 @@
+# The Traffic Manager only support running with one replica at the moment.
+# Configuring the replicaCount will be added in future versions of Telepresence
+# replicaCount: 1
+
+image:
+  repository: docker.io/datawire/tel2
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+  imagePullSecrets: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  ports:
+  - name: sshd
+    port: 8022
+    targetPort: sshd
+  - name: api
+    port: 8081
+    targetPort: api
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Create a helm chart for the traffic-manager and other server-side components.

To-do:

- [x] Update the NOTES.txt
- [x] Update Chart.yaml
- [ ] Add CHANGELOG
- [ ] Add README