### PR TITLE
Close dialer when get ConnectReject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Feature: An `also-proxy` entry in the Kubernetes cluster config will
   show up in the output of the `telepresence status` command.
 
+- Bugfix: Dialer will now close if it gets a ConnectReject. This was 
+  encountered when doing an intercept without a local process running
+  and would result in requests hanging indefinitely.
+
 - Bugfix: Made `telepresence list` command faster.
 
 ### 2.3.6 (July 20, 2021)

--- a/pkg/connpool/dialer.go
+++ b/pkg/connpool/dialer.go
@@ -117,7 +117,7 @@ func (h *dialer) handleControl(ctx context.Context, cm Control) {
 	case ConnectOK:
 		go h.writeLoop(ctx)
 		go h.readLoop(ctx)
-	case Disconnect, ConnectReject:
+	case Disconnect:
 		h.Close(ctx)
 		h.sendTCD(ctx, DisconnectOK)
 	case ReadClosed:
@@ -134,7 +134,7 @@ func (h *dialer) handleControl(ctx context.Context, cm Control) {
 				close(h.writerClosing)
 			}
 		}
-	case WriteClosed:
+	case WriteClosed, ConnectReject:
 		h.Close(ctx)
 	case KeepAlive:
 		h.resetIdle()

--- a/pkg/connpool/dialer.go
+++ b/pkg/connpool/dialer.go
@@ -117,7 +117,7 @@ func (h *dialer) handleControl(ctx context.Context, cm Control) {
 	case ConnectOK:
 		go h.writeLoop(ctx)
 		go h.readLoop(ctx)
-	case Disconnect:
+	case Disconnect, ConnectReject:
 		h.Close(ctx)
 		h.sendTCD(ctx, DisconnectOK)
 	case ReadClosed:


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

This adds a case to the dialer to close it when it gets "ConnectReject".  This is encountered when you do an intercept and your local process isn't running, if you try to curl that endpoint it will hand indefinitely:
```
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/no-process) ✗ telepresence intercept echo-easy --port 1235
Using Deployment echo-easy
intercepted
    Intercept name    : echo-easy
    State             : ACTIVE
    Workload kind     : Deployment
    Destination       : 127.0.0.1:1235
    Volume Mount Point: /var/folders/cp/2r22shfd50d9ymgrw14fd23r0000gp/T/telfs-249111851
    Intercepting      : all TCP connections
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/no-process) ✗ curl echo-easy
^C
```

And starting a process on that port still doesn't result in the request going through, so this PR correctly handles ConnectReject by closing it:
```
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/no-process) ✗ telepresence intercept echo-easy --port 1235
Using Deployment echo-easy
intercepted
    Intercept name    : echo-easy
    State             : ACTIVE
    Workload kind     : Deployment
    Destination       : 127.0.0.1:1235
    Volume Mount Point: /var/folders/cp/2r22shfd50d9ymgrw14fd23r0000gp/T/telfs-744925586
    Intercepting      : all TCP connections
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/no-process) ✗ curl echo-easy
curl: (52) Empty reply from server
```
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
