### PR TITLE
Restore functionality of overriding DNS resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change: The default log-level for the traffic-manager and the root-daemon was changed from "debug" to "info".
 - Bugfix: Using --docker-run no longer fail to mount remote volumes when docker runs as root.
 - Bugfix: Fixed a number of race conditions.
+- Bugfix: Fix a crash when there is an error communicating with the traffic-manager about Ambassador Cloud.
 
 ### 2.2.2 (May 17, 2021)
 

--- a/pkg/client/cli/intercept_state.go
+++ b/pkg/client/cli/intercept_state.go
@@ -172,8 +172,8 @@ func (ii *interceptInfo) intercept(cmd *cobra.Command, args []string) error {
 			// We default to assuming they can connect to Ambassador Cloud
 			// unless the cluster tells us they can't
 			canConnect := true
-			resp, err := cs.managerClient.CanConnectAmbassadorCloud(cmd.Context(), &empty.Empty{})
-			if err != nil {
+			if resp, err := cs.managerClient.CanConnectAmbassadorCloud(cmd.Context(), &empty.Empty{}); err == nil {
+				// We got a response from the manager; trust that response.
 				canConnect = resp.CanConnect
 			}
 			if canConnect {

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -37,7 +37,7 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 }
 
 func (o *outbound) resolveInSearch(c context.Context, qType uint16, query string) []net.IP {
-	ips := o.resolveInCluster(c, qType, query);
+	ips := o.resolveInCluster(c, qType, query)
 	if len(ips) == 0 && len(o.search) > 0 {
 		// Apply search path
 		q := query[:len(query)-1]
@@ -53,7 +53,7 @@ func (o *outbound) resolveInSearch(c context.Context, qType uint16, query string
 				// Don't append search domain if it's already there
 				continue
 			}
-			ips = o.resolveInCluster(c, qType, q + s)
+			ips = o.resolveInCluster(c, qType, q+s)
 			if len(ips) > 0 {
 				break
 			}

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -36,6 +36,32 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 	return err
 }
 
+func (o *outbound) resolveInSearch(c context.Context, qType uint16, query string) []net.IP {
+	ips := o.resolveInCluster(c, qType, query);
+	if len(ips) == 0 && len(o.search) > 0 {
+		// Apply search path
+		q := query[:len(query)-1]
+		q = strings.ToLower(q)
+		q = strings.TrimSuffix(q, dotTel2SubDomain)
+		if strings.HasSuffix(q, ".local") {
+			return nil
+		}
+
+		q += "."
+		for _, s := range o.search {
+			if strings.HasSuffix(q, s) {
+				// Don't append search domain if it's already there
+				continue
+			}
+			ips = o.resolveInCluster(c, qType, q + s)
+			if len(ips) > 0 {
+				break
+			}
+		}
+	}
+	return ips
+}
+
 func (o *outbound) runOverridingServer(c context.Context) error {
 	if o.dnsIP == nil {
 		dat, err := ioutil.ReadFile("/etc/resolv.conf")
@@ -69,6 +95,7 @@ func (o *outbound) runOverridingServer(c context.Context) error {
 		o.domainsLock.Lock()
 		o.namespaces = namespaces
 		o.search = search
+		dlog.Debugf(c, "search = %v, namespaces = %v", o.search, o.namespaces)
 		o.domainsLock.Unlock()
 	}
 
@@ -98,7 +125,7 @@ func (o *outbound) runOverridingServer(c context.Context) error {
 		unrouteDNS(ncc)
 	}()
 	dns.Flush(c)
-	srv := dns.NewServer(c, listeners, conn, o.resolveInCluster)
+	srv := dns.NewServer(c, listeners, conn, o.resolveInSearch)
 	close(o.dnsConfigured)
 	dlog.Debug(c, "Starting server")
 	err = srv.Run(c)


### PR DESCRIPTION
## Description

This PR contains a couple of fixes related to startup/shutdown and some improvements to the DNS resolver. The overriding DNS resolver in particular didn't work as expected when using `intercept --local-only` because it relied on that the search path was dealt with somewhere else (which is normally is, but not for that resolver).

This PR only affects things that hasn't been released yet and doesn't contain anything that deserves a mention in the changelog/release notes.

The PR should be tested with Linux + resolveconf in particular, since that's where most prominent fix is. I tested it using an ubuntu box with resolved disabled.

## Checklist

 - [x] My change is adequately tested.
