### PR TITLE
Improve logging and tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           # default.  `go test` gives us helpful output when that
           # happens, CircleCI doesn't.  So lengthen CircleCI's timeout
           # just a bit, so `go test`'s timeout output isn't hidden.
-          no_output_timeout: 17m
+          no_output_timeout: 20m
       - save-logs
 
   "lint":

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -178,7 +178,7 @@ format: $(tools/golangci-lint) $(tools/protolint) ## (QA) Automatically fix lint
 
 .PHONY: check
 check: $(tools/ko) $(tools/helm) ## (QA) Run the test suite
-	go test -timeout=15m ./...
+	TELEPRESENCE_MAX_LOGFILES=10 go test -timeout=18m ./...
 
 # Install
 # =======

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1258,6 +1258,7 @@ func (hs *helmSuite) TestF_MultipleInstalls() {
 		hs.Contains(stdout, "with-probes: intercepted")
 	})
 	hs.Run("Uninstalls successfully", func() {
+		telepresence(hs.T(), "quit")
 		hs.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
 		defer func() { hs.NoError(run(ctx, "kubectl", "config", "use-context", "telepresence-test-developer")) }()
 		hs.NoError(run(ctx, "helm", "uninstall", "traffic-manager", "-n", hs.managerNamespace2))

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/datawire/dlib/dtime"
+
 	"github.com/stretchr/testify/suite"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -51,6 +53,7 @@ type telepresenceSuite struct {
 	testVersion          string
 	namespace            string
 	managerTestNamespace string
+	logCapturingPods     sync.Map
 }
 
 func (ts *telepresenceSuite) SetupSuite() {
@@ -211,6 +214,7 @@ func (ts *telepresenceSuite) TestA_WithNoDaemonRunning() {
 			require.Contains(stdout, "Kubernetes context:")
 			require.Regexp(`Telepresence proxy:\s+ON`, stdout)
 			require.Contains(stdout, "Daemon quitting")
+			ts.NoError(ts.capturePodLogs(dlog.NewTestContext(ts.T(), false), "traffic-manager", ts.managerTestNamespace))
 		})
 	})
 
@@ -344,6 +348,7 @@ func (ts *telepresenceSuite) TestA_WithNoDaemonRunning() {
 		require.NoError(err)
 		desiredImage := fmt.Sprintf("%s/imageFromConfig:0.0.1", registry)
 		ts.Equal(desiredImage, image)
+		ts.NoError(ts.capturePodLogs(ctx, "traffic-manager", ts.managerTestNamespace))
 	})
 }
 
@@ -365,6 +370,7 @@ func (ts *telepresenceSuite) TestC_Uninstall() {
 		stdout, err := names()
 		require.NoError(err)
 		require.Equal(2, len(strings.Split(stdout, " "))) // The service and the deployment
+		ts.NoError(ts.capturePodLogs(ctx, "traffic-manager", ts.managerTestNamespace))
 
 		// The telepresence-test-developer will not be able to uninstall everything
 		require.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
@@ -418,6 +424,7 @@ func (cs *connectedSuite) SetupSuite() {
 		time.Second,    // polling interval
 		"Timeout waiting for network overrides to establish", // msg
 	)
+	require.NoError(cs.tpSuite.capturePodLogs(c, "traffic-manager", cs.tpSuite.managerTestNamespace))
 }
 
 func (cs *connectedSuite) TearDownSuite() {
@@ -1187,7 +1194,7 @@ func (hs *helmSuite) TestD_WebhookInjectsInManagedNamespace() {
 		hs.Empty(stderr)
 		return strings.Contains(stdout, "echo-auto-inject: ready to intercept (traffic-agent already installed)")
 	},
-		10*time.Second, // waitFor
+		20*time.Second, // waitFor
 		2*time.Second,  // polling interval
 	)
 }
@@ -1281,7 +1288,7 @@ func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, a
 	}
 	helmValues := "pkg/client/cli/testdata/test-values.yaml"
 	helmChart := "charts/telepresence"
