### PR TITLE
Misc fixes to get the CLI integration test more reliable

### DIFF
--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -21,7 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/api/resource"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -47,7 +50,7 @@ import (
 const serviceCount = 4
 
 func TestTelepresence(t *testing.T) {
-	ctx := dlog.NewTestContext(t, false)
+	ctx := testContext(t)
 	dtest.WithMachineLock(ctx, func(ctx context.Context) {
 		suite.Run(t, new(telepresenceSuite))
 	})
@@ -78,7 +81,7 @@ func (ts *telepresenceSuite) SetupSuite() {
 
 	version.Version = ts.testVersion
 
-	ctx := dlog.NewTestContext(ts.T(), false)
+	ctx := testContext(ts.T())
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -163,7 +166,7 @@ func (ts *telepresenceSuite) SetupSuite() {
 }
 
 func (ts *telepresenceSuite) TearDownSuite() {
-	ctx := dlog.NewTestContext(ts.T(), false)
+	ctx := testContext(ts.T())
 	_ = run(ctx, "kubectl", "config", "use-context", "default")
 	_ = run(ctx, "kubectl", "delete", "namespace", ts.namespace)
 	_ = run(ctx, "kubectl", "delete", "mutatingwebhookconfiguration", "agent-injector-webhook-"+ts.managerTestNamespace)
@@ -220,29 +223,14 @@ func (ts *telepresenceSuite) TestA_WithNoDaemonRunning() {
 			require.Contains(stdout, "Kubernetes context:")
 			require.Regexp(`Telepresence proxy:\s+ON`, stdout)
 			require.Contains(stdout, "Telepresence Root Daemon quitting... done")
-			ts.NoError(ts.capturePodLogs(dlog.NewTestContext(ts.T(), false), "traffic-manager", ts.managerTestNamespace))
+			ts.NoError(ts.capturePodLogs(testContext(ts.T()), "traffic-manager", ts.managerTestNamespace))
 		})
 	})
 
 	ts.Run("Root Daemon Log Level", func() {
 		t := ts.T()
 		require := ts.Require()
-
-		configDir := t.TempDir()
-
-		ctx := dlog.NewTestContext(t, false)
-		registry := dtest.DockerRegistry(ctx)
-		configYml := fmt.Sprintf(`
-logLevels:
-  rootDaemon: debug
-images:
-  registry: %[1]s
-  webhookRegistry: %[1]s
-cloud:
-  systemaHost: 127.0.0.1
-`, registry)
-		ctx, err := client.SetConfig(ctx, configDir, configYml)
-		require.NoError(err)
+		ctx := testContext(t)
 
 		logDir := t.TempDir()
 		ctx = filelocation.WithAppUserLogDir(ctx, logDir)
@@ -293,20 +281,7 @@ cloud:
 
 		require.NoError(clientcmd.WriteToFile(*cfg, kubeconfigFileName), "unable to write modified kubeconfig")
 
-		ctx := dlog.NewTestContext(t, false)
-		registry := dtest.DockerRegistry(ctx)
-		configYml := fmt.Sprintf(`
-logLevels:
-  rootDaemon: debug
-images:
-  registry: %[1]s
-  webhookRegistry: %[1]s
-cloud:
-  systemaHost: 127.0.0.1
-`, registry)
-		ctx, err = client.SetConfig(ctx, tmpDir, configYml)
-		require.NoError(err)
-
+		ctx := testContext(t)
 		defer os.Setenv("KUBECONFIG", origKubeconfigFileName)
 		os.Setenv("KUBECONFIG", kubeconfigFileName)
 		ctx = filelocation.WithAppUserLogDir(ctx, tmpDir)
@@ -351,24 +326,15 @@ cloud:
 		require.Empty(stderr)
 		require.Contains(stdout, "Root Daemon quitting... done")
 
-		configDir := t.TempDir()
-
-		// Use a config with agentImage and webhookAgentImage to validate that its the
+		// Use a config with agentImage and webhookAgentImage to validate that it's the
 		// latter that is used in the traffic-manager
-		ctx := dlog.NewTestContext(t, false)
+		ctx := testContextWithConfig(t, &client.Config{
+			Images: client.Images{
+				AgentImage:        "notUsed:0.0.1",
+				WebhookAgentImage: "imageFromConfig:0.0.1",
+			},
+		})
 		registry := dtest.DockerRegistry(ctx)
-		configYml := fmt.Sprintf(`
-images:
-  registry: %[1]s
-  agentImage: notUsed:0.0.1
-  webhookRegistry: %[1]s
-  webhookAgentImage: imageFromConfig:0.0.1
-cloud:
-  systemaHost: 127.0.0.1
-`, registry)
-		ctx, err := client.SetConfig(ctx, configDir, configYml)
-		require.NoError(err)
-
 		_, stderr = telepresenceContext(ctx, "connect")
 		require.Empty(stderr)
 
@@ -406,7 +372,7 @@ func (ts *telepresenceSuite) TestC_Uninstall() {
 
 	ts.Run("Uninstalls the traffic manager and quits", func() {
 		require := ts.Require()
-		ctx := dlog.NewTestContext(ts.T(), false)
+		ctx := testContext(ts.T())
 
 		names := func() (string, error) {
 			return ts.kubectlOut(ctx, "get",
@@ -475,29 +441,9 @@ func (cs *connectedSuite) ns() string {
 
 func (cs *connectedSuite) SetupSuite() {
 	require := cs.Require()
-	c := dlog.NewTestContext(cs.T(), false)
-
-	// Connect + quit before we change contexts to ensure the
-	// traffic-manager is installed
-	configDir := cs.T().TempDir()
-	registry := dtest.DockerRegistry(c)
-	configYml := fmt.Sprintf(`
-logLevels:
-  rootDaemon: debug
-images:
-  registry: %[1]s
-  webhookRegistry: %[1]s
-  webhookAgentImage: tel2:%[2]s
-timeouts:
-  intercept: 20s
-  trafficManagerAPI: 120s
-grpc:
-  maxReceiveSize: 10Mi
-cloud:
-  systemaHost: 127.0.0.1
-`, registry, cs.tpSuite.testVersion[1:])
-	configYml = strings.TrimSpace(configYml)
-	c, err := client.SetConfig(c, configDir, configYml)
+	c := testContextWithConfig(cs.T(), &client.Config{
+		Images: client.Images{WebhookAgentImage: "tel2:" + cs.tpSuite.testVersion[1:]},
+	})
 
 	// Uninstall and re-install to make sure the traffic-manager is installed with the right config
 	_, stderr := telepresenceContext(c, "uninstall", "-e")
@@ -507,6 +453,8 @@ cloud:
 	jobname := "echo-auto-inject"
 	require.NoError(cs.tpSuite.applyApp(c, jobname, jobname, 80))
 
+	// Connect + quit before we change contexts to ensure the
+	// traffic-manager is installed
 	_, stderr = telepresenceContext(c, "connect")
 	require.Empty(stderr)
 
@@ -529,7 +477,6 @@ cloud:
 		return run(c, "kubectl", "config", "use-context", "telepresence-test-developer") == nil
 	}, 10*time.Second, time.Second)
 
-	require.NoError(err)
 	stdout, stderr = telepresenceContext(c, "connect")
 	require.Empty(stderr)
 	require.Contains(stdout, "Connected to context")
@@ -552,7 +499,7 @@ func (cs *connectedSuite) TearDownSuite() {
 	stdout, stderr := telepresence(cs.T(), "quit")
 	cs.Empty(stderr)
 	cs.Contains(stdout, "quitting")
-	c := dlog.NewTestContext(cs.T(), false)
+	c := testContext(cs.T())
 	cs.NoError(cs.tpSuite.kubectl(c, "config", "use-context", "default"))
 	time.Sleep(time.Second) // Allow some time for processes to die and sockets to vanish
 }
@@ -573,7 +520,7 @@ func (cs *connectedSuite) TestB_ReportsStatusAsConnected() {
 }
 
 func (cs *connectedSuite) TestC_ProxiesOutboundTraffic() {
-	ctx := dlog.NewTestContext(cs.T(), false)
+	ctx := testContext(cs.T())
 	for i := 0; i < serviceCount; i++ {
 		svc := fmt.Sprintf("hello-%d.%s", i, cs.ns())
 		expectedOutput := fmt.Sprintf("Request served by hello-%d", i)
@@ -609,7 +556,7 @@ func (cs *connectedSuite) TestD_Intercepted() {
 
 func (cs *connectedSuite) TestE_PodWithSubdomain() {
 	require := cs.Require()
-	c := dlog.NewTestContext(cs.T(), false)
+	c := testContext(cs.T())
 	require.NoError(cs.tpSuite.applyApp(c, "echo-w-subdomain", "echo.subsonic", 8080))
 	defer func() {
 		cs.NoError(cs.tpSuite.kubectl(c, "delete", "svc", "subsonic", "--context", "default"))
@@ -681,7 +628,7 @@ func (cs *connectedSuite) TestI_LocalOnlyIntercept() {
 	})
 
 	cs.Run("makes services reachable using unqualified name", func() {
-		ctx := dlog.NewTestContext(cs.T(), false)
+		ctx := testContext(cs.T())
 
 		// service can be resolve with unqualified name
 		cs.Eventually(func() bool {
@@ -693,7 +640,7 @@ func (cs *connectedSuite) TestI_LocalOnlyIntercept() {
 		stdout, stderr := telepresence(cs.T(), "leave", "mylocal")
 		cs.Empty(stdout)
 		cs.Empty(stderr)
-		ctx := dlog.NewTestContext(cs.T(), false)
+		ctx := testContext(cs.T())
 		cs.Eventually(func() bool {
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
@@ -727,7 +674,7 @@ func (cs *connectedSuite) TestK_DockerRun() {
 		cs.T().SkipNow()
 	}
 	require := cs.Require()
-	ctx := dlog.NewTestContext(cs.T(), false)
+	ctx := testContext(cs.T())
 
 	svc := "hello-0"
 	tag := "telepresence/hello-test"
@@ -735,12 +682,6 @@ func (cs *connectedSuite) TestK_DockerRun() {
 	_, err := output(ctx, "docker", "build", "-t", tag, testDir)
 	require.NoError(err)
 	abs, err := filepath.Abs(testDir)
-	require.NoError(err)
-
-	// We need to explicitly set the default config since telepresenceContext
-	// is being used below
-	configDir := cs.T().TempDir()
-	ctx, err = client.SetDefaultConfig(ctx, configDir)
 	require.NoError(err)
 
 	grp := dgroup.NewGroup(ctx, dgroup.GroupConfig{
@@ -809,7 +750,7 @@ func (cs *connectedSuite) TestL_LegacySwapDeploymentDoesIntercept() {
 }
 
 func (cs *connectedSuite) TestM_AutoInjectedAgent() {
-	ctx := dlog.NewTestContext(cs.T(), false)
+	ctx := testContext(cs.T())
 	cs.NoError(cs.tpSuite.applyApp(ctx, "echo-auto-inject", "echo-auto-inject", 80))
 	defer func() {
 		cs.NoError(cs.tpSuite.kubectl(ctx, "delete", "svc,deploy", "echo-auto-inject", "--context", "default"))
@@ -821,7 +762,7 @@ func (cs *connectedSuite) TestM_AutoInjectedAgent() {
 			cs.Empty(stderr)
 			return strings.Contains(stdout, "echo-auto-inject: ready to intercept (traffic-agent already installed)")
 		},
-			10*time.Second, // waitFor
+			20*time.Second, // waitFor
 			2*time.Second,  // polling interval
 		)
 	})
@@ -851,7 +792,7 @@ func (cs *connectedSuite) TestN_ToPodPortForwarding() {
 	require.Contains(stdout, "echo-w-sidecars: intercepted")
 
 	cs.Run("Forwarded port is reachable as localhost:PORT", func() {
-		ctx := dlog.NewTestContext(cs.T(), false)
+		ctx := testContext(cs.T())
 
 		cs.Eventually(func() bool {
 			return run(ctx, "curl", "--silent", "localhost:8081") == nil
@@ -863,7 +804,7 @@ func (cs *connectedSuite) TestN_ToPodPortForwarding() {
 	})
 
 	cs.Run("Non-forwarded port is not reachable", func() {
-		ctx := dlog.NewTestContext(cs.T(), false)
+		ctx := testContext(cs.T())
 
 		cs.Eventually(func() bool {
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -1001,7 +942,7 @@ func (is *interceptedSuite) ns() string {
 
 func (is *interceptedSuite) SetupSuite() {
 	is.intercepts = make([]string, 0, serviceCount)
-	ctx, cancel := context.WithCancel(dcontext.WithSoftness(dlog.NewTestContext(is.T(), true)))
+	ctx, cancel := context.WithCancel(dcontext.WithSoftness(testContext(is.T())))
 	is.services = dgroup.NewGroup(ctx, dgroup.GroupConfig{})
 	is.cancelServices = cancel
 
@@ -1090,7 +1031,7 @@ func (is *interceptedSuite) TearDownSuite() {
 		is.Empty(stderr)
 		is.Empty(stdout)
 	}
-	ctx := dlog.NewTestContext(is.T(), true)
+	ctx := testContext(is.T())
 	err := run(ctx, "kubectl", "patch", "-n", is.tpSuite.namespace, "deploy", "hello-3", "--type=json", "-p", `[{
 	"op": "remove",
 	"path": "/spec/template/metadata/annotations"
@@ -1104,7 +1045,7 @@ func (is *interceptedSuite) TearDownSuite() {
 }
 
 func (is *interceptedSuite) TestA_VerifyingResponsesFromInterceptor() {
-	ctx := dlog.NewTestContext(is.T(), false)
+	ctx := testContext(is.T())
 	for i := 0; i < serviceCount; i++ {
 		svc := fmt.Sprintf("hello-%d", i)
 		is.Run("Test intercept "+svc, func() {
@@ -1246,7 +1187,7 @@ func (is *interceptedSuite) TestE_RestartInterceptedPod() {
 	ts := is.tpSuite
 	assert := is.Assert()
 	require := is.Require()
-	c := dlog.NewTestContext(is.T(), false)
+	c := testContext(is.T())
 	rx := regexp.MustCompile(fmt.Sprintf(`Intercept name\s*: hello-0-` + is.ns() + `\s+State\s*: ([^\n]+)\n`))
 
 	// Scale down to zero pods
@@ -1292,7 +1233,7 @@ func (is *interceptedSuite) TestF_StopInterceptedPodOfMany() {
 	ts := is.tpSuite
 	assert := is.Assert()
 	require := is.Require()
-	c := dlog.NewTestContext(is.T(), false)
+	c := testContext(is.T())
 	rx := regexp.MustCompile(fmt.Sprintf(`Intercept name\s*: hello-0-` + is.ns() + `\s+State\s*: ([^\n]+)\n`))
 
 	// Terminating is not a state, so you may want to wrap calls to this function in an eventually
@@ -1381,7 +1322,7 @@ type helmSuite struct {
 }
 
 func (hs *helmSuite) SetupSuite() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 
 	hs.appNamespace1 = hs.tpSuite.namespace
 	hs.managerNamespace1 = hs.tpSuite.managerTestNamespace
@@ -1422,7 +1363,7 @@ func (hs *helmSuite) SetupSuite() {
 }
 
 func (hs *helmSuite) TestA_CanConnect() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	stdout, stderr := telepresenceContext(ctx, "connect")
 	hs.Empty(stderr)
 	hs.Contains(stdout, "Connected to context")
@@ -1470,7 +1411,7 @@ func (hs *helmSuite) TestB_CanInterceptInManagedNamespace() {
 }
 
 func (hs *helmSuite) TestC_CannotInterceptInUnmanagedNamespace() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	hs.tpSuite.namespace = hs.appNamespace2
 	hs.NoError(hs.tpSuite.applyApp(ctx, "with-probes", "with-probes", 80))
 	defer func() {
@@ -1482,7 +1423,7 @@ func (hs *helmSuite) TestC_CannotInterceptInUnmanagedNamespace() {
 }
 
 func (hs *helmSuite) TestD_WebhookInjectsInManagedNamespace() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	hs.NoError(hs.tpSuite.applyApp(ctx, "echo-auto-inject", "echo-auto-inject", 80))
 	defer func() {
 		hs.NoError(hs.tpSuite.kubectl(ctx, "delete", "svc,deploy", "echo-auto-inject", "--context", "default"))
@@ -1499,7 +1440,7 @@ func (hs *helmSuite) TestD_WebhookInjectsInManagedNamespace() {
 }
 
 func (hs *helmSuite) TestE_WebhookDoesntInjectInUnmanagedNamespace() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	defer func() {
 		hs.NoError(hs.tpSuite.kubectl(ctx, "delete", "svc,deploy", "echo-auto-inject", "--context", "default"))
 		hs.tpSuite.namespace = hs.appNamespace1
@@ -1518,7 +1459,7 @@ func (hs *helmSuite) TestE_WebhookDoesntInjectInUnmanagedNamespace() {
 }
 
 func (hs *helmSuite) TestF_MultipleInstalls() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	telepresenceContext(ctx, "quit")
 	hs.tpSuite.namespace = hs.appNamespace2
 	os.Setenv("TELEPRESENCE_MANAGER_NAMESPACE", hs.managerNamespace2)
@@ -1535,10 +1476,6 @@ func (hs *helmSuite) TestF_MultipleInstalls() {
 		hs.NoError(hs.helmInstall(ctx, hs.managerNamespace2, hs.appNamespace2))
 	})
 	hs.Run("Can be connected to", func() {
-		configDir := hs.T().TempDir()
-		// Needed to prevent a (harmless) message on stderr stating that there's no config to use
-		ctx, err := client.SetDefaultConfig(ctx, configDir)
-		hs.NoError(err)
 		stdout, stderr := telepresenceContext(ctx, "connect")
 		hs.Empty(stderr)
 		hs.Contains(stdout, "Connected to context")
@@ -1565,14 +1502,14 @@ func (hs *helmSuite) TestF_MultipleInstalls() {
 }
 
 func (hs *helmSuite) TestG_CollidingInstalls() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
 	defer func() { hs.NoError(run(ctx, "kubectl", "config", "use-context", "telepresence-test-developer")) }()
 	hs.Error(hs.helmInstall(ctx, hs.managerNamespace2, hs.appNamespace1, hs.appNamespace2))
 }
 
 func (hs *helmSuite) TestZ_Uninstall() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
 	telepresenceContext(ctx, "quit")
 	hs.NoError(run(ctx, "helm", "uninstall", "traffic-manager", "-n", hs.managerNamespace1))
@@ -1607,7 +1544,7 @@ func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, a
 }
 
 func (hs *helmSuite) TearDownSuite() {
-	ctx := dlog.NewTestContext(hs.T(), false)
+	ctx := testContext(hs.T())
 	// Restore the rbac we blew up in the setup
 	hs.NoError(run(ctx, "kubectl", "config", "use-context", "default"))
 	hs.NoError(run(ctx, "kubectl", "apply", "-f", "k8s/client_rbac.yaml"))
@@ -1668,7 +1605,7 @@ func (ts *telepresenceSuite) kubectlOut(ctx context.Context, args ...string) (st
 }
 
 func (ts *telepresenceSuite) publishManager() error {
-	ctx := dlog.NewTestContext(ts.T(), true)
+	ctx := testContext(ts.T())
 	cmd := dexec.CommandContext(ctx, "make", "push-image")
 	if goRuntime.GOOS == "windows" {
 		cmd = dexec.CommandContext(ctx, "winmake.bat", "push-image")
@@ -1800,17 +1737,7 @@ func output(ctx context.Context, args ...string) (string, error) {
 
 // telepresence executes the CLI command
 func telepresence(t testing.TB, args ...string) (string, string) {
-	ctx := dlog.NewTestContext(t, false)
-
-	// Ensure the config.yml is using the dtest registry by default
-	configDir := t.TempDir()
-	ctx, err := client.SetDefaultConfig(ctx, configDir)
-	if err != nil {
-		t.Error(err)
-	}
-
-	ctx = filelocation.WithAppUserConfigDir(ctx, configDir)
-	return telepresenceContext(ctx, args...)
+	return telepresenceContext(testContext(t), args...)
 }
 
 // telepresence executes the CLI command in-process
@@ -1833,4 +1760,56 @@ func telepresenceContext(ctx context.Context, args ...string) (string, string) {
 	_ = cmd.Run()
 
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String())
+}
+
+func testContext(t testing.TB) context.Context {
+	return testContextWithConfig(t, nil)
+}
+
+func testContextWithConfig(t testing.TB, addConfig *client.Config) context.Context {
+	c := dlog.NewTestContext(t, false)
+	env, err := client.LoadEnv(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c = client.WithEnv(c, env)
+
+	config := client.GetDefaultConfig(c)
+	config.LogLevels.UserDaemon = logrus.DebugLevel
+	config.LogLevels.RootDaemon = logrus.DebugLevel
+
+	to := &config.Timeouts
+	to.PrivateAgentInstall = 240 * time.Second
+	to.PrivateApply = 120 * time.Second
+	to.PrivateClusterConnect = 60 * time.Second
+	to.PrivateIntercept = 30 * time.Second
+	to.PrivateProxyDial = 30 * time.Second
+	to.PrivateTrafficManagerAPI = 60 * time.Second
+	to.PrivateTrafficManagerConnect = 240 * time.Second
+	to.PrivateHelm = 230 * time.Second
+
+	registry := dtest.DockerRegistry(c)
+	config.Images.Registry = registry
+	config.Images.WebhookRegistry = registry
+
+	mz, _ := resource.ParseQuantity("10Mi")
+	config.Grpc.MaxReceiveSize = &mz
+	config.Cloud.SystemaHost = "127.0.0.1"
+
+	if addConfig != nil {
+		config.Merge(addConfig)
+	}
+	configYaml, err := yaml.Marshal(&config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configYamlStr := string(configYaml)
+
+	configDir := t.TempDir()
+	c = filelocation.WithAppUserConfigDir(c, configDir)
+	c, err = client.SetConfig(c, configDir, configYamlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -22,15 +22,15 @@ const configFile = "config.yml"
 
 // Config contains all configuration values for the telepresence CLI
 type Config struct {
-	Timeouts  Timeouts  `json:"timeouts,omitempty"`
-	LogLevels LogLevels `json:"logLevels,omitempty"`
-	Images    Images    `json:"images,omitempty"`
-	Cloud     Cloud     `json:"cloud,omitempty"`
-	Grpc      Grpc      `json:"grpc,omitempty"`
+	Timeouts  Timeouts  `json:"timeouts,omitempty" yaml:"timeouts,omitempty"`
+	LogLevels LogLevels `json:"logLevels,omitempty" yaml:"logLevels,omitempty"`
+	Images    Images    `json:"images,omitempty" yaml:"images,omitempty"`
+	Cloud     Cloud     `json:"cloud,omitempty" yaml:"cloud,omitempty"`
+	Grpc      Grpc      `json:"grpc,omitempty" yaml:"grpc,omitempty"`
 }
 
 // merge merges this instance with the non-zero values of the given argument. The argument values take priority.
-func (c *Config) merge(o *Config) {
+func (c *Config) Merge(o *Config) {
 	c.Timeouts.merge(&o.Timeouts)
 	c.LogLevels.merge(&o.LogLevels)
 	c.Images.merge(&o.Images)
@@ -99,21 +99,21 @@ type Timeouts struct {
 	// make them easy to grep for (`grep Private`) later.
 
 	// PrivateAgentInstall is how long to wait for an agent to be installed (i.e. apply of service and deploy manifests)
-	PrivateAgentInstall time.Duration `json:"agentInstall,omitempty"`
+	PrivateAgentInstall time.Duration `json:"agentInstall,omitempty" yaml:"agentInstall,omitempty"`
 	// PrivateApply is how long to wait for a k8s manifest to be applied
-	PrivateApply time.Duration `json:"apply,omitempty"`
+	PrivateApply time.Duration `json:"apply,omitempty" yaml:"apply,omitempty"`
 	// PrivateClusterConnect is the maximum time to wait for a connection to the cluster to be established
-	PrivateClusterConnect time.Duration `json:"clusterConnect,omitempty"`
+	PrivateClusterConnect time.Duration `json:"clusterConnect,omitempty" yaml:"clusterConnect,omitempty"`
 	// PrivateIntercept is the time to wait for an intercept after the agents has been installed
-	PrivateIntercept time.Duration `json:"intercept,omitempty"`
+	PrivateIntercept time.Duration `json:"intercept,omitempty" yaml:"intercept,omitempty"`
 	// PrivateProxyDial is how long to wait for the proxy to establish an outbound connection
-	PrivateProxyDial time.Duration `json:"proxyDial,omitempty"`
+	PrivateProxyDial time.Duration `json:"proxyDial,omitempty" yaml:"proxyDial,omitempty"`
 	// PrivateTrafficManagerConnect is how long to wait for the traffic-manager API to connect
-	PrivateTrafficManagerAPI time.Duration `json:"trafficManagerAPI,omitempty"`
+	PrivateTrafficManagerAPI time.Duration `json:"trafficManagerAPI,omitempty" yaml:"trafficManagerAPI,omitempty"`
 	// PrivateTrafficManagerConnect is how long to wait for the initial port-forwards to the traffic-manager
-	PrivateTrafficManagerConnect time.Duration `json:"trafficManagerConnect,omitempty"`
+	PrivateTrafficManagerConnect time.Duration `json:"trafficManagerConnect,omitempty" yaml:"trafficManagerConnect,omitempty"`
 	// PrivateHelm is how long to wait for any helm operation.
-	PrivateHelm time.Duration `json:"helm,omitempty"`
+	PrivateHelm time.Duration `json:"helm,omitempty" yaml:"helm,omitempty"`
 }
 
 type TimeoutID int
@@ -292,6 +292,45 @@ func (t *Timeouts) UnmarshalYAML(node *yaml.Node) (err error) {
 	return nil
 }
 
+const defaultTimeoutsAgentInstall = 120 * time.Second
+const defaultTimeoutsApply = 1 * time.Minute
+const defaultTimeoutsClusterConnect = 20 * time.Second
+const defaultTimeoutsIntercept = 5 * time.Second
+const defaultTimeoutsProxyDial = 5 * time.Second
+const defaultTimeoutsTrafficManagerAPI = 15 * time.Second
+const defaultTimeoutsTrafficManagerConnect = 60 * time.Second
+const defaultTimeoutsHelm = 30 * time.Second
+
+// MarshalYAML is not using pointer receiver here, because Timeouts is not pointer in the Config struct
+func (t Timeouts) MarshalYAML() (interface{}, error) {
+	tm := make(map[string]string)
+	if t.PrivateAgentInstall != 0 && t.PrivateAgentInstall != defaultTimeoutsAgentInstall {
+		tm["agentInstall"] = t.PrivateAgentInstall.String()
+	}
+	if t.PrivateApply != 0 && t.PrivateApply != defaultTimeoutsApply {
+		tm["apply"] = t.PrivateApply.String()
+	}
+	if t.PrivateClusterConnect != 0 && t.PrivateClusterConnect != defaultTimeoutsClusterConnect {
+		tm["clusterConnect"] = t.PrivateClusterConnect.String()
+	}
+	if t.PrivateIntercept != 0 && t.PrivateIntercept != defaultTimeoutsIntercept {
+		tm["intercept"] = t.PrivateIntercept.String()
+	}
+	if t.PrivateProxyDial != 0 && t.PrivateProxyDial != defaultTimeoutsProxyDial {
+		tm["proxyDial"] = t.PrivateProxyDial.String()
+	}
+	if t.PrivateTrafficManagerAPI != 0 && t.PrivateTrafficManagerAPI != defaultTimeoutsTrafficManagerAPI {
+		tm["trafficManagerAPI"] = t.PrivateTrafficManagerAPI.String()
+	}
+	if t.PrivateTrafficManagerConnect != 0 && t.PrivateTrafficManagerConnect != defaultTimeoutsTrafficManagerConnect {
+		tm["trafficManagerConnect"] = t.PrivateTrafficManagerConnect.String()
+	}
+	if t.PrivateHelm != 0 && t.PrivateHelm != defaultTimeoutsHelm {
+		tm["helm"] = t.PrivateHelm.String()
+	}
+	return tm, nil
+}
+
 // merge merges this instance with the non-zero values of the given argument. The argument values take priority.
 func (t *Timeouts) merge(o *Timeouts) {
 	if o.PrivateAgentInstall != 0 {
@@ -321,8 +360,8 @@ func (t *Timeouts) merge(o *Timeouts) {
 }
 
 type LogLevels struct {
-	UserDaemon logrus.Level `json:"userDaemon,omitempty"`
-	RootDaemon logrus.Level `json:"rootDaemon,omitempty"`
+	UserDaemon logrus.Level `json:"userDaemon,omitempty" yaml:"userDaemon,omitempty"`
+	RootDaemon logrus.Level `json:"rootDaemon,omitempty" yaml:"rootDaemon,omitempty"`
 }
 
 // UnmarshalYAML parses the logrus log-levels
@@ -367,10 +406,10 @@ func (ll *LogLevels) merge(o *LogLevels) {
 }
 
 type Images struct {
-	Registry          string `json:"registry,omitempty"`
-	AgentImage        string `json:"agentImage,omitempty"`
-	WebhookRegistry   string `json:"webhookRegistry,omitempty"`
-	WebhookAgentImage string `json:"webhookAgentImage,omitempty"`
+	Registry          string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	AgentImage        string `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
+	WebhookRegistry   string `json:"webhookRegistry,omitempty" yaml:"webhookRegistry,omitempty"`
+	WebhookAgentImage string `json:"webhookAgentImage,omitempty" yaml:"webhookAgentImage,omitempty"`
 }
 
 // UnmarshalYAML parses the images YAML
@@ -421,10 +460,10 @@ func (i *Images) merge(o *Images) {
 }
 
 type Cloud struct {
-	SkipLogin       bool          `json:"skipLogin,omitempty"`
-	RefreshMessages time.Duration `json:"refreshMessages,omitempty"`
-	SystemaHost     string        `json:"systemaHost,omitempty"`
-	SystemaPort     string        `json:"systemaPort,omitempty"`
+	SkipLogin       bool          `json:"skipLogin,omitempty" yaml:"skipLogin,omitempty"`
+	RefreshMessages time.Duration `json:"refreshMessages,omitempty" yaml:"refreshMessages,omitempty"`
+	SystemaHost     string        `json:"systemaHost,omitempty" yaml:"systemaHost,omitempty"`
+	SystemaPort     string        `json:"systemaPort,omitempty" yaml:"systemaPort,omitempty"`
 }
 
 // UnmarshalYAML parses the images YAML
@@ -469,25 +508,47 @@ func (cloud *Cloud) UnmarshalYAML(node *yaml.Node) (err error) {
 	return nil
 }
 
-func (i *Cloud) merge(o *Cloud) {
+const defaultCloudSystemAHost = "app.getambassador.io"
+const defaultCloudSystemAPort = "443"
+const defaultCloudRefreshMessages = 24 * 7 * time.Hour
+
+// MarshalYAML is not using pointer receiver here, because Cloud is not pointer in the Config struct
+func (cloud Cloud) MarshalYAML() (interface{}, error) {
+	cm := make(map[string]interface{})
+	if cloud.RefreshMessages != 0 && cloud.RefreshMessages != defaultCloudRefreshMessages {
+		cm["refreshMessages"] = cloud.RefreshMessages.String()
+	}
+	if cloud.SkipLogin {
+		cm["skipLogin"] = true
+	}
+	if cloud.SystemaHost != "" && cloud.SystemaHost != defaultCloudSystemAHost {
+		cm["systemaHost"] = cloud.SystemaHost
+	}
+	if cloud.SystemaPort != "" && cloud.SystemaPort != defaultCloudSystemAPort {
+		cm["systemaPort"] = cloud.SystemaPort
+	}
+	return cm, nil
+}
+
+func (cloud *Cloud) merge(o *Cloud) {
 	if o.SkipLogin {
-		i.SkipLogin = o.SkipLogin
+		cloud.SkipLogin = o.SkipLogin
 	}
 	if o.RefreshMessages != 0 {
-		i.RefreshMessages = o.RefreshMessages
+		cloud.RefreshMessages = o.RefreshMessages
 	}
 	if o.SystemaHost != "" {
-		i.SystemaHost = o.SystemaHost
+		cloud.SystemaHost = o.SystemaHost
 	}
 	if o.SystemaPort != "" {
-		i.SystemaPort = o.SystemaPort
+		cloud.SystemaPort = o.SystemaPort
 	}
 }
 
 type Grpc struct {
 	// MaxReceiveSize is the maximum message size in bytes the client can receive in a gRPC call or stream message.
 	// Overrides the gRPC default of 4MB.
-	MaxReceiveSize *resource.Quantity `json:"maxReceiveSize,omitempty"`
+	MaxReceiveSize *resource.Quantity `json:"maxReceiveSize,omitempty" yaml:"maxReceiveSize,omitempty"`
 }
 
 func (g *Grpc) merge(o *Grpc) {
@@ -525,6 +586,15 @@ func (g *Grpc) UnmarshalYAML(node *yaml.Node) (err error) {
 		}
 	}
 	return nil
+}
+
+// MarshalYAML is not using pointer receiver here, because Cloud is not pointer in the Config struct
+func (g Grpc) MarshalYAML() (interface{}, error) {
+	cm := make(map[string]interface{})
+	if g.MaxReceiveSize != nil {
+		cm["maxReceiveSize"] = g.MaxReceiveSize.String()
+	}
+	return cm, nil
 }
 
 var parseContext context.Context
@@ -565,14 +635,14 @@ func GetConfigFile(c context.Context) string {
 func GetDefaultConfig(c context.Context) Config {
 	cfg := Config{
 		Timeouts: Timeouts{
-			PrivateAgentInstall:          120 * time.Second,
-			PrivateApply:                 1 * time.Minute,
-			PrivateClusterConnect:        20 * time.Second,
-			PrivateIntercept:             5 * time.Second,
-			PrivateProxyDial:             5 * time.Second,
-			PrivateTrafficManagerAPI:     15 * time.Second,
-			PrivateTrafficManagerConnect: 60 * time.Second,
-			PrivateHelm:                  30 * time.Second,
+			PrivateAgentInstall:          defaultTimeoutsAgentInstall,
+			PrivateApply:                 defaultTimeoutsApply,
+			PrivateClusterConnect:        defaultTimeoutsClusterConnect,
+			PrivateIntercept:             defaultTimeoutsIntercept,
+			PrivateProxyDial:             defaultTimeoutsProxyDial,
+			PrivateTrafficManagerAPI:     defaultTimeoutsTrafficManagerAPI,
+			PrivateTrafficManagerConnect: defaultTimeoutsTrafficManagerConnect,
+			PrivateHelm:                  defaultTimeoutsHelm,
 		},
 		LogLevels: LogLevels{
 			UserDaemon: logrus.InfoLevel,
@@ -580,9 +650,9 @@ func GetDefaultConfig(c context.Context) Config {
 		},
 		Cloud: Cloud{
 			SkipLogin:       false,
-			RefreshMessages: 24 * 7 * time.Hour,
-			SystemaHost:     "app.getambassador.io",
-			SystemaPort:     "443",
+			RefreshMessages: defaultCloudRefreshMessages,
+			SystemaHost:     defaultCloudSystemAHost,
+			SystemaPort:     defaultCloudSystemAPort,
 		},
 		Grpc: Grpc{},
 	}
@@ -631,7 +701,7 @@ func LoadConfig(c context.Context) (cfg *Config, err error) {
 		if err = yaml.Unmarshal(bs, &fileConfig); err != nil {
 			return err
 		}
-		cfg.merge(&fileConfig)
+		cfg.Merge(&fileConfig)
 		return nil
 	}
 

--- a/pkg/client/connector/userd_grpc/service.go
+++ b/pkg/client/connector/userd_grpc/service.go
@@ -101,7 +101,6 @@ func (s *service) CreateIntercept(c context.Context, ir *rpc.CreateInterceptRequ
 		dlog.Debug(c, "returned")
 		return result, nil
 	}
-	dlog.Debug(c, "called")
 	defer func() { err = callRecovery(c, recover(), err) }()
 	mgr, err := s.sharedState.GetTrafficManagerBlocking(c)
 	if mgr == nil {

--- a/pkg/client/connector/userd_k8s/outbound.go
+++ b/pkg/client/connector/userd_k8s/outbound.go
@@ -170,4 +170,5 @@ func (kc *Cluster) updateDaemonNamespaces(c context.Context) {
 	if _, err := kc.callbacks.SetDNSSearchPath(c, &daemon.Paths{Paths: paths, Namespaces: namespaces}); err != nil {
 		dlog.Errorf(c, "error posting search paths %v and namespaces %v to root daemon: %v", paths, namespaces, err)
 	}
+	dlog.Debug(c, "search paths posted successfully")
 }

--- a/pkg/client/daemon/dns/flush_darwin.go
+++ b/pkg/client/daemon/dns/flush_darwin.go
@@ -2,15 +2,58 @@ package dns
 
 import (
 	"context"
+	"os"
+	"os/exec" //nolint:depguard // don't want context or logging
+	"regexp"
+	"strconv"
+	"strings"
 
-	"github.com/datawire/dlib/dexec"
+	"github.com/datawire/dlib/dlog"
 )
+
+var devNullReader *os.File
+var devNullWriter *os.File
+var majorProductVersion int
+
+func init() {
+	var err error
+	devNullReader, err = os.Open(os.DevNull)
+	if err != nil {
+		panic(err)
+	}
+	devNullWriter, err = os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		panic(err)
+	}
+	if swOut, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+		if m := regexp.MustCompile(`^(\d+)\.`).FindStringSubmatch(strings.TrimSpace(string(swOut))); m != nil {
+			majorProductVersion, _ = strconv.Atoi(m[1])
+		}
+	}
+}
+
+func devNullCmd(c context.Context, executable string, args ...string) {
+	// Run the command without having the OS bother about opening or closing file descriptors or pipes
+	cmd := exec.CommandContext(c, executable, args...)
+	cmd.Stdin = devNullReader
+	cmd.Stdout = devNullWriter
+	cmd.Stderr = devNullWriter
+	_ = cmd.Run()
+}
 
 func Flush(c context.Context) {
 	// As of macOS 11 (Big Sur), how to flush the DNS cache hasn't changed since 10.10.4 (a Yosemite version release in mid 2015),
 	// other than that in 10.12 (Sierra) it became necessary to also kill mDNSResponderHelper. On older versions the call to kill
 	// mDNSResponderHelper is unnecessary but harmless, as the process doesn't exist.
-	_ = dexec.CommandContext(c, "killall", "-HUP", "mDNSResponder").Run()
-	_ = dexec.CommandContext(c, "killall", "mDNSResponderHelper").Run()
-	_ = dexec.CommandContext(c, "dscacheutil", "-flushcache").Run()
+	dlog.Debug(c, "Flushing DNS")
+	if majorProductVersion >= 11 {
+		// Big Sur, a killall -HUP mDNSResponder doesn't restart the mDNSResponderHelper but killall -TERM of both, does`
+		dlog.Debug(c, "Flushing DNS")
+		devNullCmd(c, "killall", "-HUP", "mDNSResponder")
+	} else {
+		dlog.Debug(c, "Flushing DNS on version < Big Sur")
+		devNullCmd(c, "killall", "mDNSResponderHelper")
+		devNullCmd(c, "killall", "-HUP", "mDNSResponder", "mDNSResponderHelper")
+	}
+	devNullCmd(c, "dscacheutil", "-flushcache")
 }

--- a/pkg/client/daemon/dns/flush_darwin.go
+++ b/pkg/client/daemon/dns/flush_darwin.go
@@ -45,9 +45,8 @@ func Flush(c context.Context) {
 	// As of macOS 11 (Big Sur), how to flush the DNS cache hasn't changed since 10.10.4 (a Yosemite version release in mid 2015),
 	// other than that in 10.12 (Sierra) it became necessary to also kill mDNSResponderHelper. On older versions the call to kill
 	// mDNSResponderHelper is unnecessary but harmless, as the process doesn't exist.
-	dlog.Debug(c, "Flushing DNS")
 	if majorProductVersion >= 11 {
-		// Big Sur, a killall -HUP mDNSResponder doesn't restart the mDNSResponderHelper but killall -TERM of both, does`
+		// Big Sur, a killall -HUP mDNSResponder doesn't restart the mDNSResponderHelper, so don't kill it!
 		dlog.Debug(c, "Flushing DNS")
 		devNullCmd(c, "killall", "-HUP", "mDNSResponder")
 	} else {

--- a/pkg/client/daemon/tunrouter.go
+++ b/pkg/client/daemon/tunrouter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -196,6 +197,11 @@ func (t *tunRouter) setOutboundInfo(ctx context.Context, mi *daemon.OutboundInfo
 
 		conn, err = client.DialSocket(tc, client.ConnectorSocketName)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// The connector called us, and then it died which means we will die too. This is
+				// a race, but it's not an error.
+				return nil
+			}
 			return client.CheckTimeout(tc, err)
 		}
 		t.session = mi.Session


### PR DESCRIPTION
This PR contains a number of minor bug fixes to Telepresence, discovered while running the
`pkg/client/cli/telepresence_test.go` tests, and also a cleanup of that test to get more consistent
handling of the config.

I recommend reviewing one commit at a time.