### PR TITLE
Retry dial when socket exists after ungraceful termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Bugfix: The timeout to keep idle outbound TCP connections alive was increased from 60 to 7200 seconds which is the same as
   the Linux `tcp_keepalive_time` default.
 
+- Bugfix: Telepresence will now remove a socket that is the result of an ungraceful termination and retry instead of printing
+  an error saying "this usually means that the process has terminated ungracefully"
+
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -269,6 +269,14 @@ func TestConnect(t *testing.T) {
 		Name:    spec.Name,  // doesn't matter...
 	})
 	a.Error(err)
+	_, err = client.Depart(ctx, aliceSess2)
+	a.NoError(err)
+	_, err = client.Depart(ctx, helloSess)
+	a.NoError(err)
+	_, err = client.Depart(ctx, demo1Sess)
+	a.NoError(err)
+	_, err = client.Depart(ctx, demo2Sess)
+	a.NoError(err)
 }
 
 func getTestClientConn(t *testing.T) *grpc.ClientConn {

--- a/pkg/client/sockets_unix.go
+++ b/pkg/client/sockets_unix.go
@@ -28,13 +28,26 @@ const (
 func dialSocket(ctx context.Context, socketName string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second) // FIXME(lukeshu): Make this configurable
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "unix:"+socketName, append([]grpc.DialOption{
-		grpc.WithInsecure(),
-		grpc.WithNoProxy(),
-		grpc.WithBlock(),
-		grpc.FailOnNonTempDialError(true),
-	}, opts...)...)
-	if err != nil {
+	for firstTry := true; ; firstTry = false {
+		conn, err := grpc.DialContext(ctx, "unix:"+socketName, append([]grpc.DialOption{
+			grpc.WithInsecure(),
+			grpc.WithNoProxy(),
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+		}, opts...)...)
+		if err == nil {
+			return conn, nil
+		}
+
+		if firstTry && errors.Is(err, syscall.ECONNREFUSED) {
+			// Socket exists but doesn't accept connections. This usually means that the process
+			// terminated ungracefully. To remedy this, we make an attempt to remove the socket
+			// and dial again.
+			if rmErr := os.Remove(socketName); rmErr == nil {
+				continue
+			}
+		}
+
 		if err == context.DeadlineExceeded {
 			// grpc.DialContext doesn't wrap context.DeadlineExceeded with any useful
 			// information at all.  Fix that.
@@ -59,7 +72,6 @@ func dialSocket(ctx context.Context, socketName string, opts ...grpc.DialOption)
 		}
 		return nil, err
 	}
-	return conn, nil
 }
 
 func listenSocket(_ context.Context, processName, socketName string) (net.Listener, error) {

--- a/pkg/client/sockets_unix.go
+++ b/pkg/client/sockets_unix.go
@@ -43,7 +43,9 @@ func dialSocket(ctx context.Context, socketName string, opts ...grpc.DialOption)
 			// Socket exists but doesn't accept connections. This usually means that the process
 			// terminated ungracefully. To remedy this, we make an attempt to remove the socket
 			// and dial again.
-			if rmErr := os.Remove(socketName); rmErr == nil {
+			if rmErr := os.Remove(socketName); rmErr != nil {
+				err = fmt.Errorf("%w (socket rm failed with %v)", err, rmErr)
+			} else {
 				continue
 			}
 		}

--- a/pkg/client/sockets_unix_test.go
+++ b/pkg/client/sockets_unix_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,9 +84,9 @@ func TestDialSocket(t *testing.T) {
 		assert.Nil(t, conn)
 		assert.Error(t, err)
 		t.Log(err)
-		assert.ErrorIs(t, err, syscall.ECONNREFUSED)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 		assert.Contains(t, err.Error(), "dial unix "+sockname)
-		assert.Contains(t, err.Error(), "this usually means that the process has terminated ungracefully")
+		assert.Contains(t, err.Error(), "this usually means that the process is not running")
 	})
 	t.Run("NotExist", func(t *testing.T) {
 		ctx := dlog.NewTestContext(t, false)


### PR DESCRIPTION
## Description

The daemons will sometimes leave a socket behind in the filesystem when
it is terminated ungracefully (kill -9 or similar). Telepresence will
think that the process is running and try to connect to that socket if
it exists and it will fail because there's no process alive that listens
to it.

Prior to this PR, telepresence would inform the user about the
failed attempt and exit but now, it will instead make an attempt to
remove the socket and if that succeeds, dial again.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 