### PR TITLE
Replace --http-protocol with boolean --http-plaintext and add docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.4.10 (TBD)
 
+- Feature: The flag `--http-plaintext` can be used to ensure that an intercept uses plaintext http or grpc when 
+  communicating with the workstation process.
+
 - Feature: The port used by default in the `telepresence intercept` command (8080), can now be changed by setting
   the `intercept.defaultPort` in the `config.yml` file.
 

--- a/docs/pre-release/reference/config.md
+++ b/docs/pre-release/reference/config.md
@@ -31,6 +31,9 @@ grpc:
   maxReceiveSize: 10Mi
 telepresenceAPI:
   port: 9980
+intercept:
+  appProtocolStrategy: portName
+  defaultPort: "8088"
 ```
 
 #### Timeouts
@@ -62,8 +65,6 @@ case insensitive:
  - `info`
  - `warning` or `warn`
  - `error`
- - `fatal`
- - `panic`
 
 For whichever log-level you select, you will get logs labeled with that level and of higher severity.
 (e.g. if you use `info`, you will also get logs labeled `error`. You will NOT get logs labeled `debug`.
@@ -133,6 +134,29 @@ The size is measured in bytes. You can express it as a plain integer or as a fix
 The `telepresenceAPI` controls the behavior of Telepresence's RESTful API server that can be queried for additional information about ongoing intercepts. When present, and the `port` is set to a valid port number, it's propagated to the auto-installer so that application containers that can be intercepted gets the `TELEPRESENCE_API_PORT` environment set. The server can then be queried at `localhost:<TELEPRESENCE_API_PORT>`. In addition, the `traffic-agent` and the `user-daemon` on the workstation that performs an intercept will start the server on that port.
 If the `traffic-manager` is auto-installed, its webhook agent injector will be configured to add the `TELEPRESENCE_API_PORT` environment to the app container when the `traffic-agent` is injected.
 See [RESTful API server](../restapi) for more info.
+
+#### Intercept
+The `intercept` controls applies to how telepresence will intercept the communications to the intercepted service.
+
+The `defaultPort` controls what port that will be selected when no `--port` flag is given to the `telepresence intercept` command. The default value is "8080".
+
+The `appProtocolStrategy` is only relevant when using personal intercepts and controls how telepresence selects the application protocol to use when intercepting a service that has no `service.ports.appProtocol` defined. Valid values are:
+
+| Value        | Resulting action                                                                                       |
+|--------------|--------------------------------------------------------------------------------------------------------|
+| `http2Probe` | The telepresence traffic-agent will probe the intercepted container to check whether it supports http2 |
+| `portName`   | Telepresence will make an educated guess about the protocol based on the name of the service port      |
+| `http`       | Telepresence will use http                                                                             |
+| `http2`      | Telepresence will use http2                                                                            |
+
+When `portName` is used, Telepresence will determine the protocol by the name of the port: `<protocol>[-suffix]`. The following protocols are recognized:
+
+| Protocol | Meaning                               |
+|----------|---------------------------------------|
+| `http`   | Plaintext HTTP/1.1 traffic            |
+| `http2`  | Plaintext HTTP/2 traffic              |
+| `https`  | TLS Encrypted HTTP (1.1 or 2) traffic |
+| `grpc`   | Same as http2                         |
 
 ## Per-Cluster Configuration
 Some configuration is not global to Telepresence and is actually specific to a cluster.  Thus, we store that config information in your kubeconfig file, so that it is easier to maintain per-cluster configuration.

--- a/docs/pre-release/reference/intercepts/index.md
+++ b/docs/pre-release/reference/intercepts/index.md
@@ -68,14 +68,25 @@ your cluster; if it detects it correctly, may simply press "enter" and
 accept the default, otherwise you must tell Telepresence the correct
 value.
 
-When creating an intercept with the `http` mechanism, the
-traffic-agent sends a `GET /telepresence-http2-check` request to your
-service and to the process running on your local machine at the port
-specified in your intercept, in order to determine if they support
-HTTP/2.  This is required for the intercepts to behave correctly.  If
-you do not have a service running locally when the intercept is
-created, the traffic-agent will use the result it got from checking
-the in-cluster service.
+When creating an intercept with the `http` mechanism, Telepresence must
+determine the application protocol to use (HTTP/1.1 or HTTP/2). If the
+service's `ports.appProtocol` field is set, it will be used. If not, then
+Telepresence will use the configured [application protocol strategy](../config/#intercept)
+to determine the protocol. The default behavior (`http2Probe` strategy) is
+to send a `GET /telepresence-http2-check` request to your service in order
+to determine if it supports HTTP/2.  This is required for the intercepts to
+behave correctly.
+
+### TLS
+
+If the intercepted service expects TLS, then Telepresence must terminate the
+TLS in order to use the `http` mechanism. It is then common to also restore
+the TLS by originating it again. This is controlled using [TLS annotations](../cluster-config/#tls)
+in the workload.
+
+Use the `--http-plaintext` flag when doing an intercept when the service in the
+cluster is using TLS in case you want to use plaintext for the communication with the
+process on your local workstation. 
 
 ## Supported workloads
 
@@ -224,7 +235,7 @@ Oftentimes, there's a 1-to-1 relationship between a service and a
 workload, so telepresence is able to auto-detect which service it
 should intercept based on the workload you are trying to intercept.
 But if you use something like
-[Argo](https://www.getambassador.io/docs/argo/latest/), there may be
+[Argo](https://www.getambassador.io/docs/argo/latest/quick-start/), there may be
 two services (that use the same labels) to manage traffic between a
 canary and a stable service.
 

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -26,7 +26,6 @@
 #             `FOO/releaseNotes.yml`, then the image paths are
 #             relative to `FOO/release-notes/`.
 #         - docs: The path to the documentation page where additional information can be found.
-#         - href: A path from the root to a resource on the getambassador website, takes precedence over a docs link.
 
 docTitle: Telepresence Release Notes
 docDescription: >-
@@ -39,6 +38,43 @@ docDescription: >-
 changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELOG.md
 
 items:
+  - version: 2.4.10
+    date: "(TBD)"
+    notes:
+      - type: feature
+        title: Application Protocol Strategy
+        body: >-
+          The strategy used when selecting the application protocol for personal intercepts can now be configured using
+          the <code>intercept.appProtocolStrategy</code> in the <code>config.yml</code> file.
+        docs: reference/config/#intercept
+      - type: feature
+        title: Helm value for the Application Protocol Strategy
+        body: >-
+          The strategy when selecting the application protocol for personal intercepts in agents injected by the
+          mutating webhook can now be configured using the <code>agentInjector.appProtocolStrategy</code> in the Helm chart.
+        docs: install/helm
+      - type: feature
+        title: New <code>--http-plaintext</code> option
+        body: >-
+          The flag <code>--http-plaintext</code> can be used to ensure that an intercept uses plaintext http or grpc when
+          communicating with the workstation process.
+        docs: reference/intercepts/#tls
+      - type: feature
+        title: Configure the default intercept port
+        body: >-
+          The port used by default in the <code>telepresence intercept</code> command (8080), can now be changed by setting
+          the <code>intercept.defaultPort</code> in the <code>config.yml</code> file.
+        docs: reference/config/#intercept
+      - type: bugfix
+        title: Check conditions before asking questions
+        body: >-
+          User will not be asked to log in or add ingress information when creating an intercept until a check has been 
+          made that the intercept is possible.
+        docs: reference/intercepts/
+      - type: bugfix
+        title: Fix invalid log statement
+        body: >-
+          Telepresence will no longer log invalid: <code>"unhandled connection control message: code DIAL_OK"</code> errors.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/docs/v2.4/reference/config.md
+++ b/docs/v2.4/reference/config.md
@@ -31,6 +31,9 @@ grpc:
   maxReceiveSize: 10Mi
 telepresenceAPI:
   port: 9980
+intercept:
+  appProtocolStrategy: portName
+  defaultPort: "8088"
 ```
 
 #### Timeouts
