### PR TITLE
Make intercept recover from deletion of intercepted pod.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,15 @@ commands:
             curl -L --fail -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v<< parameters.version >>/bin/$(uname -s | tr A-Z a-z)/amd64/kubectl
             sudo install /tmp/kubectl /usr/local/bin/kubectl
 
+  "install-sshfs":
+    steps:
+      - run:
+          name: "Install sshfs"
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y sshfs
+            sudo sh -c 'echo user_allow_other >> /etc/fuse.conf'
+
   "dirty-check":
     steps:
       - run:
@@ -106,6 +115,7 @@ jobs:
       - install-go
       - run: make build
       - install-kubectl
+      - install-sshfs
       - run:
           command: make test
           # Both CircleCI and `go test` itself time out after 10m by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Bugfix: The root daemon no longer terminates when the user daemon disconnects from its gRPC streams, and instead waits to be terminated by the CLI.
 - Feature: The Helm chart is now published as part of our CI.
+- Bugfix: An intercept will survive deletion of the intercepted pod provided that another pod is created (or already exists) that can take over. 
 
 ### 2.3.2 (June 18, 2021)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59
-	github.com/datawire/dlib v1.2.4-0.20210626221837-1263db8c3201
+	github.com/datawire/dlib v1.2.4-0.20210629021142-e221f3b9c3b8
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/godbus/dbus/v5 v5.0.4-0.20201218172701-b3768b321399
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59 h1:E1B8gCq5
 github.com/datawire/ambassador v1.13.7-0.20210527054604-663dfb393e59/go.mod h1:/NtIrOjBmVRs6RPCCiHjJ7VictnZ6pkAZuLlTB3iNy0=
 github.com/datawire/dlib v1.1.0/go.mod h1:aCzh74rJ3kOireYbg4gH0CuD48/xA4G+LuHhkpcqo1s=
 github.com/datawire/dlib v1.2.0/go.mod h1:t0upKFHApJskdVFH/gyksG5+vMCl0GCKeEZIEJBBv4g=
-github.com/datawire/dlib v1.2.4-0.20210626221837-1263db8c3201 h1:vhqum68ukUAkpMS8e1tJFHcm7rqRJ3KdTr9tuo98XAA=
-github.com/datawire/dlib v1.2.4-0.20210626221837-1263db8c3201/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=
+github.com/datawire/dlib v1.2.4-0.20210629021142-e221f3b9c3b8 h1:WqvO+Sa8l7ydURsEYNrpCKTKv6ps67rb39NmYGg13ek=
+github.com/datawire/dlib v1.2.4-0.20210629021142-e221f3b9c3b8/go.mod h1:OdrErY06tawcmEkhTLeb1k3IN2HyzT3zcW4DsqQsJOM=
 github.com/datawire/grpc-go v1.38.0-dev.0.20210626184227-5ef87f395316 h1:XAaJXdJB3rus/iErfsOIz5S8bv/Yp5s/ZXnpAzcfVxI=
 github.com/datawire/grpc-go v1.38.0-dev.0.20210626184227-5ef87f395316/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a/go.mod h1:H8uUmE8qqo7z9u30MYB9riLyRckPHOPBk9ZdCuH+dQQ=
@@ -504,7 +504,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -1142,7 +1141,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/client/actions/manager_client.go
+++ b/pkg/client/actions/manager_client.go
@@ -22,25 +22,3 @@ func ListAllAgents(ctx context.Context, client rpc.ManagerClient, sessionID stri
 	}
 	return snapshot.Agents, nil
 }
-
-func listIntercepts(ctx context.Context, client rpc.ManagerClient, sessionID string, opts ...grpc.CallOption) ([]*rpc.InterceptInfo, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	stream, err := client.WatchIntercepts(ctx, &rpc.SessionInfo{SessionId: sessionID}, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("manager.WatchIntercepts dial: %w", err)
-	}
-	snapshot, err := stream.Recv()
-	if err != nil {
-		return nil, fmt.Errorf("manager.WatchIntercepts recv: %w", err)
-	}
-	return snapshot.Intercepts, nil
-}
-
-func ListAllIntercepts(ctx context.Context, client rpc.ManagerClient, opts ...grpc.CallOption) ([]*rpc.InterceptInfo, error) {
-	return listIntercepts(ctx, client, "", opts...)
-}
-
-func ListMyIntercepts(ctx context.Context, client rpc.ManagerClient, sessionID string, opts ...grpc.CallOption) ([]*rpc.InterceptInfo, error) {
-	return listIntercepts(ctx, client, sessionID, opts...)
-}

