### PR TITLE
Fixed systemd-resolved sanity check failure if the default iface has ~. domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.3.8 (TBD)
+- Bugfix: Initialisatialisation of systemd-resolved` based DNS sets
+  routing domain to improve stability in non-standard configurations.
+
 ### 2.3.7 (July 23, 2021)
 
 - Feature: An `also-proxy` entry in the Kubernetes cluster config will


### PR DESCRIPTION
## Description

The PR fixes `systemd-resolved` sanity check failure in case the original `defaultroute` interface has 
`~.` routing key set. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
