### PR TITLE
fix a nil pointer bug

### DIFF
--- a/cmd/traffic/cmd/manager/internal/state/state.go
+++ b/cmd/traffic/cmd/manager/internal/state/state.go
@@ -688,6 +688,9 @@ func (s *State) AgentTunnel(ctx context.Context, clientSessionInfo *rpc.SessionI
 		if !ok {
 			return nil, nil, status.Errorf(codes.NotFound, "client session %q not found", clientSessionID)
 		}
+		if cs.ClientTunnelServer == nil {
+			return nil, nil, status.Errorf(codes.NotFound, "client session %q has no tunnel server", clientSessionID)
+		}
 		return as, cs, nil
 	}()
 	if err != nil {


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/6763318/125753624-123c4b4f-4610-4e80-9289-6d91ddf31f00.png)

It seems that the `ClientTunnelServer` of the client session may not have been initialized when the client call the traffic-manager's `AgentTunnel` method.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
