### PR TITLE
Fix broken nightly build on linux.

### DIFF
--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -21,6 +21,9 @@ TOOLSSRCDIR=$(TOOLSDIR)/src
 GOHOSTOS=$(shell go env GOHOSTOS)
 GOHOSTARCH=$(shell go env GOHOSTARCH)
 
+# GOARCH defaults to GOHOSTARCH but can also be set by the caller of make.
+GOARCH?=$(GOHOSTARCH)
+
 export PATH := $(abspath $(TOOLSBINDIR)):$(PATH)
 
 clobber: clobber-tools


### PR DESCRIPTION
Our nightly builds on Linux are broken because GOARCH isn't set by
default. This commit sets `GOARCH` to `GOHOSTARCH` unless it's provided
as an environment variable.
