### PR TITLE
Add the clusterDomain as a "domain" instead of as a "searchPath"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 - Bugfix: Telepresence will now parse device names containing dashes correctly when determining routes that it should never block.
 
+- Bugfix: The cluster domain (typically "cluster.local") is no longer added to the DNS `search` on Linux using `systemd-resolved`. Instead,
+  it is added as a `domain` so that names ending with it are routed to the DNS server.
+
 ### 2.4.10 (January 13, 2022)
 
 - Feature: The flag `--http-plaintext` can be used to ensure that an intercept uses plaintext http or grpc when 

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -114,7 +114,7 @@ func (s *Server) updateLinkDomains(c context.Context, paths []string, dev *vif.D
 	for _, sfx := range s.config.IncludeSuffixes {
 		paths = append(paths, "~"+strings.TrimPrefix(sfx, "."))
 	}
-	paths = append(paths, s.clusterDomain)
+	paths = append(paths, "~"+s.clusterDomain)
 	namespaces[tel2SubDomain] = struct{}{}
 
 	s.domainsLock.Lock()


### PR DESCRIPTION
## Description

The DNS "search" should be used to resolve intercepted namespaces only.
There's no need to add the `clusterDomain` to that path for the
`systemd-resolved` resolver. Instead, it is added as a "domain" so that
names ending with it are routed to the DNS server.

A few sentences describing the overall goals of the pull request's commits.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
