### PR TITLE
Ensure that outbound connection is closed when closed by peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
 
+- Bugfix: Outbound connections are now properly closed when the peer closes.
+
 ### 2.4.6 (November 2, 2021)
 
 - Feature: Telepresence CLI is now built and published for Apple silicon Macs.

--- a/pkg/vif/tcp/tmgr.go
+++ b/pkg/vif/tcp/tmgr.go
@@ -108,7 +108,10 @@ func (h *handler) adjustReceiveWindow() {
 // readFromMgrLoop sends the packets read from the fromMgr channel to the TUN device
 func (h *handler) readFromMgrLoop(ctx context.Context) {
 	h.wg.Add(1)
-	defer h.wg.Done()
+	defer func() {
+		h.Close(ctx)
+		h.wg.Done()
+	}()
 	fromMgrCh, fromMgrErrs := tunnel.ReadLoop(ctx, h.stream)
 	for {
 		select {


### PR DESCRIPTION
## Description

An outbound TCP connection that got closed by the peer would cancel all
activity, but it didn't send the correct packages to negotiate the
EOF to the client. This commit ensures that the FIN,ACK is sent and
that the connection terminates.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 