### PR TITLE
Improve systemd-resolved based DNS resolver stability and handover to the overriding one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@
 
 - Bugfix: Made `telepresence list` command faster.
 
-- Bugfix: Mutating webhook injector correctly hides named ports.
+- Bugfix: Mutating webhook injector correctly hides named ports for probes.
+
+- Bugfix: Initialization of `systemd-resolved` based DNS is more stable and
+  failures causing telepresence to default to the overriding resolver will no
+  longer cause general DNS lookup failures.
 
 ### 2.3.6 (July 20, 2021)
 

--- a/pkg/client/daemon/dbus/resolved.go
+++ b/pkg/client/daemon/dbus/resolved.go
@@ -1,6 +1,7 @@
 package dbus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -8,14 +9,11 @@ import (
 	"syscall"
 
 	"github.com/godbus/dbus/v5"
+
+	"github.com/datawire/dlib/dlog"
 )
 
 type (
-	// A ResolveD is a `dbus.Conn` with methods to communicate with the ResolveD daemon.
-	ResolveD struct {
-		*dbus.Conn
-	}
-
 	// A resolvedLinkAddress is the type of the array members of the argument to the SetLinkDNS DBus call. It consists
 	// of an address family (either AF_INET or AF_INET6), followed by a 4-byte or 16-byte array with the raw address data.
 	resolvedLinkAddress struct {
@@ -32,64 +30,75 @@ type (
 	}
 )
 
-func NewResolveD() (*ResolveD, error) {
+func withDBus(c context.Context, f func(*dbus.Conn) error) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to system bus: %w", err)
+		err = fmt.Errorf("failed to connect to system bus: %w", err)
+		dlog.Error(c, err)
+		return err
 	}
-	return &ResolveD{conn}, nil
+	defer conn.Close()
+	return f(conn)
 }
 
