### PR TITLE
Switch everything to dhttp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,8 @@ linters-settings:
     packages-with-error-message:
       - os/exec:                    "Use `github.com/datawire/dlib/dexec` instead of `os/exec`"
       - github.com/golang/protobuf: "Use `google.golang.org/protobuf` instead of `github.com/golang/protobuf`"
+      - github/datawire/dlib/dutil: "Use either `github/datawire/dlib/derror` or `github/datawire/dlib/dhttp` instead of `github/datawire/dlib/dutil`"
+      - golang.org/x/net/http2/h2c: "Use `github/datawire/dlib/dhttp` instead of `golang.org/x/net/http2/h2c`"
 
   gocyclo:
     min-complexity: 35


### PR DESCRIPTION
## Description

This PR moves all remaining code to use `dhttp`, instead of `http.Server` or `grpc.Server`.  This likely resolves subtle timing bugs during shutdown, but I haven't done an analysis.  Or at least I haven't done one recently enough to include here.

For testing, I moved over all of the application code first, tested it ([test PR](https://github.com/telepresenceio/telepresence/pull/1799) / [CI](https://app.circleci.com/pipelines/github/telepresenceio/telepresence/1498/workflows/4f580ff3-94b0-4764-8fc1-e93ebb51d988/jobs/9229)), and then moved over the tests.  That is, I tested the new code with the old tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - no applicable changes
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no applicable changes
 - [x] My change is adequately tested. - I'd say so
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
