### PR TITLE
Ensure that watchable Map coalesce never enters a CPU-hogging loop.

### DIFF
--- a/cmd/traffic/cmd/manager/internal/watchable/generated_agentmap.go
+++ b/cmd/traffic/cmd/manager/internal/watchable/generated_agentmap.go
@@ -275,7 +275,7 @@ func (tm *AgentMap) coalesce(
 
 	var shutdown func()
 	shutdown = func() {
-		shutdown = func() {}
+		shutdown = func() {} // Make this function an empty one after first run to prevent calling the following goroutine multiple times
 		// Do this asyncrounously because getting the lock might block a .Store() that's
 		// waiting on us to read from 'upstream'!  We don't need to worry about separately
 		// waiting for this goroutine because we implicitly do that when we drain
@@ -346,17 +346,24 @@ func (tm *AgentMap) coalesce(
 		}
 	}
 
+	// The following loop is reading both a tm.close channel and the ctx.Done() channel. When the
+	// tm.close channel is closed, the Map as a whole has been closed, and when ctx.Done() is closed,
+	// the subscription that started this call to coalesce has ended. If one of the the channels close,
+	// the loop must call shutdown() and then continue looping,  now in a way that never selects the
+	// closed channel. The closed channel is therefore set to `nil` so that it blocks forever, which
+	// in essence means that the only way out of the loop is to close the `upstream` channel. This
+	// happens when the subscription ends.
+	closeCh := tm.close
+	doneCh := ctx.Done()
 	for {
-		done := ctx.Done()
-		if ctx.Err() != nil {
-			shutdown()
-			done = context.Background().Done()
-		}
 		if snapshot.State == nil {
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return
@@ -366,9 +373,12 @@ func (tm *AgentMap) coalesce(
 		} else {
 			// Same as above, but with an additional "downstream <- snapshot" case.
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return

--- a/cmd/traffic/cmd/manager/internal/watchable/generated_clientmap.go
+++ b/cmd/traffic/cmd/manager/internal/watchable/generated_clientmap.go
@@ -275,7 +275,7 @@ func (tm *ClientMap) coalesce(
 
 	var shutdown func()
 	shutdown = func() {
-		shutdown = func() {}
+		shutdown = func() {} // Make this function an empty one after first run to prevent calling the following goroutine multiple times
 		// Do this asyncrounously because getting the lock might block a .Store() that's
 		// waiting on us to read from 'upstream'!  We don't need to worry about separately
 		// waiting for this goroutine because we implicitly do that when we drain
@@ -346,17 +346,24 @@ func (tm *ClientMap) coalesce(
 		}
 	}
 
+	// The following loop is reading both a tm.close channel and the ctx.Done() channel. When the
+	// tm.close channel is closed, the Map as a whole has been closed, and when ctx.Done() is closed,
+	// the subscription that started this call to coalesce has ended. If one of the the channels close,
+	// the loop must call shutdown() and then continue looping,  now in a way that never selects the
+	// closed channel. The closed channel is therefore set to `nil` so that it blocks forever, which
+	// in essence means that the only way out of the loop is to close the `upstream` channel. This
+	// happens when the subscription ends.
+	closeCh := tm.close
+	doneCh := ctx.Done()
 	for {
-		done := ctx.Done()
-		if ctx.Err() != nil {
-			shutdown()
-			done = context.Background().Done()
-		}
 		if snapshot.State == nil {
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return
@@ -366,9 +373,12 @@ func (tm *ClientMap) coalesce(
 		} else {
 			// Same as above, but with an additional "downstream <- snapshot" case.
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return

--- a/cmd/traffic/cmd/manager/internal/watchable/generated_interceptmap.go
+++ b/cmd/traffic/cmd/manager/internal/watchable/generated_interceptmap.go
@@ -275,7 +275,7 @@ func (tm *InterceptMap) coalesce(
 
 	var shutdown func()
 	shutdown = func() {
-		shutdown = func() {}
+		shutdown = func() {} // Make this function an empty one after first run to prevent calling the following goroutine multiple times
 		// Do this asyncrounously because getting the lock might block a .Store() that's
 		// waiting on us to read from 'upstream'!  We don't need to worry about separately
 		// waiting for this goroutine because we implicitly do that when we drain
@@ -346,17 +346,24 @@ func (tm *InterceptMap) coalesce(
 		}
 	}
 
+	// The following loop is reading both a tm.close channel and the ctx.Done() channel. When the
+	// tm.close channel is closed, the Map as a whole has been closed, and when ctx.Done() is closed,
+	// the subscription that started this call to coalesce has ended. If one of the the channels close,
+	// the loop must call shutdown() and then continue looping,  now in a way that never selects the
+	// closed channel. The closed channel is therefore set to `nil` so that it blocks forever, which
+	// in essence means that the only way out of the loop is to close the `upstream` channel. This
+	// happens when the subscription ends.
+	closeCh := tm.close
+	doneCh := ctx.Done()
 	for {
-		done := ctx.Done()
-		if ctx.Err() != nil {
-			shutdown()
-			done = context.Background().Done()
-		}
 		if snapshot.State == nil {
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return
@@ -366,9 +373,12 @@ func (tm *InterceptMap) coalesce(
 		} else {
 			// Same as above, but with an additional "downstream <- snapshot" case.
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return

--- a/cmd/traffic/cmd/manager/internal/watchable/generic.tmpl.go
+++ b/cmd/traffic/cmd/manager/internal/watchable/generic.tmpl.go
@@ -276,7 +276,7 @@ func (tm *MAPTYPE) coalesce(
 
 	var shutdown func()
 	shutdown = func() {
-		shutdown = func() {}
+		shutdown = func() {} // Make this function an empty one after first run to prevent calling the following goroutine multiple times
 		// Do this asyncrounously because getting the lock might block a .Store() that's
 		// waiting on us to read from 'upstream'!  We don't need to worry about separately
 		// waiting for this goroutine because we implicitly do that when we drain
@@ -347,17 +347,24 @@ func (tm *MAPTYPE) coalesce(
 		}
 	}
 
+	// The following loop is reading both a tm.close channel and the ctx.Done() channel. When the
+	// tm.close channel is closed, the Map as a whole has been closed, and when ctx.Done() is closed,
+	// the subscription that started this call to coalesce has ended. If one of the the channels close,
+	// the loop must call shutdown() and then continue looping,  now in a way that never selects the
+	// closed channel. The closed channel is therefore set to `nil` so that it blocks forever, which
+	// in essence means that the only way out of the loop is to close the `upstream` channel. This
+	// happens when the subscription ends.
+	closeCh := tm.close
+	doneCh := ctx.Done()
 	for {
-		done := ctx.Done()
-		if ctx.Err() != nil {
-			shutdown()
-			done = context.Background().Done()
-		}
 		if snapshot.State == nil {
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return
@@ -367,9 +374,12 @@ func (tm *MAPTYPE) coalesce(
 		} else {
 			// Same as above, but with an additional "downstream <- snapshot" case.
 			select {
-			case <-done:
-			case <-tm.close:
+			case <-doneCh:
 				shutdown()
+				doneCh = nil
+			case <-closeCh:
+				shutdown()
+				closeCh = nil
 			case update, readOK := <-upstream:
 				if !readOK {
 					return


### PR DESCRIPTION
Fixes the coalesce method's loop so that it never ends up in a loop
where a closed channel is read over and over again and consume 100% of
a CPU core.