### PR TITLE
Read namespace from kubeconfig on each call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Feature: Helm chart has now feature to on demand regenerate certificate used for mutating webhook by setting value.
 `agentInjector.certificate.regenerate`
 
+- Bugfix: Telepresence will initialize the default namespace from the kubeconfig on each call instead of just doing it when connecting.
 
 ### 2.4.0 (August 4, 2021)
 

--- a/pkg/client/connector/userd_k8s/k8s_config.go
+++ b/pkg/client/connector/userd_k8s/k8s_config.go
@@ -147,9 +147,9 @@ func NewConfig(flagMap map[string]string, env client.Env) (*Config, error) {
 	return k, nil
 }
 
-// Equals determines if this instance is equal to the given instance with respect to everything but
-// Namespace.
-func (kf *Config) Equals(okf *Config) bool {
+// ContextServiceAndFlagsEqual determines if this instance is equal to the given instance with respect to context,
+// server, and flag arguments.
+func (kf *Config) ContextServiceAndFlagsEqual(okf *Config) bool {
 	return kf != nil && okf != nil &&
 		kf.Context == okf.Context &&
 		kf.Server == okf.Server &&


### PR DESCRIPTION
## Description

Prior to this PR, the user daemon would initialize its notion of
the default namespace during `telepresence connect` and then leave it
unchanged until a `telepresence quit`. This PR ensures that the
namespace is initialized on each call.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 