### PR TITLE
More efficient Pod deletion in refreshReplicaSet() function.

### DIFF
--- a/pkg/client/connector/userd_k8s/k8s_cluster.go
+++ b/pkg/client/connector/userd_k8s/k8s_cluster.go
@@ -140,17 +140,13 @@ func (kc *Cluster) StatefulSets(c context.Context, namespace string) ([]kates.Ob
 	return objs, nil
 }
 
-// PodNames returns the names of all pods found in the given Namespace
-func (kc *Cluster) PodNames(c context.Context, namespace string) ([]string, error) {
-	var objNames []objName
-	if err := kc.client.List(c, kates.Query{Kind: "Pod", Namespace: namespace}, &objNames); err != nil {
+// Pods returns all pods found in the given Namespace
+func (kc *Cluster) Pods(c context.Context, namespace string) ([]*kates.Pod, error) {
+	var pods []*kates.Pod
+	if err := kc.client.List(c, kates.Query{Kind: "Pod", Namespace: namespace}, &pods); err != nil {
 		return nil, err
 	}
-	names := make([]string, len(objNames))
-	for i, n := range objNames {
-		names[i] = n.Name
-	}
-	return names, nil
+	return pods, nil
 }
 
 // FindDeployment returns a deployment with the given name in the given namespace or nil


### PR DESCRIPTION
## Description

Let the `refreshReplicaSet()` function fetch Pods directly instead of
first fetching their names and then do a proper fetch.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. Not needed, this is just a minor optimization.
 - [x] My change is adequately tested.
