### PR TITLE
Directly mount volumes, obviating TELEPRESENCE_ROOT when using --docker-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 2.4.6 (TBD)
+
+- Feature: When using `--docker-run`, volumes are mounted directly to the correct paths, obviating
+  the need to use `$TELEPRESENCE_ROOT` and enabling Telepresence to work with containers that use
+  volume mounts without modifying application code.
+
 ### 2.4.5 (October 15, 2021)
 
 - Feature: Intercepting headless services is now supported. It's now possible to request a headless service on whatever port it exposes and get a response from the intercept.

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -696,8 +696,8 @@ func (is *interceptState) runInDocker(ctx context.Context, cmd safeCobraCommand,
 
 	tpMounts := is.env[tpMountsEnv]
 	for _, path := range strings.Split(tpMounts, ":") {
-		mountPointEscaped := strings.Replace(is.mountPoint, `"`, `""`, -1)
-		destination := strings.Replace(path, `"`, `""`, -1)
+		mountPointEscaped := strings.ReplaceAll(is.mountPoint, `"`, `""`)
+		destination := strings.ReplaceAll(path, `"`, `""`)
 
 		// paths are absolute and begin with a /
 		// e.g.:


### PR DESCRIPTION
## Description

When using `--docker-run`, volumes are mounted directly to the correct paths, obviating the need to use `$TELEPRESENCE_ROOT` and enabling Telepresence to work with containers that use volume mounts without modifying application code.

Caveats:

* This should be tested, but I am unfamiliar with the test harness.
* Paths with a colon in them will pose a difficulty. Ideally rather than parsing the agent-provided env var, a list of paths would be provided as a list.

Example output from an intercepted container:

```
root@b05aba634a8b:/app# ls /var/run/secrets/
kubernetes.io
```

## Checklist

 - [X] I made sure to update `./CHANGELOG.md`.
 - [X] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [X] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [X] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
