### PR TITLE
Don't use backslash in container mount paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 - Bugfix: Output to `stderr` from the traffic-agent's `sftp` and the client's `sshfs` processes are properly logged as errors.
 
+- Bugfix: Auto installer will no longer not emit backslash separators for the `/tel-app-mounts` paths in the
+  traffic-agent container spec when running on Windows
+
 ### 2.4.9 (December 9, 2021)
 
 - Bugfix: Fixed an error where access tokens were not refreshed if you login

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -88,6 +88,11 @@ items:
         body: >-
           Output to <code>stderr</code> from the traffic-agent's <code>sftp</code> and the client's <code>sshfs</code> processes
           are properly logged as errors.
+      - type: bugfix
+        title: Don't use Windows path separators in workload pod template
+        body: >-
+          Auto installer will no longer not emit backslash separators for the <code>/tel-app-mounts</code> paths in the
+          traffic-agent container spec when running on Windows.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/docs/v2.4/releaseNotes.yml
+++ b/docs/v2.4/releaseNotes.yml
@@ -88,6 +88,11 @@ items:
         body: >-
           Output to <code>stderr</code> from the traffic-agent's <code>sftp</code> and the client's <code>sshfs</code> processes
           are properly logged as errors.
+      - type: bugfix
+        title: Don't use Windows path separators in workload pod template
+        body: >-
+          Auto installer will no longer not emit backslash separators for the <code>/tel-app-mounts</code> paths in the
+          traffic-agent container spec when running on Windows.
   - version: 2.4.9
     date: "2021-12-09"
     notes:

--- a/pkg/install/container.go
+++ b/pkg/install/container.go
@@ -1,7 +1,6 @@
 package install
 
 import (
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -164,7 +163,8 @@ func agentVolumeMounts(mounts []corev1.VolumeMount) []corev1.VolumeMount {
 	for i, mount := range mounts {
 		// Keep the ServiceAccount mount unaltered or a new one will be generated
 		if !strings.HasPrefix(mount.MountPath, "/var/run/secrets") {
-			mount.MountPath = filepath.Join(TelAppMountPoint, mount.MountPath)
+			// Don't use filepath.Join here. The target is never windows
+			mount.MountPath = TelAppMountPoint + "/" + strings.TrimPrefix(mount.MountPath, "/")
 		}
 		agentMounts[i] = mount
 	}


### PR DESCRIPTION
## Description

The auto installer used `filepath.Join` to create a volume mount
path which resulted in bad paths when running it on a Windows box.

A few sentences describing the overall goals of the pull request's commits.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
