### PR TITLE
Use PR SHA for Kluster actions in GH actions

### DIFF
--- a/.github/actions/cleanup-kluster/action.yaml
+++ b/.github/actions/cleanup-kluster/action.yaml
@@ -7,6 +7,9 @@ inputs:
   token:
     description: "The kubeception token to use"
     required: true
+  github-sha:
+    description: "The sha of the PR, used for naming the kluster"
+    required: true
 outputs: {}
 runs:
   using: composite
@@ -17,4 +20,4 @@ runs:
         DEV_TELEPRESENCE_KUBECEPTION_TOKEN: ${{ inputs.token }}
       run: |
         # We don't allow the destroy to fail the build; if the kluster couldn't be destroyed now, it'll just be cleaned up when it times out
-        go run ./build-aux/kubeception destroy "tp-ci-${{ inputs.platform }}-${GITHUB_SHA}" || true
+        go run ./build-aux/kubeception destroy "tp-ci-${{ inputs.platform }}-${{ inputs.github-sha }}" || true

--- a/.github/actions/cleanup-kluster/action.yaml
+++ b/.github/actions/cleanup-kluster/action.yaml
@@ -10,6 +10,7 @@ inputs:
   github-sha:
     description: "The sha of the PR, used for naming the kluster"
     required: true
+    default: "temporary-sha"
 outputs: {}
 runs:
   using: composite

--- a/.github/actions/prepare-kluster/action.yaml
+++ b/.github/actions/prepare-kluster/action.yaml
@@ -13,6 +13,7 @@ inputs:
   github-sha:
     description: "The sha of the PR, used for naming the kluster"
     required: true
+    default: "temporary-sha"
 outputs:
   kubeconfig:
     description: "The resulting kubeconfig file"

--- a/.github/actions/prepare-kluster/action.yaml
+++ b/.github/actions/prepare-kluster/action.yaml
@@ -10,6 +10,9 @@ inputs:
   tel-image:
     description: "Path to the image to load onto the cluster"
     required: true
+  github-sha:
+    description: "The sha of the PR, used for naming the kluster"
+    required: true
 outputs:
   kubeconfig:
     description: "The resulting kubeconfig file"
@@ -23,7 +26,7 @@ runs:
       env:
         DEV_TELEPRESENCE_KUBECEPTION_TOKEN: ${{ inputs.token }}
       run: |
-        go run ./build-aux/kubeception create "tp-ci-${{ inputs.platform }}-${GITHUB_SHA}" > "$HOME/kubeconfig"
+        go run ./build-aux/kubeception create "tp-ci-${{ inputs.platform }}-${{ inputs.github-sha }}" > "$HOME/kubeconfig"
         export KUBECONFIG="$HOME/kubeconfig"
         go run ./build-aux/wait_for_cluster "$KUBECONFIG"
         if [[ "${{ inputs.platform }}" == "windows" ]]; then

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -70,6 +70,7 @@ jobs:
           platform: macos
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           tel-image: tel2-image.tar
+          github-sha: ${{ github.event.pull_request.head.sha }}
         id: kluster
       - name: Run tests
         if: steps.get_last_run.outputs.passed != 'success'
@@ -90,6 +91,7 @@ jobs:
         with:
           platform: macos
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
+          github-sha: ${{ github.event.pull_request.head.sha }}
         if: always()
 
   "windows_test":
@@ -149,6 +151,7 @@ jobs:
           platform: windows
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           tel-image: tel2-image.tar
+          github-sha: ${{ github.event.pull_request.head.sha }}
         id: kluster
       - run: |
           # We want to validate that tests still pass, even if the metrics host
@@ -175,6 +178,7 @@ jobs:
         with:
           platform: windows
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
+          github-sha: ${{ github.event.pull_request.head.sha }}
         if: always()
   "linux_test":
     runs-on: ubuntu-latest
@@ -216,6 +220,7 @@ jobs:
           platform: linux
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           tel-image: tel2-image.tar
+          github-sha: ${{ github.event.pull_request.head.sha }}
         id: kluster
       - name: Run tests
         if: steps.get_last_run.outputs.passed != 'success'
@@ -236,4 +241,5 @@ jobs:
         with:
           platform: linux
           token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
+          github-sha: ${{ github.event.pull_request.head.sha }}
         if: always()


### PR DESCRIPTION
There was a bug where we were using the GITHUB_SHA which is always going
to use the value of release/v2 since we use pull_request_target. This
means if tests run at the same time they will acquire the same
kubeception cluster which will lead to collisions.

Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
