### PR TITLE
Ensure that DPipe stderr is logged as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Bugfix: User will not be asked to log in or add ingress information when creating an intercept until a check has been 
   made that the intercept is possible.
 
+- Bugfix: Output to `stderr` from the traffic-agent's `sftp` and the client's `sshfs` processes are properly logged as errors.
+
 ### 2.4.9 (December 9, 2021)
 
 - Bugfix: Fixed an error where access tokens were not refreshed if you login

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -83,6 +83,11 @@ items:
         title: Fix invalid log statement
         body: >-
           Telepresence will no longer log invalid: <code>"unhandled connection control message: code DIAL_OK"</code> errors.
+      - type: bugfix
+        title: Log errors from sshfs/sftp
+        body: >-
+          Output to <code>stderr</code> from the traffic-agent's <code>sftp</code> and the client's <code>sshfs</code> processes
+          are properly logged as errors.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/docs/v2.4/releaseNotes.yml
+++ b/docs/v2.4/releaseNotes.yml
@@ -83,6 +83,11 @@ items:
         title: Fix invalid log statement
         body: >-
           Telepresence will no longer log invalid: <code>"unhandled connection control message: code DIAL_OK"</code> errors.
+      - type: bugfix
+        title: Log errors from sshfs/sftp
+        body: >-
+          Output to <code>stderr</code> from the traffic-agent's <code>sftp</code> and the client's <code>sshfs</code> processes
+          are properly logged as errors.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/pkg/dpipe/dpipe.go
+++ b/pkg/dpipe/dpipe.go
@@ -18,7 +18,7 @@ func DPipe(ctx context.Context, peer io.ReadWriteCloser, cmdName string, cmdArgs
 	cmd := dexec.CommandContext(ctx, cmdName, cmdArgs...)
 	cmd.Stdin = peer
 	cmd.Stdout = peer
-	cmd.Stderr = io.Discard   // Ensure error logging by passing a non nil, non *os.File here
+	cmd.Stderr = dlog.StdLogger(ctx, dlog.LogLevelError).Writer()
 	cmd.DisableLogging = true // Avoid data logging (peer is not a *os.File)
 
 	cmdLine := shellquote.ShellString(cmd.Path, cmd.Args)

--- a/pkg/dpipe/dpipe_test.go
+++ b/pkg/dpipe/dpipe_test.go
@@ -1,0 +1,65 @@
+package dpipe
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/datawire/dlib/dlog"
+)
+
+var echoBinary string
+
+func TestMain(m *testing.M) {
+	ebf, err := os.CreateTemp("", "echo")
+	if err != nil {
+		panic(err)
+	}
+	echoBinary = ebf.Name()
+	ebf.Close()
+	if err = exec.Command("go", "build", "-o", echoBinary, "./testdata/echo").Run(); err != nil {
+		panic(err)
+	}
+	defer os.Remove(echoBinary)
+	m.Run()
+}
+
+type bufClose struct {
+	bytes.Buffer
+}
+
+func (b *bufClose) Close() error {
+	return nil
+}
+
+func makeLoggerOn(bf *bytes.Buffer) context.Context {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	logger.SetOutput(bf)
+	return dlog.WithLogger(context.Background(), dlog.WrapLogrus(logger))
+}
+
+// Test that stdout of a process executed by DPipe is sent to peer
+func TestDPipe_stdout(t *testing.T) {
+	log := &bytes.Buffer{}
+	ctx := makeLoggerOn(log)
+	peer := &bufClose{}
+	assert.NoError(t, DPipe(ctx, peer, echoBinary, "-d", "1", "hello stdout"))
+	assert.Empty(t, log)
+	assert.Equal(t, peer.String(), "hello stdout\n")
+}
+
+// Test that stderr of a process executed by DPipe is logged as errors
+func TestDPipe_stderr(t *testing.T) {
+	log := &bytes.Buffer{}
+	ctx := makeLoggerOn(log)
+	peer := &bufClose{}
+	assert.NoError(t, DPipe(ctx, peer, echoBinary, "-d", "2", "hello stderr"))
+	assert.Contains(t, log.String(), `level=error msg="hello stderr"`)
+	assert.Empty(t, peer)
+}

--- a/pkg/dpipe/dpipe_test.go
+++ b/pkg/dpipe/dpipe_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -21,6 +22,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	echoBinary = ebf.Name()
+	if runtime.GOOS == "windows" {
+		echoBinary += ".exe"
+	}
 	ebf.Close()
 	if err = exec.Command("go", "build", "-o", echoBinary, "./testdata/echo").Run(); err != nil {
 		panic(err)

--- a/pkg/dpipe/testdata/echo/echo.go
+++ b/pkg/dpipe/testdata/echo/echo.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var dest string
+	flag.StringVar(&dest, "d", "1", "Destination of output. Legal values are 1 (stdout), 2 (stderr) or a file name")
+	flag.Parse()
+
+	var out *os.File
+	switch dest {
+	case "1":
+		out = os.Stdout
+	case "2":
+		out = os.Stderr
+	default:
+		var err error
+		if out, err = os.Create(dest); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+		defer out.Close()
+	}
+	for _, s := range flag.Args() {
+		fmt.Fprintln(out, s)
+	}
+}


### PR DESCRIPTION
## Description

The `DPipe` function (currently only used when mounting remote file
systems using `sftp`/`sshfs`) squelched all output to `stderr`. This
commit ensures that errors are properly logged.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
