### PR TITLE
telepresence_test: set up kubeconfig in main goroutine

### DIFF
--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -102,38 +102,12 @@ func (ts *telepresenceSuite) SetupSuite() {
 		ts.NoError(err)
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		kubeconfig := dtest.Kubeconfig(ctx)
-		os.Setenv("DTEST_KUBECONFIG", kubeconfig)
-		os.Setenv("KUBECONFIG", kubeconfig)
-		err = run(ctx, "kubectl", "create", "namespace", ts.namespace)
-		ts.NoError(err)
-		err = run(ctx, "kubectl", "apply", "-f", "k8s/client_rbac.yaml")
-		ts.NoError(err)
-
-		// This is how we create a user that has their rbac restricted to what we have in
-		// k8s/client_rbac.yaml. We do this by creating a service account and then getting
-		// the token from said service account and storing it in our kubeconfig.
-		secret, err := output(ctx, "kubectl", "get", "sa", "telepresence-test-developer", "-o", "jsonpath={.secrets[0].name}")
-		ts.NoError(err)
-		encSecret, err := output(ctx, "kubectl", "get", "secret", secret, "-o", "jsonpath={.data.token}")
-		ts.NoError(err)
-		token, err := base64.StdEncoding.DecodeString(encSecret)
-		ts.NoError(err)
-		err = run(ctx, "kubectl", "config", "set-credentials", "telepresence-test-developer", "--token", string(token))
-		ts.NoError(err)
-		err = run(ctx, "kubectl", "config", "set-context", "telepresence-test-developer", "--user", "telepresence-test-developer", "--cluster", "default")
-		ts.NoError(err)
-
-		// We start with the default context, and will switch to the
-		// telepresence-test-developer user later in the tests
-		err = run(ctx, "kubectl", "config", "use-context", "default")
-		ts.NoError(err)
-	}()
 	wg.Wait()
+
+	// We do this after the above goroutines are finished, instead of in parallel with them,
+	// because there seems to be a bug where buildExecutable sometimes modifies the kubeconfig and
+	// removes the telepresence-test-user that is created in this function.
+	ts.setupKubeConfig(ctx)
 
 	wg.Add(serviceCount)
 	for i := 0; i < serviceCount; i++ {
@@ -968,6 +942,35 @@ func (ts *telepresenceSuite) buildExecutable(c context.Context) (string, error) 
 	return executable, run(c, "go", "build", "-ldflags",
 		fmt.Sprintf("-X=github.com/telepresenceio/telepresence/v2/pkg/version.Version=%s", ts.testVersion),
 		"-o", executable, "./cmd/telepresence")
+}
+
+func (ts *telepresenceSuite) setupKubeConfig(ctx context.Context) {
+	kubeconfig := dtest.Kubeconfig(ctx)
+	os.Setenv("DTEST_KUBECONFIG", kubeconfig)
+	os.Setenv("KUBECONFIG", kubeconfig)
+	err := run(ctx, "kubectl", "create", "namespace", ts.namespace)
+	ts.NoError(err)
+	err = run(ctx, "kubectl", "apply", "-f", "k8s/client_rbac.yaml")
+	ts.NoError(err)
+
+	// This is how we create a user that has their rbac restricted to what we have in
+	// k8s/client_rbac.yaml. We do this by creating a service account and then getting
+	// the token from said service account and storing it in our kubeconfig.
+	secret, err := output(ctx, "kubectl", "get", "sa", "telepresence-test-developer", "-o", "jsonpath={.secrets[0].name}")
+	ts.NoError(err)
+	encSecret, err := output(ctx, "kubectl", "get", "secret", secret, "-o", "jsonpath={.data.token}")
+	ts.NoError(err)
+	token, err := base64.StdEncoding.DecodeString(encSecret)
+	ts.NoError(err)
+	err = run(ctx, "kubectl", "config", "set-credentials", "telepresence-test-developer", "--token", string(token))
+	ts.NoError(err)
+	err = run(ctx, "kubectl", "config", "set-context", "telepresence-test-developer", "--user", "telepresence-test-developer", "--cluster", "default")
+	ts.NoError(err)
+
+	// We start with the default context, and will switch to the
+	// telepresence-test-developer user later in the tests
+	err = run(ctx, "kubectl", "config", "use-context", "default")
+	ts.NoError(err)
 }
 
 func run(c context.Context, args ...string) error {


### PR DESCRIPTION
## Description

This seems to eliminate a bug where, for some reason, the
buildExecutable goroutine destroys the telepresence-test-user from the
kubeconfig.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
