### PR TITLE
Move get-cluster-id into traffic-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   it manually if we ever need to make homebrew point at an older version.
 
 - Feature: Helm chart has now feature to on demand regenerate certificate used for mutating webhook by setting value.
-`agentInjector.certificate.regenerate`
+  `agentInjector.certificate.regenerate`
+
+- Change: The traffic-manager now requires `get` namespace permissions to get the cluster ID instead of that value being
+  passed in as an environment variable to the traffic-manager's deployment.
 
 - Bugfix: Telepresence will initialize the default namespace from the kubeconfig on each call instead of just doing it when connecting.
 

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -14,7 +14,6 @@ their services.
 helm repo add datawire https://getambassador.io
 helm install traffic-manager -n ambassador datawire/telepresence \
 --create-namespace \
---set clusterID=$(kubectl get ns default -o jsonpath='{.metadata.uid}')
 ```
 
 ## Changelog
@@ -41,7 +40,6 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | service.type             | The type of `Service` for the Traffic Manager.                                                                          | `ClusterIP`                                                                                       |
 | resources                | Define resource requests and limits for the Traffic Manger.                                                             | `{}`                                                                                              |
 | logLevel                 | Define the logging level of the Traffic Manager                                                                         | `debug`                                                                                           |
-| clusterID                | The ID the Traffic Manager uses to identify itself. This is just the UID of the default namespace.                      | `""`                                                                                              |
 | licenseKey.create        | Create the license key `volume` and `volumeMount`. **Only required for clusters without access to the internet.**       | `false`                                                                                           |
 | licenseKey.value         | The value of the license key.                                                                                           | `""`                                                                                              |
 | licenseKey.secret.create | Define whether you want the license key `Secret` to be managed by the release or not.                                   | `true`                                                                                            |

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
             value: app.getambassador.io
           - name: SYSTEMA_PORT
             value: "443"
-          - name: CLUSTER_ID
-            value: {{ .Values.clusterID }}
           - name: TELEPRESENCE_REGISTRY
             value: {{ .Values.image.registry }}
           {{- if .Values.grpc }}

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -63,14 +63,6 @@ service:
 # Default: debug
 logLevel: debug
 
-# Telepresence requires a clusterID for identifying itself.
-# This cluster ID is just the UID of the default namespace. You can get this by
-# running `kubectl get ns default -o jsonpath='{.metadata.uid}'`
-# Telepresence will not be able to request a license without this.
-#
-# Default: ""
-clusterID: ""
-
 # GRPC configuration for the Traffic Manager.
 # This is identical to the grpc configuration for local clients.
 # See https://www.telepresence.io/docs/latest/reference/config/#grpc for more info

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -60,7 +60,6 @@ func TestTrafficAgentInjector(t *testing.T) {
 		ServerPort:  "80",
 		SystemAHost: "",
 		SystemAPort: "",
-		ClusterID:   "",
 
 		ManagerNamespace: "default",
 		AgentImage:       "docker.io/datawire/tel2:2.3.1",

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -16,7 +16,6 @@ type Env struct {
 	ServerPort  string `env:"SERVER_PORT,default=8081"`
 	SystemAHost string `env:"SYSTEMA_HOST,default=app.getambassador.io"`
 	SystemAPort string `env:"SYSTEMA_PORT,default=443"`
-	ClusterID   string `env:"CLUSTER_ID,default="`
 
 	ManagerNamespace string            `env:"MANAGER_NAMESPACE,default="`
 	AgentRegistry    string            `env:"TELEPRESENCE_REGISTRY,default=docker.io/datawire"`

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -81,7 +81,7 @@ func (m *Manager) GetLicense(ctx context.Context, _ *empty.Empty) (*rpc.License,
 		return &rpc.License{}, err
 	}
 	hostDomain := string(hostDomainData)
-	return &rpc.License{License: license, Host: hostDomain, ClusterId: managerutil.GetEnv(ctx).ClusterID}, nil
+	return &rpc.License{License: license, Host: hostDomain, ClusterId: m.clusterInfo.GetClusterID()}, nil
 }
 
 // CanConnectAmbassadorCloud checks if Ambassador Cloud is resolvable

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1412,15 +1412,10 @@ func (hs *helmSuite) TestZ_Uninstall() {
 }
 
 func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, appNamespaces ...string) error {
-	clusterID, err := hs.tpSuite.kubectlOut(ctx, "get", "ns", hs.appNamespace1, "-o", "jsonpath={.metadata.uid}")
-	if err != nil {
-		return err
-	}
 	helmValues := "pkg/client/cli/testdata/test-values.yaml"
 	helmChart := "charts/telepresence"
-	err = run(ctx, "helm", "install", "traffic-manager",
+	err := run(ctx, "helm", "install", "traffic-manager",
 		"-n", managerNamespace, helmChart,
-		"--set", fmt.Sprintf("clusterId=%s", clusterID),
 		"--set", fmt.Sprintf("image.registry=%s", dtest.DockerRegistry(ctx)),
 		"--set", fmt.Sprintf("image.tag=%s", hs.tpSuite.testVersion[1:]),
 		"--set", fmt.Sprintf("clientRbac.namespaces={%s}", strings.Join(append(appNamespaces, managerNamespace), ",")),

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -438,7 +438,8 @@ func (cs *connectedSuite) SetupSuite() {
 logLevels:
   rootDaemon: debug
 images:
-  registry: %s
+  registry: %[1]s
+  webhookRegistry: %[1]s
 timeouts:
   intercept: 20s
   trafficManagerAPI: 120s

--- a/pkg/client/connector/userd_trafficmgr/install.go
+++ b/pkg/client/connector/userd_trafficmgr/install.go
@@ -657,5 +657,5 @@ func addAgentToWorkload(
 }
 
 func (ki *installer) ensureManager(c context.Context, env *client.Env) error {
-	return resource.EnsureTrafficManager(c, ki.Client(), ki.GetManagerNamespace(), ki.GetClusterId(c), env)
+	return resource.EnsureTrafficManager(c, ki.Client(), ki.GetManagerNamespace(), env)
 }

--- a/pkg/install/resource/instance.go
+++ b/pkg/install/resource/instance.go
@@ -24,7 +24,6 @@ type Instance interface {
 // during an operation that spans several resources.
 type scope struct {
 	namespace  string
-	clusterID  string
 	tmSelector map[string]string
 	client     *kates.Client
 	env        *client.Env

--- a/pkg/install/resource/tm.go
+++ b/pkg/install/resource/tm.go
@@ -26,10 +26,9 @@ func GetTrafficManagerResources() Instances {
 	}
 }
 
-func EnsureTrafficManager(ctx context.Context, client *kates.Client, namespace, clusterID string, env *cl.Env) error {
+func EnsureTrafficManager(ctx context.Context, client *kates.Client, namespace string, env *cl.Env) error {
 	ctx = withScope(ctx, &scope{
 		namespace: namespace,
-		clusterID: clusterID,
 		tmSelector: map[string]string{
 			"app":          install.ManagerAppName,
 			"telepresence": telName,

--- a/pkg/install/resource/tm_cluster_role.go
+++ b/pkg/install/resource/tm_cluster_role.go
@@ -38,7 +38,7 @@ func (ri tmClusterRole) desiredClusterRole(ctx context.Context) *kates.ClusterRo
 		{
 			Verbs:     []string{"get", "list"},
 			APIGroups: []string{""},
-			Resources: []string{"services"},
+			Resources: []string{"services", "namespaces"},
 		},
 		{
 			Verbs:     []string{"list", "get", "watch"},

--- a/pkg/install/resource/tm_deployment.go
+++ b/pkg/install/resource/tm_deployment.go
@@ -49,7 +49,6 @@ func (ri *tmDeployment) desiredDeployment(ctx context.Context) *kates.Deployment
 		{Name: "LOG_LEVEL", Value: "info"},
 		{Name: "SYSTEMA_HOST", Value: sc.env.SystemAHost},
 		{Name: "SYSTEMA_PORT", Value: sc.env.SystemAPort},
-		{Name: "CLUSTER_ID", Value: sc.clusterID},
 		{Name: "TELEPRESENCE_REGISTRY", Value: imgConfig.WebhookRegistry},
 
 		// Manager needs to know its own namespace so that it can propagate that when


### PR DESCRIPTION
## Description

The cluster ID was added as an environment variable to the traffic-manager deployment in the past, but since the traffic-manager now communicates with the kubeapi to get various things, it makes sense for the traffic-manager to do that itself, so that's what this PR does.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. -- this was only mentioned in the helm chart, so doesn't require a docs change aside from releaseNote: https://github.com/telepresenceio/telepresence.io/pull/53
 - [ ] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
