### PR TITLE
Fix macOS DNS glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Bugfix: Fixed and improved several error messages, to hopefully be
   more helpful.
+- Bugfix: Fixed a DNS problem on macOS causing slow DNS lookups when connecting to a local cluster.
 
 ### 2.3.4 (July 9, 2021)
 

--- a/pkg/client/daemon/outbound.go
+++ b/pkg/client/daemon/outbound.go
@@ -131,7 +131,7 @@ func (o *outbound) routerServerWorker(c context.Context) (err error) {
 // in the search path declared in the Docker config. The "tel2-search" domain fills this purpose and a request for
 // "<single label name>.tel2-search." will be resolved as "<single label name>." using the search path of this resolver.
 const tel2SubDomain = "tel2-search"
-const dotTel2SubDomain = "." + tel2SubDomain + "."
+const tel2SubDomainDot = tel2SubDomain + "."
 const dotKubernetesZone = "." + kubernetesZone + "."
 
 var localhostIPv6 = []net.IP{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}}
@@ -162,7 +162,7 @@ func (o *outbound) shouldDoClusterLookup(query string) bool {
 
 func (o *outbound) resolveInCluster(c context.Context, qType uint16, query string) []net.IP {
 	query = strings.ToLower(query)
-	query = strings.TrimSuffix(query, dotTel2SubDomain)
+	query = strings.TrimSuffix(query, tel2SubDomainDot)
 
 	if query == "localhost." {
 		// BUG(lukeshu): I have no idea why a lookup

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -73,7 +73,7 @@ func (o *outbound) shouldApplySearch(query string) bool {
 // use-case.
 func (o *outbound) resolveInSearch(c context.Context, qType uint16, query string) []net.IP {
 	query = strings.ToLower(query)
-	query = strings.TrimSuffix(query, dotTel2SubDomain)
+	query = strings.TrimSuffix(query, tel2SubDomainDot)
 
 	if !o.shouldDoClusterLookup(query) {
 		return nil


### PR DESCRIPTION
## Description

DNS queries that ended with ".tel2-search." were incorrectly stripped,
not just from that suffix, but also from the trailing dot. On systems
with recursive DNS (e.g. running the cluster locally), this resulted
in sequences of queries like:
```
QTYPE[1] localhost.tel2-search. -> NOT FOUND
QTYPE[1] localhos.tel2-search. -> NOT FOUND
QTYPE[1] localho.tel2-search. -> NOT FOUND
```

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 