### PR TITLE
Fix bug causing segfault when intercepts collide on port number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - Bugfix: The user daemon would sometimes hang when it encountered a problem connecting to the cluster or the root daemon.
 
+- Bugfix: Telepresence correctly reports an intercept port conflict instead of panicking with segfault.
+
 ### 2.4.3 (September 15, 2021)
 
 - Feature: The environment variable `TELEPRESENCE_INTERCEPT_ID` is now available in the interceptor's environment.

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -313,7 +313,7 @@ func interceptMessage(r *connector.InterceptResult) error {
 	case connector.InterceptError_LOCAL_TARGET_IN_USE:
 		spec := r.InterceptInfo.Spec
 		msg = fmt.Sprintf("Port %s:%d is already in use by intercept %s",
-			spec.TargetHost, spec.TargetPort, r.ErrorText)
+			spec.TargetHost, spec.TargetPort, spec.Name)
 	case connector.InterceptError_NO_ACCEPTABLE_WORKLOAD:
 		msg = fmt.Sprintf("No interceptable deployment or replicaset matching %s found", r.ErrorText)
 	case connector.InterceptError_AMBIGUOUS_MATCH:

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -287,10 +287,9 @@ func (ts *telepresenceSuite) TestA_WithNoDaemonRunning() {
 		ctx = filelocation.WithAppUserLogDir(ctx, tmpDir)
 		_, stderr := telepresenceContext(ctx, "connect")
 		require.Empty(stderr)
-		if goRuntime.GOOS == "windows" || goRuntime.GOOS == "darwin" {
-			// FIXME(josecv) Windows and macOS need a few seconds before the DNS queries start going through the daemon
-			time.Sleep(10 * time.Second)
-		}
+		// FIXME(josecv) need a few seconds before the DNS queries start going through the daemon
+		time.Sleep(10 * time.Second)
+
 		// Test with ".org" suffix that was added as an include-suffix
 		_ = run(ctx, "curl", "--silent", "example.org")
 

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1315,6 +1315,11 @@ func (is *interceptedSuite) TestF_StopInterceptedPodOfMany() {
 	require.True(st.IsDir(), "<mount point>/var is not a directory")
 }
 
+func (is *interceptedSuite) TestG_ReportsPortConflict() {
+	_, stderr := telepresence(is.T(), "intercept", "--namespace", is.ns(), "--port", "9001", "dummy-name")
+	is.Contains(stderr, "Port 127.0.0.1:9001 is already in use by intercept hello-1-"+is.ns())
+}
+
 type helmSuite struct {
 	suite.Suite
 	tpSuite           *telepresenceSuite

--- a/pkg/client/connector/userd_trafficmgr/intercept.go
+++ b/pkg/client/connector/userd_trafficmgr/intercept.go
@@ -268,7 +268,12 @@ func (tm *trafficManager) AddIntercept(c context.Context, ir *rpc.CreateIntercep
 			return interceptError(rpc.InterceptError_ALREADY_EXISTS, errcat.User.Newf(spec.Name)), nil
 		}
 		if iCept.Spec.TargetPort == spec.TargetPort && iCept.Spec.TargetHost == spec.TargetHost {
-			return interceptError(rpc.InterceptError_LOCAL_TARGET_IN_USE, errcat.User.Newf(spec.Name)), nil
+			return &rpc.InterceptResult{
+				Error:         rpc.InterceptError_LOCAL_TARGET_IN_USE,
+				ErrorText:     spec.Name,
+				ErrorCategory: int32(errcat.User),
+				InterceptInfo: iCept,
+			}, nil
 		}
 	}
 

--- a/pkg/client/daemon/dns/flush_darwin.go
+++ b/pkg/client/daemon/dns/flush_darwin.go
@@ -45,14 +45,15 @@ func Flush(c context.Context) {
 	// As of macOS 11 (Big Sur), how to flush the DNS cache hasn't changed since 10.10.4 (a Yosemite version release in mid 2015),
 	// other than that in 10.12 (Sierra) it became necessary to also kill mDNSResponderHelper. On older versions the call to kill
 	// mDNSResponderHelper is unnecessary but harmless, as the process doesn't exist.
+	sig := "-HUP"
 	if majorProductVersion >= 11 {
-		// Big Sur, a killall -HUP mDNSResponder doesn't restart the mDNSResponderHelper, so don't kill it!
+		// Big Sur, a killall -HUP mDNSResponder doesn't restart the mDNSResponderHelper, so use -TERM instead
 		dlog.Debug(c, "Flushing DNS")
-		devNullCmd(c, "killall", "-HUP", "mDNSResponder")
+		sig = "-TERM"
 	} else {
 		dlog.Debug(c, "Flushing DNS on version < Big Sur")
-		devNullCmd(c, "killall", "mDNSResponderHelper")
-		devNullCmd(c, "killall", "-HUP", "mDNSResponder", "mDNSResponderHelper")
 	}
+	devNullCmd(c, "killall", "mDNSResponderHelper")
+	devNullCmd(c, "killall", sig, "mDNSResponder")
 	devNullCmd(c, "dscacheutil", "-flushcache")
 }


### PR DESCRIPTION
## Description

The `LOCAL_TARGET_IN_USE` intercept error didn't provide the expectd
`InterceptInfo` struct which caused a segfault panic. Also, the
name reported was the name of the current intercept, which is kind of
useless, instead of the conflicting one.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
