### PR TITLE
Issue 2329 namespaced deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Change: The global networking flags are no longer global. Using them will render a deprecation warning unless they are supported by the command.
   The subcommands that support networking flags are `connect`, `current-cluster-id`, and `genyaml`. 
 
+- Bugfix: Allow traffic-manager release name to be anything when `managerRbac.namespaced`
+
 ### 2.4.10 (January 13, 2022)
 
 - Feature: The flag `--http-plaintext` can be used to ensure that an intercept uses plaintext http or grpc when 

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -10,7 +10,8 @@ Expand the name of the chart.
 {{- if .Values.isCI }}
 {{- print $name }}
 {{- else }}
-{{- if ne $name .Release.Name }}
+{{- if .Values.managerRbac.namespaced }}
+{{- else if ne $name .Release.Name }}
 {{- fail "The name of the release MUST BE traffic-manager" }}
 {{- end }}
 {{- printf "%s" .Release.Name }}


### PR DESCRIPTION
## Description

Allows traffic-manager release name to be anything when `managerRbac.namespaced`

Fix: https://github.com/telepresenceio/telepresence/issues/2329

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
