### PR TITLE
Don't block all outbound traffic while handling a control message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Bugfix: Passing false to the intercept command's --mount flag will no longer result in a filesystem being mounted.
 
+- Bugfix: The traffic manager will establish outbound connections in parallel instead of sequentially.
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel

--- a/pkg/tun/tcp/tmgr.go
+++ b/pkg/tun/tcp/tmgr.go
@@ -50,10 +50,6 @@ func (h *handler) handleControl(ctx context.Context, ctrl connpool.Control) {
 }
 
 func (h *handler) HandleMessage(ctx context.Context, msg connpool.Message) {
-	if ctrl, ok := msg.(connpool.Control); ok {
-		h.handleControl(ctx, ctrl)
-		return
-	}
 	select {
 	case <-ctx.Done():
 	case h.fromMgr <- msg:


### PR DESCRIPTION
## Description

Control messages sent over the tunnel were handled sequentially which,
among other things, meant that slow (and possibly failing) `Dial` call
would block all outbound traffic from the workstation until the call
completed or timed out (which would take 30 seconds).

I recommend reviewing this PR with "Hide whitespace changes" checked.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
