### PR TITLE
Add nightly builds for arm64 Macs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,11 +360,17 @@ jobs:
     - install-go
     - run: sudo pip3 install awscli
     - run:
-        name: "Publish nightly macos"
+        name: "Publish nightly macos (arch amd64)"
         command: |
           newTag=$(go run build-aux/genversion.go nightly)
-          TELEPRESENCE_VERSION=$newTag make push-executable
-          TELEPRESENCE_VERSION=$newTag make promote-nightly
+          TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make push-executable
+          TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make promote-nightly
+    - run:
+        name: "Publish nightly macos (arch arm64)"
+        command: |
+          newTag=$(go run build-aux/genversion.go nightly)
+          TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make push-executable
+          TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make promote-nightly
 
 #  "release-finalize":
 #    executor: vm-linux


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Until we have a Mac M1 that our team can test, it's worth making a nightly arm64 mac build so people who want to test it out (That do have M1 macs) can!

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
