### PR TITLE
Change LargeRequest test to do multiple concurrent requests.

### DIFF
--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -27,45 +28,55 @@ func init() {
 
 func (s *multipleServicesSuite) Test_LargeRequest() {
 	require := s.Require()
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: 60 * time.Second}
 	const sendSize = 1024 * 1024 * 5
-	b := make([]byte, sendSize)
-	b[0] = '!'
-	b[1] = '\n'
-	for i := 2; i < sendSize; i++ {
-		b[i] = 'A'
+	const concurrentRequests = 3
+
+	wg := sync.WaitGroup{}
+	wg.Add(concurrentRequests)
+	for i := 0; i < concurrentRequests; i++ {
+		go func() {
+			defer wg.Done()
+			b := make([]byte, sendSize)
+			b[0] = '!'
+			b[1] = '\n'
+			for i := 2; i < sendSize; i++ {
+				b[i] = 'A'
+			}
+			req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("http://%s-0.%s/put", s.Name(), s.AppNamespace()), bytes.NewBuffer(b))
+			require.NoError(err)
+
+			resp, err := client.Do(req)
+			require.NoError(err)
+			defer resp.Body.Close()
+			require.Equal(resp.StatusCode, 200)
+
+			// Read start
+			buf := make([]byte, 1)
+			_, err = resp.Body.Read(buf)
+			for err == nil && buf[0] != '!' {
+				_, err = resp.Body.Read(buf)
+			}
+			require.NoError(err)
+			_, err = resp.Body.Read(buf)
+			require.Equal(buf[0], byte('\n'))
+			require.NoError(err)
+
+			buf = make([]byte, sendSize-2)
+			i := 0
+			for err == nil {
+				var j int
+				j, err = resp.Body.Read(buf[i:])
+				i += j
+			}
+
+			require.Equal(io.EOF, err)
+			require.Equal(len(buf), i)
+			// Do this instead of require.Equal(b[2:], buf) so that on failure we don't print two 5MB buffers to the terminal
+			require.Equal(true, bytes.Equal(b[2:], buf))
+		}()
 	}
-	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("http://%s-0.%s/put", s.Name(), s.AppNamespace()), bytes.NewBuffer(b))
-	require.NoError(err)
-
-	resp, err := client.Do(req)
-	require.NoError(err)
-	defer resp.Body.Close()
-	require.Equal(resp.StatusCode, 200)
-
-	// Read start
-	buf := make([]byte, 1)
-	_, err = resp.Body.Read(buf)
-	for err == nil && buf[0] != '!' {
-		_, err = resp.Body.Read(buf)
-	}
-	require.NoError(err)
-	_, err = resp.Body.Read(buf)
-	require.Equal(buf[0], byte('\n'))
-	require.NoError(err)
-
-	buf = make([]byte, sendSize-2)
-	i := 0
-	for err == nil {
-		var j int
-		j, err = resp.Body.Read(buf[i:])
-		i += j
-	}
-
-	require.Equal(io.EOF, err)
-	s.Equal(len(buf), i)
-	// Do this instead of cs.Equal(b[2:], buf) so that on failure we don't print two 5MB buffers to the terminal
-	s.Equal(true, bytes.Equal(b[2:], buf))
+	wg.Wait()
 }
 
 func (s *multipleServicesSuite) Test_List() {


### PR DESCRIPTION
Concurrency was the root cause of a past regression, so this will cover
that scenario.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
