### PR TITLE
Ensure that added include-suffixes are properly removed on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.2 TBD
+
+- Bug: On a MacOS, files generated under /etc/resolver as the result of using include-suffixes in the cluster config, are now properly removed on quit.
+
 ### 2.3.1 (June 14, 2021)
 
 - Feature: Agents can now be installed using a mutator webhook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 2.3.2 TBD
+### 2.3.2 (TBD)
 
 - Bug: On a MacOS, files generated under /etc/resolver as the result of using include-suffixes in the cluster config, are now properly removed on quit.
 

--- a/pkg/client/daemon/outbound_darwin.go
+++ b/pkg/client/daemon/outbound_darwin.go
@@ -247,7 +247,7 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 		_ = os.Remove(resolverFileName)
 
 		// Remove each namespace resolver file
-		for namespace := range o.namespaces {
+		for namespace := range o.domains {
 			_ = os.Remove(namespaceResolverFile(namespace))
 		}
 		dns.Flush(dcontext.HardContext(c))


### PR DESCRIPTION
## Description

A cluster configured with dns `include-suffixes` will generate
files under /etc/resolver that corresponds to the added suffixes.
This commit fixes a glitch causing those files to remain in
place after `telepresence quit`.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
