### PR TITLE
Add env metadata to scout reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Bugfix: A potential deadlock situation is fixed that sometimes caused the user daemon to hang when the user
   was logged in. 
 
+- Feature: The scout reports will now include additional metadata coming from environment variables starting with
+  `TELEPRESENCE_REPORT_`.
+
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.


### PR DESCRIPTION
## Description

This PR adds support for additional metadata to be sent in scout reports based on environment variables starting with `TELEPRESENCE_REPORT_`. The metadata defined this way will be overridden by the `BaseMetadata` of the `Reporter` and by any `ScoutMeta` being passed to the `Report()` function.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
