### PR TITLE
Fix garbage in log statement caused by %s on []byte.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.4 (TBD)
+
+- Bugfix: Some log statements that contained garbage instead of a proper IP address now produce the correct address. 
+
 ### 2.3.3 (July 7, 2021)
 
 - Feature: Telepresence now supports installing the Traffic Manager

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -96,6 +96,8 @@ func NewInfo(ctx context.Context) Info {
 				dlog.Infof(ctx, "Extracting service subnet %v from create service error message", cidr)
 				oi.ServiceSubnet = iputil.IPNetToRPC(cidr)
 			}
+		} else {
+			dlog.Errorf(ctx, "unable to extract service subnet from error message %q", err.Error())
 		}
 	}
 
@@ -104,7 +106,7 @@ func NewInfo(ctx context.Context) Info {
 		// and would quite possibly also require elevated permissions, so instead, we derive the service subnet
 		// from the kubeDNS IP. This is cheating but a cluster may only have one service subnet and the mask is
 		// unlikely to cover less than half the bits.
-		dlog.Infof(ctx, "Deriving serviceSubnet from %s (the IP of kube-dns.kube-system)", oi.KubeDnsIp)
+		dlog.Infof(ctx, "Deriving serviceSubnet from %s (the IP of kube-dns.kube-system)", net.IP(oi.KubeDnsIp))
 		bits := len(oi.KubeDnsIp) * 8
 		ones := bits / 2
 		mask := net.CIDRMask(ones, bits) // will yield a 16 bit mask on IPv4 and 64 bit mask on IPv6.

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -941,10 +941,17 @@ func (is *interceptedSuite) TestE_StopInterceptedPodOfMany() {
 		dlog.Infof(c, "Pods = '%s'", pods)
 		return strings.Split(pods, " ")
 	}
-	// Get current pod
-	currentPods := helloZeroPods()
-	require.True(len(currentPods) == 1)
-	currentPod := currentPods[0]
+
+	// Wait for exactly one active pod
+	var currentPod string
+	require.Eventually(func() bool {
+		currentPods := helloZeroPods()
+		if len(currentPods) == 1 {
+			currentPod = currentPods[0]
+			return true
+		}
+		return false
+	}, 5*time.Second, time.Second)
 
 	// Scale up to two pods
 	require.NoError(ts.kubectl(c, "--context", "default", "scale", "deploy", "hello-0", "--replicas", "2"))

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -99,7 +99,7 @@ func (o *outbound) runOverridingServer(c context.Context) error {
 			if strings.HasPrefix(strings.TrimSpace(line), "nameserver") {
 				fields := strings.Fields(line)
 				o.dnsConfig.LocalIp = net.ParseIP(fields[1])
-				dlog.Infof(c, "Automatically set -dns=%s", o.dnsConfig.LocalIp)
+				dlog.Infof(c, "Automatically set -dns=%s", net.IP(o.dnsConfig.LocalIp))
 				break
 			}
 		}


### PR DESCRIPTION
This fixes a regression in a PR that hasn't been merged but not
released yet so no CHANGELOG statement is needed.
