### PR TITLE
Ensure that images.repository is used with images.agentImage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Feature: The scout reports will now include additional metadata coming from environment variables starting with
   `TELEPRESENCE_REPORT_`.
 
+- Bugfix: The config setting `images.agentImage` is no longer required to contain the repository. The repository is
+  instead picked from `images.repository`.
 ### 2.4.0 (August 4, 2021)
 
 - Feature: There is now a native Windows client for Telepresence.

--- a/pkg/client/cli/extensions/extensions.go
+++ b/pkg/client/cli/extensions/extensions.go
@@ -299,10 +299,12 @@ func urlSchemeIsOneOf(urlStr string, schemes ...string) bool {
 	return false
 }
 
+// AgentImage returns the repository/name combination that will be assigned to the container
+// image attribute.
 func (es *ExtensionsState) AgentImage(ctx context.Context, env client.Env) (string, error) {
 	cfg := client.GetConfig(ctx)
 	if cfg.Images.AgentImage != "" {
-		return cfg.Images.AgentImage, nil
+		return fmt.Sprintf("%s/%s", cfg.Images.Registry, cfg.Images.AgentImage), nil
 	}
 	if es.cachedImage.Image != "" || es.cachedImage.Err != nil {
 		return es.cachedImage.Image, es.cachedImage.Err


### PR DESCRIPTION
## Description

The configuration contains settings for both repository and image (for
both the CLI installer and the mutating webhook). Prior to this commit,
the `images.agentImage` was assigned verbatim to the container's
`image` attribute and the `repository` setting was ignored for the
agent. Now both are attributes are used.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
