### PR TITLE
Throw away repeated SYN packages during connect

### DIFF
--- a/build-aux/kubeception/main.go
+++ b/build-aux/kubeception/main.go
@@ -57,7 +57,7 @@ func run() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		err := client.Retry(ctx, "kubeception", func(ctx context.Context) error {
-			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 			defer cancel()
 			kubeconfig, err := kubeceptionRequest(ctx, cli, "PUT", token, clusterName, map[string]string{
 				"wait":           "true",
@@ -70,7 +70,7 @@ func run() error {
 			}
 			fmt.Println(kubeconfig)
 			return nil
-		}, 2*time.Second, 10*time.Second)
+		}, 10*time.Second, 10*time.Second)
 		if err != nil {
 			return err
 		}

--- a/pkg/client/rootd/router.go
+++ b/pkg/client/rootd/router.go
@@ -191,7 +191,10 @@ func (s *session) tcp(c context.Context, pkt tcp.Packet) {
 		pkt.Release()
 		return
 	}
-	wf.(tcp.PacketHandler).HandlePacket(c, pkt)
+	// if wf is nil, the packet should simply be ignored
+	if wf != nil {
+		wf.(tcp.PacketHandler).HandlePacket(c, pkt)
+	}
 }
 
 func (s *session) udp(c context.Context, dg udp.Datagram) {


### PR DESCRIPTION
A slow connect will cause repeated SYN-packages to arrive while the
connection is establishing. Those packages should be disregarded instead
of handled once the connection is established.
