### PR TITLE
Enable global flags when using legacy flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.4.7 (TBD)
 
+- Bugfix: Legacy flags such as `--swap-deployment` can now be used together with global flags.
+
 - Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
 
 ### 2.4.6 (November 2, 2021)

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -132,6 +132,33 @@ func Command(ctx context.Context) *cobra.Command {
 		})
 	*/
 
+	rootCmd.InitDefaultHelpCmd()
+	AddCommandGroups(rootCmd, []CommandGroup{
+		{
+			Name:     "Session Commands",
+			Commands: []*cobra.Command{connectCommand(), LoginCommand(), LogoutCommand(), LicenseCommand(), statusCommand(), quitCommand()},
+		},
+		{
+			Name:     "Traffic Commands",
+			Commands: []*cobra.Command{listCommand(), interceptCommand(ctx), leaveCommand(), previewCommand()},
+		},
+		{
+			Name:     "Debug Commands",
+			Commands: []*cobra.Command{loglevelCommand(), gatherLogsCommand()},
+		},
+		{
+			Name:     "Other Commands",
+			Commands: []*cobra.Command{versionCommand(), uninstallCommand(), dashboardCommand(), ClusterIdCommand(), genYAMLCommand()},
+		},
+	})
+	initGlobalFlagGroups()
+	for _, group := range globalFlagGroups {
+		rootCmd.PersistentFlags().AddFlagSet(group.Flags)
+	}
+	return rootCmd
+}
+
+func initGlobalFlagGroups() {
 	globalFlagGroups = []FlagGroup{
 		{
 			Name: "Kubernetes flags",
@@ -176,28 +203,4 @@ func Command(ctx context.Context) *cobra.Command {
 			return flags
 		}(),
 	})
-
-	rootCmd.InitDefaultHelpCmd()
-	AddCommandGroups(rootCmd, []CommandGroup{
-		{
-			Name:     "Session Commands",
-			Commands: []*cobra.Command{connectCommand(), LoginCommand(), LogoutCommand(), LicenseCommand(), statusCommand(), quitCommand()},
-		},
-		{
-			Name:     "Traffic Commands",
-			Commands: []*cobra.Command{listCommand(), interceptCommand(ctx), leaveCommand(), previewCommand()},
-		},
-		{
-			Name:     "Debug Commands",
-			Commands: []*cobra.Command{loglevelCommand(), gatherLogsCommand()},
-		},
-		{
-			Name:     "Other Commands",
-			Commands: []*cobra.Command{versionCommand(), uninstallCommand(), dashboardCommand(), ClusterIdCommand(), genYAMLCommand()},
-		},
-	})
-	for _, group := range globalFlagGroups {
-		rootCmd.PersistentFlags().AddFlagSet(group.Flags)
-	}
-	return rootCmd
 }

--- a/pkg/client/cli/legacy_command_test.go
+++ b/pkg/client/cli/legacy_command_test.go
@@ -56,6 +56,11 @@ func Test_legacyCommands(t *testing.T) {
 			outputTP2Command:   "intercept myserver --port 80 --docker-run -- -i -t nginx:latest",
 		},
 		{
+			name:               "swapDeploymentGlobalFlag",
+			inputLegacyCommand: "telepresence --as system:serviceaccount:default:telepresence-test-developer --swap-deployment myserver --expose 9090 --run python3 -m http.server 9090",
+			outputTP2Command:   "intercept myserver --port 9090 --as system:serviceaccount:default:telepresence-test-developer -- python3 -m http.server 9090",
+		},
+		{
 			name:               "runCommand",
 			inputLegacyCommand: "telepresence --run curl http://myservice:8080/",
 			outputTP2Command:   "connect -- curl http://myservice:8080/",
@@ -78,6 +83,7 @@ func Test_legacyCommands(t *testing.T) {
 		},
 	}
 
+	initGlobalFlagGroups()
 	for _, tc := range testCases {
 		tcName := tc.name
 		tc := tc
@@ -87,8 +93,8 @@ func Test_legacyCommands(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assert.Equal(t, msg, tc.msg)
-			assert.Equal(t, genTPCmd, tc.outputTP2Command)
+			assert.Equal(t, tc.msg, msg)
+			assert.Equal(t, tc.outputTP2Command, genTPCmd)
 		})
 	}
 }


### PR DESCRIPTION
## Description

All global flags are now accepted when using legacy flags such as
`--swap-deployment`.

This fix is primarily driven by the fact that we need to use the `--as`
flag when running our integration tests.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 