### PR TITLE
Fixes an edge case when selecting a container by port number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### 2.3.8 (TBD)
 - Bugfix: Initialisatialisation of systemd-resolved` based DNS sets
   routing domain to improve stability in non-standard configurations.
+  
+- Bugfix: Edge case error when targeting a container by port number. 
+  Before if your matching/target container was at containers list index 0, 
+  but if there was a container at index 1 with no ports, then the 
+  "no ports" container would end up the selected one
 
 ### 2.3.7 (July 23, 2021)
 

--- a/pkg/install/discovery.go
+++ b/pkg/install/discovery.go
@@ -168,7 +168,7 @@ Please specify the Service port you want to intercept by passing the --port=loca
 		//     kubectl create deploy my-deploy --image my-image
 		//     kubectl expose deploy my-deploy --port 80 --target-port 8080
 		if matchingContainer == nil {
-			for ci := 0; ci < len(cns); ci++ {
+			for ci := range cns {
 				cn := &cns[ci]
 				if len(cn.Ports) == 0 {
 					matchingServicePort = port

--- a/pkg/install/discovery.go
+++ b/pkg/install/discovery.go
@@ -148,8 +148,8 @@ Please specify the Service port you want to intercept by passing the --port=loca
 			}
 		}
 	} else {
-		portNum := port.TargetPort.IntVal
 		// First see if we have a container with a matching port
+		portNum := port.TargetPort.IntVal
 	containerLoop:
 		for ci := range cns {
 			cn := &cns[ci]
@@ -158,7 +158,7 @@ Please specify the Service port you want to intercept by passing the --port=loca
 					matchingServicePort = port
 					matchingContainer = cn
 					containerPortIndex = pi
-					break
+					break containerLoop
 				}
 			}
 		}
@@ -175,7 +175,7 @@ Please specify the Service port you want to intercept by passing the --port=loca
 					matchingContainer = cn
 					containerPortIndex = -1
 					break
-				}	
+				}
 			}
 		}
 	}

--- a/pkg/install/discovery.go
+++ b/pkg/install/discovery.go
@@ -150,7 +150,8 @@ Please specify the Service port you want to intercept by passing the --port=loca
 	} else {
 		portNum := port.TargetPort.IntVal
 		// First see if we have a container with a matching port
-		for ci := 0; ci < len(cns); ci++ {
+	containerLoop:
+		for ci := range cns {
 			cn := &cns[ci]
 			for pi := range cn.Ports {
 				if cn.Ports[pi].ContainerPort == portNum {

--- a/pkg/install/discovery.go
+++ b/pkg/install/discovery.go
@@ -162,7 +162,11 @@ Please specify the Service port you want to intercept by passing the --port=loca
 				}
 			}
 		}
-		// If no container matched, then use the first container with no ports at all
+		// If no container matched, then use the first container with no ports at all. This
+		// enables intercepts of containers that indeed do listen a port but lack a matching
+		// port description in the manifest, which is what you get if you do:
+		//     kubectl create deploy my-deploy --image my-image
+		//     kubectl expose deploy my-deploy --port 80 --target-port 8080
 		if matchingContainer == nil {
 			for ci := 0; ci < len(cns); ci++ {
 				cn := &cns[ci]


### PR DESCRIPTION
## Description

This fixes an edge case when selecting a container by port number. The solution was to make the logic much clearer and easier to read.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

resolves #1926 
