### PR TITLE
Use the correct apikey for smoke-tests

### DIFF
--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -109,7 +109,7 @@ get_workstation_apikey() {
         exit 1
         ;;
     esac
-    apikey=$(jq -r '.[]|.["telepresence:workstation"]|strings' "$cache_file")
+    apikey=$(jq -r '.[]|.["telepresence:agent-http"]|strings' "$cache_file")
     if [[ -z $apikey ]]; then
         echo "No apikey found"
         exit 1


### PR DESCRIPTION
Previously we had used an apikey that only exists when you communicate
with Ambassador Cloud to get the Smart Agent version, when you are
manually overriding the Smart Agent image, you don't get that apikey.

I've switched it to use the apikey that we generate when doing an
intercept so this should be more resilient.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
