### PR TITLE
Ensure update of both version and app-version in the embedded Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Bugfix: The app-version value of the Helm chart embedded in the telepresence binary is now automatically updated at build time. The value is hardcoded in the
   original Helm chart when we release so this fix will only affect our nightly builds. 
 
+- Bugfix: The configured webhookRegistry is now propagated to the webhook installer even if no webhookAgentImage has been set.
+
 ### 2.4.6 (November 2, 2021)
 
 - Feature: Telepresence CLI is now built and published for Apple silicon Macs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 - Bugfix: Fixed a potential deadlock when a new agent joined the traffic manager.
 
+- Bugfix: The app-version value of the Helm chart embedded in the telepresence binary is now automatically updated at build time. The value is hardcoded in the
+  original Helm chart when we release so this fix will only affect our nightly builds. 
+
 ### 2.4.6 (November 2, 2021)
 
 - Feature: Telepresence CLI is now built and published for Apple silicon Macs.

--- a/build-aux/package_embedded_chart/main.go
+++ b/build-aux/package_embedded_chart/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/datawire/dlib/dexec"
 )
@@ -30,7 +31,8 @@ func run() error {
 		return fmt.Errorf("failed to stat tools/bin/helm (%v); try running \"make tools/bin/helm\"", err)
 	}
 	version := os.Args[1]
-	err = dexec.CommandContext(context.Background(), helm, "package", chartSource, "--version="+version).Run()
+	version = strings.TrimPrefix(version, "v")
+	err = dexec.CommandContext(context.Background(), helm, "package", chartSource, "--version="+version, "--app-version="+version).Run()
 	if err != nil {
 		return fmt.Errorf("error from helm package: %w", err)
 	}

--- a/pkg/install/helm/install.go
+++ b/pkg/install/helm/install.go
@@ -50,23 +50,24 @@ func getValues(ctx context.Context) map[string]interface{} {
 			"maxReceiveSize": clientConfig.Grpc.MaxReceiveSize.String(),
 		}
 	}
-	if imgConfig.WebhookAgentImage != "" {
-		parts := strings.Split(imgConfig.WebhookAgentImage, ":")
-		image := imgConfig.WebhookAgentImage
-		tag := ""
-		if len(parts) > 1 {
-			image = parts[0]
-			tag = parts[1]
+	if imgConfig.WebhookAgentImage != "" || imgConfig.WebhookRegistry != "" {
+		agentImage := make(map[string]interface{})
+		if imgConfig.WebhookAgentImage != "" {
+			parts := strings.Split(imgConfig.WebhookAgentImage, ":")
+			image := imgConfig.WebhookAgentImage
+			tag := ""
+			if len(parts) > 1 {
+				image = parts[0]
+				tag = parts[1]
+			}
+			agentImage["name"] = image
+			agentImage["tag"] = tag
 		}
-		values["agentInjector"] = map[string]interface{}{
-			"agentImage": map[string]interface{}{
-				"registry": imgConfig.WebhookRegistry,
-				"name":     image,
-				"tag":      tag,
-			},
+		if imgConfig.WebhookRegistry != "" {
+			agentImage["registry"] = imgConfig.WebhookRegistry
 		}
+		values["agentInjector"] = map[string]interface{}{"agentImage": agentImage}
 	}
-
 	return values
 }
 


### PR DESCRIPTION
Add a `--app-version=VERSION` to the embedded Helm chart packager so
that the `app-version` value of the embedded chart is the same as the
version of the binary.