### PR TITLE
force choosing context in problematic test

### DIFF
--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1485,8 +1485,13 @@ func (hs *helmSuite) TestZ_Uninstall() {
 	hs.NoError(run(ctx, "helm", "uninstall", "traffic-manager", "-n", hs.managerNamespace1))
 	// Make sure the RBAC was cleaned up by uninstall
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "telepresence-test-developer"))
-	hs.Error(run(ctx, "kubectl", "get", "namespaces"))
-	hs.Error(run(ctx, "kubectl", "get", "deploy", "-n", hs.managerNamespace1))
+	// There seems to sometimes be a delay when rapidly changing contexts, so let's
+	// ensure these commands use the correct context
+	// TODO: if we stop seeing issues here, whenever we are using kubectl directly in these
+	// tests that need a non-default context, we should do it manually and stop depending on
+	// setting the context since it seems flakey.
+	hs.Error(run(ctx, "kubectl", "get", "namespaces", "--context", "telepresence-test-developer"))
+	hs.Error(run(ctx, "kubectl", "get", "deploy", "-n", hs.managerNamespace1, "--context", "telepresence-test-developer"))
 }
 
 func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, appNamespaces ...string) error {


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

I think this should help this flake we are seeing quite a bit:
```
            cmd.go:202: dexec.pid=33976 level="info" msg="finished successfully: exit status 0"
            telepresence_test.go:1462: 
                	Error Trace:	telepresence_test.go:1462
                	Error:      	An error is expected but got nil.
                	Test:       	TestTelepresence/TestD_HelmChart/TestZ_Uninstall
            cmd.go:154: dexec.pid=33981 level="info" msg="started command [\"kubectl\" \"get\" \"deploy\" \"-n\" \"ambassador-547947d568a80116a747b7933549deb00b056a19\"]"
            cmd.go:133: dexec.err=&errors.errorString{s:"EOF"} dexec.pid=33981 dexec.stream="stdin" level="info" msg=""
            cmd.go:133: dexec.data="Error from server (Forbidden): deployments.apps is forbidden: User \"system:serviceaccount:default:telepresence-test-developer\" cannot list resource \"deployments\" in API group \"apps\" in the namespace \"ambassador-547947d568a80116a747b7933549deb00b056a19\"\n" dexec.pid=33981 dexec.stream="stdout+stderr" level="info" msg=""
```

if this works, more work will be done to do this in more places in our tests

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
