### PR TITLE
Let the telepresence status command report correct DNS IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - Bugfix: The traffic manager will establish outbound connections in parallel instead of sequentially.
 
+- Bugfix: The `telepresence status` command reports correct DNS settings instead of "Local IP: nil, Remote IP: nil"
+
 ### 2.4.2 (September 1, 2021)
 
 - Feature: A new `telepresence loglevel <level>` subcommand was added that enables changing the loglevel

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -152,7 +152,7 @@ func Command(ctx context.Context) *cobra.Command {
 			netflags := pflag.NewFlagSet("", 0)
 			// TODO: Those flags aren't applicable on a Linux with systemd-resolved configured either but
 			//  that's unknown until it's been tested during the first connect attempt.
-			if runtime.GOOS != "darwin" {
+			if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
 				netflags.StringVarP(&dnsIP,
 					"dns", "", "",
 					"DNS IP address to intercept locally. Defaults to the first nameserver listed in /etc/resolv.conf.",

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -53,14 +53,18 @@ func daemonStatus(cmd *cobra.Command) error {
 			return err
 		}
 
+		dns := status.OutboundConfig.Dns
 		fmt.Fprintln(out, "Root Daemon: Running")
 		fmt.Fprintf(out, "  Version   : %s (api %d)\n", version.Version, version.ApiVersion)
 		fmt.Fprintf(out, "  DNS       :\n")
-		fmt.Fprintf(out, "    Local IP        : %v\n", net.IP(status.OutboundConfig.Dns.LocalIp))
-		fmt.Fprintf(out, "    Remote IP       : %v\n", net.IP(status.OutboundConfig.Dns.RemoteIp))
-		fmt.Fprintf(out, "    Exclude suffixes: %v\n", status.OutboundConfig.Dns.ExcludeSuffixes)
-		fmt.Fprintf(out, "    Include suffixes: %v\n", status.OutboundConfig.Dns.IncludeSuffixes)
-		fmt.Fprintf(out, "    Timeout         : %v\n", status.OutboundConfig.Dns.LookupTimeout.AsDuration())
+		if dns.LocalIp != nil {
+			// Local IP is only set when the overriding resolver is used
+			fmt.Fprintf(out, "    Local IP        : %v\n", net.IP(dns.LocalIp))
+		}
+		fmt.Fprintf(out, "    Remote IP       : %v\n", net.IP(dns.RemoteIp))
+		fmt.Fprintf(out, "    Exclude suffixes: %v\n", dns.ExcludeSuffixes)
+		fmt.Fprintf(out, "    Include suffixes: %v\n", dns.IncludeSuffixes)
+		fmt.Fprintf(out, "    Timeout         : %v\n", dns.LookupTimeout.AsDuration())
 		fmt.Fprintf(out, "  Also Proxy: (%d subnets)\n", len(status.OutboundConfig.AlsoProxySubnets))
 		for _, subnet := range status.OutboundConfig.AlsoProxySubnets {
 			fmt.Fprintf(out, "    - %s\n", iputil.IPNetFromRPC(subnet))

--- a/pkg/client/daemon/outbound.go
+++ b/pkg/client/daemon/outbound.go
@@ -224,7 +224,15 @@ func (o *outbound) setInfo(ctx context.Context, info *rpc.OutboundInfo) error {
 
 func (o *outbound) getInfo() *rpc.OutboundInfo {
 	info := rpc.OutboundInfo{
-		Dns: o.dnsConfig,
+		Dns: &rpc.DNSConfig{
+			RemoteIp: o.router.dnsIP,
+		},
+	}
+	if o.dnsConfig != nil {
+		info.Dns.LocalIp = o.dnsConfig.LocalIp
+		info.Dns.ExcludeSuffixes = o.dnsConfig.ExcludeSuffixes
+		info.Dns.IncludeSuffixes = o.dnsConfig.IncludeSuffixes
+		info.Dns.LookupTimeout = o.dnsConfig.LookupTimeout
 	}
 
 	if len(o.router.alsoProxySubnets) > 0 {

--- a/pkg/client/daemon/service.go
+++ b/pkg/client/daemon/service.go
@@ -48,7 +48,6 @@ to troubleshoot problems.
 // service represents the state of the Telepresence Daemon
 type service struct {
 	rpc.UnsafeDaemonServer
-	dns           string
 	hClient       *http.Client
 	outbound      *outbound
 	cancel        context.CancelFunc
@@ -149,7 +148,6 @@ func run(c context.Context, loggingDir, configDir, dns string) error {
 	dlog.Debug(c, "Listener opened")
 
 	d := &service{
-		dns: dns,
 		hClient: &http.Client{
 			Timeout: 15 * time.Second,
 			Transport: &http.Transport{


### PR DESCRIPTION
## Description

The `telepresence status` would report that both local and remote
IP is "nil" on most platforms. The local IP is only used on Linux and
only by the overriding DNS resolver and should only be reported when
it's set. The remote IP is always set (but perhaps not in the config)
and the current value should be reported.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 