### PR TITLE
Remove --preserve-env from the sudo call that starts the root daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Change: The global networking flags are no longer global. Using them will render a deprecation warning unless they are supported by the command.
   The subcommands that support networking flags are `connect`, `current-cluster-id`, and `genyaml`. 
 
+- Bugfix: The also-proxy and never-proxy subnets are now displayed correctly when using the `telepresence status` command
+
 - Bugfix: Telepresence will now parse device names containing dashes correctly when determining routes that it should never block.
 
 - Bugfix: The cluster domain (typically "cluster.local") is no longer added to the DNS `search` on Linux using `systemd-resolved`. Instead,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Bugfix: The also-proxy and never-proxy subnets are now displayed correctly when using the `telepresence status` command
 
+- Bugfix: Telepresence will no longer require `SETENV` privileges when starting the root daemon.
+
 - Bugfix: Telepresence will now parse device names containing dashes correctly when determining routes that it should never block.
 
 - Bugfix: The cluster domain (typically "cluster.local") is no longer added to the DNS `search` on Linux using `systemd-resolved`. Instead,

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -67,8 +67,11 @@ func daemonStatus(cmd *cobra.Command) error {
 			fmt.Fprintf(out, "    Include suffixes: %v\n", dns.IncludeSuffixes)
 			fmt.Fprintf(out, "    Timeout         : %v\n", dns.LookupTimeout.AsDuration())
 			fmt.Fprintf(out, "  Also Proxy : (%d subnets)\n", len(obc.AlsoProxySubnets))
-			fmt.Fprintf(out, "  Never Proxy: (%d subnets)\n", len(obc.NeverProxySubnets))
 			for _, subnet := range obc.AlsoProxySubnets {
+				fmt.Fprintf(out, "    - %s\n", iputil.IPNetFromRPC(subnet))
+			}
+			fmt.Fprintf(out, "  Never Proxy: (%d subnets)\n", len(obc.NeverProxySubnets))
+			for _, subnet := range obc.NeverProxySubnets {
 				fmt.Fprintf(out, "    - %s\n", iputil.IPNetFromRPC(subnet))
 			}
 		}

--- a/pkg/proc/exec_unix.go
+++ b/pkg/proc/exec_unix.go
@@ -71,7 +71,7 @@ func startInBackgroundAsRoot(ctx context.Context, args ...string) error {
 				return err
 			}
 		}
-		args = append([]string{"sudo", "--non-interactive", "--preserve-env"}, args...)
+		args = append([]string{"sudo", "--non-interactive"}, args...)
 	}
 
 	return startInBackground(args...)


### PR DESCRIPTION
The root daemon does not need a preserved environment. The log and
config directories are explicitly passed as arguments.

Partial fix for #2314
