### PR TITLE
Add detailed docs on the podCIDRStrategy to the chart's README.md

### DIFF
--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -146,3 +146,17 @@ Error: rendered manifests contain a resource that already exists. Unable to cont
 ```
 
 To fix this error, fix the overlap either by removing `b` from the first install, or from the second.
+
+## Pod CIDRs
+
+The traffic manager is responsible for keeping track of what CIDRs the cluster uses for the pods. The Telepresence client uses this
+information to configure the network so that it provides access to the pods. In some cases, the traffic-manager will not be able to retrieve
+this information, or will do it in a way that is inefficient. To remedy this, the strategy that the traffic manager uses can be configured
+using the `podCIDRStrategy`.
+
+|Value|Meaning|
+|-----|-------|
+|`auto`|First try `nodePodCIDRs` and if that fails, try `coverPodIPs`|
+|`nodePodCIDRs`|Obtain the CIDRs from the`podCIDR` and `podCIDRs` of all `Node` resource specifications.|
+|`coverPodIPs`|Obtain all IPs from the `podIP` and `podIPs` of all `Pod` resource statuses and calculate the CIDRs needed to cover them.|
+|`environment`|Pick the CIDRs from the traffic manager's `POD_CIDRS` environment variable. Use `podCIDRs` to set that variable.|

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -352,7 +352,7 @@ func (oi *info) GetTrafficAgentPods(ctx context.Context, agents string) ([]*core
 	return agentPods, nil
 }
 
-// GetTrafficAgentPods gets all pods in the manager's namespace that have
+// GetTrafficManagerPods gets all pods in the manager's namespace that have
 // `traffic-manager` in the name
 func (oi *info) GetTrafficManagerPods(ctx context.Context) ([]*corev1.Pod, error) {
 	clientset := managerutil.GetK8sClientset(ctx)


### PR DESCRIPTION
The readme mentions the variable but doesn't say anything about what
the possible values are or how they are used. This commit provides
a bit more info.

Triggered by discussion in #2135.