### PR TITLE
correctly set GOARCH arg

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -180,7 +180,7 @@ promote-to-stable: ## (Release) Update stable.txt in S3
 		--key tel2/$(GOHOSTOS)/$(GOARCH)/stable.txt \
 		--body $(BUILDDIR)/stable.txt
 ifeq ($(GOHOSTOS), darwin)
-	packaging/homebrew-package.sh $(patsubst v%,%,$(TELEPRESENCE_VERSION)) $GOARCH
+	packaging/homebrew-package.sh $(patsubst v%,%,$(TELEPRESENCE_VERSION)) $(GOARCH)
 endif
 
 # Prerequisites:


### PR DESCRIPTION
## Description

There was an error in the circle config which caused the homebrew-package.sh script to be run like this in ci `packaging/homebrew-package.sh 2.4.7 OARCH` which failed... and this had been hidden for so long since the curl was failing bc of cert issues, so at least that was fixed!

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
