### PR TITLE
Support sending messages from Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-### 2.3.8 (TBD)
+### 2.4.0 (TBD)
+- Feature: Telepresence can now receive messages from the cloud and raise
+  them to the user when they perform certain commands.
+
 - Bugfix: Initialization of systemd-resolved` based DNS sets
   routing domain to improve stability in non-standard configurations.
   

--- a/pkg/client/cli/cloud_messages.go
+++ b/pkg/client/cli/cloud_messages.go
@@ -116,6 +116,13 @@ func raiseCloudMessage(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 	}
+
+	// If the user has specified they are in an air-gapped cluster,
+	// we shouldn't try to get messages
+	if client.GetConfig(cmd.Context()).Cloud.SkipLogin {
+		return nil
+	}
+
 	// The command is the first word of cmd.Use
 	cmdUsed := strings.Split(cmd.Use, " ")[0]
 

--- a/pkg/client/cli/cloud_messages.go
+++ b/pkg/client/cli/cloud_messages.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/datawire/dlib/dtime"
+
+	"github.com/spf13/cobra"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/systema"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cache"
+)
+
+const messagesCacheFilename = "cloud-messages.json"
+
+type cloudMessageCache struct {
+	NextCheck         time.Time       `json:"next_check"`
+	Intercept         string          `json:"intercept"`
+	MessagesDelivered map[string]bool `json:"messagess_delivered"`
+}
+
+// newCloudMessageCache returns a new CloudMessageCache, initialized from the users' if it exists
+func newCloudMessageCache(ctx context.Context) (*cloudMessageCache, error) {
+	cmc := &cloudMessageCache{}
+
+	if err := cache.LoadFromUserCache(ctx, cmc, messagesCacheFilename); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		cmc.NextCheck = time.Time{}
+		cmc.MessagesDelivered = make(map[string]bool)
+		_ = cache.SaveToUserCache(ctx, cmc, messagesCacheFilename)
+	}
+	return cmc, nil
+}
+
+// getCloudMessages communicates with Ambassador Cloud and stores those messages
+// in the cloudMessageCache.
+// For now this function will just return a fake result from the cloud
+// this will be replaced with the code to talk to Ambassador Cloud
+// via GetUnauthenticatedCommandMessages in a later commit
+func (cmc *cloudMessageCache) getCloudMessages() error {
+	msgResponse := systema.CommandMessageResponse{
+		Intercept: "Use `login` to connect to Ambassador Cloud and perform selective intercepts.",
+	}
+	cmc.Intercept = msgResponse.GetIntercept()
+	return nil
+}
+
+// raiseCloudMessage is what is called from `PostRunE` in a command and is responsible
+// for raising the message for the command used.
+func raiseCloudMessage(cmd *cobra.Command, _ []string) error {
+	// The command is the first word of cmd.Use
+	cmdUsed := strings.Split(cmd.Use, " ")[0]
+
+	// Load the config
+	cmc, err := newCloudMessageCache(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	// Check if it is time to get new messages from Ambassador Cloud
+	if dtime.Now().After(cmc.NextCheck) {
+		err := cmc.getCloudMessages()
+		if err != nil {
+			// We try again in an hour since we encountered an error
+			cmc.NextCheck = dtime.Now().Add(1 * time.Hour)
+		} else {
+			// This was successful so we'll get updates in a week
+			cmc.NextCheck = dtime.Now().Add(24 * 7 * time.Hour)
+			// We reset the messages delivered for all commands since they
+			// may have changed
+			for key := range cmc.MessagesDelivered {
+				cmc.MessagesDelivered[key] = false
+			}
+		}
+	}
+
+	// Ensure that the message hasn't already been delivered to the user
+	// if it has, then we don't want to print any output so as to not
+	// annoy the user.
+	if val, ok := cmc.MessagesDelivered[cmdUsed]; ok {
+		if val {
+			return nil
+		}
+	}
+
+	// Check if we have a message for the given command
+	var msg string
+	switch cmdUsed {
+	case "intercept":
+		msg = cmc.Intercept
+	default:
+		// We don't currently have any messages for this command
+		// so our msg will be empty
+	}
+	cmc.MessagesDelivered[cmdUsed] = true
+	fmt.Fprintf(cmd.OutOrStdout(), "%s", msg)
+	_ = cache.SaveToUserCache(cmd.Context(), cmc, messagesCacheFilename)
+
+	return nil
+}

--- a/pkg/client/cli/cloud_messages.go
+++ b/pkg/client/cli/cloud_messages.go
@@ -72,7 +72,8 @@ func (cmc *cloudMessageCache) updateCacheMessages(ctx context.Context, resp *sys
 	cmc.Intercept = resp.GetIntercept()
 
 	// Update the time to do the next check since we were successful
-	cmc.NextCheck = dtime.Now().Add(24 * 7 * time.Hour)
+	refreshMsgs := client.GetConfig(ctx).Cloud.RefreshMessages
+	cmc.NextCheck = dtime.Now().Add(refreshMsgs)
 
 	// We reset the messages delivered for all commands since they
 	// may have changed

--- a/pkg/client/cli/cloud_messages.go
+++ b/pkg/client/cli/cloud_messages.go
@@ -2,17 +2,25 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/datawire/dlib/dtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spf13/cobra"
 
+	"github.com/datawire/dlib/dtime"
+
 	"github.com/telepresenceio/telepresence/rpc/v2/systema"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cache"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/cliutil"
 )
 
 const messagesCacheFilename = "cloud-messages.json"
@@ -43,29 +51,64 @@ func newCloudMessageCache(ctx context.Context) (*cloudMessageCache, error) {
 // For now this function will just return a fake result from the cloud
 // this will be replaced with the code to talk to Ambassador Cloud
 // via GetUnauthenticatedCommandMessages in a later commit
-func (cmc *cloudMessageCache) getCloudMessages() error {
-	msgResponse := systema.CommandMessageResponse{
-		Intercept: "Use `login` to connect to Ambassador Cloud and perform selective intercepts.",
+func (cmc *cloudMessageCache) getCloudMessages(ctx context.Context, systemaURL string) error {
+	u, err := url.Parse(systemaURL)
+	if err != nil {
+		return err
 	}
-	cmc.Intercept = msgResponse.GetIntercept()
+	conn, err := grpc.DialContext(ctx,
+		(&url.URL{Scheme: "dns", Path: "/" + u.Host}).String(),
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{ServerName: u.Hostname()})))
+	if err != nil {
+		return err
+	}
+
+	systemaClient := systema.NewSystemACliClient(conn)
+	resp, err := systemaClient.GetUnauthenticatedCommandMessages(ctx, &empty.Empty{})
+	if err != nil {
+		/*
+			we can uncomment this to 'fake' it while we wait for Ambassador Cloud
+			to implement this RPC
+
+			msgResponse := systema.CommandMessageResponse{
+				Intercept: "Use `login` to connect to Ambassador Cloud and perform selective intercepts.",
+			}
+			cmc.Intercept = msgResponse.GetIntercept()
+		*/
+		return err
+	}
+	cmc.Intercept = resp.GetIntercept()
 	return nil
 }
 
 // raiseCloudMessage is what is called from `PostRunE` in a command and is responsible
 // for raising the message for the command used.
 func raiseCloudMessage(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	// Currently we only have messages that should be served when a user
+	// isn't logged in, so we check that here
+	if cliutil.HasLoggedIn(cmd.Context()) {
+		if _, err := cliutil.GetCloudUserInfo(ctx, false, true); err == nil {
+			return nil
+		}
+	}
 	// The command is the first word of cmd.Use
 	cmdUsed := strings.Split(cmd.Use, " ")[0]
 
 	// Load the config
-	cmc, err := newCloudMessageCache(cmd.Context())
+	cmc, err := newCloudMessageCache(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Check if it is time to get new messages from Ambassador Cloud
 	if dtime.Now().After(cmc.NextCheck) {
-		err := cmc.getCloudMessages()
+		env, err := client.LoadEnv(ctx)
+		if err != nil {
+			return err
+		}
+		systemaURL := fmt.Sprintf("https://%s:%s", env.SystemAHost, env.SystemAPort)
+		err = cmc.getCloudMessages(ctx, systemaURL)
 		if err != nil {
 			// We try again in an hour since we encountered an error
 			cmc.NextCheck = dtime.Now().Add(1 * time.Hour)
@@ -100,7 +143,7 @@ func raiseCloudMessage(cmd *cobra.Command, _ []string) error {
 	}
 	cmc.MessagesDelivered[cmdUsed] = true
 	fmt.Fprintf(cmd.OutOrStdout(), "%s", msg)
-	_ = cache.SaveToUserCache(cmd.Context(), cmc, messagesCacheFilename)
+	_ = cache.SaveToUserCache(ctx, cmc, messagesCacheFilename)
 
 	return nil
 }

--- a/pkg/client/cli/cloud_messages_test.go
+++ b/pkg/client/cli/cloud_messages_test.go
@@ -54,10 +54,8 @@ func Test_cloudGetMessageFromCache(t *testing.T) {
 			if tc.res != res {
 				t.Error("error: expected", tc.res, "received", res)
 			}
-			if val, ok := cmc.MessagesDelivered[tc.cmd]; !ok {
+			if _, ok := cmc.MessagesDelivered[tc.cmd]; !ok {
 				t.Error("error: expected", tc.cmd, "to be present in MessagesDelivered")
-			} else if !val {
-				t.Error(" error: expected", tc.cmd, "to be true in MessagesDelivered")
 			}
 		})
 	}
@@ -97,11 +95,9 @@ func Test_cloudUpdateMessages(t *testing.T) {
 	cmc.updateCacheMessages(ctx, updatedMessageResponse)
 
 	// Updating the messages resets `MessagesDelivered` so ensure
-	// it is now false for "intercept"
-	if val, ok := cmc.MessagesDelivered["intercept"]; !ok {
-		t.Error("error: expected", "intercept", "to be present in MessagesDelivered")
-	} else if val {
-		t.Error(" error: expected", "intercept", "to be false in MessagesDelivered")
+	// the "intercept" command is not in the map
+	if _, ok := cmc.MessagesDelivered["intercept"]; ok {
+		t.Error("error: expected", "intercept", "not to be present in MessagesDelivered")
 	}
 
 	// Ensure we get the new message

--- a/pkg/client/cli/cloud_messages_test.go
+++ b/pkg/client/cli/cloud_messages_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/rpc/v2/systema"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+func Test_cloudGetMessageFromCache(t *testing.T) {
+	ctx := dlog.NewTestContext(t, false)
+
+	// Create a fake user cache directory
+	ctx = filelocation.WithUserHomeDir(ctx, t.TempDir())
+
+	// Pre-load cmc with a message for intercept
+	cmc, err := newCloudMessageCache(ctx)
+	ceptMessage := "Test Intercept Message"
+	cmc.Intercept = ceptMessage
+	if err != nil {
+		t.Error(err)
+	}
+
+	tests := []struct {
+		name string
+		cmd  string
+		res  string
+	}{
+		{
+			"command without a message",
+			"leave",
+			"",
+		},
+		{
+			"command with a message",
+			"intercept",
+			ceptMessage,
+		},
+		{
+			"second time running a command that has a message",
+			"intercept",
+			"",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Test a command we don't have a message for
+			res := cmc.getMessageFromCache(ctx, tc.cmd)
+			if tc.res != res {
+				t.Error("error: expected", tc.res, "received", res)
+			}
+			if val, ok := cmc.MessagesDelivered[tc.cmd]; !ok {
+				t.Error("error: expected", tc.cmd, "to be present in MessagesDelivered")
+			} else if !val {
+				t.Error(" error: expected", tc.cmd, "to be true in MessagesDelivered")
+			}
+		})
+	}
+}
+
+func Test_cloudUpdateMessages(t *testing.T) {
+	ctx := dlog.NewTestContext(t, false)
+
+	// Create a fake user cache directory
+	ctx = filelocation.WithUserHomeDir(ctx, t.TempDir())
+
+	// Pre-load cmc with a message for intercept
+	cmc, err := newCloudMessageCache(ctx)
+	ceptMessage := "Test Old Intercept Message"
+	cmc.Intercept = ceptMessage
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Ensure we get the current message in the cache
+	res := cmc.getMessageFromCache(ctx, "intercept")
+	if res != ceptMessage {
+		t.Error("error: expected", ceptMessage, "received", res)
+	}
+
+	// Ensure we don't get a message since we just got one
+	res = cmc.getMessageFromCache(ctx, "intercept")
+	if res != "" {
+		t.Error("error: expected", "", "received", res)
+	}
+
+	// Mock what we get from `GetUnauthenticatedCommandMessages`
+	newCeptMsg := "New intercept message"
+	updatedMessageResponse := &systema.CommandMessageResponse{
+		Intercept: newCeptMsg,
+	}
+	cmc.updateCacheMessages(ctx, updatedMessageResponse)
+
+	// Updating the messages resets `MessagesDelivered` so ensure
+	// it is now false for "intercept"
+	if val, ok := cmc.MessagesDelivered["intercept"]; !ok {
+		t.Error("error: expected", "intercept", "to be present in MessagesDelivered")
+	} else if val {
+		t.Error(" error: expected", "intercept", "to be false in MessagesDelivered")
+	}
+
+	// Ensure we get the new message
+	res = cmc.getMessageFromCache(ctx, "intercept")
+	if res != newCeptMsg {
+		t.Error("error: expected", newCeptMsg, "received", res)
+	}
+
+	// Ensure the NextCheck time is sufficiently in the future
+	futureTime := time.Now().Add(time.Hour * 24 * 6)
+	if !cmc.NextCheck.After(futureTime) {
+		t.Error("error: expected nextCheck time to be greater than 6 days")
+	}
+}

--- a/pkg/client/cli/cloud_messages_test.go
+++ b/pkg/client/cli/cloud_messages_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/systema"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
@@ -108,10 +109,53 @@ func Test_cloudUpdateMessages(t *testing.T) {
 	if res != newCeptMsg {
 		t.Error("error: expected", newCeptMsg, "received", res)
 	}
-
 	// Ensure the NextCheck time is sufficiently in the future
 	futureTime := time.Now().Add(time.Hour * 24 * 6)
 	if !cmc.NextCheck.After(futureTime) {
 		t.Error("error: expected nextCheck time to be greater than 6 days")
+	}
+
+	futureTime = time.Now().Add(time.Hour * 24 * 8)
+	if cmc.NextCheck.After(futureTime) {
+		t.Error("error: expected nextCheck time to be less than 8 days")
+	}
+}
+
+func Test_cloudRefreshMessagesConfig(t *testing.T) {
+	ctx := dlog.NewTestContext(t, false)
+
+	// Create a fake user cache directory + config directory
+	ctx = filelocation.WithUserHomeDir(ctx, t.TempDir())
+	confDir := t.TempDir()
+
+	// Update the config to a shorter time
+	configYml := "cloud:\n  refreshMessages: 24h"
+	ctx, err := client.SetConfig(ctx, confDir, configYml)
+	if err != nil {
+		t.Error(err)
+	}
+
+	cmc, err := newCloudMessageCache(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	// Mock what we get from `GetUnauthenticatedCommandMessages`
+	ceptMessage := "Intercept message, testing config"
+	updatedMessageResponse := &systema.CommandMessageResponse{
+		Intercept: ceptMessage,
+	}
+
+	// Call updateCacheMessage to update cmc with new message + nextCheck
+	cmc.updateCacheMessages(ctx, updatedMessageResponse)
+
+	// Ensure the NextCheck time is sufficiently in the future
+	futureTime := time.Now().Add(time.Hour * 22)
+	if !cmc.NextCheck.After(futureTime) {
+		t.Error("error: expected nextCheck time to be greater than 22 hours")
+	}
+
+	futureTime = time.Now().Add(time.Hour * 26)
+	if cmc.NextCheck.After(futureTime) {
+		t.Error("error: expected nextCheck time to be less than 26 hours")
 	}
 }

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -98,8 +98,9 @@ func interceptCommand(ctx context.Context) *cobra.Command {
 		Use:  "intercept [flags] <intercept_base_name> [-- <command with arguments...>]",
 		Args: cobra.MinimumNArgs(1),
 
-		Short:   "Intercept a service",
-		PreRunE: updateCheckIfDue,
+		Short:    "Intercept a service",
+		PreRunE:  updateCheckIfDue,
+		PostRunE: raiseCloudMessage,
 	}
 	args := interceptArgs{}
 	flags := cmd.Flags()

--- a/pkg/client/configtest.go
+++ b/pkg/client/configtest.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/datawire/ambassador/pkg/dtest"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+// ResetConfig updates configOnce with a new sync.Once. This is currently only used
+// for tests.
+func ResetConfig(c context.Context) {
+	configOnce = new(sync.Once)
+}
+
+// setDefaultConfig creates a config that has the registry set correctly.
+// This ensures that the config on the machine of whatever is running the test,
+// isn't used, which could cause conflict with the tests.
+func SetDefaultConfig(ctx context.Context, configDir string) (context.Context, error) {
+	registry := dtest.DockerRegistry(ctx)
+	configYml := fmt.Sprintf("images:\n  registry: %s\n  webhookRegistry: %s\n", registry, registry)
+	return SetConfig(ctx, configDir, configYml)
+}
+
+// SetConfig clears the config and creates one from the configYml provided. Use this
+// if you are testing components of the config.yml, otherwise you can use setDefaultConfig.
+func SetConfig(ctx context.Context, configDir, configYml string) (context.Context, error) {
+	ResetConfig(ctx)
+	config, err := os.Create(filepath.Join(configDir, "config.yml"))
+	if err != nil {
+		return ctx, err
+	}
+
+	_, err = config.WriteString(configYml)
+	if err != nil {
+		return ctx, err
+	}
+	config.Close()
+
+	ctx = filelocation.WithAppUserConfigDir(ctx, configDir)
+	return ctx, nil
+}


### PR DESCRIPTION
## Description

This PR enables us to have the cloud send messages to users when they perform certain commands. This will enable us to send messages to users to help enhance their experience using Telepresence.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - still have to do
 - [x] My change is adequately tested. - I want to write more tests but this is a start
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
