### PR TITLE
fix the traffic manager's cluster role

### DIFF
--- a/charts/telepresence/templates/trafficManagerRbac.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac.yaml
@@ -24,6 +24,7 @@ rules:
   verbs:
   - get
   - list
+  - create
 - apiGroups:
   - ""
   resources:

--- a/pkg/install/resource/tm_cluster_role.go
+++ b/pkg/install/resource/tm_cluster_role.go
@@ -36,7 +36,7 @@ func (ri tmClusterRole) desiredClusterRole(ctx context.Context) *kates.ClusterRo
 	cl := ri.clusterRole(ctx)
 	cl.Rules = []rbac.PolicyRule{
 		{
-			Verbs:     []string{"get", "list"},
+			Verbs:     []string{"get", "list", "create"},
 			APIGroups: []string{""},
 			Resources: []string{"services"},
 		},


### PR DESCRIPTION
## Description

fix #1840 

the traffic manager also need the create permission to create the bogus service to parse the accurate service subnet.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
