### PR TITLE
Add nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,27 @@ jobs:
     - checkout
     - run: |
         [[ $CIRCLE_TAG == *-* ]] || BUCKET_DIR="charts" make push-chart
+  
+  "tag-nightly":
+    executor: vm-linux
+    steps:
+    - checkout
+    - install-go
+    - run:
+        name: "Tag nightly"
+        command: |
+          existingTags=$(git tag --points-at HEAD)
+          if [[ -n $existingTags ]]; then
+              echo "Tag for the HEAD of release/v2 already exists:"
+              echo $existingTags
+              exit 0
+          else
+              lastTag=$(git describe --tags --match="v*" --abbrev=0
+              time=$(date +"%s")
+              newTag="$lastTag-nightly-$time"
+              make prepare-release TELEPRESENCE_VERSION=$newTag
+              git push origin {,rpc/}$time
+          fi
 
 #  "release-finalize":
 #    executor: vm-linux
@@ -215,6 +236,17 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+
+  'Nightly':
+    triggers:
+    - schedule:
+        cron: "0 0 * * 1-5"
+        filters:
+          branches:
+            only:
+              - release/v2
+    jobs:
+      - tag-nightly
       #- release-finalize:
       #    context: telepresence2-release
       #    requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ jobs:
       - run: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-images push-executable
       - run: |
           [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-to-stable
+          [[ $CIRCLE_TAG == *-nightly-* ]] && TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-nightly
 
   "release-macos":
     executor: vm-macos
@@ -169,6 +170,7 @@ jobs:
       - run: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-executable
       - run: |
           [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-to-stable
+          [[ $CIRCLE_TAG == *-nightly-* ]] && TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-nightly
 
   "release-chart":
     executor: vm-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,6 @@ jobs:
       - run: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-images push-executable
       - run: |
           [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-to-stable
-          [[ $CIRCLE_TAG == *-nightly-* ]] && TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-nightly
 
   "release-macos":
     executor: vm-macos
@@ -170,7 +169,6 @@ jobs:
       - run: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-executable
       - run: |
           [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-to-stable
-          [[ $CIRCLE_TAG == *-nightly-* ]] && TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-nightly
 
   "release-chart":
     executor: vm-linux
@@ -179,26 +177,35 @@ jobs:
     - run: |
         [[ $CIRCLE_TAG == *-* ]] || BUCKET_DIR="charts" make push-chart
   
-  "tag-nightly":
+  "publish-nightly-linux":
     executor: vm-linux
     steps:
     - checkout
     - install-go
+    - run: pip3 install awscli
     - run:
-        name: "Tag nightly"
+        name: Docker login
         command: |
-          existingTags=$(git tag --points-at HEAD)
-          if [[ -n $existingTags ]]; then
-              echo "Tag for the HEAD of release/v2 already exists:"
-              echo $existingTags
-              exit 0
-          else
-              lastTag=$(git describe --tags --match="v*" --abbrev=0
-              time=$(date +"%s")
-              newTag="$lastTag-nightly-$time"
-              make prepare-release TELEPRESENCE_VERSION=$newTag
-              git push origin {,rpc/}$time
-          fi
+          docker login -u="${DOCKERHUB_USERNAME}" -p="${DOCKERHUB_PASSWORD}"
+    - run:
+        name: "Publish nightly linux"
+        command: |
+          newTag=$(go run build-aux/genversion.go nightly)
+          TELEPRESENCE_VERSION=$newTag make push-images push-executable
+          TELEPRESENCE_VERSION=$newTag make promote-nightly
+
+  "publish-nightly-macos":
+    executor: vm-macos
+    steps:
+    - checkout
+    - install-go
+    - run: sudo pip3 install awscli
+    - run:
+        name: "Publish nightly macos"
+        command: |
+          newTag=$(go run build-aux/genversion.go nightly)
+          TELEPRESENCE_VERSION=$newTag push-executable
+          TELEPRESENCE_VERSION=$newTag make promote-nightly
 
 #  "release-finalize":
 #    executor: vm-linux
@@ -248,7 +255,8 @@ workflows:
             only:
               - release/v2
     jobs:
-      - tag-nightly
+      - publish-nightly-linux
+      - publish-nightly-macos
       #- release-finalize:
       #    context: telepresence2-release
       #    requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+<<<<<<< HEAD
 ### 2.3.4 (TBD)
 
 - Bugfix: Some log statements that contained garbage instead of a proper IP address now produce the correct address.
@@ -25,6 +26,8 @@
 
 - Feature: `telepresence status` now includes more information about
   the root daemon.
+
+- Feature: We now do nightly builds of Telepresence for commits on release/v2 that haven't been tagged and published yet.
 
 - Change: Telepresence no longer automatically shuts down the old
   `api_version=1` `edgectl` daemon.  If migrating from such an old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-<<<<<<< HEAD
 ### 2.3.4 (TBD)
 
 - Bugfix: Some log statements that contained garbage instead of a proper IP address now produce the correct address.

--- a/build-aux/genversion.go
+++ b/build-aux/genversion.go
@@ -39,9 +39,21 @@ func Main() error {
 	}
 	gitDescVer.Patch++
 
-	_, err = fmt.Printf("v%s-%d\n", gitDescVer, time.Now().Unix())
-	if err != nil {
-		return err
+	// If an additional arg has been used, we include it in the tag
+	if len(os.Args) >= 2 {
+		// gitDescVer.Pre[0] contains the number of commits since the last tag and the
+		// shortHash with a 'g' appended.  Since the first section isn't relevant,
+		// we get the shortHash this way since we don't need that extra information.
+		shortHash, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Printf("v%d.%d.%d-%s-%s\n", gitDescVer.Major, gitDescVer.Minor, gitDescVer.Patch, os.Args[1], shortHash)
+	} else {
+		_, err = fmt.Printf("v%s-%d\n", gitDescVer, time.Now().Unix())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -146,7 +146,7 @@ endif
 # The awscli command must be installed and configured with credentials to upload
 # to the datawire-static-files bucket.
 .PHONY: promote-nightly
-promote-nightly: ## (Release) Update stable.txt in S3
+promote-nightly: ## (Release) Update nightly.txt in S3
 	mkdir -p $(BUILDDIR)
 	echo $(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/nightly.txt
 	AWS_PAGER="" aws s3api put-object \

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -142,6 +142,18 @@ ifeq ($(GOHOSTOS), darwin)
 	packaging/homebrew-package.sh $(patsubst v%,%,$(TELEPRESENCE_VERSION))
 endif
 
+# Prerequisites:
+# The awscli command must be installed and configured with credentials to upload
+# to the datawire-static-files bucket.
+.PHONY: promote-nightly
+promote-nightly: ## (Release) Update stable.txt in S3
+	mkdir -p $(BUILDDIR)
+	echo $(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/nightly.txt
+	AWS_PAGER="" aws s3api put-object \
+		--bucket datawire-static-files \
+		--key tel2/$(GOHOSTOS)/$(GOHOSTARCH)/nightly.txt \
+		--body $(BUILDDIR)/nightly.txt
+
 # Quality Assurance: Make sure things are good
 # ============================================
 


### PR DESCRIPTION
## Description

Adding nightly builds to our telepresence ci. This PR depends on this change in saas_app (https://github.com/datawire/saas_app/pull/1364) which will enable the nightly build to be consumed.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - TBD
 - [ ] My change is adequately tested. 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
