### PR TITLE
pkg/client/logging: Implement dupToStd for GOOS=windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Bugfix: A timing related bug was fixed that sometimes caused a "daemon did not start" failure.
 
+- Bugfix: On Windows, crash stack traces and other errors were not
+  written to the log files, now they are.
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel
@@ -20,7 +23,7 @@
 - Bugfix: The timeout for Helm actions wasn't always respected which could cause a failing install of the
   `traffic-manager` to make the user daemon to hang indefinitely.
 
-- Bugfix: The cluster domain used by the DNS resolver is retrieved from the traffic-manager instead of being 
+- Bugfix: The cluster domain used by the DNS resolver is retrieved from the traffic-manager instead of being
   hard-coded to "cluster.local".
 
 ### 2.4.1 (August 30, 2021)
@@ -55,7 +58,7 @@
 - Change: Failure to report metrics is logged using loglevel info rather than error.
 
 - Bugfix: A potential deadlock situation is fixed that sometimes caused the user daemon to hang when the user
-  was logged in. 
+  was logged in.
 
 - Feature: The scout reports will now include additional metadata coming from environment variables starting with
   `TELEPRESENCE_REPORT_`.

--- a/pkg/client/logging/dup_test.go
+++ b/pkg/client/logging/dup_test.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/datawire/dlib/dexec"
+	"github.com/datawire/dlib/dlog"
+)
+
+func head(str string, n int) string {
+	end := 0
+	for i := 0; i < n; i++ {
+		nl := strings.IndexByte(str[end:], '\n')
+		if nl < 0 {
+			return str
+		}
+		end += nl + 1
+	}
+	return str[:end]
+}
+
+func TestDupToStd(t *testing.T) {
+	dirname := t.TempDir()
+
+	ctx := dlog.NewTestContext(t, true)
+	cmd := dexec.CommandContext(ctx, os.Args[0], "-test.v", "-test.run="+t.Name()+"Helper", "--", dirname)
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1")
+
+	err := cmd.Run()
+	var eerr *dexec.ExitError
+	require.ErrorAs(t, err, &eerr)
+	require.True(t, eerr.Exited())
+	require.Equal(t, 2, eerr.ExitCode())
+
+	content, err := os.ReadFile(filepath.Join(dirname, "log.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "this is stdout\nthis is stderr\npanic: this is panic\n",
+		head(string(content), 3))
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		os.Exit(testDupToStdHelper())
+	}
+	os.Exit(m.Run())
+}
+
+func testDupToStdHelper() int {
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "expected exactly 1 argument, got %d\n", len(args))
+		return 1
+	}
+
+	dirname := args[0]
+
+	file, err := os.OpenFile(filepath.Join(dirname, "log.txt"), os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open: %v\n", err)
+		return 1
+	}
+
+	if err := dupToStd(file); err != nil {
+		fmt.Fprintf(os.Stderr, "dup: %v\n", err)
+		return 1
+	}
+
+	fmt.Println("this is stdout")
+	fmt.Fprintln(os.Stderr, "this is stderr")
+	panic("this is panic")
+}

--- a/pkg/client/logging/dup_unix.go
+++ b/pkg/client/logging/dup_unix.go
@@ -10,15 +10,16 @@ import (
 
 // dupToStd ensures that anything written to the file descriptor used by
 // internal functions such as panic and println will end up in the given file.
-//
-// https://github.com/golang/go/issues/325
 func dupToStd(file *os.File) (err error) {
+	// https://github.com/golang/go/issues/325
+
 	fd := file.Fd()
 
-	// Dup2 to file descriptors 1 and 2 explicitly instead of using os.Stdout.Fd() and os.Stderr.Fd() since even if
-	// the latter two may have been overridden, the builtin functions will still use 1 and 2.
-	if err = syscall.Dup2(int(fd), 1); err == nil {
-		err = syscall.Dup2(int(fd), 2)
+	if err := syscall.Dup2(int(fd), 1); err != nil {
+		return err
 	}
-	return err
+	if err := syscall.Dup2(int(fd), 2); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/client/logging/dup_windows.go
+++ b/pkg/client/logging/dup_windows.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func dupToStd(file *os.File) error {
+	// https://stackoverflow.com/questions/34772012/capturing-panic-in-golang/34772516
+
+	fd := file.Fd()
+
+	if err := windows.SetStdHandle(windows.STD_OUTPUT_HANDLE, windows.Handle(fd)); err != nil {
+		return err
+	}
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(fd)); err != nil {
+		return err
+	}
+
+	os.Stdout = file
+	os.Stderr = file
+
+	return nil
+}

--- a/pkg/client/logging/rotatingfile.go
+++ b/pkg/client/logging/rotatingfile.go
@@ -209,9 +209,8 @@ func (rf *RotatingFile) Write(data []byte) (int, error) {
 
 func (rf *RotatingFile) afterOpen() {
 	if rf.captureStd {
-		err := dupToStd(rf.file)
-		if err != nil {
-			// Dup2 failed (or isn't implemented on the current platform)
+		if err := dupToStd(rf.file); err != nil {
+			// Dup2 failed
 			os.Stdout = rf.file
 			os.Stderr = rf.file
 		} else {

--- a/pkg/client/logging/sysinfo_windows.go
+++ b/pkg/client/logging/sysinfo_windows.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func dupToStd(_ *os.File) interface{} {
-	return errors.New("dupToStd() is not implemented on windows")
-}
-
 type WindowsSysInfo interface {
 	SysInfo
 	Owner() *windows.SID


### PR DESCRIPTION
## Description

Implement dupToStd for GOOS=windows, and tidy up stuff around dupToStd.

This is split out from https://github.com/telepresenceio/telepresence/pull/2037

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`. - yep
 - [x] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes. - no doc changes
 - [x] My change is adequately tested. - yep, I added tests
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
