### PR TITLE
webhook agent uninstall, test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Bugfix: The cluster domain used by the DNS resolver is retrieved from the traffic-manager instead of being
   hard-coded to "cluster.local".
 
+  - Bugfix: Agents installed with the mutating webhook were not uninstalled with "telepresence uninstall -e", now they are
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -87,7 +87,7 @@ RBAC rules required to create an intercept in a namespace; excludes any rules th
 - apiGroups:
   - "apps"
   resources: ["deployments", "replicasets", "statefulsets"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
 - apiGroups:
   - "getambassador.io"
   resources: ["hosts", "mappings"]

--- a/k8s/client_rbac.yaml
+++ b/k8s/client_rbac.yaml
@@ -29,7 +29,7 @@ rules:
 - apiGroups:
   - "apps"
   resources: ["deployments", "replicasets", "statefulsets"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
 - apiGroups:
   - "getambassador.io"
   resources: ["hosts", "mappings"]

--- a/pkg/client/connector/userd_trafficmgr/install.go
+++ b/pkg/client/connector/userd_trafficmgr/install.go
@@ -51,6 +51,7 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 	}
 
 	// Remove the agent from all deployments
+	webhookAgentChannel := make(chan kates.Object, len(agents))
 	wg := sync.WaitGroup{}
 	wg.Add(len(agents))
 	for _, ai := range agents {
@@ -72,6 +73,7 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 				return
 			}
 			if _, ok := ann[annTelepresenceActions]; !ok {
+				webhookAgentChannel <- agent
 				return
 			}
 			if err = ki.undoObjectMods(c, agent); err != nil {
@@ -85,12 +87,29 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 	}
 	// wait for all agents to be removed
 	wg.Wait()
+	close(webhookAgentChannel)
 
 	if !agentsOnly && len(errs) == 0 {
 		// agent removal succeeded. Remove the manager resources
 		if err := helm.DeleteTrafficManager(c, ki.ConfigFlags, ki.GetManagerNamespace()); err != nil {
 			addError(err)
 		}
+
+		// roll all agents installed by webhook
+		webhookWaitGroup := sync.WaitGroup{}
+		webhookWaitGroup.Add(len(webhookAgentChannel))
+		for agent := range webhookAgentChannel {
+			agent := agent // pin ?
+			go func() {
+				defer webhookWaitGroup.Done()
+				err := ki.rolloutRestart(c, agent)
+				if err != nil {
+					addError(err)
+				}
+			}()
+		}
+		// wait for all agents to be removed
+		webhookWaitGroup.Wait()
 	}
 
 	switch len(errs) {
@@ -106,6 +125,16 @@ func (ki *installer) removeManagerAndAgents(c context.Context, agentsOnly bool, 
 		return errors.New(bld.String())
 	}
 	return nil
+}
+
+// recreates "kubectl rollout restart <obj>" for kates.obj
+func (ki *installer) rolloutRestart(c context.Context, obj kates.Object) error {
+	restartAnnotation := fmt.Sprintf(
+		"{\"spec\": {\"template\": {\"metadata\": {\"annotations\": {\"%srestartedAt\": \"%s\"}}}}}",
+		install.DomainPrefix,
+		time.Now().Format(time.RFC3339),
+	)
+	return ki.Client().Patch(c, obj, kates.StrategicMergePatchType, []byte(restartAnnotation), obj)
 }
 
 // Finds the Referenced Service in an objects' annotations


### PR DESCRIPTION
## Description

Uninstalls agents installed with agent-injector by rolling their pods after agent-injector has been uninstalled.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
