### PR TITLE
Ensure that the manager's RoleBinding appoints the correct Role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Fixed an issue that could cause the user daemon to crash
   during shutdown.
+- Bugfix: The Traffic Manager's RoleBinding now correctly appoint the "traffic-manager" role so that service subnet discovery works correctly.
 
 ### 2.3.5 (July 15, 2021)
 

--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: traffic-manager-{{ include "telepresence.namespace" $ }}
+  name: traffic-manager
   namespace: {{ . }}
   labels:
     {{- include "telepresence.labels" $ | nindent 4 }}
@@ -40,14 +40,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: traffic-manager-{{ include "telepresence.namespace" $ }}
+  name: traffic-manager
   namespace: {{ . }}
   labels:
     {{- include "telepresence.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: traffic-manager-{{ include "telepresence.namespace" $ }}
+  name: traffic-manager
 subjects:
 - kind: ServiceAccount
   name: traffic-manager
@@ -61,7 +61,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ include "telepresence.namespace" . }}
-  name: traffic-manager-{{ include "telepresence.namespace" . }}
+  name: traffic-manager
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 rules:
@@ -77,7 +77,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: traffic-manager
-  name: traffic-manager-{{ include "telepresence.namespace" . }}
   labels:
     {{- include "telepresence.labels" . | nindent 4 }}
 roleRef:

--- a/pkg/install/resource/tm_role.go
+++ b/pkg/install/resource/tm_role.go
@@ -27,7 +27,7 @@ func (ri tmRole) role(ctx context.Context) *kates.Role {
 		APIVersion: "rbac.authorization.k8s.io/v1",
 	}
 	cr.ObjectMeta = kates.ObjectMeta{
-		Name:      fmt.Sprintf("%s-%s", install.ManagerAppName, getScope(ctx).namespace),
+		Name:      install.ManagerAppName,
 		Namespace: getScope(ctx).namespace,
 	}
 	return cr

--- a/pkg/install/resource/tm_role_binding.go
+++ b/pkg/install/resource/tm_role_binding.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 
 	rbac "k8s.io/api/rbac/v1"
 
@@ -23,7 +22,7 @@ func (ri tmRoleBinding) roleBinding(ctx context.Context) *kates.RoleBinding {
 		APIVersion: "rbac.authorization.k8s.io/v1",
 	}
 	cr.ObjectMeta = kates.ObjectMeta{
-		Name:      fmt.Sprintf("%s-%s", install.ManagerAppName, getScope(ctx).namespace),
+		Name:      install.ManagerAppName,
 		Namespace: getScope(ctx).namespace,
 	}
 	return cr


### PR DESCRIPTION
## Description

The installer created a `RoleBinding` in the Traffic Manager's namespace
that pointed to a non existing role. The `RoleRef` in that binding used
the name "traffic-manager" but the actual `Role` was named
"traffic-manager-<traffic-manager-ns>".

This commit solves the problem by removing "<traffic-manager-ns>" from
the `metadata.name` of both the `Role` and the `RoleRef`. It's redundant
anyway since those objects are namespace scoped.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
