### PR TITLE
Copy GOVERNANCE.md and MAINTAINERS.md from release/v1

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,29 @@
+# Governance
+
+## Maintainer responsibilities
+
+* Monitor email aliases.
+* Monitor Slack (delayed response is perfectly acceptable).
+* Triage GitHub issues and perform pull request reviews for other maintainers and the community.
+* Make sure that ongoing PRs are moving forward at the right pace or closing them.
+* In general continue to be willing to spend at least 20% of one's time working on Telepresence (~1 business day/week).
+
+## Process for becoming a maintainer
+
+* Express interest to the current maintainers (see [MAINTAINERS.md](MAINTAINERS.md)) that your organization is interested in becoming a maintainer. Becoming a maintainer generally means that you are going to be spending substantial time (>20%) on Telepresence for the foreseeable future.
+* We will expect you to start contributing increasingly complicated PRs, under the guidance of the existing maintainers.
+* We may ask you to do some PRs from our backlog.
+* As you gain experience with the code base and our standards, we will ask you to do code reviews for incoming PRs. All maintainers are expected to shoulder a proportional share of community reviews.
+* After a period of approximately 2-3 months of working together and making sure we see eye to eye, the existing maintainers will confer and decide whether to grant maintainer status or not. We make no guarantees on the length of time this will take, but 2-3 months is the goal.
+
+## When does a maintainer lose maintainer status?
+
+If a maintainer is no longer interested or cannot perform the maintainer duties listed above, they should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of the maintainers per the voting process below.
+
+## Conflict resolution and voting
+
+In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved. If a dispute cannot be decided independently, the maintainers can be called in to decide an issue. If the maintainers themselves cannot decide an issue, the issue will be resolved by voting. The voting process is a simple majority in which each maintainer receives one vote.
+
+## Adding new projects to the Telepresence GitHub organization
+
+New projects will be added to the Telepresence organization via GitHub issue discussion in one of the existing projects in the organization. Once sufficient discussion has taken place (~3-5 business days but depending on the volume of conversation), the maintainers of *the project where the issue was opened* (since different projects in the organization may have different maintainers) will decide whether the new project should be added. See the section above on voting if the maintainers cannot easily decide.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+# Maintainers
+
+The current maintainers of the Telepresence project are:
+
+* Abhay Saxena [ark3](https://github.com/ark3), <ark3@email.com>, core maintainer
+* Rafael Schloming [rhs](https://github.com/rhs), <rhs@datawire.io>, core maintainer
+* Luke Shumaker [LukeShu](https://github.com/LukeShu), <lukeshu@datawire.io>, core maintainer
+* Richard Li [richarddli](https://github.com/richarddli), <richard@datawire.io>, documentation
+
+See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and maintainer responsibilities.


### PR DESCRIPTION
## Description

These are files that the CNCF cares about (though a little less so for us lowly sandbox projects), and I realized that they never made it off of the release/v1 branch.  I did not look over the files, I just copied them.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - no applicable changes
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no applicable chanches
 - [x] My change is adequately tested. - not a code change
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