-func (conn *ResolveD) IsRunning() bool {
-	var names []string
-	err := conn.BusObject().Call("org.freedesktop.DBus.ListNames", 0).Store(&names)
-	if err != nil {
-		return false
-	}
-	for _, name := range names {
-		if name == "org.freedesktop.resolve1" {
-			return true
+func IsResolveDRunning(c context.Context) bool {
+	err := withDBus(c, func(conn *dbus.Conn) error {
+		var names []string
+		if err := conn.BusObject().CallWithContext(c, "org.freedesktop.DBus.ListNames", 0).Store(&names); err != nil {
+			return err
 		}
-	}
-	return false
+		for _, name := range names {
+			if name == "org.freedesktop.resolve1" {
+				return nil
+			}
+		}
+		return errors.New("not found")
+	})
+	return err == nil
 }
 
-func (conn *ResolveD) SetLinkDNS(networkIndex int, ips ...net.IP) error {
-	addrs := make([]resolvedLinkAddress, len(ips))
-	for i, ip := range ips {
-		addr := &addrs[i]
-		switch len(ip) {
-		case 4:
-			addr.Dialect = syscall.AF_INET
-		case 16:
-			addr.Dialect = syscall.AF_INET6
-		default:
-			return errors.New("illegal IP (not AF_INET or AF_INET6")
+func SetLinkDNS(c context.Context, networkIndex int, ips ...net.IP) error {
+	return withDBus(c, func(conn *dbus.Conn) error {
+		addrs := make([]resolvedLinkAddress, len(ips))
+		for i, ip := range ips {
+			addr := &addrs[i]
+			switch len(ip) {
+			case 4:
+				addr.Dialect = syscall.AF_INET
+			case 16:
+				addr.Dialect = syscall.AF_INET6
+			default:
+				return errors.New("illegal IP (not AF_INET or AF_INET6")
+			}
+			addr.IP = ip
 		}
-		addr.IP = ip
-	}
-	return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").Call(
-		"org.freedesktop.resolve1.Manager.SetLinkDNS", dbus.FlagNoReplyExpected, int32(networkIndex), addrs).Err
+		return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").CallWithContext(
+			c, "org.freedesktop.resolve1.Manager.SetLinkDNS", 0, int32(networkIndex), addrs).Err
+	})
 }
 
-func (conn *ResolveD) SetLinkDomains(networkIndex int, domains ...string) error {
-	dds := make([]resolvedDomain, 0, len(domains))
-	for _, domain := range domains {
-		if domain == "" {
-			continue
+func SetLinkDomains(c context.Context, networkIndex int, domains ...string) error {
+	return withDBus(c, func(conn *dbus.Conn) error {
+		dds := make([]resolvedDomain, 0, len(domains))
+		for _, domain := range domains {
+			if domain == "" {
+				continue
+			}
+			routing := false
+			if strings.HasPrefix(domain, "~") {
+				domain = domain[1:]
+				routing = true
+			}
+			dds = append(dds, resolvedDomain{Name: domain, RoutingOnly: routing})
 		}
-		routing := false
-		if strings.HasPrefix(domain, "~") {
-			domain = domain[1:]
-			routing = true
-		}
-		dds = append(dds, resolvedDomain{Name: domain, RoutingOnly: routing})
-	}
-	return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").Call(
-		"org.freedesktop.resolve1.Manager.SetLinkDomains", dbus.FlagNoReplyExpected, int32(networkIndex), dds).Err
+		return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").CallWithContext(
+			c, "org.freedesktop.resolve1.Manager.SetLinkDomains", 0, int32(networkIndex), dds).Err
+	})
 }
 
-func (conn *ResolveD) RevertLink(networkIndex int) error {
-	return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").Call(
-		"org.freedesktop.resolve1.Manager.RevertLink", dbus.FlagNoReplyExpected, int32(networkIndex)).Err
+func RevertLink(c context.Context, networkIndex int) error {
+	return withDBus(c, func(conn *dbus.Conn) error {
+		return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").CallWithContext(
+			c, "org.freedesktop.resolve1.Manager.RevertLink", 0, int32(networkIndex)).Err
+	})
 }

--- a/pkg/client/daemon/outbound_darwin.go
+++ b/pkg/client/daemon/outbound_darwin.go
@@ -260,9 +260,7 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 		case <-c.Done():
 			return nil
 		case dnsIP := <-o.kubeDNS:
-			if err = o.router.configureDNS(c, dnsIP, uint16(53), o.dnsListener.LocalAddr().(*net.UDPAddr)); err != nil {
-				dlog.Error(c, err)
-			}
+			o.router.configureDNS(c, dnsIP, uint16(53), o.dnsListener.LocalAddr().(*net.UDPAddr))
 		}
 		defer o.dnsListener.Close()
 		v := dns.NewServer(c, []net.PacketConn{o.dnsListener}, nil, o.resolveInCluster)

--- a/pkg/client/daemon/outbound_darwin.go
+++ b/pkg/client/daemon/outbound_darwin.go
@@ -135,7 +135,11 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 	resolverDirName := filepath.Join("/etc", "resolver")
 	resolverFileName := filepath.Join(resolverDirName, "telepresence.local")
 
-	dnsAddr, err := splitToUDPAddr(o.dnsListener.LocalAddr())
+	listener, err := newLocalUDPListener(c)
+	if err != nil {
+		return err
+	}
+	dnsAddr, err := splitToUDPAddr(listener.LocalAddr())
 	if err != nil {
 		return err
 	}
@@ -260,10 +264,10 @@ func (o *outbound) dnsServerWorker(c context.Context) error {
 		case <-c.Done():
 			return nil
 		case dnsIP := <-o.kubeDNS:
-			o.router.configureDNS(c, dnsIP, uint16(53), o.dnsListener.LocalAddr().(*net.UDPAddr))
+			o.router.configureDNS(c, dnsIP, uint16(53), listener.LocalAddr().(*net.UDPAddr))
 		}
