### PR TITLE
Ensure session synchronization handles premature cancel correctly

### DIFF
--- a/pkg/client/userd/grpc.go
+++ b/pkg/client/userd/grpc.go
@@ -74,20 +74,13 @@ func (s *service) Version(_ context.Context, _ *empty.Empty) (*common.VersionInf
 
 func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *rpc.ConnectInfo, err error) {
 	s.logCall(ctx, "Connect", func(c context.Context) {
-		s.sessionLock.RLock()
-		if s.session != nil {
-			result = s.session.UpdateStatus(s.sessionContext, cr)
-			s.sessionLock.RUnlock()
-			return
-		}
-		s.sessionLock.RUnlock()
-
 		select {
 		case <-ctx.Done():
 			err = status.Error(codes.Unavailable, ctx.Err().Error())
 			return
 		case s.connectRequest <- cr:
 		}
+
 		select {
 		case <-ctx.Done():
 			err = status.Error(codes.Unavailable, ctx.Err().Error())
@@ -99,12 +92,7 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 
 func (s *service) Disconnect(c context.Context, _ *empty.Empty) (*empty.Empty, error) {
 	s.logCall(c, "Disconnect", func(c context.Context) {
-		s.sessionLock.RLock()
-		defer s.sessionLock.RUnlock()
-		if s.session != nil {
-			s.session = nil
-			s.sessionCancel()
-		}
+		s.cancelSession()
 	})
 	return &empty.Empty{}, nil
 }

--- a/pkg/client/userd/service.go
+++ b/pkg/client/userd/service.go
@@ -138,42 +138,63 @@ func (s *service) manageSessions(c context.Context, sessionServices []trafficmgr
 	c, s.quit = context.WithCancel(c)
 	for {
 		// Wait for a connection request
-		var oi *rpc.ConnectRequest
+		var cr *rpc.ConnectRequest
 		select {
 		case <-c.Done():
 			return nil
-		case oi = <-s.connectRequest:
+		case cr = <-s.connectRequest:
 		}
 
-		// Respond by setting the session and returning the error (or nil
-		// if everything is ok)
-		s.sessionLock.Lock() // Locked until Run
+		var session trafficmgr.Session
 		var rsp *rpc.ConnectInfo
-		s.session, rsp = trafficmgr.NewSession(c, s.scout, oi, s, sessionServices)
+
+		s.sessionLock.Lock() // Locked during creation
+		if s.session != nil {
+			// UpdateStatus sets rpc.ConnectInfo_ALREADY_CONNECTED if successful
+			rsp = s.session.UpdateStatus(s.sessionContext, cr)
+		} else {
+			sCtx, sCancel := context.WithCancel(c)
+			session, rsp = trafficmgr.NewSession(sCtx, s.scout, cr, s, sessionServices)
+			if sCtx.Err() == nil && rsp.Error == rpc.ConnectInfo_UNSPECIFIED {
+				s.sessionContext = session.WithK8sInterface(sCtx)
+				s.sessionCancel = sCancel
+				s.session = session
+			} else {
+				sCancel()
+			}
+		}
+		s.sessionLock.Unlock()
+
 		select {
 		case <-c.Done():
-			s.sessionLock.Unlock()
 			return nil
 		case s.connectResponse <- rsp:
+		default:
+			// Nobody there to read the response? That's fine. The user may have got
+			// impatient.
+			s.cancelSession()
+			continue
 		}
 		if rsp.Error != rpc.ConnectInfo_UNSPECIFIED {
-			s.session = nil
-			s.sessionLock.Unlock()
 			continue
 		}
 
-		// Run the session synchronously and ensure that it is cleaned
-		// up properly when the context is cancelled
-		func(c context.Context) {
-			// The d.session.Cancel is called from Disconnect
-			c, s.sessionCancel = context.WithCancel(c)
-			c = s.session.WithK8sInterface(c)
-			s.sessionContext = c
-			s.sessionLock.Unlock()
-			if err := s.session.Run(c); err != nil {
+		// Run the session asynchronously. We must be able to respond to connect (with UpdateStatus) while
+		// the session is running. The s.sessionCancel is called from Disconnect
+		go func() {
+			if err := s.session.Run(s.sessionContext); err != nil {
 				dlog.Error(c, err)
 			}
-		}(c)
+		}()
+	}
+}
+
+func (s *service) cancelSession() {
+	s.sessionLock.Lock()
+	defer s.sessionLock.Unlock()
+	if s.session != nil {
+		s.session = nil
+		s.sessionCancel()
 	}
 }
 


### PR DESCRIPTION
A long-running connect, such as failing create the traffic-manager,
that was interrupted by `<ctrl>-c`, resulted in a hanging user daemon
because the `sessionLock` never got unlocked before checking for
`c.Done()` which never arrived because all other calls using the
`sessionLock` was blocked (including `Quit`). This commit ensures that
the `sessionLock` cannot block context cancellation.