### PR TITLE
Removing github-sha defaults in kluster actions

### DIFF
--- a/.github/actions/cleanup-kluster/action.yaml
+++ b/.github/actions/cleanup-kluster/action.yaml
@@ -10,7 +10,6 @@ inputs:
   github-sha:
     description: "The sha of the PR, used for naming the kluster"
     required: true
-    default: "temporary-sha"
 outputs: {}
 runs:
   using: composite

--- a/.github/actions/prepare-kluster/action.yaml
+++ b/.github/actions/prepare-kluster/action.yaml
@@ -13,7 +13,6 @@ inputs:
   github-sha:
     description: "The sha of the PR, used for naming the kluster"
     required: true
-    default: "temporary-sha"
 outputs:
   kubeconfig:
     description: "The resulting kubeconfig file"


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Removing the default parameter in the kluster actions

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
