### PR TITLE
Call quit before trying to get the session lock.

### DIFF
--- a/pkg/client/userd/grpc.go
+++ b/pkg/client/userd/grpc.go
@@ -340,9 +340,8 @@ func (s *service) SetLogLevel(ctx context.Context, request *manager.LogLevelRequ
 
 func (s *service) Quit(ctx context.Context, _ *empty.Empty) (*empty.Empty, error) {
 	s.logCall(ctx, "Quit", func(c context.Context) {
-		s.sessionLock.Lock()
-		defer s.sessionLock.Unlock()
-		s.session = nil
+		s.sessionLock.RLock()
+		defer s.sessionLock.RUnlock()
 		s.quit()
 	})
 	return &empty.Empty{}, nil

--- a/pkg/dpipe/dpipe_test.go
+++ b/pkg/dpipe/dpipe_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	//nolint:depguard // This short script has no logging and no Contexts.
 	"os/exec"
@@ -69,6 +70,7 @@ func TestDPipe_stderr(t *testing.T) {
 	ctx := makeLoggerOn(log)
 	peer := &bufClose{}
 	assert.NoError(t, DPipe(ctx, peer, echoBinary, "-d", "2", "hello stderr"))
+	time.Sleep(time.Second)
 	assert.Contains(t, log.String(), `level=error msg="hello stderr"`)
 	assert.Empty(t, peer.String())
 }


### PR DESCRIPTION
This will cancel every holder of the lock, preventing us from locking
forever when we run telepresence quit while there are open grpc streams

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
