### PR TITLE
always roll before intercept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Feature: The agent injector now supports injecting Traffic Agents into pods that have unnamed ports.
 
+- Bugfix: If a deployment annotated with webhook annotations is deployed before telepresence is installed, telepresence will now install an agent in that deployment before intercept
+
 ### 2.4.3 (September 15, 2021)
 
 - Feature: The environment variable `TELEPRESENCE_INTERCEPT_ID` is now available in the interceptor's environment.

--- a/pkg/client/connector/userd_trafficmgr/install.go
+++ b/pkg/client/connector/userd_trafficmgr/install.go
@@ -220,6 +220,12 @@ func (ki *installer) ensureAgent(c context.Context, namespace, name, svcName, po
 		if err != nil {
 			return "", "", err
 		}
+		// We cannot check if agent already installed using kates,
+		// as agent will not be listed in the deployment
+		err = ki.rolloutRestart(c, obj)
+		if err != nil {
+			return "", "", err
+		}
 		return string(svc.GetUID()), kind, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description

If a deployment with the webhook annotation is deployed before telepresence is installed, telepresence will timeout on intercept. To fix this, we have to ensure that an agent is present. Since we cannot check if the agent is present using kates (the agent will not be listed in the deployment), we roll the pod before every intercept, ensuring the agent is installed.

A possible alternative is to check if the agent is known to the traffic manager in a process similar to "telepresence list", but this would disrupt the current code structure

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
