### PR TITLE
Fixed traffic-manager unable to detect service IP range

### DIFF
--- a/pkg/install/resource/tm_role.go
+++ b/pkg/install/resource/tm_role.go
@@ -27,7 +27,7 @@ func (ri tmRole) role(ctx context.Context) *kates.Role {
 		APIVersion: "rbac.authorization.k8s.io/v1",
 	}
 	cr.ObjectMeta = kates.ObjectMeta{
-		Name:      fmt.Sprintf("%s-%s", install.ManagerAppName, getScope(ctx).namespace),
+		Name:      install.ManagerAppName,
 		Namespace: getScope(ctx).namespace,
 	}
 	return cr


### PR DESCRIPTION
## Description

The PR fixes issue with an auto-installed traffic-manager unable to detect services IP range on the cluster.
The root cause was incorrectly named role traffic-manager-ambassador instead of traffic-manager. 

The patch is proved to fix the issue but was not completely tested.