--- a/pkg/client/cli/cliutil/daemon.go
+++ b/pkg/client/cli/cliutil/daemon.go
@@ -61,8 +61,14 @@ func launchDaemon(ctx context.Context, dnsIP string) error {
 		// use `sudo`'s `--prompt` flag for this because (1) we don't want it to be
 		// re-displayed if they typo their password, and (2) it might be ignored anyway
 		// depending on `passprompt_override` in `/etc/sudoers`.  So we'll do a pre-flight
-		// `sudo --non-interactive --validate` to decide whether to display it.
-		needPwCmd := dexec.CommandContext(ctx, "sudo", "--non-interactive", "--validate")
+		// `sudo --non-interactive true` to decide whether to display it.
+		//
+		// Note: Using `sudo --non-interactive --validate` does not work well in situations
+		// where the user has configured `myuser ALL=(ALL:ALL) NOPASSWD: ALL` in the sudoers
+		// file. Hence the use of `sudo --non-interactive true`. A plausible cause can be
+		// found in the first comment here:
+		// https://unix.stackexchange.com/questions/50584/why-sudo-timestamp-is-not-updated-when-nopasswd-is-set
+		needPwCmd := dexec.CommandContext(ctx, "sudo", "--non-interactive", "true")
 		needPwCmd.DisableLogging = true
 		if err := needPwCmd.Run(); err != nil {
 			fmt.Printf("Need root privileges to run: %s\n", logging.ShellString(args[0], args[1:]))

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -978,13 +978,19 @@ func (is *interceptedSuite) TestE_StopInterceptedPodOfMany() {
 	}, 5*time.Second, time.Second)
 
 	// Verify response from intercepting client
-	hc := http.Client{Timeout: time.Second}
-	resp, err := hc.Get("http://hello-0")
-	require.NoError(err)
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	assert.NoError(err)
-	assert.Equal("hello-0 from intercept at /", string(body))
+	assert.Eventually(func() bool {
+		hc := http.Client{Timeout: time.Second}
+		resp, err := hc.Get("http://hello-0")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		return "hello-0 from intercept at /" == string(body)
+	}, 5*time.Second, time.Second)
 
 	// Verify that volume mount is restored
 	st, err := os.Stat(filepath.Join(is.mountPoint, "var"))

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -348,7 +348,11 @@ func (cs *connectedSuite) ns() string {
 func (cs *connectedSuite) SetupSuite() {
 	require := cs.Require()
 	c := dlog.NewTestContext(cs.T(), false)
-	cs.NoError(cs.tpSuite.kubectl(c, "config", "use-context", "telepresence-test-developer"))
+
+	cs.Eventually(func() bool {
+		return run(c, "kubectl", "config", "use-context", "telepresence-test-developer") == nil
+	}, 5*time.Second, time.Second)
+
 	stdout, stderr := telepresence(cs.T(), "connect")
 	require.Empty(stderr)
 	require.Contains(stdout, "Connected to context")

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -746,6 +746,7 @@ type interceptedSuite struct {
 	suite.Suite
 	tpSuite        *telepresenceSuite
 	intercepts     []string
+	mountPoint     string // mount point for service 0.
 	services       *dgroup.Group
 	cancelServices context.CancelFunc
 }
@@ -783,14 +784,21 @@ func (is *interceptedSuite) SetupSuite() {
 		)
 	})
 
+	is.mountPoint = is.T().TempDir()
 	is.Run("adding intercepts", func() {
-		for i := 0; i < serviceCount; i++ {
+		// Add all `hello-N` intercepts. Let `hello-0` have a mounted volume.
+		addIntercept := func(i int, extraArgs ...string) {
 			svc := fmt.Sprintf("hello-%d", i)
 			port := strconv.Itoa(9000 + i)
-			stdout, stderr := telepresence(is.T(), "intercept", "--namespace", is.ns(), "--mount", "false", svc, "--port", port)
+			args := []string{"intercept", "--namespace", is.ns(), svc, "--port", port}
+			stdout, stderr := telepresence(is.T(), append(args, extraArgs...)...)
 			is.Require().Empty(stderr)
 			is.intercepts = append(is.intercepts, svc)
 			is.Contains(stdout, "Using Deployment "+svc)
+		}
+		addIntercept(0, "--mount", is.mountPoint)
+		for i := 1; i < serviceCount; i++ {
+			addIntercept(i, "--mount", "false")
 		}
 	})
 
@@ -860,6 +868,124 @@ func (is *interceptedSuite) TestB_ListingActiveIntercepts() {
 	for i := 0; i < serviceCount; i++ {
 		require.Contains(stdout, fmt.Sprintf("hello-%d: intercepted", i))
 	}
+}
+
+func (is *interceptedSuite) TestC_MountedFilesystem() {
+	require := is.Require()
+	st, err := os.Stat(is.mountPoint)
+	require.NoError(err, "Stat on <mount point> failed")
+	require.True(st.IsDir(), "Mount point is not a directory")
+	st, err = os.Stat(filepath.Join(is.mountPoint, "var"))
+	require.NoError(err, "Stat on <mount point>/var failed")
+	require.True(st.IsDir(), "<mount point>/var is not a directory")
+}
+
+func (is *interceptedSuite) TestD_RestartInterceptedPod() {
+	ts := is.tpSuite
+	assert := is.Assert()
+	require := is.Require()
+	c := dlog.NewTestContext(is.T(), false)
+	rx := regexp.MustCompile(fmt.Sprintf(`Intercept name\s*: hello-0-` + is.ns() + `\s+State\s*: ([^\n]+)\n`))
+
+	// Scale down to zero pods
+	require.NoError(ts.kubectl(c, "--context", "default", "scale", "deploy", "hello-0", "--replicas", "0"))
+
+	// Verify that intercept remains but that no agent is found
+	assert.Eventually(func() bool {
+		stdout, _ := telepresence(is.T(), "--namespace", is.ns(), "list")
+		if match := rx.FindStringSubmatch(stdout); match != nil {
+			dlog.Infof(c, "Got match '%s'", match[1])
+			return match[1] == "WAITING" || strings.Contains(match[1], `No agent found for "hello-0"`)
+		}
+		return false
+	}, 5*time.Second, time.Second)
+
+	// Verify that volume mount is broken
+	_, err := os.Stat(filepath.Join(is.mountPoint, "var"))
+	assert.Error(err, "Stat on <mount point>/var succeeded although no agent was found")
+
+	// Scale up again (start intercepted pod)
+	assert.NoError(ts.kubectl(c, "--context", "default", "scale", "deploy", "hello-0", "--replicas", "1"))
+
+	// Verify that intercept becomes active
+	assert.Eventually(func() bool {
+		stdout, _ := telepresence(is.T(), "--namespace", is.ns(), "list")
+		if match := rx.FindStringSubmatch(stdout); match != nil {
+			return match[1] == "ACTIVE"
+		}
+		return false
+	}, 5*time.Second, time.Second)
+
+	// Verify that volume mount is restored
+	st, err := os.Stat(filepath.Join(is.mountPoint, "var"))
+	require.NoError(err, "Stat on <mount point>/var failed")
+	assert.True(st.IsDir(), "<mount point>/var is not a directory")
+}
+
+func (is *interceptedSuite) TestE_StopInterceptedPodOfMany() {
+	ts := is.tpSuite
+	assert := is.Assert()
+	require := is.Require()
+	c := dlog.NewTestContext(is.T(), false)
+	rx := regexp.MustCompile(fmt.Sprintf(`Intercept name\s*: hello-0-` + is.ns() + `\s+State\s*: ([^\n]+)\n`))
+
+	helloZeroPods := func() []string {
+		pods, err := ts.kubectlOut(c, "get", "pods", "--field-selector", "status.phase==Running", "-l", "app=hello-0", "-o", "jsonpath={.items[*].metadata.name}")
+		assert.NoError(err)
+		pods = strings.TrimSpace(pods)
+		dlog.Infof(c, "Pods = '%s'", pods)
+		return strings.Split(pods, " ")
+	}
+	// Get current pod
+	currentPods := helloZeroPods()
+	require.True(len(currentPods) == 1)
+	currentPod := currentPods[0]
+
+	// Scale up to two pods
+	require.NoError(ts.kubectl(c, "--context", "default", "scale", "deploy", "hello-0", "--replicas", "2"))
+	defer func() {
+		_ = ts.kubectl(c, "--context", "default", "scale", "deploy", "hello-0", "--replicas", "1")
+	}()
+
+	// Wait for second pod to arrive
+	assert.Eventually(func() bool { return len(helloZeroPods()) == 2 }, 5*time.Second, time.Second)
+
+	// Delete the currently intercepted pod
+	require.NoError(ts.kubectl(c, "--context", "default", "delete", "pod", currentPod))
+
+	// Wait for that pod to disappear
+	assert.Eventually(
+		func() bool {
+			for _, zp := range helloZeroPods() {
+				if zp == currentPod {
+					return false
+				}
+			}
+			return true
+		}, 5*time.Second, time.Second)
+
+	// Verify that intercept is still active
+	assert.Eventually(func() bool {
+		stdout, _ := telepresence(is.T(), "--namespace", is.ns(), "list", "--intercepts")
+		if match := rx.FindStringSubmatch(stdout); match != nil {
+			return match[1] == "ACTIVE"
+		}
+		return false
+	}, 5*time.Second, time.Second)
+
+	// Verify response from intercepting client
+	hc := http.Client{Timeout: time.Second}
+	resp, err := hc.Get("http://hello-0")
+	require.NoError(err)
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(err)
+	assert.Equal("hello-0 from intercept at /", string(body))
+
+	// Verify that volume mount is restored
+	st, err := os.Stat(filepath.Join(is.mountPoint, "var"))
+	require.NoError(err, "Stat on <mount point>/var failed")
+	require.True(st.IsDir(), "<mount point>/var is not a directory")
 }
 
 func (ts *telepresenceSuite) applyApp(c context.Context, name, svcName string, port int) error {

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -921,9 +921,10 @@ func (is *interceptedSuite) TestD_RestartInterceptedPod() {
 	}, 5*time.Second, time.Second)
 
 	// Verify that volume mount is restored
-	st, err := os.Stat(filepath.Join(is.mountPoint, "var"))
-	require.NoError(err, "Stat on <mount point>/var failed")
-	assert.True(st.IsDir(), "<mount point>/var is not a directory")
+	assert.Eventually(func() bool {
+		st, err := os.Stat(filepath.Join(is.mountPoint, "var"))
+		return err == nil && st.IsDir()
+	}, 5*time.Second, time.Second)
 }
 
 func (is *interceptedSuite) TestE_StopInterceptedPodOfMany() {

--- a/pkg/client/connector/intercept.go
+++ b/pkg/client/connector/intercept.go
@@ -236,9 +236,14 @@ func (tm *trafficManager) getCurrentIntercepts() []*manager.InterceptInfo {
 
 	// Amend with local info
 	for _, ii := range intercepts {
-		if mp, ok := tm.mountPoints.Load(ii.Spec.Name); ok {
-			ii.Spec.MountPoint = mp.(string)
-		}
+		ii := ii // Pin it
+		tm.mountPoints.Range(func(k, v interface{}) bool {
+			if v.(string) == ii.Spec.Name {
+				ii.Spec.MountPoint = k.(string)
+				return false
+			}
+			return true
+		})
 	}
 	return intercepts
 }

--- a/pkg/client/connector/intercept.go
+++ b/pkg/client/connector/intercept.go
@@ -414,7 +414,7 @@ func (tm *trafficManager) workerPortForwardIntercept(ctx context.Context, pf por
 	}
 	f := forwarder.NewForwarder(&addr, pf.PodIP, pf.Port)
 	err := f.Serve(ctx)
-	if err != nil {
+	if err != nil && ctx.Err() == nil {
 		dlog.Errorf(ctx, "port-forwarder failed with %v", err)
 	}
 }
@@ -476,7 +476,7 @@ func (tm *trafficManager) workerMountForwardIntercept(ctx context.Context, mf mo
 		return dpipe.DPipe(ctx, dexec.CommandContext(ctx, "sshfs", sshfsArgs...), conn)
 	}, 3*time.Second, 6*time.Second)
 
-	if err != nil {
+	if err != nil && ctx.Err() == nil {
 		dlog.Error(ctx, err)
 	}
 }

--- a/pkg/client/connector/traffic_manager.go
+++ b/pkg/client/connector/traffic_manager.go
@@ -459,9 +459,8 @@ func (tm *trafficManager) setStatus(ctx context.Context, r *rpc.ConnectInfo) {
 		}
 	} else {
 		agents, _ := actions.ListAllAgents(ctx, tm.managerClient, tm.session().SessionId)
-		intercepts := tm.getCurrentIntercepts()
 		r.Agents = &manager.AgentInfoSnapshot{Agents: agents}
-		r.Intercepts = &manager.InterceptInfoSnapshot{Intercepts: intercepts}
+		r.Intercepts = &manager.InterceptInfoSnapshot{Intercepts: tm.getCurrentIntercepts()}
 		r.SessionInfo = tm.session()
 		r.BridgeOk = true
 	}

