### PR TITLE
Traffic-manager needs permissions to get namespaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
             # points to a broken IP
             echo "127.0.0.1 metriton.datawire.io" | sudo tee -a /etc/hosts
             DTEST_KUBECONFIG="$HOME/kubeconfig" PATH="/c/:/c/Program Files/SSHFS-Win/bin:$PATH" DTEST_REGISTRY="docker.io/datawire" make test
-          no_output_timeout: 25m
+          no_output_timeout: 27m
       - cleanup-kluster:
           platform: windows
       - save-logs
@@ -247,7 +247,7 @@ jobs:
           # default.  `go test` gives us helpful output when that
           # happens, CircleCI doesn't.  So lengthen CircleCI's timeout
           # just a bit, so `go test`'s timeout output isn't hidden.
-          no_output_timeout: 20m
+          no_output_timeout: 22m
       - save-logs
       - cleanup-kluster:
           platform: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Change: The default log-level is now `info` for all components of Telepresence.
 
+- Bugfix: The RBAC was not updated in the helm chart to enable the traffic-manager to `get` and `list`
+  namespaces, which would impact users who use licensed features of the Telepresence extensions in an
+  air-gapped environment.
+
 - Bugfix: The timeout for Helm actions wasn't always respected which could cause a failing install of the
   `traffic-manager` to make the user daemon to hang indefinitely.
 

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -203,7 +203,7 @@ check: $(tools/ko) $(tools/helm) pkg/install/helm/telepresence-chart.tgz ## (QA)
 	# We run the test suite with TELEPRESENCE_LOGIN_DOMAIN set to localhost since that value
 	# is only used for extensions. Therefore, we want to validate that our tests, and
 	# telepresence, run without requiring any outside dependencies.
-	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 go test -timeout=18m ./...
+	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 go test -timeout=20m ./...
 
 .PHONY: _login
 _login:

--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -24,6 +24,7 @@ rules:
   - ""
   resources:
   - services
+  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

I (incorrectly) had only made this change in the install code https://github.com/telepresenceio/telepresence/pull/1986/files#diff-eee97f14c46153ca010e2a5ed9907c065101c225a972e05c9f7bfa83927cf55a and that then went away with Jose's PR to move all the yaml into one place (that would have prevented me from making this error in the first place.. which is to say Jose made a _very_ good change bc it prevents bugs like this from happening)


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
