### PR TITLE
Check if k8s version is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Feature: Intercepting headless services is now supported. It's now possible to request a headless service on whatever port it exposes and get a response from the intercept.
 
+- Bugfix: Telepresence will now log that the kubernetes server version is unsupported when using a version older than 1.17.
+
 ### 2.4.4 (September 27, 2021)
 
 - Feature: The strategy used by traffic-manager's discovery of pod CIDRs can now be configured using the Helm chart.

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/blang/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -18,6 +19,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/subnet"
 )
+
+const supportedKubeAPIVersion = "1.17.0"
 
 type Info interface {
 	// Watch changes of an ClusterInfo and write them on the given stream
@@ -53,8 +56,29 @@ func NewInfo(ctx context.Context) Info {
 	oi := info{}
 	oi.waiter.L = &oi.accLock
 	clientset := managerutil.GetK8sClientset(ctx)
-	client := clientset.CoreV1()
 
+	// Validate that the kubernetes server version is supported
+	dc := clientset.Discovery()
+	info, err := dc.ServerVersion()
+	if err != nil {
+		dlog.Errorf(ctx, "unable to get server information")
+	} else {
+		gitVer, err := semver.Parse(strings.TrimPrefix(info.GitVersion, "v"))
+		if err != nil {
+			dlog.Errorf(ctx, "error converting version %s to semver: %s", info.GitVersion, err)
+		}
+		supGitVer, err := semver.Parse(supportedKubeAPIVersion)
+		if err != nil {
+			dlog.Errorf(ctx, "error converting known version %s to semver: %s", supportedKubeAPIVersion, err)
+		}
+		if gitVer.LT(supGitVer) {
+			dlog.Errorf(ctx,
+				"kubernetes server versions older than %s are not supported, using %s .",
+				supportedKubeAPIVersion, info.GitVersion)
+		}
+	}
+
+	client := clientset.CoreV1()
 	// Get the clusterID from the default namespaces
 	// We use a default clusterID because we don't want to fail if
 	// the traffic-manager doesn't have the ability to get the namespace

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -61,7 +61,7 @@ func NewInfo(ctx context.Context) Info {
 	dc := clientset.Discovery()
 	info, err := dc.ServerVersion()
 	if err != nil {
-		dlog.Errorf(ctx, "unable to get server information")
+		dlog.Errorf(ctx, "error getting server information: %s", err)
 	} else {
 		gitVer, err := semver.Parse(strings.TrimPrefix(info.GitVersion, "v"))
 		if err != nil {


### PR DESCRIPTION
## Description

We have known that we don't support k8s versions older than 1.17, so let's let users know.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
