### PR TITLE
Add "also-proxy" to the kubeconfig Cluster extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.3.1 (TBD)
 
 - Feature: DNS resolver can now be configured with respect to what IP addresses that are used, and what lookups that gets sent to the cluster.
+- Feature: Telepresence can now be configured to proxy subnets that aren't part of the cluster but only accesible from the cluster.
 - Bugfix: Fix a bug where sometimes large transfers from services on the cluster would hang indefinitely
 
 ### 2.3.0 (June 1, 2021)

--- a/pkg/client/connector/k8s_config.go
+++ b/pkg/client/connector/k8s_config.go
@@ -41,7 +41,8 @@ type dnsConfig struct {
 
 // kubeconfigExtension is an extension read from the selected kubeconfig Cluster.
 type kubeconfigExtension struct {
-	DNS *dnsConfig `json:"dns,omitempty"`
+	DNS       *dnsConfig       `json:"dns,omitempty"`
+	AlsoProxy []*iputil.Subnet `json:"also-proxy,omitempty"`
 }
 
 type k8sConfig struct {

--- a/pkg/client/connector/traffic_manager.go
+++ b/pkg/client/connector/traffic_manager.go
@@ -628,7 +628,6 @@ func (tm *trafficManager) getOutboundInfo(c context.Context, mgrPort int32) (*da
 		Session:       tm.sessionInfo,
 		ManagerPort:   mgrPort,
 		ServiceSubnet: serviceSubnet,
-		PodSubnets:    podCIDRs,
 		Dns: &daemon.DNSConfig{
 			RemoteIp: kubeDNS,
 		},
@@ -642,5 +641,9 @@ func (tm *trafficManager) getOutboundInfo(c context.Context, mgrPort int32) (*da
 		}
 		info.Dns.LookupTimeout = int64(tm.DNS.LookupTimeout.Duration)
 	}
+	for _, subnet := range tm.AlsoProxy {
+		podCIDRs = append(podCIDRs, iputil.IPNetToRPC((*net.IPNet)(subnet)))
+	}
+	info.PodSubnets = podCIDRs
 	return info, nil
 }

--- a/pkg/iputil/ipnet.go
+++ b/pkg/iputil/ipnet.go
@@ -1,6 +1,7 @@
 package iputil
 
 import (
+	"encoding/json"
 	"net"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/daemon"
@@ -19,4 +20,23 @@ func IPNetFromRPC(r *daemon.IPNet) *net.IPNet {
 		IP:   r.Ip,
 		Mask: net.CIDRMask(int(r.Mask), len(r.Ip)*8),
 	}
+}
+
+type Subnet net.IPNet
+
+func (s *Subnet) MarshalJSON() ([]byte, error) {
+	return json.Marshal((*net.IPNet)(s).String())
+}
+
+func (s *Subnet) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	_, ipNet, err := net.ParseCIDR(str)
+	if err != nil {
+		return err
+	}
+	*s = *(*Subnet)(ipNet)
+	return nil
 }


### PR DESCRIPTION
## Description

Adds a `also-proxy` entry to Telepresence's extension for the
kubeconfig Cluster configuration as a list of subnets. The subnets
will be added to the TUN-device so that all connections to the
addresses that they cover are dispatched to the cluster.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
