### PR TITLE
Provide environment variable TELEPRESENCE_INTERCEPT_ID during intercept.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.4.3 (TBD)
 
+- Feature: The environment variable `TELEPRESENCE_INTERCEPT_ID` is now available in the interceptor's environment.
+
 - Bugfix: A timing related bug was fixed that sometimes caused a "daemon did not start" failure.
 
 - Bugfix: On Windows, crash stack traces and other errors were not

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -590,6 +590,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 		is.Scout.SetMetadatum("intercept_id", intercept.Id)
 
 		is.env = r.Environment
+		is.env["TELEPRESENCE_INTERCEPT_ID"] = intercept.Id
 		if is.args.envFile != "" {
 			if err = is.writeEnvFile(); err != nil {
 				return true, err

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -751,7 +751,8 @@ func (cs *connectedSuite) TestK_DockerRun() {
 	})
 
 	grp.Go("client", func(ctx context.Context) error {
-		expectedOutput := "Hello from intercepted echo-server!"
+		// Response contains env variables TELEPRESENCE_CONTAINER and TELEPRESENCE_INTERCEPT_ID
+		expectedOutput := regexp.MustCompile(`Hello from intercepted echo-server with id [0-9a-f-]+:` + svc)
 		cs.Eventually(
 			// condition
 			func() bool {
@@ -763,11 +764,11 @@ func (cs *connectedSuite) TestK_DockerRun() {
 					return false
 				}
 				dlog.Info(ctx, out)
-				return strings.Contains(out, expectedOutput)
+				return expectedOutput.MatchString(out)
 			},
 			30*time.Second, // waitFor
 			1*time.Second,  // polling interval
-			`body of %q equals %q`, "http://"+svc, expectedOutput,
+			`body of %q matches %q`, "http://"+svc, expectedOutput,
 		)
 		return nil
 	})

--- a/pkg/client/cli/testdata/hello/server.py
+++ b/pkg/client/cli/testdata/hello/server.py
@@ -2,7 +2,7 @@ import os
 from flask import Flask
 
 PORT = 8000
-MESSAGE = "Hello from intercepted {}!\n".format(os.environ["TELEPRESENCE_CONTAINER"])
+MESSAGE = "Hello from intercepted {} with id {}!\n".format(os.environ["TELEPRESENCE_CONTAINER"], os.environ["TELEPRESENCE_INTERCEPT_ID"])
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Description

It is sometimes useful to know if a process is running locally on the
workstation, serving an intercept, or if it runs non-intercepted in
a pod, and if the former is true, also know the actual intercept ID
that is being used. The `TELEPRESENCE_INTERCEPT_ID` environment variable
can help with both cases. It is only set for processes running locally
on the workstation.

Having the intercept ID available can be helpful when dealing with
pub/sub systems like Kafka, who can then have all processes that doesn't
have the `TELEPRESENCE_INTERCEPT_ID` set, filter out all messages that
contain an `x-intercept-id` header and those who have the environment
variable set, filter based on the matching `x-intercept-id` header. This
will assure that such messages only are consumed by the correct process.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 