### PR TITLE
Thallgren/chart nil exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Bugfix: Fixed an error where access tokens were not refreshed if you login
   while the daemons are already running.
 
+- Bugfix: A helm upgrade using the --reuse-values flag no longer fails on a "nil pointer" error caused by a nil `telpresenceAPI` value.
+
 ### 2.4.8 (December 3, 2021)
 
 - Feature: A RESTful service was added to Telepresence, both locally to the client and to the `traffic-agent` to help determine if messages with a set of headers should be

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -47,12 +47,12 @@ spec:
             value: {{ .Values.systemaPort | quote }}
           - name: TELEPRESENCE_REGISTRY
             value: {{ .Values.agentInjector.agentImage.registry }}
-            {{- with .Values.telepresenceAPI }}
-            {{- if .port }}
+          {{- with .Values.telepresenceAPI }}
+          {{- if .port }}
           - name: TELEPRESENCE_API_PORT
             value: {{ .port | quote }}
-            {{- end }}
-            {{- end }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.grpc }}
           {{- if .Values.grpc.maxReceiveSize }}
           - name: TELEPRESENCE_MAX_RECEIVE_SIZE

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -47,10 +47,12 @@ spec:
             value: {{ .Values.systemaPort | quote }}
           - name: TELEPRESENCE_REGISTRY
             value: {{ .Values.agentInjector.agentImage.registry }}
-          {{- if .Values.telepresenceAPI.port }}
+            {{- with .Values.telepresenceAPI }}
+            {{- if .port }}
           - name: TELEPRESENCE_API_PORT
-            value: {{ .Values.telepresenceAPI.port | quote }}
-          {{- end }}
+            value: {{ .port | quote }}
+            {{- end }}
+            {{- end }}
           {{- if .Values.grpc }}
           {{- if .Values.grpc.maxReceiveSize }}
           - name: TELEPRESENCE_MAX_RECEIVE_SIZE


### PR DESCRIPTION
## Description

The new `telepresenceAPI.port` value causes a "nil pointer" error when
upgrading from earlier chart versions using the `--reuse-values` flag
because the container for the `.port` is nil. This commit ensures that
the part of the template that is failing is ignored when the value is
missing.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.