### PR TITLE
Allow the traffic agent to be manually injected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Bugfix: Telepresence will no longer attempt to proxy requests to the API server when it happens to have an IP address within the CIDR range of pods/services.
 
+- Feature: Telepresence now supports manually injecting the traffic-agent YAML into workload manifests.
+  Use the `genyaml` command to create the sidecar YAML, then add the `telepresence.getambassador.io/manually-injected: "true"` annotation to to your pods to allow Telepresence to intercept them.
+
 ### 2.4.5 (October 15, 2021)
 
 - Feature: Intercepting headless services is now supported. It's now possible to request a headless service on whatever port it exposes and get a response from the intercept.

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -235,6 +235,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
 				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
 				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_PORT","value":"9900"},` +
 				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +
 				`],` +
 				`"resources":{},` +
@@ -295,6 +296,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
 				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
 				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_PORT","value":"9900"},` +
 				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +
 				`],` +
 				`"resources":{},` +
@@ -359,6 +361,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
 				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
 				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_PORT","value":"9900"},` +
 				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +
 				`],` +
 				`"resources":{},` +
@@ -468,6 +471,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 				`{"name":"_TEL_AGENT_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},` +
 				`{"name":"_TEL_AGENT_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}},` +
 				`{"name":"_TEL_AGENT_APP_PORT","value":"8888"},` +
+				`{"name":"_TEL_AGENT_PORT","value":"9900"},` +
 				`{"name":"_TEL_AGENT_APP_MOUNTS","value":"/tel_app_mounts"},` +
 				`{"name":"TELEPRESENCE_MOUNTS","value":"/var/run/secrets/kubernetes.io/serviceaccount"},` +
 				`{"name":"_TEL_AGENT_MANAGER_HOST","value":"traffic-manager.default"}` +

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.3.11
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.25.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	helm.sh/helm/v3 v3.6.3
 	k8s.io/api v0.21.0
