### PR TITLE
Surface logs on error

### DIFF
--- a/cmd/telepresence/main.go
+++ b/cmd/telepresence/main.go
@@ -61,8 +61,8 @@ func summarizeLogs(ctx context.Context, cmd *cobra.Command) {
 		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %+v\n", cmd.CommandPath(), err)
 	}
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", daemonLogs)
 	if daemonLogs != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", daemonLogs)
 	}
 	if connectorLogs != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", connectorLogs)

--- a/cmd/telepresence/main.go
+++ b/cmd/telepresence/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/connector"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
@@ -45,6 +46,25 @@ func main() {
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %v\n", cmd.CommandPath(), err)
+		summarizeLogs(ctx, cmd)
 		os.Exit(1)
+	}
+}
+
+func summarizeLogs(ctx context.Context, cmd *cobra.Command) {
+	daemonLogs, err := logging.SummarizeLog(ctx, daemon.ProcessName)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %+v\n", cmd.CommandPath(), err)
+	}
+	connectorLogs, err := logging.SummarizeLog(ctx, connector.ProcessName)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %+v\n", cmd.CommandPath(), err)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", daemonLogs)
+	if daemonLogs != "" {
+	}
+	if connectorLogs != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", connectorLogs)
 	}
 }

--- a/cmd/telepresence/main.go
+++ b/cmd/telepresence/main.go
@@ -46,9 +46,15 @@ func main() {
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "%s: error: %v\n", cmd.CommandPath(), err)
-		summarizeLogs(ctx, cmd)
+		if !isBackground() {
+			summarizeLogs(ctx, cmd)
+		}
 		os.Exit(1)
 	}
+}
+
+func isBackground() bool {
+	return len(os.Args) > 1 && (os.Args[1] == "daemon-foreground" || os.Args[1] == "connector-foreground")
 }
 
 func summarizeLogs(ctx context.Context, cmd *cobra.Command) {
@@ -66,5 +72,9 @@ func summarizeLogs(ctx context.Context, cmd *cobra.Command) {
 	}
 	if connectorLogs != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s", connectorLogs)
+	}
+
+	if daemonLogs != "" || connectorLogs != "" {
+		fmt.Fprintln(cmd.ErrOrStderr())
 	}
 }

--- a/pkg/client/connector/command.go
+++ b/pkg/client/connector/command.go
@@ -33,7 +33,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
-const processName = "connector"
+const ProcessName = "connector"
 const titleName = "Connector"
 
 var help = `The Telepresence ` + titleName + ` is a background component that manages a connection. It
@@ -43,7 +43,7 @@ Launch the Telepresence ` + titleName + `:
     telepresence connect
 
 Examine the ` + titleName + `'s log output in
-    ` + filepath.Join(func() string { dir, _ := filelocation.AppUserLogDir(context.Background()); return dir }(), processName+".log") + `
+    ` + filepath.Join(func() string { dir, _ := filelocation.AppUserLogDir(context.Background()); return dir }(), ProcessName+".log") + `
 to troubleshoot problems.
 `
 
