### PR TITLE
Discard logging when metriton fails in CLI app.

### DIFF
--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
+
 	"github.com/spf13/cobra"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 
@@ -566,7 +568,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 				},
 			})
 			if err != nil {
-				is.Scout.Report(ctx, "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
+				is.Scout.Report(logging.WithDiscardingLogger(ctx), "preview_domain_create_fail", client.ScoutMeta{Key: "error", Value: err.Error()})
 				err = fmt.Errorf("creating preview domain: %w", err)
 				return true, err
 			}
@@ -594,7 +596,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 			volumeMountProblem = checkMountCapability(ctx)
 		}
 		fmt.Fprintln(is.cmd.OutOrStdout(), DescribeIntercept(intercept, volumeMountProblem, false))
-		is.Scout.Report(ctx, "intercept_success")
+		is.Scout.Report(logging.WithDiscardingLogger(ctx), "intercept_success")
 		return true, nil
 	case connector.InterceptError_ALREADY_EXISTS:
 		fmt.Fprintln(is.cmd.OutOrStdout(), interceptMessage(r))

--- a/pkg/client/cli/legacy_command.go
+++ b/pkg/client/cli/legacy_command.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
+
+	"github.com/datawire/dlib/dlog"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -213,6 +217,7 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	dlog.WithLogger(cmd.Context(), nil)
 	scout := client.NewScout(cmd.Context(), "cli")
 
 	// Add metadata for the main legacy Telepresence commands so we can
@@ -232,7 +237,7 @@ func checkLegacyCmd(cmd *cobra.Command, args []string) error {
 	if lc.unsupportedFlags != nil {
 		scout.SetMetadatum("unsupported_flags", lc.unsupportedFlags)
 	}
-	scout.Report(cmd.Context(), "Used legacy syntax")
+	scout.Report(logging.WithDiscardingLogger(cmd.Context()), "Used legacy syntax")
 
 	// Generate output to user letting them know legacy Telepresence was used,
 	// what the Telepresence command is, and runs it.

--- a/pkg/client/logging/discard.go
+++ b/pkg/client/logging/discard.go
@@ -1,0 +1,30 @@
+package logging
+
+import (
+	"context"
+	"io"
+	"log"
+
+	"github.com/datawire/dlib/dlog"
+)
+
+type discard int
+
+func (d discard) Helper() {
+}
+
+func (d discard) WithField(_ string, _ interface{}) dlog.Logger {
+	return d
+}
+
+func (d discard) StdLogger(_ dlog.LogLevel) *log.Logger {
+	return log.New(io.Discard, "", 0)
+}
+
+func (d discard) Log(_ dlog.LogLevel, _ string) {
+}
+
+// WithDiscardingLogger returns a context that discards all log output
+func WithDiscardingLogger(ctx context.Context) context.Context {
+	return dlog.WithLogger(ctx, discard(0))
+}


### PR DESCRIPTION
The CLI app writes directly to stdout/stderr instead of a log file so
any logs produced by failures in the metriton reporting must be removed.
Metriton errors doesn't affect normal operation. They are not a user
concern and will just cause confusion if printed on the console.
