### PR TITLE
Add service port annotation for the mutating webhook agent injector.

### DIFF
--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -78,7 +78,10 @@ func agentInjector(ctx context.Context, req *admission.AdmissionRequest) ([]patc
 		dlog.Error(ctx, err)
 		return nil, nil
 	}
-	servicePort, appContainer, containerPortIndex, err := install.FindMatchingPort(pod.Spec.Containers, "", svc)
+
+	// The ServicePortAnnotation is expected to contain a string that identifies the service port.
+	portNameOrNumber := pod.Annotations[install.ServicePortAnnotation]
+	servicePort, appContainer, containerPortIndex, err := install.FindMatchingPort(pod.Spec.Containers, portNameOrNumber, svc)
 	if err != nil {
 		dlog.Error(ctx, err)
 		return nil, nil

--- a/pkg/install/constants.go
+++ b/pkg/install/constants.go
@@ -6,6 +6,7 @@ const (
 	AgentInjectorName         = "agent-injector"
 	DomainPrefix              = "telepresence.getambassador.io/"
 	InjectAnnotation          = DomainPrefix + "inject-" + AgentContainerName
+	ServicePortAnnotation     = DomainPrefix + "inject-service-port"
 	ManagerAppName            = "traffic-manager"
 	ManagerPortHTTP           = 8081
 	MutatorWebhookPortHTTPS   = 8443

--- a/pkg/tun/tcp/handler.go
+++ b/pkg/tun/tcp/handler.go
@@ -623,10 +623,10 @@ type resend struct {
 
 func (h *handler) processResends(ctx context.Context) {
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			ticker.Stop()
 			return
 		case <-ticker.C:
 		}


### PR DESCRIPTION
## Description

Add service port annotation for the mutating webhook agent injector.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 