### PR TITLE
Allow device dash in device name when parsing output from "ip route get"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Change: The global networking flags are no longer global. Using them will render a deprecation warning unless they are supported by the command.
   The subcommands that support networking flags are `connect`, `current-cluster-id`, and `genyaml`. 
 
+- Bugfix: Telepresence will now parse device names containing dashes correctly when determining routes that it should never block.
+
 ### 2.4.10 (January 13, 2022)
 
 - Feature: The flag `--http-plaintext` can be used to ensure that an intercept uses plaintext http or grpc when 

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -89,9 +89,13 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 	itest.TelepresenceOk(ctx, "connect")
 	defer itest.TelepresenceQuitOk(ctx)
 
-	stdout := itest.TelepresenceOk(ctx, "status")
 	// The cluster's IP address will also be never proxied, so we gotta account for that.
-	require.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", len(ips)+1))
+	neverProxiedCount := len(ips) + 1
+	s.Eventually(func() bool {
+		stdout := itest.TelepresenceOk(ctx, "status")
+		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount))
+	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
+
 	s.Eventually(func() bool {
 		return itest.Run(ctx, "curl", "--silent", "--max-time", "0.5", ip) != nil
 	}, 15*time.Second, 2*time.Second, fmt.Sprintf("never-proxied IP %s is reachable", ip))

--- a/pkg/vif/routing/routing_linux.go
+++ b/pkg/vif/routing/routing_linux.go
@@ -14,7 +14,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
-const findInterfaceRegex = "[0-9.]+( via (?P<gw>[0-9.]+))? dev (?P<dev>[a-z0-9]+) src (?P<src>[0-9.]+)"
+const findInterfaceRegex = "^[0-9.]+( via (?P<gw>[0-9.]+))? dev (?P<dev>[a-z0-9-]+) src (?P<src>[0-9.]+)"
 
 var (
 	findInterfaceRe = regexp.MustCompile(findInterfaceRegex)


### PR DESCRIPTION
## Description

Telepresence was not capable of parsing the output from `ip route get`
when it contained device names like "br-88ebaed94912". Such devices will
show up when using minikube with the docker driver on a Linux box.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
