### PR TITLE
Check that the client version is the same as version of the daemons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.4.7 (TBD)
+
+- Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
+
 ### 2.4.6 (November 2, 2021)
 
 - Feature: Telepresence CLI is now built and published for Apple silicon Macs.

--- a/pkg/client/cli/cliutil/connector.go
+++ b/pkg/client/cli/cliutil/connector.go
@@ -81,6 +81,12 @@ func withConnector(ctx context.Context, maybeStart bool, fn func(context.Context
 	ctx = context.WithValue(ctx, connectorConnCtxKey{}, conn)
 	ctx = context.WithValue(ctx, connectorStartedCtxKey{}, started)
 	connectorClient := connector.NewConnectorClient(conn)
+	if !started {
+		// Ensure that the already running daemon has the correct version
+		if err := versionCheck(ctx, "User", connectorClient); err != nil {
+			return err
+		}
+	}
 
 	grp := dgroup.NewGroup(ctx, dgroup.GroupConfig{
 		ShutdownOnNonError: true,

--- a/pkg/client/cli/cliutil/daemon.go
+++ b/pkg/client/cli/cliutil/daemon.go
@@ -107,7 +107,14 @@ func withDaemon(ctx context.Context, maybeStart bool, dnsIP string, fn func(cont
 	defer conn.Close()
 	ctx = context.WithValue(ctx, daemonConnCtxKey{}, conn)
 	ctx = context.WithValue(ctx, daemonStartedCtxKey{}, started)
+
 	daemonClient := daemon.NewDaemonClient(conn)
+	if !started {
+		// Ensure that the already running daemon has the correct version
+		if err := versionCheck(ctx, "Root", daemonClient); err != nil {
+			return err
+		}
+	}
 
 	return fn(ctx, daemonClient)
 }
@@ -120,8 +127,11 @@ func DidLaunchDaemon(ctx context.Context) bool {
 	return launched
 }
 
+type quitting struct{}
+
 // QuitDaemon shuts down the root daemon. When it shuts down, it will tell the connector to shut down.
 func QuitDaemon(ctx context.Context) (err error) {
+	ctx = context.WithValue(ctx, quitting{}, true)
 	defer func() {
 		// Ensure the connector is killed even if daemon isn't running.  If the daemon already
 		// shut down the connector, then this is a no-op.

--- a/pkg/client/cli/cliutil/version_check.go
+++ b/pkg/client/cli/cliutil/version_check.go
@@ -1,0 +1,30 @@
+package cliutil
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	empty "google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/common"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
+)
+
+func versionCheck(ctx context.Context, daemonType string, client interface {
+	Version(context.Context, *empty.Empty, ...grpc.CallOption) (*common.VersionInfo, error)
+}) error {
+	if ctx.Value(quitting{}) != nil {
+		return nil
+	}
+	// Ensure that the already running daemon has the correct version
+	vi, err := client.Version(ctx, &empty.Empty{})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve version of %s Daemon: %w", daemonType, err)
+	}
+	if version.Version != vi.Version {
+		return errcat.User.Newf("version mismatch. Client %s != %s Daemon %s, please quit telepresence and reconnect", version.Version, daemonType, vi.Version)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a version check that triggers when Telepresence connects to an
already started daemon. If there's a version mismatch, then the connect
is refused and the user is asked to quit and reconnect.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
