### PR TITLE
Increase the time to keep idle connections alive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 - Bugfix: Telepresence will initialize the default namespace from the kubeconfig on each call instead of just doing it when connecting.
 
+- Bugfix: The timeout to keep idle outbound TCP connections alive was increased from 60 to 7200 seconds which is the same as
+  the Linux `tcp_keepalive_time` default.
+
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.


### PR DESCRIPTION
## Description

This PR increases the time to keep idle connections alive from
60 seconds to 7,200 seconds which is the same as the Linux default for
`tcp_keepalive_time`.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 