### PR TITLE
Avoid adding all subcommands except "daemon-foreground" for root daemon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed an issue that could cause the user daemon to crash
   during shutdown.
 - Bugfix: The Traffic Manager's RoleBinding now correctly appoint the "traffic-manager" role so that service subnet discovery works correctly.
+- Bugfix: Restored logging configuration for the root daemon that got broken in 2.3.5.
 
 ### 2.3.5 (July 15, 2021)
 

--- a/cmd/telepresence/main.go
+++ b/cmd/telepresence/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
@@ -18,7 +20,14 @@ func main() {
 		ctx = filelocation.WithAppUserLogDir(ctx, dir)
 	}
 
-	cmd := cli.Command(ctx)
+	var cmd *cobra.Command
+	if len(os.Args) > 1 && os.Args[1] == "daemon-foreground" || len(os.Args) > 2 && os.Args[2] == "daemon-foreground" && os.Args[1] == "help" {
+		// Avoid the initialization of all subcommands except for daemon-foreground.
+		cmd = cli.RootDaemonCommand(ctx)
+	} else {
+		cmd = cli.Command(ctx)
+	}
+
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %v\n", cmd.CommandPath(), err)
 		os.Exit(1)

--- a/pkg/client/daemon/service.go
+++ b/pkg/client/daemon/service.go
@@ -55,7 +55,7 @@ type service struct {
 // Command returns the telepresence sub-command "daemon-foreground"
 func Command() *cobra.Command {
 	return &cobra.Command{
-		Use:    processName + "-foreground",
+		Use:    processName + "-foreground <logging dir> <config dir> <dns>",
 		Short:  "Launch Telepresence " + titleName + " in the foreground (debug)",
 		Args:   cobra.ExactArgs(3),
 		Hidden: true,


### PR DESCRIPTION
## Description

Attempting to load extensions or provide other options to commands in
the root daemon is pointless. This commit ensures that if the subcommand
is `daemon-foreground`, then only that subcommand is added.

Among other things, this restores the logging functionality in the
daemon which was otherwise initialized too early which cause the config
to be read from the roots config directory rather than the users.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
