### PR TITLE
Prevent deadlock when connectorWorker encounters problem early.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Bugfix: The TUN-device no longer builds an unlimited internal buffer before sending it when receiving lots of TCP-packets without PSH.
   Instead, the buffer is flushed when it reaches a size of 64K.
 
+- Bugfix: The user daemon would sometimes hang when it encountered a problem connecting to the cluster or the root daemon.
+
 ### 2.4.3 (September 15, 2021)
 
 - Feature: The environment variable `TELEPRESENCE_INTERCEPT_ID` is now available in the interceptor's environment.

--- a/pkg/client/connector/command.go
+++ b/pkg/client/connector/command.go
@@ -168,6 +168,8 @@ func (s *service) connectWorker(c context.Context, cr *rpc.ConnectRequest, k8sCo
 	conn, err := client.DialSocket(c, client.DaemonSocketName)
 	if err != nil {
 		dlog.Errorf(c, "unable to connect to daemon: %+v", err)
+		s.sharedState.MaybeSetCluster(nil)
+		s.sharedState.MaybeSetTrafficManager(nil)
 		s.cancel()
 		return connectError(rpc.ConnectInfo_DAEMON_FAILED, err)
 	}
@@ -193,6 +195,8 @@ func (s *service) connectWorker(c context.Context, cr *rpc.ConnectRequest, k8sCo
 	}()
 	if err != nil {
 		dlog.Errorf(c, "unable to track k8s cluster: %+v", err)
+		s.sharedState.MaybeSetCluster(nil)
+		s.sharedState.MaybeSetTrafficManager(nil)
 		s.cancel()
 		return connectError(rpc.ConnectInfo_CLUSTER_FAILED, err)
 	}
@@ -225,6 +229,7 @@ func (s *service) connectWorker(c context.Context, cr *rpc.ConnectRequest, k8sCo
 	if err != nil {
 		dlog.Errorf(c, "Unable to connect to TrafficManager: %s", err)
 		// No point in continuing without a traffic manager
+		s.sharedState.MaybeSetTrafficManager(nil)
 		s.cancel()
 		return connectError(rpc.ConnectInfo_TRAFFIC_MANAGER_FAILED, err)
 	}


### PR DESCRIPTION
## Description

If the connector encountered problems when connecting to the daemon
or to the cluster, the connector process would sometimes lock up
forever waiting for the cluster and traffic-manager to become ready.
Now, a nil entry will be posted on those channels when a failure occurs
so that they are unblocked.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 