### PR TITLE
Let dialer ignore DialOK controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.4.10 (TBD)
+
+- Bugfix: Telepresence will no longer log invalid: "unhandled connection control message: code DIAL_OK" errors.
+
 ### 2.4.9 (December 9, 2021)
 
 - Bugfix: Fixed an error where access tokens were not refreshed if you login

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -128,6 +128,14 @@ func (h *dialer) handleControl(ctx context.Context, cm Message) {
 		h.Close(ctx)
 	case KeepAlive:
 		h.resetIdle()
+	case DialOK:
+		// So how can a dialer get a DialOK from a peer? Surely, there cannot be a dialer at both ends?
+		// Well, the story goes like this:
+		// 1. A request to the service is made on the workstation.
+		// 2. This agent's listener receives a connection.
+		// 3. Since an intercept is active, the agent creates a tunnel to the workstation
+		// 4. A new dialer is attached to that tunnel (reused as a tunnel endpoint)
+		// 5. The dialer at the workstation dials and responds with DialOK, and here we are.
 	default:
 		dlog.Errorf(ctx, "!! CONN %s: unhandled connection control message: %s", h.stream.ID(), cm)
 	}


### PR DESCRIPTION
## Description

A `Dialer` is reused as a tunnel endpoint. The peer endpoint may also be
a `Dialer` and may respond with the `DialOK` control message. It's an
indication that everything is OK and can be safely ignored.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.