### PR TITLE
MAINTAINERS.md: Update to reflect reality

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,19 @@
-# Maintainers
+# Telepresence Maintainers
 
-The current maintainers of the Telepresence project are:
+[GOVERNANCE.md](GOVERNANCE.md) describes governance guidelines and
+maintainer responsibilities.
 
-* Abhay Saxena [ark3](https://github.com/ark3), <ark3@email.com>, core maintainer
-* Rafael Schloming [rhs](https://github.com/rhs), <rhs@datawire.io>, core maintainer
-* Luke Shumaker [LukeShu](https://github.com/LukeShu), <lukeshu@datawire.io>, core maintainer
-* Richard Li [richarddli](https://github.com/richarddli), <richard@datawire.io>, documentation
+## Maintainers
 
-See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
+Maintainers are listed in alphabetical order.
+
+* Donny Yung, [donnyyung](https://github.com/donnyyung), <donaldyung@datawire.io>
+* Jose Cortes, [josecv](https://github.com/josecv), <josecortes@datawire.io>
+* Thomas Hallgren [thallgren](https://github.com/thallgren), <thomas@datawire.io>
+
+## Maintainers Emeriti
+
+* Abhay Saxena, [ark3](https://github.com/ark3), <ark3@email.com>
+* Luke Shumaker, [LukeShu](https://github.com/LukeShu), <lukeshu@datawire.io>
+* Rafael Schloming, [rhs](https://github.com/rhs), <rhs@datawire.io>
+* Richard Li, [richarddli](https://github.com/richarddli), <richard@datawire.io>


### PR DESCRIPTION
I realized that I should probably edit MAINTAINERS.md to move myself to
emeritus status, since I will no longer be spending >20% of my time on
Telepresence.

And when I went to do so, I realized that the list is entirely out of
date; no one listed is still spending their day-to-day working on
Telepresence (though still making the occasional contribution).

Meanwhile; Thomas, Donny, and Jose have effectively been maintainers for
many months (13, 9, and 4 respectively).  So I'm using my final action as
maintainer to put-forward granting them maintainer status (that really
they effectively already have, but you know, gotta follow GOVERNANCE.md).

I did not include Nick in the list of added maintainers, as he has only
been contributing for about a month, and GOVERNANCE.md specifies 2-3
months before being added to the list of maintainers.  I have no doubt
that in 1-2 more months the other maintainers will agree to add him to the
list:

    * Nick Powell, [njayp](https://github.com/njayp), <nickpowell@datawire.io>

I am including all removed maintainers as reviewers on this PR: in order
to (1) ask that they agree to grant maintainer status to Thomas, Donny,
and Jose ("confer and decide" in the terms of GOVERNANCE.md); and (2) ask
that they volunteer to be moved to emeritus status as they aren't
"performing their maintainer duties" (per GOVERANCE.md) (I'd vastly prefer
to not have to call a vote of maintainers to move anyone who doesn't
volunteer, I'm not trying to force anyone out here, just acknowledge the
reality of the situation).