-	return run(ctx, "helm", "install", "traffic-manager",
+	err = run(ctx, "helm", "install", "traffic-manager",
 		"-n", managerNamespace, helmChart,
 		"--set", fmt.Sprintf("clusterId=%s", clusterID),
 		"--set", fmt.Sprintf("image.registry=%s", dtest.DockerRegistry(ctx)),
@@ -1290,6 +1297,10 @@ func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, a
 		"--set", fmt.Sprintf("managerRbac.namespaces={%s}", strings.Join(append(appNamespaces, managerNamespace), ",")),
 		"-f", helmValues,
 	)
+	if err == nil {
+		err = hs.tpSuite.capturePodLogs(ctx, "traffic-manager", managerNamespace)
+	}
+	return err
 }
 
 func (hs *helmSuite) TearDownSuite() {
@@ -1412,6 +1423,54 @@ func (ts *telepresenceSuite) setupKubeConfig(ctx context.Context) {
 	// telepresence-test-developer user later in the tests
 	err = run(ctx, "kubectl", "config", "use-context", "default")
 	ts.NoError(err)
+}
+
+func (ts *telepresenceSuite) capturePodLogs(ctx context.Context, app, ns string) error {
+	var pods string
+	for i := 0; ; i++ {
+		var err error
+		pods, err = output(ctx, "kubectl", "-n", ns, "get", "pods", "-l", "app="+app, "-o", "jsonpath={.items[*].metadata.name}")
+		if err != nil {
+			return fmt.Errorf("failed to get %s pod in namespace %s: %w", app, ns, err)
+		}
+		pods = strings.TrimSpace(pods)
+		if pods != "" || i == 5 {
+			break
+		}
+		dtime.SleepWithContext(ctx, 2*time.Second)
+	}
+	if pods == "" {
+		return fmt.Errorf("found no %s pods in namespace %s", app, ns)
+	}
+
+	// Let command die when the pod that it logs die
+	ctx = dcontext.WithoutCancel(ctx)
+
+	present := struct{}{}
+	logDir, _ := filelocation.AppUserLogDir(ctx)
+	for _, pod := range strings.Split(pods, " ") {
+		if _, ok := ts.logCapturingPods.LoadOrStore(pod, present); ok {
+			continue
+		}
+		logFile, err := os.Create(filepath.Join(logDir, pod+"-"+ns+".log"))
+		if err != nil {
+			ts.logCapturingPods.Delete(pod)
+			return err
+		}
+
+		cmd := dexec.CommandContext(ctx, "kubectl", "-n", ns, "logs", "-f", pod)
+		cmd.Stdout = logFile
+		go func(pod string) {
+			defer func() {
+				_ = logFile.Close()
+				ts.logCapturingPods.Delete(pod)
+			}()
+			if err := cmd.Run(); err != nil {
+				dlog.Error(ctx, err)
+			}
+		}(pod)
+	}
+	return nil
 }
 
 func run(c context.Context, args ...string) error {

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1275,6 +1275,7 @@ func (hs *helmSuite) TestG_CollidingInstalls() {
 func (hs *helmSuite) TestZ_Uninstall() {
 	ctx := dlog.NewTestContext(hs.T(), false)
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
+	telepresenceContext(ctx, "quit")
 	hs.NoError(run(ctx, "helm", "uninstall", "traffic-manager", "-n", hs.managerNamespace1))
 	// Make sure the RBAC was cleaned up by uninstall
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "telepresence-test-developer"))

--- a/pkg/client/connector/userd_trafficmgr/traffic_manager.go
+++ b/pkg/client/connector/userd_trafficmgr/traffic_manager.go
@@ -117,7 +117,7 @@ func (tm *trafficManager) Run(c context.Context) error {
 		return err
 	}
 
-	grpcDialer, err := dnet.NewK8sPortForwardDialer(tm.ConfigFlags, tm.Client())
+	grpcDialer, err := dnet.NewK8sPortForwardDialer(c, tm.ConfigFlags, tm.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 
@@ -37,7 +38,15 @@ func InitContext(ctx context.Context, name string) (context.Context, error) {
 		if err != nil {
 			return ctx, err
 		}
-		rf, err := OpenRotatingFile(filepath.Join(dir, name+".log"), "20060102T150405", true, true, 0600, NewRotateOnce(), 5)
+		maxFiles := uint16(5)
+
+		// TODO: Also make this a configurable setting in config.yml
+		if me := os.Getenv("TELEPRESENCE_MAX_LOGFILES"); me != "" {
+			if mx, err := strconv.Atoi(me); err == nil && mx >= 0 {
+				maxFiles = uint16(mx)
+			}
+		}
+		rf, err := OpenRotatingFile(filepath.Join(dir, name+".log"), "20060102T150405", true, true, 0600, NewRotateOnce(), maxFiles)
 		if err != nil {
 			return ctx, err
 		}

--- a/pkg/client/logging/initcontext_test.go
+++ b/pkg/client/logging/initcontext_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -159,7 +160,13 @@ func TestInitContext(t *testing.T) {
 		ctx, logDir, _ := testSetup(t)
 		check := require.New(t)
 
-		for i := 0; i < 7; i++ {
+		maxFiles := 5
+		if me := os.Getenv("TELEPRESENCE_MAX_LOGFILES"); me != "" {
+			if mx, err := strconv.Atoi(me); err == nil && mx >= 0 {
+				maxFiles = mx
+			}
+		}
+		for i := 0; i < maxFiles+2; i++ {
 			ft.Step(24 * time.Hour)
 			c, err := InitContext(ctx, logName)
 			loggerForTest.AddHook(&dtimeHook{})
@@ -174,6 +181,6 @@ func TestInitContext(t *testing.T) {
 
 		files, err := ioutil.ReadDir(logDir)
 		check.NoError(err)
-		check.Equal(5, len(files))
+		check.Equal(maxFiles, len(files))
 	})
 }


### PR DESCRIPTION
## Description

This PR fixes the logging of the `PortForwardDialer`, increases the number of log files that can rotate when running tests, fixes capture of the `traffic-manager` logs during tests, and fixes a glitch in a test where helm uninstalled the `traffic-manager` without first quitting the client (this is what made all subsequent calls to `Remain()` fail).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. (no entries needed. This is all about our test framework).
 - [x] My change is adequately tested.