@@ -75,7 +75,7 @@ type service struct {
 // Command returns the CLI sub-command for "connector-foreground"
 func Command() *cobra.Command {
 	c := &cobra.Command{
-		Use:    processName + "-foreground",
+		Use:    ProcessName + "-foreground",
 		Short:  "Launch Telepresence " + titleName + " in the foreground (debug)",
 		Args:   cobra.ExactArgs(0),
 		Hidden: true,
@@ -293,11 +293,11 @@ func (s *service) connectWorker(c context.Context, cr *rpc.ConnectRequest, k8sCo
 
 // run is the main function when executing as the connector
 func run(c context.Context) error {
-	c, err := logging.InitContext(c, processName)
+	c, err := logging.InitContext(c, ProcessName)
 	if err != nil {
 		return err
 	}
-	c = dgroup.WithGoroutineName(c, "/"+processName)
+	c = dgroup.WithGoroutineName(c, "/"+ProcessName)
 
 	env, err := client.LoadEnv(c)
 	if err != nil {
@@ -359,7 +359,7 @@ func run(c context.Context) error {
 		if err != nil {
 			if errors.Is(err, syscall.EADDRINUSE) {
 				return fmt.Errorf("socket %q exists so the %s is either already running or terminated ungracefully",
-					client.SocketURL(client.ConnectorSocketName), processName)
+					client.SocketURL(client.ConnectorSocketName), ProcessName)
 			}
 			return err
 		}

--- a/pkg/client/daemon/service.go
+++ b/pkg/client/daemon/service.go
@@ -29,7 +29,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
-const processName = "daemon"
+const ProcessName = "daemon"
 const titleName = "Daemon"
 
 var help = `The Telepresence ` + titleName + ` is a long-lived background component that manages
@@ -39,7 +39,7 @@ Launch the Telepresence ` + titleName + `:
     sudo telepresence service
 
 Examine the ` + titleName + `'s log output in
-    ` + filepath.Join(func() string { dir, _ := filelocation.AppUserLogDir(context.Background()); return dir }(), processName+".log") + `
+    ` + filepath.Join(func() string { dir, _ := filelocation.AppUserLogDir(context.Background()); return dir }(), ProcessName+".log") + `
 to troubleshoot problems.
 `
 
@@ -55,7 +55,7 @@ type service struct {
 // Command returns the telepresence sub-command "daemon-foreground"
 func Command() *cobra.Command {
 	return &cobra.Command{
-		Use:    processName + "-foreground <logging dir> <config dir> <dns>",
+		Use:    ProcessName + "-foreground <logging dir> <config dir> <dns>",
 		Short:  "Launch Telepresence " + titleName + " in the foreground (debug)",
 		Args:   cobra.ExactArgs(3),
 		Hidden: true,
@@ -98,7 +98,7 @@ func (d *service) SetOutboundInfo(ctx context.Context, info *rpc.OutboundInfo) (
 // run is the main function when executing as the daemon
 func run(c context.Context, loggingDir, configDir, dns string) error {
 	if os.Geteuid() != 0 {
-		return fmt.Errorf("telepresence %s must run as root", processName)
+		return fmt.Errorf("telepresence %s must run as root", ProcessName)
 	}
 
 	// Spoof the AppUserLogDir and AppUserConfigDir so that they return the original user's
@@ -106,7 +106,7 @@ func run(c context.Context, loggingDir, configDir, dns string) error {
 	c = filelocation.WithAppUserLogDir(c, loggingDir)
 	c = filelocation.WithAppUserConfigDir(c, configDir)
 
-	c, err := logging.InitContext(c, processName)
+	c, err := logging.InitContext(c, ProcessName)
 	if err != nil {
 		return err
 	}
@@ -142,10 +142,10 @@ func run(c context.Context, loggingDir, configDir, dns string) error {
 	})
 
 	// The d.cancel will start a "quit" go-routine that will cause the group to initiate a a shutdown when it returns.
-	d.cancel = func() { g.Go(processName+"-quit", d.quitAll) }
+	d.cancel = func() { g.Go(ProcessName+"-quit", d.quitAll) }
 
 	dlog.Info(c, "---")
-	dlog.Infof(c, "Telepresence %s %s starting...", processName, client.DisplayVersion())
+	dlog.Infof(c, "Telepresence %s %s starting...", ProcessName, client.DisplayVersion())
 	dlog.Infof(c, "PID is %d", os.Getpid())
 	dlog.Info(c, "")
 
@@ -196,7 +196,7 @@ func run(c context.Context, loggingDir, configDir, dns string) error {
 		if err != nil {
 			if errors.Is(err, syscall.EADDRINUSE) {
 				return fmt.Errorf("socket %q exists so the %s is either already running or terminated ungracefully",
-					client.SocketURL(client.DaemonSocketName), processName)
+					client.SocketURL(client.DaemonSocketName), ProcessName)
 			}
 			return err
 		}

--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -81,46 +81,19 @@ func SummarizeLog(ctx context.Context, name string) (string, error) {
 	scanner := bufio.NewScanner(file)
 
 	errors := []string{}
-	tail := []string{}
 	for scanner.Scan() {
 		text := scanner.Text()
 		// XXX: is there a better way to detect error lines?
 		parts := strings.Fields(text)
 		if len(parts) > 2 && parts[2] == "error" {
 			errors = append(errors, text)
-			if len(errors) > 10 {
-				errors = errors[len(errors)-10:]
-			}
-		}
-		tail = append(tail, text)
-		if len(tail) > 10 {
-			tail = tail[len(tail)-10:]
 		}
 	}
 
-	var lines []string
-	var desc string
-	if len(errors) == 0 {
-		lines = tail
-		desc = "line"
-	} else {
-		lines = errors
-		desc = "error"
+	desc := fmt.Sprintf("%d error", len(errors))
+	if len(errors) != 1 {
+		desc += "s"
 	}
 
-	if len(lines) > 1 {
-		desc = fmt.Sprintf("%d %ss", len(lines), desc)
-	}
-
-	if len(lines) == 0 {
-		return "", nil
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Last %s from %s:\n\n", desc, filename))
-	for _, line := range lines {
-		sb.WriteString(fmt.Sprintf("  %s\n", line))
-	}
-
-	return sb.String(), nil
+	return fmt.Sprintf("See logs for details (%s found): %s", desc, filename), nil
 }


### PR DESCRIPTION
## Description

Display a summary of the daemon and connector logs to the user whenever telepresence exits with an error. This will help advertise the location of the logs and also give users a better chance of diagnosing/fixing issues.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
