### PR TITLE
Fix deadlock in login handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 - Change: Failure to report metrics is logged using loglevel info rather than error.
 
+- Bugfix: A potential deadlock situation is fixed that sometimes caused the user daemon to hang when the user
+  was logged in. 
+
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.


### PR DESCRIPTION
## Description

The access-token "refresh" routine has a select case that calls the
`loginExecutor.getToken` method which in turn would retrieve the `Token`
and potentially end up in a callback writing to the `refreshTimerReset`
channel that was read by another case in that same select, which lead
to a dead-lock because there would be nothing reading that channel.

This commit ensures that the `loginExecutor.getToken` method is called
in a separate goroutine to avoid blocking the for-loop containing the
select.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