@@ -151,6 +150,7 @@ require (
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	gopkg.in/gorp.v1 v1.7.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.21.0 // indirect
 	k8s.io/apiserver v0.21.0 // indirect
 	k8s.io/cli-runtime v0.21.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.3.11
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	helm.sh/helm/v3 v3.6.3
 	k8s.io/api v0.21.0
@@ -150,7 +151,6 @@ require (
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	gopkg.in/gorp.v1 v1.7.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.21.0 // indirect
 	k8s.io/apiserver v0.21.0 // indirect
 	k8s.io/cli-runtime v0.21.0 // indirect

--- a/k8s/echo-manual-inject-deploy.yaml
+++ b/k8s/echo-manual-inject-deploy.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "manual-inject"
+  labels:
+    service: manual-inject
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: manual-inject
+  template:
+    metadata:
+      labels:
+        service: manual-inject
+    spec:
+      containers:
+        - name: echo-container
+          image: jmalloc/echo-server
+          ports:
+            - containerPort: 8080
+          resources: {}

--- a/k8s/echo-manual-inject-svc.yaml
+++ b/k8s/echo-manual-inject-svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "manual-inject"
+spec:
+  type: ClusterIP
+  selector:
+    service: manual-inject
+  ports:
+    - port: 80
+      # This port is not defined in k8s/echo-manual-inject-deploy.yaml because it will be the port used by the manually added traffic-agent
+      targetPort: 9900

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -193,7 +193,7 @@ func Command(ctx context.Context) *cobra.Command {
 		},
 		{
 			Name:     "Other Commands",
-			Commands: []*cobra.Command{versionCommand(), uninstallCommand(), dashboardCommand(), ClusterIdCommand()},
+			Commands: []*cobra.Command{versionCommand(), uninstallCommand(), dashboardCommand(), ClusterIdCommand(), genYAMLCommand()},
 		},
 	})
 	for _, group := range globalFlagGroups {

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/connector/userd_k8s"
+	"github.com/telepresenceio/telepresence/v2/pkg/install"
+)
+
+type genYAMLInfo struct {
+	outputFile string
+	inputFile  string
+}
+
+func genYAMLCommand() *cobra.Command {
+	info := genYAMLInfo{}
+	cmd := &cobra.Command{
+		Use:  "genyaml",
+		Args: cobra.NoArgs,
+
+		Short: "Generate YAML for use in kubernetes manifests.",
+		Long: `Generate traffic-agent yaml for use in kubernetes manifests.
+This allows the traffic agent to be injected by hand into existing kubernetes manifests.
+For your modified workload to be valid, you'll have to manually inject both the container and the volume; you can do this by running "genyaml container" or "genyaml volume"
+It is recommended that you not do this unless strictly necessary. Instead, we suggest use of the webhook injector to configure traffic agents.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("please run genyaml as \"genyaml container\" or \"genyaml volume\"")
+		},
+	}
+	cmd.PersistentFlags().StringVar(&info.inputFile, "input", "",
+		"Path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc)")
+	cmd.PersistentFlags().StringVar(&info.outputFile, "output", "",
+		"Path to the file to place the output in.")
+	_ = cmd.MarkPersistentFlagRequired("output")
+	_ = cmd.MarkPersistentFlagRequired("input")
+	cmd.AddCommand(
+		genContainerSubCommand(&info),
+		genVolumeSubCommand(&info),
+	)
+	return cmd
+}
+
+func (i *genYAMLInfo) getOutputWriter() (io.WriteCloser, error) {
+	if i.outputFile == "-" {
+		return os.Stdout, nil
+	}
+	f, err := os.Create(i.outputFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open output file %s: %w", i.outputFile, err)
+	}
+	return f, nil
+}
+
+func (i *genYAMLInfo) writeObjToOutput(obj interface{}) error {
+	// So this sucks: Kubernetes structs don't have yaml serialization tags!
+	// This means that we can't just yaml.Marshal the object. Now, we could use
+	// the client-go to marshal it, but that's actually really hard given that
+	// we're dealing with partial objects (e.g. containers, not pods).
+	// However, it turns out that since k8s sends objects over the wire in json,
+	// the structs do have json serialization tags; so if we serialize the object to json,
+	// read it back as a plain old map, and then re-serialize to yaml, we'll get a reasonable result.
+	doc, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("unable to marshal agent container: %w", err)
+	}
+	temp := map[string]interface{}{}
+	err = json.Unmarshal(doc, &temp)
+	if err != nil {
+		// Be a bit weird if this happened, but okay.
+		return fmt.Errorf("unable to unmarshal intermediate representation: %w", err)
+	}
+	doc, err = yaml.Marshal(&temp)
+	if err != nil {
+		return fmt.Errorf("unable to marshal intermediate representation to yaml: %w", err)
+	}
+	w, err := i.getOutputWriter()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	_, err = w.Write(doc)
+	if err != nil {
+		return fmt.Errorf("unable to write to output %s: %w", i.outputFile, err)
+	}
+	return nil
+}
+
+func (i *genYAMLInfo) getInputReader() (io.ReadCloser, error) {
+	if i.inputFile == "-" {
+		return os.Stdin, nil
+	}
+	f, err := os.Open(i.inputFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open input file %s: %w", i.inputFile, err)
+	}
+	return f, nil
+}
+
+type genContainerInfo struct {
+	*genYAMLInfo
+	containerName string
+	serviceName   string
+	appPort       int
+	agentPort     int
+	appProto      string
+}
+
+func genContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
+	info := genContainerInfo{genYAMLInfo: yamlInfo}
+	cmd := &cobra.Command{
+		Use:   "container",
+		Args:  cobra.NoArgs,
+		Short: "Generate YAML for the traffic-agent container.",
+		Long:  "Generate YAML for the traffic-agent container. See genyaml for more info on what this means",
+		RunE:  info.run,
+	}
+	cmd.Flags().StringVar(&info.containerName, "container-name", "",
+		"The name of the container hosting the application you wish to intercept.")
+	cmd.Flags().IntVar(&info.appPort, "port", 0,
+		"The port number you wish to intercept")
+	cmd.Flags().StringVar(&info.appProto, "protocol", string(corev1.ProtocolTCP),
+		"The protocol the app's port speaks")
+	cmd.Flags().IntVar(&info.agentPort, "agent-port", 9900,
+		"The port number you wish the agent to listen on.")
+	cmd.Flags().StringVar(&info.serviceName, "service-name", "",
+		`The name of the service that's exposing this deployment and that you will wish to intercept.
+Defaults to the name of the deployment.`)
+	_ = cmd.MarkFlagRequired("container-name")
+	_ = cmd.MarkFlagRequired("port")
+	return cmd
+}
+
+func (i *genContainerInfo) run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	f, err := i.getInputReader()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("error reading from %s: %w", i.inputFile, err)
+	}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(schema.GroupVersion{Group: appsv1.GroupName, Version: "v1"}, &appsv1.StatefulSet{}, &appsv1.Deployment{}, &appsv1.ReplicaSet{})
+	codecFactory := serializer.NewCodecFactory(scheme)
+	deserializer := codecFactory.UniversalDeserializer()
+
+	obj, kind, err := deserializer.Decode(b, nil, nil)
+	if err != nil {
+		return fmt.Errorf("unable to parse yaml in %s: %w", i.inputFile, err)
+	}
+	var containers []corev1.Container
+	name := ""
+	switch o := obj.(type) {
+	case *appsv1.Deployment:
+		containers = o.Spec.Template.Spec.Containers
+		name = o.Name
+	case *appsv1.StatefulSet:
+		containers = o.Spec.Template.Spec.Containers
+		name = o.Name
+	case *appsv1.ReplicaSet:
+		containers = o.Spec.Template.Spec.Containers
+		name = o.Name
+	default:
+		return fmt.Errorf("unexpected object of kind %s; please pass in a Deployment or StatefulSet", kind)
+	}
+	containerIdx := -1
+	for j, c := range containers {
+		if c.Name == i.containerName {
+			containerIdx = j
+			break
+		}
+	}
+	if containerIdx < 0 {
+		return fmt.Errorf("container %s not found in %s given", i.containerName, kind)
+	}
+	container := &containers[containerIdx]
+
+	if i.serviceName == "" {
+		i.serviceName = name
+	}
+
+	cfg := client.GetConfig(ctx)
+	k8sConfig, err := userd_k8s.NewConfig(ctx, kubeFlagMap())
+	if err != nil {
+		return fmt.Errorf("unable to get k8s config: %w", err)
+	}
+	agentContainer := install.AgentContainer(
+		i.serviceName,
+		fmt.Sprintf("%s/%s", cfg.Images.Registry, cfg.Images.AgentImage),
+		container,
+		corev1.ContainerPort{
+			Protocol:      corev1.Protocol(i.appProto),
+			ContainerPort: int32(i.agentPort),
+		},
+		i.appPort,
+		k8sConfig.GetManagerNamespace(),
+		false,
+	)
+
+	return i.writeObjToOutput(&agentContainer)
+}
+
+type genVolumeInfo struct {
+	*genYAMLInfo
+}
+
+func genVolumeSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
+	info := genVolumeInfo{genYAMLInfo: yamlInfo}
+	cmd := &cobra.Command{
+		Use:   "volume",
+		Args:  cobra.NoArgs,
+		Short: "Generate YAML for the traffic-agent volume.",
+		Long:  "Generate YAML for the traffic-agent volume. See genyaml for more info on what this means",
+		RunE:  info.run,
+	}
+	return cmd
+}
+
+func (i *genVolumeInfo) run(_ *cobra.Command, _ []string) error {
+	volume := install.AgentVolume()
+	return i.writeObjToOutput(&volume)
+}

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,10 +40,9 @@ It is recommended that you not do this unless strictly necessary. Instead, we su
 		},
 	}
 	cmd.PersistentFlags().StringVar(&info.inputFile, "input", "",
-		"Path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc)")
-	cmd.PersistentFlags().StringVar(&info.outputFile, "output", "",
-		"Path to the file to place the output in.")
-	_ = cmd.MarkPersistentFlagRequired("output")
+		"Path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc). Pass '-' for stdin.")
+	cmd.PersistentFlags().StringVar(&info.outputFile, "output", "-",
+		"Path to the file to place the output in. Defaults to '-' which means stdout.")
 	_ = cmd.MarkPersistentFlagRequired("input")
 	cmd.AddCommand(
 		genContainerSubCommand(&info),

--- a/pkg/client/connector/userd_k8s/k8s_cluster.go
+++ b/pkg/client/connector/userd_k8s/k8s_cluster.go
@@ -189,7 +189,7 @@ func (kc *Cluster) FindAgain(c context.Context, obj kates.Object) (kates.Object,
 	return obj, nil
 }
 
-// FindPodFromDeployName returns a pod with the given name-hex-hex
+// FindPodFromSelector returns a pod with the given name-hex-hex
 func (kc *Cluster) FindPodFromSelector(c context.Context, namespace string, selector map[string]string) (*kates.Pod, error) {
 	pods, err := kc.Pods(c, namespace)
 	if err != nil {

--- a/pkg/client/connector/userd_k8s/k8s_cluster.go
+++ b/pkg/client/connector/userd_k8s/k8s_cluster.go
@@ -340,7 +340,3 @@ func (kc *Cluster) GetClusterId(ctx context.Context) string {
 func (kc *Cluster) Client() *kates.Client {
 	return kc.client
 }
-
-func (kc *Cluster) GetManagerNamespace() string {
-	return kc.kubeconfigExtension.Manager.Namespace
-}

--- a/pkg/client/connector/userd_k8s/k8s_config.go
+++ b/pkg/client/connector/userd_k8s/k8s_config.go
@@ -156,6 +156,10 @@ func (kf *Config) ContextServiceAndFlagsEqual(okf *Config) bool {
 		sliceEqual(kf.flagArgs, okf.flagArgs)
 }
 
+func (kf *Config) GetManagerNamespace() string {
+	return kf.kubeconfigExtension.Manager.Namespace
+}
+
 func sliceEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/client/connector/userd_trafficmgr/install.go
+++ b/pkg/client/connector/userd_trafficmgr/install.go
@@ -197,6 +197,61 @@ func checkSvcSame(c context.Context, obj kates.Object, svcName, portNameOrNumber
 
 var agentNotFound = errors.New("no such agent")
 
+func (ki *installer) getSvcForInjectedPod(
+	c context.Context,
+	namespace,
+	name,
+	svcName,
+	portNameOrNumber string,
+	podTemplate *kates.PodTemplateSpec,
+	obj kates.Object,
+) (*kates.Service, error) {
+	a := podTemplate.ObjectMeta.Annotations
+	webhookInjected := a != nil && a[install.InjectAnnotation] == "enabled"
+	// agent is injected using a mutating webhook, or manually. Get its service and skip the rest
+	svc, err := install.FindMatchingService(c, ki.Client(), portNameOrNumber, svcName, namespace, podTemplate.Labels)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find pod from svc.
+	// On fail, assume agent not present and roll (only if injected via webhook; rolling a manually managed deployment will do no good)
+	pod, err := ki.FindPodFromSelector(c, namespace, svc.Spec.Selector)
+	if err != nil {
+		if webhookInjected {
+			dlog.Warnf(c, "Error finding pod for %s, rolling and proceeding anyway: %v", name, err)
+			err = ki.rolloutRestart(c, obj)
+			if err != nil {
+				return nil, err
+			}
+			return svc, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	// Check pod for agent. If missing and webhookInjected, roll pod
+	roll := true
+	for _, containter := range pod.Spec.Containers {
+		if containter.Name == install.AgentContainerName {
+			roll = false
+			break
+		}
+	}
+	if roll {
+		if webhookInjected {
+			err = ki.rolloutRestart(c, obj)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// The user claims to have manually added the agent but we can't find it; report the error.
+			return nil, fmt.Errorf("the %s annotation is set but no traffic agent was found in %s", install.ManualInjectAnnotation, name)
+		}
+	}
+	return svc, nil
+}
+
 // This does a lot of things but at a high level it ensures that the traffic agent
 // is installed alongside the proper workload. In doing that, it also ensures that
 // the workload is referenced by a service. Lastly, it returns the service UID
@@ -214,39 +269,14 @@ func (ki *installer) ensureAgent(c context.Context, namespace, name, svcName, po
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 
 	var svc *kates.Service
-	if a := podTemplate.ObjectMeta.Annotations; a != nil && a[install.InjectAnnotation] == "enabled" {
-		// agent is injected using a mutating webhook. Get its service and skip the rest
-		svc, err = install.FindMatchingService(c, ki.Client(), portNameOrNumber, svcName, namespace, podTemplate.Labels)
+	a := podTemplate.ObjectMeta.Annotations
+	webhookInjected := a != nil && a[install.InjectAnnotation] == "enabled"
+	manuallyManaged := a != nil && a[install.ManualInjectAnnotation] == "true"
+	if webhookInjected || manuallyManaged {
+		svc, err := ki.getSvcForInjectedPod(c, namespace, name, svcName, portNameOrNumber, podTemplate, obj)
 		if err != nil {
 			return "", "", err
 		}
-
-		// Find pod from svc. On fail, assume agent not present and roll
-		pod, err := ki.FindPodFromSelector(c, namespace, svc.Spec.Selector)
-		if err != nil {
-			dlog.Warnf(c, "Error finding pod for %s, rolling and proceeding anyway: %v", name, err)
-			err = ki.rolloutRestart(c, obj)
-			if err != nil {
-				return "", "", err
-			}
-			return string(svc.GetUID()), kind, nil
-		}
-
-		// Check pod for agent. If missing, roll pod
-		roll := true
-		for _, containter := range pod.Spec.Containers {
-			if containter.Name == install.AgentContainerName {
-				roll = false
-				break
-			}
-		}
-		if roll {
-			err = ki.rolloutRestart(c, obj)
-			if err != nil {
-				return "", "", err
-			}
-		}
-
 		return string(svc.GetUID()), kind, nil
 	}
 

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-initializer.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-initializer.output.yaml
@@ -63,6 +63,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "3000"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-0.output.yaml
@@ -58,6 +58,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "9090"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-1.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-1.output.yaml
@@ -35,6 +35,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-2.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-2.output.yaml
@@ -35,6 +35,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-3.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-mp-tc-3.output.yaml
@@ -35,6 +35,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-0.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-1.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-1.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-10.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-10.output.yaml
@@ -57,6 +57,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-11.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-11.output.yaml
@@ -61,6 +61,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-2.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-2.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-3.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-3.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-4.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-4.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-5.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-5.output.yaml
@@ -53,6 +53,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-6.output.yaml
@@ -66,6 +66,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-7.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-7.output.yaml
@@ -56,6 +56,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_APP_MOUNTS
             value: /tel_app_mounts
           - name: TELEPRESENCE_MOUNTS

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-8.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-8.output.yaml
@@ -78,6 +78,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           envFrom:

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-9.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/deployment-tc-9.output.yaml
@@ -83,6 +83,8 @@ deployment:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "3000"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-mp-tc-0.output.yaml
@@ -34,6 +34,8 @@ replicaset:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/replicaset-tc-0.output.yaml
@@ -34,6 +34,8 @@ replicaset:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-mp-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-mp-tc-0.output.yaml
@@ -53,6 +53,8 @@ statefulset:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-tc-0.output.yaml
+++ b/pkg/client/connector/userd_trafficmgr/testdata/addAgentToWorkload/cur/statefulset-tc-0.output.yaml
@@ -51,6 +51,8 @@ statefulset:
                 fieldPath: status.podIP
           - name: _TEL_AGENT_APP_PORT
             value: "8080"
+          - name: _TEL_AGENT_PORT
+            value: "9900"
           - name: _TEL_AGENT_MANAGER_HOST
             value: traffic-manager.ambassador
           image: localhost:5000/tel2:{{.Version}}

--- a/pkg/client/envconfig.go
+++ b/pkg/client/envconfig.go
@@ -3,8 +3,11 @@ package client
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/sethvargo/go-envconfig"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type Env struct {
@@ -83,6 +86,9 @@ func LoadEnv(ctx context.Context) (*Env, error) {
 	var env Env
 	if err := envconfig.Process(ctx, &env); err != nil {
 		return nil, err
+	}
+	if env.AgentImage == "" {
+		env.AgentImage = "tel2:" + strings.TrimPrefix(version.Version, "v")
 	}
 	return &env, nil
 }

--- a/pkg/install/constants.go
+++ b/pkg/install/constants.go
@@ -7,6 +7,7 @@ const (
 	DomainPrefix              = "telepresence.getambassador.io/"
 	InjectAnnotation          = DomainPrefix + "inject-" + AgentContainerName
 	ServicePortAnnotation     = DomainPrefix + "inject-service-port"
+	ManualInjectAnnotation    = DomainPrefix + "manually-injected"
 	ManagerAppName            = "traffic-manager"
 	ManagerPortHTTP           = 8081
 	MutatorWebhookPortHTTPS   = 8443

--- a/pkg/install/container.go
+++ b/pkg/install/container.go
@@ -37,7 +37,7 @@ func AgentContainer(
 		Image:           imageName,
 		Args:            []string{"agent"},
 		Ports:           []corev1.ContainerPort{port},
-		Env:             agentEnvironment(name, appContainer, appPort, managerNamespace),
+		Env:             agentEnvironment(name, appContainer, appPort, managerNamespace, port),
 		EnvFrom:         appContainer.EnvFrom,
 		VolumeMounts:    agentVolumeMounts(appContainer.VolumeMounts),
 		SecurityContext: securityContext,
@@ -82,7 +82,7 @@ func InitContainer(imageName string, port corev1.ContainerPort, appPort int) cor
 	}
 }
 
-func agentEnvironment(agentName string, appContainer *kates.Container, appPort int, managerNamespace string) []corev1.EnvVar {
+func agentEnvironment(agentName string, appContainer *kates.Container, appPort int, managerNamespace string, port corev1.ContainerPort) []corev1.EnvVar {
 	appEnv := appEnvironment(appContainer)
 	env := make([]corev1.EnvVar, len(appEnv), len(appEnv)+7)
 	copy(env, appEnv)
@@ -114,7 +114,12 @@ func agentEnvironment(agentName string, appContainer *kates.Container, appPort i
 		corev1.EnvVar{
 			Name:  EnvPrefix + "APP_PORT",
 			Value: strconv.Itoa(appPort),
-		})
+		},
+		corev1.EnvVar{
+			Name:  EnvPrefix + "PORT",
+			Value: strconv.Itoa(int(port.ContainerPort)),
+		},
+	)
 	if len(appContainer.VolumeMounts) > 0 {
 		env = append(env, corev1.EnvVar{
 			Name:  EnvPrefix + "APP_MOUNTS",


### PR DESCRIPTION
## Description

Allows manual agent injection. For this, the sidecar container must be generated:

```
telepresence genyaml --manifest-type container --container-name echo-easy --port 8080 --output - --input k8s/echo-easy.yaml
```

As well as the volume:

```
telepresence genyaml --manifest-type volume --container-name echo-easy --port 8080 --output - --input k8s/echo-easy.yaml
``` 

Then once both are injected into the application's deployment YAML, the pods will have to be annotated as `telepresence.getambassador.io/manually-injected: "true"`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
