### PR TITLE
Try preview provider using SNI relay.

### DIFF
--- a/.github/actions/prepare-kluster/action.yaml
+++ b/.github/actions/prepare-kluster/action.yaml
@@ -40,7 +40,7 @@ runs:
       run: |
         export KUBECONFIG="$HOME/kubeconfig"
         kubectl apply -f build-aux/image-importer.yaml
+        kubectl rollout status -w deployment/image-importer
         POD_NAME=$(kubectl get pod -ojsonpath='{.items[0].metadata.name}' -l app=image-importer)
-        kubectl wait --for=condition=ready pod $POD_NAME
         kubectl cp "${{ inputs.tel-image }}" "$POD_NAME:/tmp/image.tar"
         kubectl exec $POD_NAME -- //hostbin/ctr images import //tmp/image.tar

--- a/build-aux/kubeception/main.go
+++ b/build-aux/kubeception/main.go
@@ -60,10 +60,11 @@ func run() error {
 			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			kubeconfig, err := kubeceptionRequest(ctx, cli, "PUT", token, clusterName, map[string]string{
-				"wait":        "true",
-				"timeoutSecs": "7200",
-				"version":     "1.19",
-				"provider":    "production"})
+				"wait":           "true",
+				"timeoutSecs":    "7200",
+				"version":        "1.19",
+				"provider":       "preview",
+				"enableSNIRelay": "true"})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

This PR enables the kubeception preview provider along with the SNI relay feature flag. Previously the preview provider would not work with the telepresence test suite due to intermittent "404 NR"s that were introduced by the proxies in front of the API server. The SNI relay feature flag enables a fix for this problem by routing connections directly to the API server using SNI.

I'd like to get broader telepresence CI usage of the preview provider (with the SNI relay feature flag enabled) because (a) it should be faster and more reliable than the legacy provider at this point and (b) once this has proven stable enough for the whole team to depend on, I can promote the preview provider to production and retire the legacy provider.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
