### PR TITLE
ci: store nightly builds on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,10 @@ jobs:
           newTag=$(go run ./build-aux/genversion nightly)
           TELEPRESENCE_VERSION=$newTag make push-images push-executable
           TELEPRESENCE_VERSION=$newTag make promote-nightly
+    - store_artifacts:
+        name: "Store nightly artifacts"
+        path: build-output/
+        destination: nightly-linux-artifacts
 
   "publish-nightly-windows":
     executor:
@@ -412,6 +416,10 @@ jobs:
           newTag=$(go run ./build-aux/genversion nightly)
           TELEPRESENCE_VERSION=$newTag make push-executable
           TELEPRESENCE_VERSION=$newTag make promote-nightly
+    - store_artifacts:
+        name: "Store nightly artifacts"
+        path: build-output/
+        destination: nightly-windows-artifacts
 
   "publish-nightly-macos":
     executor: vm-macos
@@ -425,12 +433,20 @@ jobs:
           newTag=$(go run ./build-aux/genversion nightly)
           TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make push-executable
           TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make promote-nightly
+    - store_artifacts:
+        name: "Store nightly artifacts"
+        path: build-output/
+        destination: nightly-macos-amd64-artifacts
     - run:
         name: "Publish nightly macos (arch arm64)"
         command: |
           newTag=$(go run ./build-aux/genversion nightly)
           TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make push-executable
           TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make promote-nightly
+    - store_artifacts:
+        name: "Store nightly artifacts"
+        path: build-output/
+        destination: nightly-macos-arm64-artifacts
 
 #  "release-finalize":
 #    executor: vm-linux


### PR DESCRIPTION
## Description

I added the ability to store the nightly builds on circleci. better to go there and download directly just in a click.

## Checklist


 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
