### PR TITLE
Revert "Don't report metriton failures as errors"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
 - Bugfix: Telepresence will now remove a socket that is the result of an ungraceful termination and retry instead of printing
   an error saying "this usually means that the process has terminated ungracefully"
 
-- Change: Failure to report metrics is logged using loglevel info rather than error.
-
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -566,7 +566,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 				},
 			})
 			if err != nil {
-				is.Scout.Report(ctx, "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
+				_ = is.Scout.Report(ctx, "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
 				err = fmt.Errorf("creating preview domain: %w", err)
 				return true, err
 			}
@@ -594,7 +594,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 			volumeMountProblem = checkMountCapability(ctx)
 		}
 		fmt.Fprintln(is.cmd.OutOrStdout(), DescribeIntercept(intercept, volumeMountProblem, false))
-		is.Scout.Report(ctx, "intercept_success")
+		_ = is.Scout.Report(ctx, "intercept_success")
 		return true, nil
 	case connector.InterceptError_ALREADY_EXISTS:
 		fmt.Fprintln(is.cmd.OutOrStdout(), interceptMessage(r))

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -232,7 +232,7 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	if lc.unsupportedFlags != nil {
 		scout.SetMetadatum("unsupported_flags", lc.unsupportedFlags)
 	}
-	scout.Report(cmd.Context(), "Used legacy syntax")
+	_ = scout.Report(cmd.Context(), "Used legacy syntax")
 
 	// Generate output to user letting them know legacy Telepresence was used,
 	// what the Telepresence command is, and runs it.

--- a/pkg/client/connector/command.go
+++ b/pkg/client/connector/command.go
@@ -454,7 +454,10 @@ func run(c context.Context) error {
 					Value: v,
 				})
 			}
-			s.scoutClient.Report(c, report.Action, metadata...)
+			if err := s.scoutClient.Report(c, report.Action, metadata...); err != nil {
+				// error is logged and is not fatal
+				dlog.Errorf(c, "report failed: %+v", err)
+			}
 		}
 		return nil
 	})

--- a/pkg/client/scout.go
+++ b/pkg/client/scout.go
@@ -9,9 +9,9 @@ import (
 	"runtime"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/datawire/ambassador/pkg/metriton"
-	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/connector/userd_auth/authdata"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
@@ -176,7 +176,7 @@ func (s *Scout) SetMetadatum(key string, value interface{}) {
 // call. It also includes and increments the index, which can be used to
 // determine the correct order of reported events for this installation
 // attempt (correlated by the trace_id set at the start).
-func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) {
+func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) error {
 	s.index++
 	metadata := map[string]interface{}{
 		"action": action,
@@ -193,6 +193,10 @@ func (s *Scout) Report(ctx context.Context, action string, meta ...ScoutMeta) {
 
 	_, err = s.Reporter.Report(ctx, metadata)
 	if err != nil && ctx.Err() == nil {
-		dlog.Infof(ctx, "scout report %q failed: %v", action, err)
+		return errors.Wrap(err, "scout report")
 	}
+	// TODO: Do something useful (alert the user if there's an available
+	// upgrade?) with the response (discarded as "_" above)?
+
+	return nil
 }


### PR DESCRIPTION
I sadly think we can't do this because then the errors are exposed on stdout when users run intercepts and other commands:
```
(⎈ |default:default)➜  ~/go/telepresenceio git:(release/v2) ✗ telepresence intercept echo-easy --port 8000
Using Deployment echo-easy
intercepted
    Intercept name    : echo-easy
    State             : ACTIVE
    Workload kind     : Deployment
    Destination       : 127.0.0.1:8000
    Volume Mount Point: /var/folders/cp/2r22shfd50d9ymgrw14fd23r0000gp/T/telfs-210508298
    Intercepting      : all TCP connections
INFO[0005] scout report "intercept_success" failed: Post "https://metriton.datawire.io/scout": dial tcp 127.0.0.1:443: connect: connection refused  THREAD=/main
``` 
so I think it makes more sense to have them as errors and handle them that way, since this unfortunately makes the errors more apparent :/.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
