### PR TITLE
Always build arm64 for mac in our builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,9 @@ jobs:
           no_output_timeout: *testsTimeout
       - cleanup-kluster:
           platform: macos
+      - run:
+          name: "Test arm64 build"
+          command: GOARCH=arm64 make build
       - save-logs
 
   "build-and-test":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   "vm-macos":
     macos:
-      xcode: "12.4.0" # macOS 10.15.5
+      xcode: "12.5.1" # macOS 11.4.0
 
 commands:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   "vm-macos":
     macos:
-      xcode: "12.2.0" # macOS 10.15.5
+      xcode: "12.4.0" # macOS 10.15.5
 
 commands:
 
@@ -240,6 +240,9 @@ jobs:
     steps:
       - checkout
       - install-go
+      - run:
+          name: "Test arm64 build"
+          command: GOARCH=arm64 make build
       - run: make build
       - install-kubectl
       - install-sshfs-macos
@@ -260,9 +263,6 @@ jobs:
           no_output_timeout: *testsTimeout
       - cleanup-kluster:
           platform: macos
-      - run:
-          name: "Test arm64 build"
-          command: GOARCH=arm64 make build
       - save-logs
 
   "build-and-test":


### PR DESCRIPTION
While we can't test the arm64 builds in circle, we should still validate
that we can build successfully so we don't break it accidentally and not
find out until we go to release it.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
