### PR TITLE
Ensure that overriding DNS resolver doesn't apply search to localhost.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Change: The default log-level is now `info` for all components of Telepresence.
 
+- Bugfix: The overriding DNS resolver will no longer apply search paths when resolving "localhost".
+
 - Bugfix: The RBAC was not updated in the helm chart to enable the traffic-manager to `get` and `list`
   namespaces, which would impact users who use licensed features of the Telepresence extensions in an
   air-gapped environment.

--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -42,6 +42,10 @@ func (o *outbound) shouldApplySearch(query string) bool {
 		return false
 	}
 
+	if query == "localhost." {
+		return false
+	}
+
 	// Don't apply search paths to the kubernetes zone
 	if strings.HasSuffix(query, dotKubernetesZone) {
 		return false


### PR DESCRIPTION
## Description

The resolver used on Linux when systemd-resolved isn't configured
(typically use case is when running telepresence in a docker container)
would apply it search path to "localhost". This is now fixed.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