@@ -62,8 +65,6 @@ case insensitive:
  - `info`
  - `warning` or `warn`
  - `error`
- - `fatal`
- - `panic`
 
 For whichever log-level you select, you will get logs labeled with that level and of higher severity.
 (e.g. if you use `info`, you will also get logs labeled `error`. You will NOT get logs labeled `debug`.
@@ -133,6 +134,29 @@ The size is measured in bytes. You can express it as a plain integer or as a fix
 The `telepresenceAPI` controls the behavior of Telepresence's RESTful API server that can be queried for additional information about ongoing intercepts. When present, and the `port` is set to a valid port number, it's propagated to the auto-installer so that application containers that can be intercepted gets the `TELEPRESENCE_API_PORT` environment set. The server can then be queried at `localhost:<TELEPRESENCE_API_PORT>`. In addition, the `traffic-agent` and the `user-daemon` on the workstation that performs an intercept will start the server on that port.
 If the `traffic-manager` is auto-installed, its webhook agent injector will be configured to add the `TELEPRESENCE_API_PORT` environment to the app container when the `traffic-agent` is injected.
 See [RESTful API server](../restapi) for more info.
+
+#### Intercept
+The `intercept` controls applies to how telepresence will intercept the communications to the intercepted service.
+
+The `defaultPort` controls what port that will be selected when no `--port` flag is given to the `telepresence intercept` command. The default value is "8080".
+
+The `appProtocolStrategy` is only relevant when using personal intercepts and controls how telepresence selects the application protocol to use when intercepting a service that has no `service.ports.appProtocol` defined. Valid values are:
+
+| Value        | Resulting action                                                                                       |
+|--------------|--------------------------------------------------------------------------------------------------------|
+| `http2Probe` | The telepresence traffic-agent will probe the intercepted container to check whether it supports http2 |
+| `portName`   | Telepresence will make an educated guess about the protocol based on the name of the service port      |
+| `http`       | Telepresence will use http                                                                             |
+| `http2`      | Telepresence will use http2                                                                            |
+
+When `portName` is used, Telepresence will determine the protocol by the name of the port: `<protocol>[-suffix]`. The following protocols are recognized:
+
+| Protocol | Meaning                               |
+|----------|---------------------------------------|
+| `http`   | Plaintext HTTP/1.1 traffic            |
+| `http2`  | Plaintext HTTP/2 traffic              |
+| `https`  | TLS Encrypted HTTP (1.1 or 2) traffic |
+| `grpc`   | Same as http2                         |
 
 ## Per-Cluster Configuration
 Some configuration is not global to Telepresence and is actually specific to a cluster.  Thus, we store that config information in your kubeconfig file, so that it is easier to maintain per-cluster configuration.

--- a/docs/v2.4/reference/intercepts/index.md
+++ b/docs/v2.4/reference/intercepts/index.md
@@ -68,14 +68,25 @@ your cluster; if it detects it correctly, may simply press "enter" and
 accept the default, otherwise you must tell Telepresence the correct
 value.
 
-When creating an intercept with the `http` mechanism, the
-traffic-agent sends a `GET /telepresence-http2-check` request to your
-service and to the process running on your local machine at the port
-specified in your intercept, in order to determine if they support
-HTTP/2.  This is required for the intercepts to behave correctly.  If
-you do not have a service running locally when the intercept is
-created, the traffic-agent will use the result it got from checking
-the in-cluster service.
+When creating an intercept with the `http` mechanism, Telepresence must
+determine the application protocol to use (HTTP/1.1 or HTTP/2). If the
+service's `ports.appProtocol` field is set, it will be used. If not, then
+Telepresence will use the configured [application protocol strategy](../config/#intercept)
+to determine the protocol. The default behavior (`http2Probe` strategy) is
+to send a `GET /telepresence-http2-check` request to your service in order
+to determine if it supports HTTP/2.  This is required for the intercepts to
+behave correctly.
+
+### TLS
+
+If the intercepted service expects TLS, then Telepresence must terminate the
+TLS in order to use the `http` mechanism. It is then common to also restore
+the TLS by originating it again. This is controlled using [TLS annotations](../cluster-config/#tls)
+in the workload.
+
+Use the `--http-plaintext` flag when doing an intercept when the service in the
+cluster is using TLS in case you want to use plaintext for the communication with the
+process on your local workstation. 
 
 ## Supported workloads
 

--- a/docs/v2.4/releaseNotes.yml
+++ b/docs/v2.4/releaseNotes.yml
@@ -38,6 +38,43 @@ docDescription: >-
 changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELOG.md
 
 items:
+  - version: 2.4.10
+    date: "(TBD)"
+    notes:
+      - type: feature
+        title: Application Protocol Strategy
+        body: >-
+          The strategy used when selecting the application protocol for personal intercepts can now be configured using
+          the <code>intercept.appProtocolStrategy</code> in the <code>config.yml</code> file.
+        docs: reference/config/#intercept
+      - type: feature
+        title: Helm value for the Application Protocol Strategy
+        body: >-
+          The strategy when selecting the application protocol for personal intercepts in agents injected by the
+          mutating webhook can now be configured using the <code>agentInjector.appProtocolStrategy</code> in the Helm chart.
+        docs: install/helm
+      - type: feature
+        title: New <code>--http-plaintext</code> option
+        body: >-
+          The flag <code>--http-plaintext</code> can be used to ensure that an intercept uses plaintext http or grpc when
+          communicating with the workstation process.
+        docs: reference/intercepts/#tls
+      - type: feature
+        title: Configure the default intercept port
+        body: >-
+          The port used by default in the <code>telepresence intercept</code> command (8080), can now be changed by setting
+          the <code>intercept.defaultPort</code> in the <code>config.yml</code> file.
+        docs: reference/config/#intercept
+      - type: bugfix
+        title: Check conditions before asking questions
+        body: >-
+          User will not be asked to log in or add ingress information when creating an intercept until a check has been 
+          made that the intercept is possible.
+        docs: reference/intercepts/
+      - type: bugfix
+        title: Fix invalid log statement
+        body: >-
+          Telepresence will no longer log invalid: <code>"unhandled connection control message: code DIAL_OK"</code> errors.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/pkg/client/cli/extensions/builtin.go
+++ b/pkg/client/cli/extensions/builtin.go
@@ -48,13 +48,12 @@ func builtinExtensions(ctx context.Context) map[string]ExtensionInfo {
 								`If this flag is given multiple times, then it will only intercept traffic that matches *all* of the specifiers. ` +
 								`(default "auto" if you are logged in with 'telepresence login', default "all" otherwise)`,
 						},
-						"protocol": {
-							Type: "string",
+						"plaintext": {
+							Type: "bool",
 							Usage: `` +
-								`Supported protocols are ` +
-								`"http" (Plaintext HTTP/1.1), ` +
-								`"http2" (Plaintext HTTP/2), ` +
-								`"tls" (TLS Encrypted data)`,
+								`Use plaintext format when communicating with the interceptor process on the local workstation. Only ` +
+								`meaningful when intercepting workloads annotated with "getambassador.io/inject-originating-tls-secret" ` +
+								`to prevent that TLS is used during intercepts`,
 						},
 					},
 				},


### PR DESCRIPTION
## Description

It doesn't make much sense to try and override the protocol that was
selected for communication between the traffic-agent and the container
that it acts as a sidecar for when doing an intercept. The only thing
that does make sense is to disable TLS and that only makes sense when
the "getambassador.io/inject-originating-tls-secret" is used.

This commit adds the boolean `--http-plaintext` to do just that, and
removes the `--http-protocol` that were added in a previous commit.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.