### PR TITLE
Prevent subnet updates when subnets haven't changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Bugfix: Initialisatialisation of systemd-resolved` based DNS sets
   routing domain to improve stability in non-standard configurations.
 
+- Bugfix: The `traffic-manager` will only send subnet updates to a
+  client root daemon when the subnets actually change.
+
 ### 2.3.7 (July 23, 2021)
 
 - Feature: An `also-proxy` entry in the Kubernetes cluster config will


### PR DESCRIPTION
## Description

The `traffic-manager` listens to `Nodes` or `Pods` to determine what
pod-subnets that are used. The `Nodes` or `Pods` may change frequently
although the subnet set remains the same, causing a lot of unnecessary
information to be sent from the `traffic-manager` to connected clients.
Especially o larger clusters.

This commit ensures that changes that don't alter the actual subnets
are ignored and not propagated to the root daemon.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
