### PR TITLE
Login always uses credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-service-name`, that can be used to set the name of the service to be intercepted.
   This will help disambiguate which service to intercept for when a workload is exposed by multiple services, such as can happen with Argo Rollouts
 
+- Feature: The kubeconfig extensions now support a `never-proxy` argument, analogous to `also-proxy`, that defines a set of subnets that will never be proxied via telepresence.
+
 - Bugfix: Legacy flags such as `--swap-deployment` can now be used together with global flags.
 
 - Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
@@ -27,6 +29,7 @@
 
 - Bugfix: The configured webhookRegistry is now propagated to the webhook installer even if no webhookAgentImage has been set.
 
+- Bugfix: Login logs the user in when their access token has expired, instead of having no effect.
 
 ### 2.4.6 (November 2, 2021)
 

--- a/pkg/client/connector/userd_auth/login.go
+++ b/pkg/client/connector/userd_auth/login.go
@@ -238,7 +238,7 @@ func (l *loginExecutor) Worker(ctx context.Context) error {
 			case <-l.refreshTimer.C:
 				dlog.Infoln(ctx, "refreshing access token...")
 				if token, err := l.getToken(ctx); err != nil {
-					dlog.Infof(ctx, "could not refresh assess token: %v", err)
+					dlog.Infof(ctx, "could not refresh access token: %v", err)
 				} else if token != "" {
 					dlog.Infof(ctx, "got new access token")
 				}

--- a/pkg/client/connector/userd_grpc/service.go
+++ b/pkg/client/connector/userd_grpc/service.go
@@ -205,7 +205,10 @@ func (s *service) Login(ctx context.Context, req *rpc.LoginRequest) (*rpc.LoginR
 			return &rpc.LoginResult{Code: rpc.LoginResult_OLD_LOGIN_REUSED}, nil
 		}
 	} else {
-		if _, err := s.sharedState.LoginExecutor.GetUserInfo(ctx, false); err == nil {
+		// We should refresh here because the user is explicitly logging in so
+		// even if we have cache'd user info, if they are unable to get new
+		// user info, then it should trigger the login function
+		if _, err := s.sharedState.LoginExecutor.GetUserInfo(ctx, true); err == nil {
 			dlog.Debug(ctx, "returned")
 			return &rpc.LoginResult{Code: rpc.LoginResult_OLD_LOGIN_REUSED}, nil
 		}


### PR DESCRIPTION
Currently, if there is cached user-info, we don't try a new login. This
creates issues when the token expires, so this will ensure that if the
token has expired and a user runs login, it will make them login again.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

This is basically a bandaid until I can figure out why the refresh token logic doesn't seem to be working. 

Here is the problem users are seeing:
```
User Daemon: Running
  Version           : v2.4.7-52-geb199abe-1637180824 (api 3)
  Ambassador Cloud  : Login expired (or otherwise no-longer-operational)
  Status            : Connected
  Kubernetes server : https://35.224.222.254
  Kubernetes context: default
  Telepresence proxy: ON (networking to the cluster is enabled)
  Intercepts        : 0 total
```

But login currently doesn't do anything because the user-info is cached on their machine, but the token has expired... With this fix when you do a login, this is what happens:
```
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/expired-login) ✗ telepresence login
Launching browser authentication flow...
Login successful.
(⎈ |default:default)➜  ~/go/telepresenceio git:(donnyyung/expired-login) ✗ telepresence status
Root Daemon: Running
  Version   : v2.4.7-52-geb199abe-1637180824 (api 3)
  DNS       :
    Remote IP       : 10.43.0.10
    Exclude suffixes: [.arpa .com .io .net .org .ru]
    Include suffixes: []
    Timeout         : 4s
  Also Proxy: (1 subnets)
    - 35.224.222.0/24
User Daemon: Running
  Version           : v2.4.7-52-geb199abe-1637180824 (api 3)
  Ambassador Cloud  : Logged in
  Status            : Connected
  ``` 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
