### PR TITLE
Fix race between reading from the cluster and closing the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.1 (TBD)
+
+- Bugfix: Fix a bug where sometimes large transfers from services on the cluster would hang indefinitely
+
 ### 2.3.0 (June 1, 2021)
 
 - Feature: Telepresence is now installable via brew

--- a/cmd/traffic/logger.go
+++ b/cmd/traffic/logger.go
@@ -12,11 +12,11 @@ import (
 func makeBaseLogger() dlog.Logger {
 	logrusLogger := logrus.New()
 	logrusFormatter := &logrus.TextFormatter{
-		TimestampFormat: "2006-01-02 15:04:05",
+		TimestampFormat: "2006-01-02 15:04:05.0000",
 		FullTimestamp:   true,
 	}
 	logrusLogger.SetFormatter(logrusFormatter)
-	logrusLogger.SetReportCaller(false)
+	logrusLogger.SetReportCaller(true)
 
 	const defaultLogLevel = logrus.InfoLevel
 

--- a/pkg/connpool/dialer.go
+++ b/pkg/connpool/dialer.go
@@ -161,7 +161,7 @@ func (h *dialer) sendTCD(ctx context.Context, code ControlCode) {
 func (h *dialer) readLoop(ctx context.Context) {
 	defer func() {
 		// allow write to drain and perform the close of the connection
-		dtime.SleepWithContext(ctx, 100*time.Millisecond)
+		dtime.SleepWithContext(ctx, 200*time.Millisecond)
 		close(h.incoming)
 	}()
 	b := make([]byte, 0x8000)


### PR DESCRIPTION
Basically when transferring a large file from the cluster, sometimes the
daemon would process a FIN from the remote end before all packets that
came before the FIN had been routed.



---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
