### PR TITLE
Improve process around running tests for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,10 +374,18 @@ workflows:
           context: telepresence2-release
           requires:
             - build-dev-image
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/#
+              ignore: /pull\/[0-9]+/
       - build-and-test-windows:
           context: telepresence2-release
           requires:
             - build-dev-image
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/#
+              ignore: /pull\/[0-9]+/
       - lint
       - generate
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@ A few sentences describing the overall goals of the pull request's commits.
  - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
  - [ ] My change is adequately tested.
  - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
+ - [ ] If a PR from a fork, a maintainer has pushed these changes upstream to ensure full test suite passes.


### PR DESCRIPTION
We have secrets that are required for running our tests in circle, since
forked PRs don't have those secrets, we shouldn't run those tests on
forked PRs.

## Description

This PR is still a WIP but working on a better process so only the correct tests run on forked PRs and that there is a mechanism for maintainers to run the full set of tests on forked PRs.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
