### PR TITLE
Fix problems with rotating log file on Windows

### DIFF
--- a/pkg/client/logging/initcontext_test.go
+++ b/pkg/client/logging/initcontext_test.go
@@ -162,6 +162,55 @@ func TestInitContext(t *testing.T) {
 		check.Contains(string(bs), fmt.Sprintf("%s info    %s\n", infoTs, infoMsg))
 	})
 
+	t.Run("birthtime updates after rotate", func(t *testing.T) {
+		ctx, _, _ := testSetup(t)
+		check := require.New(t)
+
+		c, err := InitContext(ctx, logName, NewRotateOnce())
+		loggerForTest.AddHook(&dtimeHook{})
+		check.NoError(err)
+		check.NotNil(c)
+		dlog.Info(c, "info message")
+		bt1 := loggerForTest.Out.(*RotatingFile).birthTime
+		closeLog(t)
+
+		c, err = InitContext(ctx, logName, NewRotateOnce())
+		loggerForTest.AddHook(&dtimeHook{})
+		check.NoError(err)
+		check.NotNil(c)
+		dlog.Info(c, "info message")
+		bt2 := loggerForTest.Out.(*RotatingFile).birthTime
+		closeLog(t)
+		check.Equal(bt1, bt2)
+	})
+
+	t.Run("next session appends when no rotate", func(t *testing.T) {
+		ctx, _, logFile := testSetup(t)
+		check := require.New(t)
+
+		c, err := InitContext(ctx, logName, RotateNever)
+		loggerForTest.AddHook(&dtimeHook{})
+		check.NoError(err)
+		check.NotNil(c)
+		infoMsg1 := "info message 1"
+		dlog.Info(c, infoMsg1)
+		closeLog(t)
+
+		c, err = InitContext(ctx, logName, RotateNever)
+		loggerForTest.AddHook(&dtimeHook{})
+		check.NoError(err)
+		check.NotNil(c)
+		infoMsg2 := "info message 2"
+		dlog.Info(c, infoMsg2)
+		closeLog(t)
+
+		bs, err := os.ReadFile(logFile)
+		check.NoError(err)
+		infoTs := dtime.Now().Format("2006-01-02 15:04:05.0000")
+		check.Contains(string(bs), fmt.Sprintf("%s info    %s\n", infoTs, infoMsg1))
+		check.Contains(string(bs), fmt.Sprintf("%s info    %s\n", infoTs, infoMsg2))
+	})
+
 	t.Run("old files are removed", func(t *testing.T) {
 		ctx, logDir, _ := testSetup(t)
 		check := require.New(t)

--- a/pkg/client/logging/rotatingfile_unix.go
+++ b/pkg/client/logging/rotatingfile_unix.go
@@ -4,20 +4,14 @@
 package logging
 
 import (
-	"io/fs"
-	"os"
+	"time"
 
 	"golang.org/x/term"
 )
 
-// createFile creates a new file or truncates an existing file.
-func createFile(fullPath string, perm fs.FileMode) (*os.File, error) {
-	return os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
-}
-
-// openForAppend opens a file for append or creates it if it doesn't exist.
-func openForAppend(logfilePath string, perm fs.FileMode) (*os.File, error) {
-	return os.OpenFile(logfilePath, os.O_WRONLY|os.O_APPEND, perm)
+// restoreCTimeAfterRename is a noop on unixes since the renamed file retains the creation time of the source.
+func restoreCTimeAfterRename(_ string, _ time.Time) error {
+	return nil
 }
 
 // IsTerminal returns whether the given file descriptor is a terminal

--- a/pkg/client/logging/rotatingfile_windows.go
+++ b/pkg/client/logging/rotatingfile_windows.go
@@ -1,56 +1,31 @@
 package logging
 
 import (
-	"io/fs"
-	"os"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
 
-// createFile creates a new file or truncates an existing file. The
-// file is opened in a way that makes it possible to rename it without
-// first closing it.
-func createFile(path string, _ fs.FileMode) (*os.File, error) {
-	uPath, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return nil, err
-	}
-	// The FILE_SHARE_xxx flags are needed to make it possible to rename a file
-	// while its still in use by a process.
-	h, err := windows.CreateFile(uPath,
-		windows.GENERIC_READ|windows.GENERIC_WRITE,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
-		nil,
-		windows.CREATE_ALWAYS,
-		windows.FILE_ATTRIBUTE_NORMAL, 0)
-	if err != nil {
-		return nil, err
-	}
-	return os.NewFile(uintptr(h), path), nil
-}
-
-// openForAppend opens a file for append or creates it if it doesn't exist. The
-// file is opened in a way that makes it possible to rename it without first closing it.
-func openForAppend(path string, _ fs.FileMode) (*os.File, error) {
-	uPath, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return nil, err
-	}
-	// The FILE_SHARE_xxx flags are needed to make it possible to rename a file
-	// while its still in use by a process.
-	h, err := windows.CreateFile(uPath,
-		windows.GENERIC_READ|windows.GENERIC_WRITE,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
-		nil,
-		windows.OPEN_ALWAYS,
-		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_WRITE_THROUGH, 0)
-	if err != nil {
-		return nil, err
-	}
-	return os.NewFile(uintptr(h), path), nil
-}
-
 // IsTerminal returns whether the given file descriptor is a terminal
 var IsTerminal = func(fd int) bool {
 	return false
+}
+
+// restoreCTimeAfterRename will restore the creation time on a file on Windows where
+// the file otherwise gets the creation time of the existing file that the operation
+// overwrites.
+func restoreCTimeAfterRename(path string, ctime time.Time) error {
+	p16, e := windows.UTF16PtrFromString(path)
+	if e != nil {
+		return e
+	}
+	h, e := windows.CreateFile(p16,
+		windows.FILE_WRITE_ATTRIBUTES, windows.FILE_SHARE_WRITE, nil,
+		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if e != nil {
+		return e
+	}
+	defer windows.Close(h)
+	c := windows.NsecToFiletime(ctime.UnixNano())
+	return windows.SetFileTime(h, &c, nil, nil)
 }


### PR DESCRIPTION
The RotatingFile on Windows was flawed. It didn't append when not
rotating and it would always rotate when using daily rotation because
the creation time of the file never changed (when renaming a file in
Windows, the source file receives the timestamp of the file that gets
overridden, go figure).

These problems only became visible because we're now using
long-running daemons, so no user has been exposed to them yet.