### PR TITLE
Ensure that conpool tunnels are backward compatible.

### DIFF
--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -468,6 +468,9 @@ func (m *Manager) ClientTunnel(server rpc.Manager_ClientTunnelServer) error {
 	if err != nil {
 		return err
 	}
+	if err = tunnel.Send(ctx, connpool.VersionControl()); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "failed to send manager tunnel version: %v", err)
+	}
 	return m.state.ClientTunnel(managerutil.WithSessionInfo(ctx, sessionInfo), tunnel)
 }
 
@@ -481,6 +484,9 @@ func (m *Manager) AgentTunnel(server rpc.Manager_AgentTunnelServer) error {
 	clientSessionInfo, err := readTunnelSessionID(ctx, tunnel)
 	if err != nil {
 		return err
+	}
+	if err = tunnel.Send(ctx, connpool.VersionControl()); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "failed to send manager tunnel version: %v", err)
 	}
 	return m.state.AgentTunnel(managerutil.WithSessionInfo(ctx, agentSessionInfo), clientSessionInfo, tunnel)
 }

--- a/pkg/client/daemon/tunrouter.go
+++ b/pkg/client/daemon/tunrouter.go
@@ -335,6 +335,9 @@ func (t *tunRouter) run(c context.Context) error {
 		if err = tunnel.Send(c, connpool.SessionInfoControl(t.session)); err != nil {
 			return err
 		}
+		if err = tunnel.Send(c, connpool.VersionControl()); err != nil {
+			return err
+		}
 		t.tunnel = tunnel
 		dlog.Debug(c, "MGR read loop starting")
 		err = t.tunnel.DialLoop(c, t.handlers)

--- a/pkg/connpool/connid.go
+++ b/pkg/connpool/connid.go
@@ -39,6 +39,10 @@ func NewConnID(proto int, src, dst net.IP, srcPort, dstPort uint16) ConnID {
 	return ConnID(bs)
 }
 
+func NewZeroID() ConnID {
+	return ConnID(make([]byte, 13))
+}
+
 // IsIPv4 returns true if the source and destination of this ConnID are IPv4
 func (id ConnID) IsIPv4() bool {
 	return len(id) == 13

--- a/pkg/connpool/dialer.go
+++ b/pkg/connpool/dialer.go
@@ -129,7 +129,7 @@ func (h *dialer) handleControl(ctx context.Context, cm Control) {
 		h.sendTCD(ctx, h.open(ctx))
 	case ConnectOK:
 		go h.readLoop(ctx)
-	case Disconnect: // Peer requests a disconnect. No more messages will arrive
+	case ReadClosed, WriteClosed, Disconnect: // Peer requests a disconnect. No more messages will arrive
 		h.Close(ctx)
 		h.sendTCD(ctx, DisconnectOK)
 	case DisconnectOK: // Peer responded to our disconnect or wants to hard-close. No more messages will arrive

--- a/pkg/tun/tcp/tmgr.go
+++ b/pkg/tun/tcp/tmgr.go
@@ -40,7 +40,7 @@ func (h *handler) handleControl(ctx context.Context, ctrl connpool.Control) {
 		}
 		h.setState(ctx, stateFinWait1)
 		h.sendFin(ctx, true)
-	case connpool.Disconnect:
+	case connpool.ReadClosed, connpool.WriteClosed, connpool.Disconnect:
 		_ = h.sendConnControl(ctx, connpool.DisconnectOK)
 		h.Close(ctx)
 	case connpool.DisconnectOK:


### PR DESCRIPTION
## Description

Ensures that control numbers retain their values between 2.4.2
and 2.4.3 and introduces the concept of a `tunnelVersion` to
ensure backward compatibility.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] My change is adequately tested.
 