### PR TITLE
Add link to docs in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.4.6 (TBD)
 
+- Changelog: `--help` text now includes a link to https://www.telepresence.io/ so users who download Telepresence via Brew or some other mechanism are able to find the documentation easily.
+
 - Bugfix: Telepresence will no longer attempt to proxy requests to the API server when it happens to have an IP address within the CIDR range of pods/services.
 
 ### 2.4.5 (October 15, 2021)

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -30,8 +30,6 @@ Unless the daemons are already started, an attempt will be made to start them.
 This will involve a call to sudo unless this command is run as root (not
 recommended) which in turn may result in a password prompt.`
 
-// TODO: Provide a link in the help text to more info about telepresence
-
 // global options
 var dnsIP string
 var mappedNamespaces []string

--- a/pkg/client/cli/command_group.go
+++ b/pkg/client/cli/command_group.go
@@ -111,6 +111,8 @@ Global Flags:{{range $group := globalFlagGroups}}
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.
+
+For complete documentation and quick-start guides, check out our website at https://www.telepresence.io{{end}}
 `)
 }


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Our `--help` output should link to the docs since that may intrigue users so this PR adds that.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
