### PR TITLE
Generate arm64 linux executables on all releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,20 @@ jobs:
           name: Docker login
           command: |
             docker login -u="${DOCKERHUB_USERNAME}" -p="${DOCKERHUB_PASSWORD}"
-      - run: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-images push-executable
-      - run: |
-          [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG make promote-to-stable
+      - run:
+          name: "Publish linux (arch amd64)"
+          command: TELEPRESENCE_VERSION=$CIRCLE_TAG GOARCH=amd64 make push-images push-executable
+      - run:
+          name: "Publish linux (arch arm64)"
+          command: TELEPRESENCE_VERSION=$CIRCLE_TAG GOARCH=arm64 make push-executable
+      - run:
+          name: "Promote linux (arch amd64)"
+          command: |
+            [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG GOARCH=amd64 make promote-to-stable
+      - run:
+          name: "Promote linux (arch arm64)"
+          command: |
+            [[ $CIRCLE_TAG == *-* ]] || TELEPRESENCE_VERSION=$CIRCLE_TAG GOARCH=arm64 make promote-to-stable
 
   "release-macos":
     executor: vm-macos
@@ -136,15 +147,25 @@ jobs:
         command: |
           docker login -u="${DOCKERHUB_USERNAME}" -p="${DOCKERHUB_PASSWORD}"
     - run:
-        name: "Publish nightly linux"
+        name: "Publish nightly linux (arch amd64)"
         command: |
           newTag=$(go run ./build-aux/genversion nightly)
-          TELEPRESENCE_VERSION=$newTag make push-images push-executable
-          TELEPRESENCE_VERSION=$newTag make promote-nightly
+          TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make push-images push-executable
+          TELEPRESENCE_VERSION=$newTag GOARCH=amd64 make promote-nightly
     - store_artifacts:
         name: "Store nightly artifacts"
         path: build-output/
-        destination: nightly-linux-artifacts
+        destination: nightly-linux-amd64-artifacts
+    - run:
+        name: "Publish nightly linux (arch arm64)"
+        command: |
+          newTag=$(go run ./build-aux/genversion nightly)
+          TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make push-executable
+          TELEPRESENCE_VERSION=$newTag GOARCH=arm64 make promote-nightly
+    - store_artifacts:
+        name: "Store nightly artifacts"
+        path: build-output/
+        destination: nightly-linux-arm64-artifacts
 
   "publish-nightly-windows":
     executor:


### PR DESCRIPTION
## Description

This PRs changes the CircleCI spec to also generate linux/arm64 binaries for the `telepresence` executable. This is similar to what was done to generate arm64 binaries for macOS.

Having linux/arm64 binaries is useful for running telepresence natively on arm64 machines and also for running it inside arm64 linux VMs on a M1 mac.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
