### PR TITLE
Fix a race between closing a connection to the agent and writing to it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.3.2 (TBD)
 
 - Bug: On a MacOS, files generated under /etc/resolver as the result of using include-suffixes in the cluster config, are now properly removed on quit.
+- Bugfix: Fix a bug where large transfers from intercepted services would sometimes terminate early
 
 ### 2.3.1 (June 14, 2021)
 


### PR DESCRIPTION
## Description

This was causing issues when an intercepted service transfers a large
file; the last packet wouldn't always make it to the traffic agent, since
the manager would get the instruction to close the connection from the
daemon and act upon it immediately, without allowing the last packet to
be written to the agent.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md` (updated as part of #1782).
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
