### PR TITLE
Don't report metriton failures as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Bugfix: The timeout to keep idle outbound TCP connections alive was increased from 60 to 7200 seconds which is the same as
   the Linux `tcp_keepalive_time` default.
 
+- Change: Failure to report metrics is logged using loglevel info rather than error.
+
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -566,7 +566,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 				},
 			})
 			if err != nil {
-				_ = is.Scout.Report(ctx, "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
+				is.Scout.Report(ctx, "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
 				err = fmt.Errorf("creating preview domain: %w", err)
 				return true, err
 			}
@@ -594,7 +594,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 			volumeMountProblem = checkMountCapability(ctx)
 		}
 		fmt.Fprintln(is.cmd.OutOrStdout(), DescribeIntercept(intercept, volumeMountProblem, false))
-		_ = is.Scout.Report(ctx, "intercept_success")
+		is.Scout.Report(ctx, "intercept_success")
 		return true, nil
 	case connector.InterceptError_ALREADY_EXISTS:
 		fmt.Fprintln(is.cmd.OutOrStdout(), interceptMessage(r))

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -232,7 +232,7 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	if lc.unsupportedFlags != nil {
 		scout.SetMetadatum("unsupported_flags", lc.unsupportedFlags)
 	}
-	_ = scout.Report(cmd.Context(), "Used legacy syntax")
+	scout.Report(cmd.Context(), "Used legacy syntax")
 
 	// Generate output to user letting them know legacy Telepresence was used,
 	// what the Telepresence command is, and runs it.

--- a/pkg/client/connector/command.go
+++ b/pkg/client/connector/command.go
@@ -454,10 +454,7 @@ func run(c context.Context) error {
 					Value: v,
 				})
 			}
-			if err := s.scoutClient.Report(c, report.Action, metadata...); err != nil {
-				// error is logged and is not fatal
-				dlog.Errorf(c, "report failed: %+v", err)
-			}
+			s.scoutClient.Report(c, report.Action, metadata...)
 		}
 		return nil
 	})

--- a/pkg/client/scout.go
+++ b/pkg/client/scout.go
@@ -9,9 +9,9 @@ import (
 	"runtime"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/datawire/ambassador/pkg/metriton"
+	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/connector/userd_auth/authdata"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
@@ -176,7 +176,7 @@ func (s *Scout) SetMetadatum(key string, value interface{}) {
 // call. It also includes and increments the index, which can be used to
 // determine the correct order of reported events for this installation
 // attempt (correlated by the trace_id set at the start).
-func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) error {
+func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) {
 	s.index++
 	metadata := map[string]interface{}{
 		"action": action,
@@ -193,10 +193,6 @@ func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) er
 
 	_, err = s.Reporter.Report(ctx, metadata)
 	if err != nil && ctx.Err() == nil {
-		return errors.Wrap(err, "scout report")
+		dlog.Infof(ctx, "scout report %q failed: %v", action, err)
 	}
-	// TODO: Do something useful (alert the user if there's an available
-	// upgrade?) with the response (discarded as "_" above)?
-
-	return nil
 }


### PR DESCRIPTION
## Description

Metriton reporting failures must be logged as an info instead of error
because thanks to #1910, we now show error counts from the logs in order
to help the user locate problems and such failures aren't problems that
the user needs to be concerned about.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 