### PR TITLE
Wait for daemon shutdown signal when the connector hangs up on streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.3.3 (TBD)
 
 - Feature: `telepresence intercept` now supports a `--to-pod` flag that can be used to port-forward sidecars' ports from an intercepted pod
+- Bugfix: The root daemon no longer terminates when the user daemon disconnects from its gRPC streams, and instead waits to be terminated by the CLI.
 
 ### 2.3.2 (June 18, 2021)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59
-	github.com/datawire/dlib v1.2.1
+	github.com/datawire/dlib v1.2.2
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/godbus/dbus/v5 v5.0.4-0.20201218172701-b3768b321399
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59 h1:E1B8gCq5
 github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59/go.mod h1:/NtIrOjBmVRs6RPCCiHjJ7VictnZ6pkAZuLlTB3iNy0=
 github.com/datawire/dlib v1.1.0/go.mod h1:aCzh74rJ3kOireYbg4gH0CuD48/xA4G+LuHhkpcqo1s=
 github.com/datawire/dlib v1.2.0/go.mod h1:t0upKFHApJskdVFH/gyksG5+vMCl0GCKeEZIEJBBv4g=
-github.com/datawire/dlib v1.2.1 h1:a5YOsQfzlzpcAkRvNOL4xY4r6c1jyixZSJF0iz3kS3M=
-github.com/datawire/dlib v1.2.1/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=
+github.com/datawire/dlib v1.2.2 h1:xjhaiW1MIVNJy2TNrO9tL/esAFN5vnsL3lgLdtHSMx4=
+github.com/datawire/dlib v1.2.2/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a/go.mod h1:H8uUmE8qqo7z9u30MYB9riLyRckPHOPBk9ZdCuH+dQQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/client/cli/session.go
+++ b/pkg/client/cli/session.go
@@ -97,7 +97,7 @@ func (si *sessionInfo) newConnectorState(daemon daemon.DaemonClient) (*connector
 func connectCommand() *cobra.Command {
 	si := &sessionInfo{}
 	cmd := &cobra.Command{
-		Use:  "connect [flags] [-- <additional kubectl arguments...>]",
+		Use:  "connect [flags] [-- <command to run while connected>]",
 		Args: cobra.ArbitraryArgs,
 
 		Short: "Connect to a cluster",

--- a/pkg/client/stream_error.go
+++ b/pkg/client/stream_error.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RecvEOF should be returned when a component has returned EOF from a stream.
+// Do not use this if, for example, the initial dial to a stream fails.
+type RecvEOF struct {
+	msg string
+	err error
+}
+
+func (e *RecvEOF) Error() string {
+	return fmt.Sprintf("%s: %v", e.msg, e.err)
+}
+
+func (e *RecvEOF) Unwrap() error {
+	return e.err
+}
+
+// WrapRecvErr wraps an error from a Recv call. If the error is nil, nil is returned.
+// If the error indicates that the remote end has , a RecvEOF wrapping the error will be returned.
+// Otherwise, the original error will be wrapped as fmt.Errorf("%s: %w", msg, err)
+func WrapRecvErr(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.Unavailable || err == io.EOF {
+		return &RecvEOF{msg, err}
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}

--- a/pkg/connpool/stream.go
+++ b/pkg/connpool/stream.go
@@ -2,10 +2,10 @@ package connpool
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 )
 
 type Stream struct {
@@ -30,7 +30,7 @@ func (s *Stream) ReadLoop(ctx context.Context, closing *int32) (<-chan Message, 
 			cm, err := s.Recv()
 			if err != nil {
 				if atomic.LoadInt32(closing) == 0 && ctx.Err() == nil {
-					errCh <- fmt.Errorf("read from grpc.ClientStream failed: %w", err)
+					errCh <- client.WrapRecvErr(err, "read from grpc.ClientStream failed")
 				}
 				return
 			}


### PR DESCRIPTION
This is to prevent the daemon from dying too early when the connector
goes away.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
