### PR TITLE
Bump regression test timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           # default.  `go test` gives us helpful output when that
           # happens, CircleCI doesn't.  So lengthen CircleCI's timeout
           # just a bit, so `go test`'s timeout output isn't hidden.
-          no_output_timeout: 12m
+          no_output_timeout: 17m
       - save-logs
 
   "lint":

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -154,7 +154,7 @@ format: $(tools/golangci-lint) $(tools/protolint) ## (QA) Automatically fix lint
 
 .PHONY: check
 check: $(tools/ko) ## (QA) Run the test suite
-	go test ./...
+	go test -timeout=15m ./...
 
 # Install
 # =======

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -880,17 +880,17 @@ func (ts *telepresenceSuite) applyEchoService(c context.Context, name string) er
 }
 
 func (ts *telepresenceSuite) waitForService(c context.Context, name string, port int) error {
-	c, cancel := context.WithTimeout(c, 90*time.Second)
+	c, cancel := context.WithTimeout(c, 120*time.Second)
 	defer cancel()
 
 	// Since this function can be called multiple times in parallel
-	// we add the name of the servie to the title of the pod so they
+	// we add the name of the service to the title of the pod so they
 	// can run at the same time. We strip out any characters that we
 	// can't use in a name in k8s.
 	reg := regexp.MustCompile("[^a-zA-Z0-9-]+")
 	k8sSafeName := reg.ReplaceAllString(name, "")
 	containerName := fmt.Sprintf("curl-%s-from-cluster", k8sSafeName)
-	for i := 0; i < 60; i++ {
+	for c.Err() == nil {
 		time.Sleep(time.Second)
 		err := ts.kubectl(c, "run", containerName, "--context", "default", "--rm", "-it",
 			"--image=docker.io/pstauffer/curl", "--restart=Never", "--",


### PR DESCRIPTION
## Description

This lengthens the timeout for apps to become ready in the test suite, and as a result also needs slightly longer timeouts for `go test` itself, as the tests can now run for longer

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
