### PR TITLE
Fix certs in mac circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,13 +339,18 @@ jobs:
       # once we update our mac runner to a version past Catalina (12.5.1+)
       # we can remove this.  But since we all run Big Sur on our machines right now
       # we thought we should keep testing Catalina in our CI.
+      # UPDATE: Macfuse doesn't seem to be working on any exectutor past Catalina,
+      # so we need to figure that out...
       # https://blog.bytesguy.com/resolving-lets-encrypt-issues-with-curl-on-macos
       - run:
           name: Update Let's Encrypt Certs
           command: |
             curl -k https://curl.se/ca/cacert.pem -o ~/.cacert.pem
+            # These work for non-sudo cases
             export CURL_CA_BUNDLE=~/.cacert.pem
             export AWS_CA_BUNDLE=~/.cacert.pem
+            # This makes it work when using sudo with curl
+            sudo cp ~/.cacert.pem /etc/ssl/cert.pem
       - run:
           name: "Publish macos (arch amd64)"
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-service-name`, that can be used to set the name of the service to be intercepted.
   This will help disambiguate which service to intercept for when a workload is exposed by multiple services, such as can happen with Argo Rollouts
 
+- Feature: The kubeconfig extensions now support a `never-proxy` argument, analogous to `also-proxy`, that defines a set of subnets that will never be proxied via telepresence.
+
+- Feature: Added flags to "telepresence intercept" that set the ingress fields as an alternative to using the dialogue.
+
 - Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
 
 - Change: Telepresence DNS now uses a very short TTL instead of explicitly flushing DNS by killing the `mDNSResponder` or doing `resolvectl flush-caches`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 - Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-service-name`, that can be used to set the name of the service to be intercepted.
   This will help disambiguate which service to intercept for when a workload is exposed by multiple services, such as can happen with Argo Rollouts
 
-- Feature: The kubeconfig extensions now support a `never-proxy` argument, analogous to `also-proxy`, that defines a set of subnets that will never be proxied via telepresence.
+- Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
+
+- Change: Telepresence DNS now uses a very short TTL instead of explicitly flushing DNS by killing the `mDNSResponder` or doing `resolvectl flush-caches`
 
 - Bugfix: Legacy flags such as `--swap-deployment` can now be used together with global flags.
-
-- Change: Telepresence check the versions of the client and the daemons and ask the user to quit and restart if they don't match.
 
 - Bugfix: Outbound connections are now properly closed when the peer closes.
 
@@ -18,11 +18,7 @@
 - Bugfix: The TUN-device will trap failed connection attempts that results in recursive calls back into the TUN-device (may happen when the 
   cluster runs in a docker-container on the client).
 
-- Change: Telepresence DNS now uses a very short TTL instead of explicitly flushing DNS by killing the `mDNSResponder` or doing `resolvectl flush-caches`
-
 - Bugfix: Fixed a potential deadlock when a new agent joined the traffic manager.
-
-- Feature: Added flags to "telepresence intercept" that set the ingress fields as an alternative to using the dialogue.
 
 - Bugfix: The app-version value of the Helm chart embedded in the telepresence binary is now automatically updated at build time. The value is hardcoded in the
   original Helm chart when we release so this fix will only affect our nightly builds. 


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

The problem (I believe) is that curl was picking up the new CA Certs, but sudo curl was not, this should fix that.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