-		defer o.dnsListener.Close()
-		v := dns.NewServer(c, []net.PacketConn{o.dnsListener}, nil, o.resolveInCluster)
+		// Server will close the listener, so no need to close it here.
+		v := dns.NewServer(c, []net.PacketConn{listener}, nil, o.resolveInCluster)
 		return v.Run(c)
 	})
 	dns.Flush(c)

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -159,7 +159,11 @@ func (o *outbound) runOverridingServer(c context.Context) error {
 }
 
 func (o *outbound) dnsListeners(c context.Context) ([]net.PacketConn, error) {
-	listeners := []net.PacketConn{o.dnsListener}
+	listener, err := newLocalUDPListener(c)
+	if err != nil {
+		return nil, err
+	}
+	listeners := []net.PacketConn{listener}
 	if runningInDocker() {
 		// Inside docker. Don't add docker bridge
 		return listeners, nil
@@ -175,7 +179,7 @@ func (o *outbound) dnsListeners(c context.Context) ([]net.PacketConn, error) {
 		return listeners, nil
 	}
 
-	localAddr, err := splitToUDPAddr(o.dnsListener.LocalAddr())
+	localAddr, err := splitToUDPAddr(listener.LocalAddr())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/daemon/resolved_linux.go
+++ b/pkg/client/daemon/resolved_linux.go
@@ -31,12 +31,7 @@ func (o *outbound) tryResolveD(c context.Context, dev *tun.Device) error {
 	}
 
 	// Create a new local address that the DNS resolver can listen to.
-	dnsResolverListener, err := net.ListenPacket("udp", "127.0.0.1:")
-	if err != nil {
-		dlog.Error(c, err)
-		return errResolveDNotConfigured
-	}
-	dnsResolverAddr, err := splitToUDPAddr(dnsResolverListener.LocalAddr())
+	dnsResolverAddr, err := splitToUDPAddr(o.dnsListener.LocalAddr())
 	if err != nil {
 		dlog.Error(c, err)
 		return errResolveDNotConfigured

--- a/pkg/client/daemon/resolved_linux.go
+++ b/pkg/client/daemon/resolved_linux.go
@@ -98,11 +98,7 @@ func (o *outbound) tryResolveD(c context.Context, dev *tun.Device) error {
 				}
 			}()
 			dnsServer = dns.NewServer(c, listeners, nil, o.resolveInCluster)
-			if err = o.router.configureDNS(c, dnsIP, uint16(53), dnsResolverAddr); err != nil {
-				dlog.Error(c, err)
-				initDone <- struct{}{}
-				return err
-			}
+			o.router.configureDNS(c, dnsIP, uint16(53), dnsResolverAddr)
 			close(initDone)
 			return dnsServer.Run(c)
 		}

--- a/pkg/client/daemon/tunrouter.go
+++ b/pkg/client/daemon/tunrouter.go
@@ -131,11 +131,10 @@ func (t *tunRouter) configured() <-chan struct{} {
 	return t.cfgComplete
 }
 
-func (t *tunRouter) configureDNS(_ context.Context, dnsIP net.IP, dnsPort uint16, dnsLocalAddr *net.UDPAddr) error {
+func (t *tunRouter) configureDNS(_ context.Context, dnsIP net.IP, dnsPort uint16, dnsLocalAddr *net.UDPAddr) {
 	t.dnsIP = dnsIP
 	t.dnsPort = dnsPort
 	t.dnsLocalAddr = dnsLocalAddr
-	return nil
 }
 
 func (t *tunRouter) refreshSubnets(ctx context.Context) error {


### PR DESCRIPTION
## Description

This PR deals with initialization of the `systemd-resolved` DNS resolver and if it fails, how telepresence defaults to the overriding resolver. The first three commits should be considered more of a clean-up and consistency nature. Please review one commit at a time.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
