### PR TITLE
Put a limit on output buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 - Bugfix: Fix an issue where the traffic-manager would sometimes go into a CPU loop.
 
+- Bugfix: The TUN-device no longer builds an unlimited internal buffer before sending it when receiving lots of TCP-packets without PSH.
+  Instead, the buffer is flushed when it reaches a size of 64K.
+
 ### 2.4.3 (September 15, 2021)
 
 - Feature: The environment variable `TELEPRESENCE_INTERCEPT_ID` is now available in the interceptor's environment.

--- a/pkg/tun/tcp/handler.go
+++ b/pkg/tun/tcp/handler.go
@@ -53,7 +53,7 @@ func (s state) String() (txt string) {
 
 const maxReceiveWindow = uint64(0x40000)
 const ioChannelSize = 0x40
-const maxAckWaits = 0x80
+const maxAckWaits = 0x400
 
 type queueElement struct {
 	sequence uint32


### PR DESCRIPTION
## Description

The output buffer used when the TUN-device was sending data to gRPC
could grow quite large before any data was sent if the sender process
didn't send any PSH messages (that would always flush). This PR
ensures that the buffer size never exceeds 64k. It also shortens the
timer trigger from 10ms to 2ms.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] My change is adequately tested.
