### PR TITLE
Dialer close message must be sent after write queue is drained.

### DIFF
--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -73,7 +73,7 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 
 	defer func() {
 		if _, err := manager.Depart(ctx, session); err != nil {
-			dlog.Debugf(ctx, "depart session: %+v", err)
+			dlog.Errorf(ctx, "depart session: %+v", err)
 		}
 	}()
 
@@ -90,7 +90,7 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 		for {
 			snapshot, err := stream.Recv()
 			if err != nil {
-				dlog.Debugf(ctx, "stream recv: %+v", err) // May be io.EOF
+				dlog.Errorf(ctx, "stream Recv: %+v", err) // May be io.EOF
 				return
 			}
 			snapshots <- snapshot


### PR DESCRIPTION
## Description

The read-close message was sent prematurely when EOF was encountered on read
of a connection. Now moved to after the write queue is drained.

## Checklist

 - [x] My change is adequately tested.
