### PR TITLE
Update homebrew formula for telepresence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Feature: Telepresence can now be configured to proxy subnets that aren't part of the cluster but only accesible from the cluster.
 - Change: The `trafficManagerConnect` timout default has changed from 20 seconds to 60 seconds, in order to facilitate
   the extended time it takes to apply everything needed for the mutator webhook.
+- Change: Telepresence is now installable via `brew install datawire/blackbird/telepresence`
 - Bugfix: Fix a bug where sometimes large transfers from services on the cluster would hang indefinitely
 
 ### 2.3.0 (June 1, 2021)

--- a/packaging/homebrew-formula.rb
+++ b/packaging/homebrew-formula.rb
@@ -1,6 +1,6 @@
 # This script is generated automatically by the release automation code in the
 # Telepresence repository:
-class Telepresence2 < Formula
+class Telepresence < Formula
   desc "Local dev environment attached to a remote Kubernetes cluster"
   homepage "https://telepresence.io"
   url "https://app.getambassador.io/download/tel2/darwin/amd64/__NEW_VERSION__/telepresence"

--- a/packaging/homebrew-package.sh
+++ b/packaging/homebrew-package.sh
@@ -15,7 +15,7 @@ BINDIR="${BINDIR:-./build-output/bin}"
 BUILD_HOMEBREW_DIR=$(mktemp -d)
 echo "Cloning into ${BUILD_HOMEBREW_DIR}..."
 git clone git@github.com:datawire/homebrew-blackbird.git "${BUILD_HOMEBREW_DIR}"
-FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence2.rb"
+FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence.rb"
 
 # Update recipe
 cp packaging/homebrew-formula.rb "$FORMULA"


### PR DESCRIPTION
Once https://github.com/datawire/homebrew-blackbird/pull/14 is merged, we can merge this PR so that we publish new versions of telepresence to the correct brew formula

---
