### PR TITLE
build-sys: Statically link the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change: The traffic-agent no longer has a sshd running. Remote volume mounts use sshfs in slave mode, talking directly to sftp.
 - Change: The local DNS now routes the name lookups to intercepted agents or traffic-manager.
 - Change: The default log-level for the traffic-manager and the root-daemon was changed from "debug" to "info".
+- Change: The command line is now statically-linked, so it is usable on systems with different libc's.
 - Bugfix: Using --docker-run no longer fail to mount remote volumes when docker runs as root.
 - Bugfix: Fixed a number of race conditions.
 - Bugfix: Fix a crash when there is an error communicating with the traffic-manager about Ambassador Cloud.

--- a/build/go.mk
+++ b/build/go.mk
@@ -48,7 +48,7 @@ PKG_VERSION = $(shell go list ./pkg/version)
 .PHONY: build
 build: ## (Build) Build all the source code
 	mkdir -p $(BINDIR)
-	go build -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $(BINDIR) ./cmd/...
+	CGO_ENABLED=0 go build -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $(BINDIR) ./cmd/...
 
 .ko.yaml: .ko.yaml.in base-image
 	sed $(foreach v,TELEPRESENCE_REGISTRY TELEPRESENCE_BASE_VERSION, -e 's|@$v@|$($v)|g') <$< >$@


### PR DESCRIPTION
## Description

We always did this with `teleproxy`, somehow we lost it along the way to Telepresence 2.  Bring it back!

Well, we only did it for GOOS=linux with `teleproxy`, and not for GOOS=darwin because it needed CGo for github.com/datawire/pf.  But we don't use that anymore now that we have the TUN device, so we can do it on GOOS=darwin now too!

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - yep
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no docs nescessary
 - [x] My change is adequately tested. - I tested that it builds fine for GOOS=linux and GOOS=darwin
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
