### PR TITLE
Fix default image config blocking extensions

### DIFF
--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -17,6 +18,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/connector/userd_k8s"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type genYAMLInfo struct {
@@ -200,9 +202,19 @@ func (i *genContainerInfo) run(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to get k8s config: %w", err)
 	}
+
+	registry := cfg.Images.Registry
+	agentImage := cfg.Images.AgentImage
+	// Use sane defaults if the user hasn't configured the registry and/or image
+	if registry == "" {
+		registry = "datawire"
+	}
+	if agentImage == "" {
+		agentImage = "tel2:" + strings.TrimPrefix(version.Version, "v")
+	}
 	agentContainer := install.AgentContainer(
 		i.serviceName,
-		fmt.Sprintf("%s/%s", cfg.Images.Registry, cfg.Images.AgentImage),
+		fmt.Sprintf("%s/%s", registry, agentImage),
 		container,
 		corev1.ContainerPort{
 			Protocol:      corev1.Protocol(i.appProto),

--- a/pkg/client/cli/telepresence_test.go
+++ b/pkg/client/cli/telepresence_test.go
@@ -1822,6 +1822,7 @@ func (hs *helmSuite) helmInstall(ctx context.Context, managerNamespace string, a
 		// We don't want the tests or telepresence to depend on an extension host resolving, so we set it to localhost.
 		"--set", "systemaHost=127.0.0.1",
 		"-f", helmValues,
+		"--wait",
 	)
 	if err == nil {
 		err = hs.tpSuite.capturePodLogs(ctx, "traffic-manager", managerNamespace)

--- a/pkg/client/envconfig.go
+++ b/pkg/client/envconfig.go
@@ -3,11 +3,8 @@ package client
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/sethvargo/go-envconfig"
-
-	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type Env struct {
@@ -86,9 +83,6 @@ func LoadEnv(ctx context.Context) (*Env, error) {
 	var env Env
 	if err := envconfig.Process(ctx, &env); err != nil {
 		return nil, err
-	}
-	if env.AgentImage == "" {
-		env.AgentImage = "tel2:" + strings.TrimPrefix(version.Version, "v")
 	}
 	return &env, nil
 }

--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -353,6 +353,7 @@ fi
 
 VERYLARGEJAVASERVICE=verylargejavaservice.default:8080
 $TELEPRESENCE connect >"$output_location"
+$TELEPRESENCE loglevel debug --duration 5m >"$output_location"
 
 # When the sevice is initially deployed, it can take a few seconds (~7)
 # before the service is actually running, so we build in a few retries


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

We were setting this config value all the time which broke extensions' ability to get their own agent image.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
