### PR TITLE
[v2] Make logging in user- and root daemon configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Change: The traffic-agent no longer has a sshd running. Remote volume mounts use sshfs in slave mode, talking directly to sftp.
 - Change: The local DNS now routes the name lookups to intercepted agents or traffic-manager.
 - Feature: Telepresence is now installable via brew
-- Change: The default log-level for the traffic-manager and the root-daemon was changed to "info".
+- Change: The default log-level for the traffic-manager and the root-daemon was changed from "debug' to "info".
 
 ### 2.2.2 (May 17, 2021)
 - Feature: Telepresence translates legacy Telepresence commands into viable Telepresence commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change: The traffic-agent no longer has a sshd running. Remote volume mounts use sshfs in slave mode, talking directly to sftp.
 - Change: The local DNS now routes the name lookups to intercepted agents or traffic-manager.
 - Feature: Telepresence is now installable via brew
+- Change: The default log-level for the traffic-manager and the root-daemon was changed to "info".
 
 ### 2.2.2 (May 17, 2021)
 - Feature: Telepresence translates legacy Telepresence commands into viable Telepresence commands.

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,15 +21,22 @@ func TestGetConfig(t *testing.T) {
 		/* sys1 */ `
 timeouts:
   agentInstall: 2m10s
+logLevels:
+  userDaemon: info
+  rootDaemon: debug
 `,
 		/* sys2 */ `
 timeouts:
   apply: 33s
+logLevels:
+  userDaemon: debug
 `,
 		/* user */ `
 timeouts:
   clusterConnect: 25
   proxyDial: 17.0
+logLevels:
+  rootDaemon: trace
 `,
 	}
 
@@ -52,4 +61,7 @@ timeouts:
 	assert.Equal(t, 17*time.Second, to.ProxyDial)                  // from user
 	assert.Equal(t, defaultConfig.Timeouts.Intercept, to.Intercept)
 	assert.Equal(t, defaultConfig.Timeouts.TrafficManagerConnect, to.TrafficManagerConnect)
+
+	assert.Equal(t, logrus.DebugLevel, cfg.LogLevels.UserDaemon) // from sys2
+	assert.Equal(t, logrus.TraceLevel, cfg.LogLevels.RootDaemon) // from user
 }

--- a/pkg/client/connector/install.go
+++ b/pkg/client/connector/install.go
@@ -1025,7 +1025,7 @@ func (ki *installer) managerDeployment(c context.Context, env client.Env, addLic
 
 	var containerEnv []corev1.EnvVar
 
-	containerEnv = append(containerEnv, corev1.EnvVar{Name: "LOG_LEVEL", Value: "debug"})
+	containerEnv = append(containerEnv, corev1.EnvVar{Name: "LOG_LEVEL", Value: "info"})
 	if env.SystemAHost != "" {
 		containerEnv = append(containerEnv, corev1.EnvVar{Name: "SYSTEMA_HOST", Value: env.SystemAHost})
 	}

--- a/pkg/client/connector/intercept.go
+++ b/pkg/client/connector/intercept.go
@@ -279,7 +279,6 @@ func (tm *trafficManager) addAgent(c context.Context, namespace, agentName, svcN
 
 	dlog.Infof(c, "waiting for agent for %s %q.%s", kind, agentName, namespace)
 	agent, err := tm.waitForAgent(c, agentName, namespace)
-	dlog.Infof(c, "agent found for %s %q %s", kind, agent.Name, agent.Namespace)
 	if err != nil {
 		dlog.Error(c, err)
 		return &rpc.InterceptResult{

--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -18,7 +20,12 @@ var IsTerminal = terminal.IsTerminal
 // InitContext sets up standard Telepresence logging for a background process
 func InitContext(ctx context.Context, name string) (context.Context, error) {
 	logger := logrus.StandardLogger()
-	logger.SetLevel(logrus.DebugLevel)
+	logLevels := client.GetConfig(ctx).LogLevels
+	if name == "daemon" {
+		logger.SetLevel(logLevels.RootDaemon)
+	} else if name == "connector" {
+		logger.SetLevel(logLevels.UserDaemon)
+	}
 
 	if IsTerminal(int(os.Stdout.Fd())) {
 		logger.Formatter = NewFormatter("15:04:05")


### PR DESCRIPTION
## Description

This PR adds a new `logLevels` object to the Telepresence config file so that the level for the user- and root daemon can be configured. The default for the root daemon is now "info" to avoid network traffic logging. The PR also changes the default logging for the traffic-manager to info.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 