### PR TITLE
Fix TCP throttling issue

### DIFF
--- a/pkg/vif/tcp/tmgr.go
+++ b/pkg/vif/tcp/tmgr.go
@@ -44,11 +44,11 @@ func (h *handler) sendToMgr(ctx context.Context, pkt Packet) bool {
 
 func (h *handler) adjustReceiveWindow() {
 	// Adjust window size based on current queue sizes.
-	queueFactor := ioChannelSize - (len(h.toMgrCh) + len(h.fromTun))
+	queueFactor := 2*ioChannelSize - (len(h.toMgrCh) + len(h.fromTun))
 	windowSize := 0
 	if queueFactor > 0 {
 		// Make window size dependent on the number o element on the queue
-		windowSize = queueFactor * (maxReceiveWindow / ioChannelSize)
+		windowSize = queueFactor * (maxReceiveWindow / (2 * ioChannelSize))
 
 		// Strip the last 8 bits so that we don't change so often
 		windowSize &^= 0xff


### PR DESCRIPTION
The sum of the channel lengths used when computing the TCP window size
was sometimes greater than the `ioChannelSize`, causing a negative
`queueFactor` when the queues were more than half full and hence no
change in window size took place, which resulted in packet loss.
