### PR TITLE
Add goarch metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Change: The global networking flags are no longer global. Using them will render a deprecation warning unless they are supported by the command.
   The subcommands that support networking flags are `connect`, `current-cluster-id`, and `genyaml`. 
 
+- Change: Telepresence now includes GOARCH of the binary in the metadata reprted.
+
 - Bugfix: The also-proxy and never-proxy subnets are now displayed correctly when using the `telepresence status` command
 
 - Bugfix: Telepresence will no longer require `SETENV` privileges when starting the root daemon.

--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -153,12 +153,12 @@ func NewReporter(ctx context.Context, mode string) *Reporter {
 			},
 		},
 	}
-	r.initialize(ctx, mode, runtime.GOOS)
+	r.initialize(ctx, mode, runtime.GOOS, runtime.GOARCH)
 	return r
 }
 
 // initialization broken out or constructor for the benefit of testing
-func (r *Reporter) initialize(ctx context.Context, mode, goos string) {
+func (r *Reporter) initialize(ctx context.Context, mode, goos, goarch string) {
 	r.buffer = make(chan bufEntry, bufferSize)
 
 	// Fixed (growing) metadata passed with every report
@@ -166,6 +166,7 @@ func (r *Reporter) initialize(ctx context.Context, mode, goos string) {
 	baseMeta["mode"] = mode
 	baseMeta["trace_id"] = uuid.New()
 	baseMeta["goos"] = goos
+	baseMeta["goarch"] = goarch
 
 	// Discover how Telepresence was installed based on the binary's location
 	installMethod, err := client.GetInstallMechanism()

--- a/pkg/client/scout/reporter_test.go
+++ b/pkg/client/scout/reporter_test.go
@@ -327,6 +327,7 @@ func TestReport(t *testing.T) {
 		mockInstallID   = "00000000-1111-2222-3333-444444444444"
 		mockMode        = "test-mode"
 		mockOS          = "linux"
+		mockARCH        = "amd64"
 		mockAction      = "test-action"
 	)
 	type testcase struct {
@@ -340,6 +341,7 @@ func TestReport(t *testing.T) {
 				"action": mockAction,
 				"mode":   mockMode,
 				"goos":   mockOS,
+				"goarch": mockARCH,
 			},
 		},
 		"with-additional-scout-meta": {
@@ -357,6 +359,7 @@ func TestReport(t *testing.T) {
 				"action":        mockAction,
 				"mode":          mockMode,
 				"goos":          mockOS,
+				"goarch":        mockARCH,
 				"extra_field_1": "extra value 1",
 				"extra_field_2": "extra value 2",
 			},
@@ -370,6 +373,7 @@ func TestReport(t *testing.T) {
 				"action":        mockAction,
 				"mode":          mockMode,
 				"goos":          mockOS,
+				"goarch":        mockARCH,
 				"extra_field_1": "extra value 1",
 				"extra_field_2": "extra value 2",
 			},
@@ -389,6 +393,7 @@ func TestReport(t *testing.T) {
 				"action":        mockAction,
 				"mode":          mockMode,
 				"goos":          mockOS,
+				"goarch":        mockARCH,
 				"extra_field_1": "extra value 1",
 			},
 		},
@@ -403,6 +408,7 @@ func TestReport(t *testing.T) {
 				"action": mockAction,
 				"mode":   "overridden mode",
 				"goos":   mockOS,
+				"goarch": mockARCH,
 			},
 		},
 	}
@@ -452,7 +458,7 @@ func TestReport(t *testing.T) {
 					Endpoint: testServer.URL,
 				},
 			}
-			scout.initialize(ctx, mockMode, mockOS)
+			scout.initialize(ctx, mockMode, mockOS, mockARCH)
 
 			// Start scout report processing...
 			sc, cancel := context.WithCancel(dcontext.WithSoftness(ctx))


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Including GOARCH as base metadata

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
