### PR TITLE
Allow the user's GOROOT to be set in unit tests.

### DIFF
--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -810,7 +810,7 @@ func (ts *telepresenceSuite) publishManager() error {
 		"TELEPRESENCE_VERSION=" + ts.testVersion,
 		"TELEPRESENCE_REGISTRY=" + dtest.DockerRegistry(ctx),
 	}
-	includeEnv := []string{"KO_DOCKER_REPO=", "HOME=", "PATH=", "LOGNAME=", "TMPDIR=", "MAKELEVEL="}
+	includeEnv := []string{"KO_DOCKER_REPO=", "HOME=", "PATH=", "LOGNAME=", "TMPDIR=", "MAKELEVEL=", "GOROOT="}
 	for _, env := range os.Environ() {
 		for _, incl := range includeEnv {
 			if strings.HasPrefix(env, incl) {

--- a/pkg/client/connector/install_test.go
+++ b/pkg/client/connector/install_test.go
@@ -37,7 +37,7 @@ func publishManager(t *testing.T) {
 		"TELEPRESENCE_VERSION=" + version.Version,
 		"TELEPRESENCE_REGISTRY=" + dtest.DockerRegistry(ctx),
 	}
-	includeEnv := []string{"KO_DOCKER_REPO=", "HOME=", "PATH=", "LOGNAME=", "TMPDIR=", "MAKELEVEL="}
+	includeEnv := []string{"KO_DOCKER_REPO=", "HOME=", "PATH=", "LOGNAME=", "TMPDIR=", "MAKELEVEL=", "GOROOT="}
 	for _, env := range os.Environ() {
 		for _, incl := range includeEnv {
 			if strings.HasPrefix(env, incl) {


### PR DESCRIPTION
This is needed to make the unit tests more robust with brew-installed
ko



---

## Helpful information

- CircleCI will run the linters and unit tests on your PR.
  - The results of that CI run will be listed as "check-local."
  - You can run the same tests yourself:

    ```shell
    make lint check-local
    ```

  - The other checks for your PR will succeed immediately without testing anything. They rely on Datawire secrets to push images or talk to a Kubernetes cluster, so they are disabled for forked-repo PRs.

- Please include a changelog entry as a file `newsfragments/issue_number.type`.
  - `type` is one of `incompat`, `feature`, `bugfix`, or `misc`
  - E.g., `1003.bugfix` would contain the text
    > Attaching a debugger to the process running under Telepresence no longer causes the session to end.
  - You can preview the changelog with

    ```shell
    virtualenv/bin/towncrier --draft
    ```

- Please delete this pre-filled text ("Helpful information"). Note that you can edit the description after submitting the PR if you prefer.

Thank you for your contribution!
