### PR TITLE
Fix nil pointer crash when doing telepresence current-cluster-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   failures causing telepresence to default to the overriding resolver will no
   longer cause general DNS lookup failures.
 
+- Bugfix: Fixed a regression introduced in 2.3.5 that caused `telepresence current-cluster-id`
+  to crash.
+
 ### 2.3.6 (July 20, 2021)
 
 - Bugfix: Fixed a regression introduced in 2.3.5 that caused preview

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -136,7 +136,7 @@ func Command(ctx context.Context) *cobra.Command {
 			Name: "Kubernetes flags",
 			Flags: func() *pflag.FlagSet {
 				kubeFlags = pflag.NewFlagSet("", 0)
-				kubeConfig := kates.NewConfigFlags(false)
+				kubeConfig = kates.NewConfigFlags(false)
 				kubeConfig.Namespace = nil // some of the subcommands, like "connect", don't take --namespace
 				kubeConfig.AddFlags(kubeFlags)
 				return kubeFlags


### PR DESCRIPTION
## Description

Fixes a regression in 2.3.5 causing a nil pointer panic for the
command `telepresence current-cluster-id`.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
