### PR TITLE
Don't use a default for userDaemonBinary

### DIFF
--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -249,9 +249,6 @@ func (s *cluster) withBasicConfig(c context.Context, t *testing.T) context.Conte
 	config.Grpc.MaxReceiveSize, _ = resource.ParseQuantity("10Mi")
 	config.Cloud.SystemaHost = "127.0.0.1"
 
-	executable := s.Executable()
-	config.Daemons.UserDaemonBinary = executable
-
 	configYaml, err := yaml.Marshal(&config)
 	require.NoError(t, err)
 	configYamlStr := string(configYaml)

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -770,10 +770,6 @@ func GetConfigFile(c context.Context) string {
 
 // GetDefaultConfig returns the default configuration settings
 func GetDefaultConfig(c context.Context) Config {
-	executable, err := os.Executable()
-	if err != nil {
-		dlog.Errorf(c, "unable to get telepresence executable: %s", err)
-	}
 	cfg := Config{
 		Timeouts: Timeouts{
 			PrivateAgentInstall:          defaultTimeoutsAgentInstall,
@@ -799,9 +795,7 @@ func GetDefaultConfig(c context.Context) Config {
 		},
 		Grpc:            Grpc{},
 		TelepresenceAPI: TelepresenceAPI{},
-		Daemons: Daemons{
-			UserDaemonBinary: executable,
-		},
+		Daemons:         Daemons{},
 		Intercept: Intercept{
 			DefaultPort: defaultInterceptDefaultPort,
 		},


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Setting a default in the config leads to some non-ideal behavior with certain IDEs, so let's not do that.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
