### PR TITLE
Move incorrectly merged CHANGELOG.md entries from 2.4.2 to 2.4.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   continues to use the old behavior of using the change-time in place
   of the birth-time.
 
+- Bugfix: The overriding DNS resolver will no longer apply search paths when resolving "localhost".
+
+- Bugfix: The cluster domain used by the DNS resolver is retrieved from the traffic-manager instead of being
+  hard-coded to "cluster.local".
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel
@@ -27,9 +32,6 @@
 
 - Bugfix: The timeout for Helm actions wasn't always respected which could cause a failing install of the
   `traffic-manager` to make the user daemon to hang indefinitely.
-
-- Bugfix: The cluster domain used by the DNS resolver is retrieved from the traffic-manager instead of being
-  hard-coded to "cluster.local".
 
 ### 2.4.1 (August 30, 2021)
 


### PR DESCRIPTION
Two entries were accidentally merged into the 2.4.2. section after
the release of 2.4.2. This commit moves them to 2.4.3.
