### PR TITLE
Ensure that traffic-manager creates dummy service in correct namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Some log statements that contained garbage instead of a proper IP address now produce the correct address.
 - Bugfix: Telepresence will no longer panic when multiple services match a workload.
+- Bugfix: The traffic-manager will now accurately determine the service subnet by creating a dummy-service in its own namespace.
 
 ### 2.3.3 (July 7, 2021)
 

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -73,12 +73,14 @@ func NewInfo(ctx context.Context) Info {
 	//   https://stackoverflow.com/questions/44190607/how-do-you-find-the-cluster-service-cidr-of-a-kubernetes-cluster
 	// This requires an additional permission to create a service, which the traffic-manager
 	// should have.
+	env := managerutil.GetEnv(ctx)
 	svc := kates.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "t2-tst-dummy",
+			Namespace: env.ManagerNamespace,
+			Name:      "t2-tst-dummy",
 		},
 		Spec: v1.ServiceSpec{
 			Ports:     []kates.ServicePort{{Port: 443}},


### PR DESCRIPTION
## Description

The `traffic-manager` only has permissions to create services in the
namespace that it resides in (typically "ambassador"). Before this
commit it would make an attemtp to create a dummy service in the
"default" namespace to provoke an error message that contains the
service subnet. This would sometimes fail on a permission error because
the `traffic-manager` isn't allowed to create services in the "default"
namespace.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 