### PR TITLE
Fix never released regression in the overriding DNS-resolver.

### DIFF
--- a/pkg/client/daemon/outbound_linux.go
+++ b/pkg/client/daemon/outbound_linux.go
@@ -161,7 +161,7 @@ func (o *outbound) runOverridingServer(c context.Context) error {
 				o.domainsLock.Unlock()
 				return nil
 			})
-			v := dns.NewServer(c, listeners, nil, o.resolveInSearch)
+			v := dns.NewServer(c, listeners, conn, o.resolveInSearch)
 			return v.Run(c)
 		}
 	})


### PR DESCRIPTION
This commit fixes a regression in the overriding DNS-resolver used on
Linux systems that run without systemd-resolved. The regression was
introduced in pr #2038 and never released.
