### PR TITLE
Fix access token not refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.4.9 (TBD)
+
+- Bugfix: Fixed an error where access tokens were not refreshed if you login
+  while the daemons are already running.
+
 ### 2.4.8 (December 3, 2021)
 
 - Feature: A RESTful service was added to Telepresence, both locally to the client and to the `traffic-agent` to help determine if messages with a set of headers should be


### PR DESCRIPTION
## Description
This fixes an error where if you do `telepresence login` after `telepresence connect` the access tokens never refresh because the login command overrides the newTokenSource with a context that is canceled as soon as the command finishes, which causes the refresh token function to fail since it uses the expired context.

I've fixed this by passing the token to the goroutine via a channel and the refresh goroutine will update the newTokenSource with that token and a context that isn't expired so the refresh token function no longer fails.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to either submit a docs PR, or tell Matt about the necessary documentation changes.
 - [ ] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
