### PR TITLE
Use plain os/exec Cmd for the DPipe

### DIFF
--- a/pkg/dpipe/dpipe.go
+++ b/pkg/dpipe/dpipe.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/datawire/dlib/dexec"
+	//nolint:depguard // We want no logging and no soft-context signal handling
+	"os/exec"
+
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
 )
@@ -15,18 +17,17 @@ func DPipe(ctx context.Context, peer io.ReadWriteCloser, cmdName string, cmdArgs
 		_ = peer.Close()
 	}()
 
-	cmd := dexec.CommandContext(ctx, cmdName, cmdArgs...)
+	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
 	cmd.Stdin = peer
 	cmd.Stdout = peer
 	cmd.Stderr = dlog.StdLogger(ctx, dlog.LogLevelError).Writer()
-	cmd.DisableLogging = true // Avoid data logging (peer is not a *os.File)
 
 	cmdLine := shellquote.ShellString(cmd.Path, cmd.Args)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start %s: %w", cmdLine, err)
 	}
 
-	ctx = dlog.WithField(ctx, "dexec.pid", cmd.Process.Pid)
+	ctx = dlog.WithField(ctx, "exec.pid", cmd.Process.Pid)
 	dlog.Infof(ctx, "started command %s", cmdLine)
 	defer dlog.Infof(ctx, "ended command %s", cmdName)
 	runFinished := make(chan error)

--- a/pkg/dpipe/dpipe_test.go
+++ b/pkg/dpipe/dpipe_test.go
@@ -60,7 +60,7 @@ func TestDPipe_stdout(t *testing.T) {
 	peer := &bufClose{}
 	assert.NoError(t, DPipe(ctx, peer, echoBinary, "-d", "1", "hello stdout"))
 	assert.Empty(t, log)
-	assert.Equal(t, peer.String(), "hello stdout\n")
+	assert.Equal(t, "hello stdout\n", peer.String())
 }
 
 // Test that stderr of a process executed by DPipe is logged as errors
@@ -70,5 +70,5 @@ func TestDPipe_stderr(t *testing.T) {
 	peer := &bufClose{}
 	assert.NoError(t, DPipe(ctx, peer, echoBinary, "-d", "2", "hello stderr"))
 	assert.Contains(t, log.String(), `level=error msg="hello stderr"`)
-	assert.Empty(t, peer)
+	assert.Empty(t, peer.String())
 }

--- a/pkg/dpipe/dpipe_unix.go
+++ b/pkg/dpipe/dpipe_unix.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/sys/unix"
+	//nolint:depguard // We want no logging and no soft-context signal handling
+	"os/exec"
 
-	"github.com/datawire/dlib/dexec"
+	"golang.org/x/sys/unix"
 )
 
-func killProcess(_ context.Context, cmd *dexec.Cmd) {
+func killProcess(_ context.Context, cmd *exec.Cmd) {
 	// A process is sometimes not terminated gracefully by the SIGTERM, so we give
 	// it a second to succeed and then kill it forcefully.
 	time.AfterFunc(time.Second, func() {

--- a/pkg/dpipe/dpipe_windows.go
+++ b/pkg/dpipe/dpipe_windows.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"unsafe"
 
+	//nolint:depguard // We want no logging and no soft-context signal handling
+	"os/exec"
+
 	"golang.org/x/sys/windows"
 
-	"github.com/datawire/dlib/dexec"
 	"github.com/datawire/dlib/dlog"
 )
 
@@ -20,7 +22,7 @@ type processInfo struct {
 	exe  string
 }
 
-func killProcess(ctx context.Context, cmd *dexec.Cmd) {
+func killProcess(ctx context.Context, cmd *exec.Cmd) {
 	pes := make([]*processInfo, 0, 100)
 	err := eachProcess(func(pe *windows.ProcessEntry32) bool {
 		pes = append(pes, &processInfo{


### PR DESCRIPTION
No logging nor soft-context signal handling is desired for the `Cmd`
used by `DPipe`

Perhaps this will help getting rid of the intermittent and inexplicable dpipe_test failures?