### PR TITLE
Make max size for messages received over gRPC configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Traffic Managers in multiple namespaces. This will allow operators to
   install Traffic Managers with limited permissions that match the
   permissions restrictions that Telepresence users are subject to.
+- Feature: The maximum size of messages that the client can receive over gRPC can now be configured. The gRPC default of 4MB isn't enough
+  under some circumstances.
 - Change: `TELEPRESENCE_AGENT_IMAGE` and `TELEPRESENCE_REGISTRY` are now only configurable via config.yml.
 - Bugfix: Fixed and improved several error messages, to hopefully be
   more helpful.

--- a/pkg/client/sockets.go
+++ b/pkg/client/sockets.go
@@ -69,15 +69,15 @@ func SocketURL(socket string) string {
 }
 
 // DialSocket dials the given unix socket and returns the resulting connection
-func DialSocket(ctx context.Context, socketName string) (*grpc.ClientConn, error) {
+func DialSocket(ctx context.Context, socketName string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second) // FIXME(lukeshu): Make this configurable
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, SocketURL(socketName),
+	conn, err := grpc.DialContext(ctx, SocketURL(socketName), append([]grpc.DialOption{
 		grpc.WithInsecure(),
 		grpc.WithNoProxy(),
 		grpc.WithBlock(),
 		grpc.FailOnNonTempDialError(true),
-	)
+	}, opts...)...)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			// grpc.DialContext doesn't wrap context.DeadlineExceeded with any useful


### PR DESCRIPTION
## Description

Adds a `grpc` entry to the `config.yml` that contains `maxReceiveSize`
entry of type [resource Quantity](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities) which enables entry of strings like "10MiB".

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR.
 - [x] My change is adequately tested.
 