--- a/pkg/client/connector/traffic_manager.go
+++ b/pkg/client/connector/traffic_manager.go
@@ -54,6 +54,19 @@ type trafficManager struct {
 
 	// Map of desired mount points for intercepts
 	mountPoints sync.Map
+
+	// currentIntercepts is the latest snapshot returned by the intercept watcher
+	currentIntercepts     []*manager.InterceptInfo
+	currentInterceptsLock sync.Mutex
+
+	// activeInterceptsWaiters contains chan interceptResult keyed by intercept name
+	activeInterceptsWaiters sync.Map
+}
+
+// interceptResult is what gets written to the activeInterceptsWaiters channels
+type interceptResult struct {
+	intercept *manager.InterceptInfo
+	err       error
 }
 
 // newTrafficManager returns a TrafficManager resource for the given
@@ -353,15 +366,12 @@ func (tm *trafficManager) workloadInfoSnapshot(ctx context.Context, rq *rpc.List
 	}
 
 	<-tm.startup
-	if is, _ := actions.ListMyIntercepts(ctx, tm.managerClient, tm.session().SessionId); is != nil {
-		iMap = make(map[string]*manager.InterceptInfo, len(is))
-		for _, i := range is {
-			if i.Spec.Namespace == namespace {
-				iMap[i.Spec.Agent] = i
-			}
+	is := tm.getCurrentIntercepts()
+	iMap = make(map[string]*manager.InterceptInfo, len(is))
+	for _, i := range is {
+		if i.Spec.Namespace == namespace {
+			iMap[i.Spec.Agent] = i
 		}
-	} else {
-		iMap = map[string]*manager.InterceptInfo{}
 	}
 	var aMap map[string]*manager.AgentInfo
 	if as, _ := actions.ListAllAgents(ctx, tm.managerClient, tm.session().SessionId); as != nil {
@@ -449,7 +459,7 @@ func (tm *trafficManager) setStatus(ctx context.Context, r *rpc.ConnectInfo) {
 		}
 	} else {
 		agents, _ := actions.ListAllAgents(ctx, tm.managerClient, tm.session().SessionId)
-		intercepts, _ := actions.ListMyIntercepts(ctx, tm.managerClient, tm.session().SessionId)
+		intercepts := tm.getCurrentIntercepts()
 		r.Agents = &manager.AgentInfoSnapshot{Agents: agents}
 		r.Intercepts = &manager.InterceptInfoSnapshot{Intercepts: intercepts}
 		r.SessionInfo = tm.session()

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -77,6 +77,9 @@ func (f *Forwarder) ServeListener(ctx context.Context, listener *net.TCPListener
 
 		conn, err := listener.AcceptTCP()
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
 			dlog.Infof(ctx, "Error on accept: %+v", err)
 			continue
 		}

--- a/pkg/tun/device_darwin.go
+++ b/pkg/tun/device_darwin.go
@@ -143,9 +143,9 @@ type addrIfReq6 struct {
 	addr           unix.RawSockaddrInet6
 	dest           unix.RawSockaddrInet6
 	mask           unix.RawSockaddrInet6
-	flags          int32 // nolint:structcheck
-	expire         int64 // nolint:structcheck
-	preferred      int64 // nolint:structcheck
+	flags          int32 //nolint:structcheck
+	expire         int64 //nolint:structcheck
+	preferred      int64 //nolint:structcheck
 	validLifeTime  uint32
 	prefixLifeTime uint32
 }


### PR DESCRIPTION
## Description

This PR will make intercepts survive when the pod that is currently intercepted is deleted. The intercept will be dormant until a new pod is ready to accept responsibility for it (which may be immediately in case the replica count was greater than 1). The PR contains necessary changes to all binaries, client, manager, and agent. Everything is divided into concise logical and fairly small pieces and a commit by commit review is strongly advised.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to submit a docs PR.
 - [x] My change is adequately tested.
