### PR TITLE
Let daemons open their socket listeners prior to performing other tasks. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.4.3 (TBD)
+
+- Bugfix: A timing related bug was fixed that sometimes caused a "daemon did not start" failure.
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel

--- a/pkg/client/cli/cliutil/connector.go
+++ b/pkg/client/cli/cliutil/connector.go
@@ -70,7 +70,7 @@ func withConnector(ctx context.Context, maybeStart bool, fn func(context.Context
 
 				if err := client.WaitUntilSocketAppears("connector", client.ConnectorSocketName, 10*time.Second); err != nil {
 					logDir, _ := filelocation.AppUserLogDir(ctx)
-					return fmt.Errorf("connector service did not start (see %q for more info)", filepath.Join(logDir, "connector.log"))
+					return fmt.Errorf("connector service did not start (see %q for more info): %w", filepath.Join(logDir, "connector.log"), err)
 				}
 
 				maybeStart = false

--- a/pkg/client/cli/cliutil/daemon.go
+++ b/pkg/client/cli/cliutil/daemon.go
@@ -95,7 +95,7 @@ func withDaemon(ctx context.Context, maybeStart bool, dnsIP string, fn func(cont
 
 				if err := client.WaitUntilSocketAppears("daemon", client.DaemonSocketName, 10*time.Second); err != nil {
 					logDir, _ := filelocation.AppUserLogDir(ctx)
-					return fmt.Errorf("daemon service did not start (see %q for more info)", filepath.Join(logDir, "daemon.log"))
+					return fmt.Errorf("daemon service did not start (see %q for more info): %w", filepath.Join(logDir, "daemon.log"), err)
 				}
 
 				maybeStart = false

--- a/pkg/client/sockets.go
+++ b/pkg/client/sockets.go
@@ -25,18 +25,18 @@ func RemoveSocket(listener net.Listener) error {
 }
 
 // SocketExists returns true if a socket is found with the given name
-func SocketExists(name string) bool {
+func SocketExists(name string) (bool, error) {
 	return socketExists(name)
 }
 
 // WaitUntilSocketVanishes waits until the socket at the given path is removed
 // and returns when that happens. The wait will be max ttw (time to wait) long.
 // An error is returned if that time is exceeded before the socket is removed.
-func WaitUntilSocketVanishes(name, path string, ttw time.Duration) (err error) {
+func WaitUntilSocketVanishes(name, path string, ttw time.Duration) error {
 	giveUp := time.Now().Add(ttw)
 	for giveUp.After(time.Now()) {
-		if !SocketExists(path) {
-			return nil
+		if exists, err := SocketExists(path); err != nil || !exists {
+			return err
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
@@ -46,11 +46,11 @@ func WaitUntilSocketVanishes(name, path string, ttw time.Duration) (err error) {
 // WaitUntilSocketAppears waits until the socket at the given path comes into
 // existence and returns when that happens. The wait will be max ttw (time to wait) long.
 // An error is returned if that time is exceeded before the socket is removed.
-func WaitUntilSocketAppears(name, path string, ttw time.Duration) (err error) {
+func WaitUntilSocketAppears(name, path string, ttw time.Duration) error {
 	giveUp := time.Now().Add(ttw)
 	for giveUp.After(time.Now()) {
-		if SocketExists(path) {
-			return nil
+		if exists, err := SocketExists(path); err != nil || exists {
+			return err
 		}
 		time.Sleep(250 * time.Millisecond)
 	}

--- a/pkg/client/sockets_unix.go
+++ b/pkg/client/sockets_unix.go
@@ -100,7 +100,16 @@ func removeSocket(listener net.Listener) error {
 }
 
 // socketExists returns true if a socket is found at the given path
-func socketExists(path string) bool {
+func socketExists(path string) (bool, error) {
 	s, err := os.Stat(path)
-	return err == nil && s.Mode()&os.ModeSocket != 0
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+		return false, err
+	}
+	if s.Mode()&os.ModeSocket == 0 {
+		return false, fmt.Errorf("%q is not a socket", path)
+	}
+	return true, nil
 }


### PR DESCRIPTION
## Description

Some tasks performed by the daemons at boot could take longer time than
the client would wait for the socket/pipe to appear, and hence, make it
think that the daemon didn't start.

Signed-off-by: Thomas Hallgren <thomas@datawire.io>

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
