### PR TITLE
Make references in agent's environment work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ### 2.3.8 (TBD)
-- Bugfix: Initialisatialisation of systemd-resolved` based DNS sets
+- Bugfix: Initialization of systemd-resolved` based DNS sets
   routing domain to improve stability in non-standard configurations.
+
+- Bugfix: A `$(NAME)` reference in the agent's environment will now be
+  interpolated correctly.
 
 ### 2.3.7 (July 23, 2021)
 

--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -23,26 +23,26 @@ import (
 )
 
 type Config struct {
-	Name        string `env:"AGENT_NAME,required"`
-	Namespace   string `env:"AGENT_NAMESPACE,default="`
-	PodIP       string `env:"AGENT_POD_IP,default="`
-	AgentPort   int32  `env:"AGENT_PORT,default=9900"`
-	AppMounts   string `env:"APP_MOUNTS,default=/tel_app_mounts"`
-	AppPort     int32  `env:"APP_PORT,required"`
-	ManagerHost string `env:"MANAGER_HOST,default=traffic-manager"`
-	ManagerPort int32  `env:"MANAGER_PORT,default=8081"`
+	Name        string `env:"_TEL_AGENT_NAME,required"`
+	Namespace   string `env:"_TEL_AGENT_NAMESPACE,default="`
+	PodIP       string `env:"_TEL_AGENT_POD_IP,default="`
+	AgentPort   int32  `env:"_TEL_AGENT_PORT,default=9900"`
+	AppMounts   string `env:"_TEL_AGENT_APP_MOUNTS,default=/tel_app_mounts"`
+	AppPort     int32  `env:"_TEL_AGENT_APP_PORT,required"`
+	ManagerHost string `env:"_TEL_AGENT_MANAGER_HOST,default=traffic-manager"`
+	ManagerPort int32  `env:"_TEL_AGENT_MANAGER_PORT,default=8081"`
 }
 
 var skipKeys = map[string]bool{
 	// Keys found in the Config
-	"AGENT_NAME":      true,
-	"AGENT_NAMESPACE": true,
-	"AGENT_POD_IP":    true,
-	"AGENT_PORT":      true,
-	"APP_MOUNTS":      true,
-	"APP_PORT":        true,
-	"MANAGER_HOST":    true,
-	"MANAGER_PORT":    true,
+	"_TEL_AGENT_NAME":         true,
+	"_TEL_AGENT_NAMESPACE":    true,
+	"_TEL_AGENT_POD_IP":       true,
+	"_TEL_AGENT_PORT":         true,
+	"_TEL_AGENT_APP_MOUNTS":   true,
+	"_TEL_AGENT_APP_PORT":     true,
+	"_TEL_AGENT_MANAGER_HOST": true,
+	"_TEL_AGENT_MANAGER_PORT": true,
 
 	// Keys that aren't useful when running on the local machine
 	"HOME":     true,
@@ -63,9 +63,7 @@ func AppEnvironment() map[string]string {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) == 2 {
 			k := pair[0]
-			if strings.HasPrefix(k, "TEL_APP_") {
-				appEnv[k[len("TEL_APP_"):]] = pair[1]
-			} else if _, skip := skipKeys[k]; !skip {
+			if _, skip := skipKeys[k]; !skip {
 				fullEnv[k] = pair[1]
 			}
 		}
@@ -113,14 +111,14 @@ func Main(ctx context.Context, args ...string) error {
 	dlog.Infof(ctx, "Traffic Agent %s [pid:%d]", version.Version, os.Getpid())
 
 	// Add defaults for development work
-	user := os.Getenv("USER)")
+	user := os.Getenv("USER")
 	if user != "" {
 		dlog.Infof(ctx, "Launching in dev mode ($USER is set)")
-		if os.Getenv("AGENT_NAME") == "" {
-			os.Setenv("AGENT_NAME", "test-agent")
+		if os.Getenv("_TEL_AGENT_NAME") == "" {
+			os.Setenv("_TEL_AGENT_NAME", "test-agent")
 		}
-		if os.Getenv("APP_PORT") == "" {
-			os.Setenv("APP_PORT", "8080")
+		if os.Getenv("_TEL_AGENT_APP_PORT") == "" {
+			os.Setenv("_TEL_AGENT_APP_PORT", "8080")
 		}
 	}
 

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -220,12 +220,12 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`"ports":[{"name":"http","containerPort":9900,"protocol":"TCP"}],` +
 				`"env":[` +
 				`{"name":"TELEPRESENCE_CONTAINER","value":"some-app-name"},` +
-				`{"name":"LOG_LEVEL","value":"debug"},` +
-				`{"name":"AGENT_NAME","value":"some-name"},` +
-				`{"name":"AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
-				`{"name":"AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
-				`{"name":"APP_PORT","value":"8888"},` +
-				`{"name":"MANAGER_HOST","value":"traffic-manager.default"}` +
+				`{"name":"_TEL_AGENT_LOG_LEVEL","value":"debug"},` +
+				`{"name":"_TEL_AGENT_NAME","value":"some-name"},` +
+				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
+				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
+				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +
 				`],` +
 				`"resources":{},` +
 				`"volumeMounts":[{"name":"traffic-annotations","mountPath":"/tel_pod_info"}],` +
@@ -271,14 +271,14 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`"ports":[{"name":"http","containerPort":9900,"protocol":"TCP"}],` +
 				`"env":[` +
 				`{"name":"TELEPRESENCE_CONTAINER","value":"some-app-name"},` +
-				`{"name":"LOG_LEVEL","value":"debug"},` +
-				`{"name":"AGENT_NAME","value":"some-name"},` +
-				`{"name":"AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
-				`{"name":"AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
-				`{"name":"APP_PORT","value":"8888"},` +
-				`{"name":"APP_MOUNTS","value":"/tel_app_mounts"},` +
-				`{"name":"TEL_APP_TELEPRESENCE_MOUNTS","value":"/var/run/secrets/kubernetes.io/serviceaccount"},` +
-				`{"name":"MANAGER_HOST","value":"traffic-manager.default"}` +
+				`{"name":"_TEL_AGENT_LOG_LEVEL","value":"debug"},` +
+				`{"name":"_TEL_AGENT_NAME","value":"some-name"},` +
+				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
+				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
+				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_APP_MOUNTS","value":"/tel_app_mounts"},` +
+				`{"name":"TELEPRESENCE_MOUNTS","value":"/var/run/secrets/kubernetes.io/serviceaccount"},` +
+				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +
 				`],` +
 				`"resources":{},` +
 				`"volumeMounts":[` +

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-initializer.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-initializer.output.yaml
@@ -45,25 +45,25 @@ deployment:
         - args:
           - agent
           env:
-          - name: TEL_APP_LISTEN_PORT
+          - name: LISTEN_PORT
             value: "3000"
           - name: TELEPRESENCE_CONTAINER
             value: sample-app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: sample-app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "3000"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-0.output.yaml
@@ -44,21 +44,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-mp-0
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "9090"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-1.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-1.output.yaml
@@ -21,21 +21,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-2.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-2.output.yaml
@@ -21,21 +21,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-3.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-3.output.yaml
@@ -21,21 +21,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-0.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-0
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-1.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-1.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-1
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-10.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-10.output.yaml
@@ -43,21 +43,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-10
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-11.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-11.output.yaml
@@ -47,21 +47,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server-pick
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-11
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-2.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-2.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-2
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-3.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-3.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-3
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-4.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-4.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-4
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-5.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-5.output.yaml
@@ -39,21 +39,21 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-5
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.input.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.input.yaml
@@ -38,6 +38,13 @@ deployment:
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PREFIX
+              value: $(POD_NAMESPACE)/stuff
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.output.yaml
@@ -31,29 +31,42 @@ deployment:
           app: hello-6
       spec:
         containers:
-        - image: jmalloc/echo-server:0.1.0
+        - env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PREFIX
+            value: $(POD_NAMESPACE)/stuff
+          image: jmalloc/echo-server:0.1.0
           name: echo-server
           resources: {}
         - args:
           - agent
           env:
-          - name: TELEPRESENCE_CONTAINER
-            value: echo-server
-          - name: LOG_LEVEL
-            value: debug
-          - name: AGENT_NAME
-            value: hello-6
-          - name: AGENT_NAMESPACE
+          - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: PREFIX
+            value: $(POD_NAMESPACE)/stuff
+          - name: TELEPRESENCE_CONTAINER
+            value: echo-server
+          - name: _TEL_AGENT_LOG_LEVEL
+            value: debug
+          - name: _TEL_AGENT_NAME
+            value: hello-6
+          - name: _TEL_AGENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-7.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-7.output.yaml
@@ -42,25 +42,25 @@ deployment:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-7
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: APP_MOUNTS
+          - name: _TEL_AGENT_APP_MOUNTS
             value: /tel_app_mounts
-          - name: TEL_APP_TELEPRESENCE_MOUNTS
+          - name: TELEPRESENCE_MOUNTS
             value: /usr/share/nginx/html
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-8.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-8.output.yaml
@@ -53,38 +53,37 @@ deployment:
         - args:
           - agent
           env:
-          - name: TEL_APP_TEST_PATH
+          - name: TEST_PATH
             value: /path/to/one
-          - name: TEL_APP_TEST_TXT
+          - name: TEST_TXT
             value: some arbitrary text
-          - name: TEL_APP_TEST_FROM
+          - name: TEST_FROM
             valueFrom:
               configMapKeyRef:
                 key: some-key
                 name: some-map
           - name: TELEPRESENCE_CONTAINER
             value: echo-server
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: hello-8
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           envFrom:
-          - prefix: TEL_APP_
-            secretRef:
+          - secretRef:
               name: test-secret
-          - prefix: TEL_APP_SC_
+          - prefix: SC_
             secretRef:
               name: test-secret2
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-9.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-9.output.yaml
@@ -65,25 +65,25 @@ deployment:
         - args:
           - agent
           env:
-          - name: TEL_APP_LISTEN_PORT
+          - name: LISTEN_PORT
             value: "3000"
           - name: TELEPRESENCE_CONTAINER
             value: sample-app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: with-probes
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "3000"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-mp-tc-0.output.yaml
@@ -20,21 +20,21 @@ replicaset:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-tc-0.output.yaml
@@ -20,21 +20,21 @@ replicaset:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-mp-tc-0.output.yaml
@@ -39,21 +39,21 @@ statefulset:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-tc-0.output.yaml
@@ -37,21 +37,21 @@ statefulset:
           env:
           - name: TELEPRESENCE_CONTAINER
             value: app
-          - name: LOG_LEVEL
+          - name: _TEL_AGENT_LOG_LEVEL
             value: debug
-          - name: AGENT_NAME
+          - name: _TEL_AGENT_NAME
             value: app
-          - name: AGENT_NAMESPACE
+          - name: _TEL_AGENT_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: AGENT_POD_IP
+          - name: _TEL_AGENT_POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: APP_PORT
+          - name: _TEL_AGENT_APP_PORT
             value: "8080"
-          - name: MANAGER_HOST
+          - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}
           name: traffic-agent


### PR DESCRIPTION
## Description

The `traffic-agent` would receive a copy of the intercepted containers
environment where the names were prefixed with "TEL_APP_" to distinguish
those names from the names found in the agent's own environment. That
was problematic, given that when Kubernetes starts a container, it
interpolates references to other variables in the form "$(NAME)".

This commit removes the prefixes so that the names in the environment
copy are left intact. Instead, it's ensured that the names used in the
agent's own environment are prefixed in such a way that a name collision
is highly unlikely.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
