### PR TITLE
Deprecate --http-match in favor of --http-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - Feature: Telepresence Login now prompts you to optionally install Telepresence Pro, which has some additional features when used with Ambassador Cloud.
 
+- Change: The flag `--http-match` was renamed to `--http-header`. Old flag still works, but is deprecated and doesn't
+  show up in the help.
+
 - Change: The verb "watch" was added to the set of required verbs when accessing services and workloads for the client RBAC ClusterRole
 
 - Change: Telepresence is no longer backward compatible with versions 2.4.4 or older because the deprecated multiplexing tunnel functionality was removed.

--- a/pkg/client/cli/extensions/builtin.go
+++ b/pkg/client/cli/extensions/builtin.go
@@ -39,12 +39,18 @@ func builtinExtensions(ctx context.Context) map[string]ExtensionInfo {
 					Preference: 100,
 					Flags: map[string]FlagInfo{
 						"match": {
+							Type:       "stringArray",
+							Default:    json.RawMessage(`["auto"]`),
+							Usage:      "",
+							Deprecated: "use --http-header",
+						},
+						"header": {
 							Type:    "stringArray",
 							Default: json.RawMessage(`["auto"]`),
 							Usage: `` +
 								`Only intercept traffic that matches this "HTTP2_HEADER=REGEXP" specifier. ` +
-								`Instead of a "--http-match=HTTP2_HEADER=REGEXP" pair, you may say "--http-match=auto", which will automatically select a unique matcher for your intercept. ` +
-								`Alternatively, you may say "--http-match=all", which is a no-op, but will inhibit the default "--http-match=auto" when you are logged in. ` +
+								`Instead of a "--http-header=HTTP2_HEADER=REGEXP" pair, you may say "--http-header=auto", which will automatically select a unique matcher for your intercept. ` +
+								`Alternatively, you may say "--http-header=all", which is a no-op, but will inhibit the default "--http-header=auto" when you are logged in. ` +
 								`If this flag is given multiple times, then it will only intercept traffic that matches *all* of the specifiers. ` +
 								`(default "auto" if you are logged in with 'telepresence login', default "all" otherwise)`,
 						},

--- a/pkg/client/cli/extensions/extensions.go
+++ b/pkg/client/cli/extensions/extensions.go
@@ -202,8 +202,13 @@ func LoadExtensions(ctx context.Context, existingFlags *pflag.FlagSet) (es *Exte
 					flagname,
 					err)
 			}
-			es.flags.Var(val, mechname+"-"+flagname,
-				flagdata.Usage+fmt.Sprintf(" (implies %q)", "--mechanism="+mechname))
+			usage := ""
+			if flagdata.Usage != "" {
+				usage = fmt.Sprintf(`%s (implies "--mechanism=%s")`, flagdata.Usage, mechname)
+			}
+			flag := es.flags.VarPF(val, mechname+"-"+flagname, "", usage)
+			flag.Hidden = usage == ""
+			flag.Deprecated = flagdata.Deprecated
 		}
 	}
 
@@ -427,4 +432,10 @@ type FlagInfo struct {
 	// Default is the default value for this flag.  This field is optional; if it isn't
 	// specitified then the zero value is used.
 	Default json.RawMessage `json:"default,omitempty"`
+
+	//nolint:gocritic // this is not a deprecation comment
+	// Deprecated is set if the flag is deprecated in favor of something else. Deprecation
+	// means that the flag retains its original function, is hidden from help, and that using it will
+	// display this field as a warning.
+	Deprecated string `json:"deprecated,omitempty"`
 }

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -343,28 +344,8 @@ func (tm *TrafficManager) CanIntercept(c context.Context, ir *rpc.CreateIntercep
 			}
 		}
 		if agentVer != nil {
-			switch {
-			case semver.MustParse("1.11.7").GE(*agentVer):
-				mas := ir.Spec.MechanismArgs
-				l := len(mas) - 1
-				for i, ma := range mas {
-					switch ma {
-					case "--plaintext=true":
-						return interceptError(rpc.InterceptError_UNKNOWN_FLAG, errcat.User.New("--http-plaintext")), nil, nil
-					case "--plaintext=false":
-						// Not supported by <= 1.11.7. Just remove it
-						mas[i] = mas[l]
-						l--
-					}
-				}
-				ir.Spec.MechanismArgs = mas[:l+1]
-			case semver.MustParse("1.11.8").GE(*agentVer):
-				for _, ma := range ir.Spec.MechanismArgs {
-					switch ma {
-					case "--meta", "--path-equal", "--path-prefix", "--path-regex":
-						return interceptError(rpc.InterceptError_UNKNOWN_FLAG, errcat.User.New("--http-"+ma)), nil, nil
-					}
-				}
+			if ir.Spec.MechanismArgs, err = makeFlagsCompatible(agentVer, ir.Spec.MechanismArgs); err != nil {
+				return interceptError(rpc.InterceptError_UNKNOWN_FLAG, err), nil, nil
 			}
 		}
 	}
@@ -376,6 +357,51 @@ func (tm *TrafficManager) CanIntercept(c context.Context, ir *rpc.CreateIntercep
 	}
 
 	return nil, obj, svcprops
+}
+
+func makeFlagsCompatible(agentVer *semver.Version, args []string) ([]string, error) {
+	// We get a normalized representation of all flags here, regardless of if they've
+	// been set or not, so we start splitting them into flag and value and skipping
+	// those that aren't set.
+	m := make(map[string][]string, len(args))
+	ks := make([]string, 0, len(args))
+	for _, ma := range args {
+		if eqi := strings.IndexByte(ma, '='); eqi > 2 && eqi+1 < len(ma) {
+			k := ma[2:eqi]
+			ks = append(ks, k)
+			m[k] = append(m[k], ma[eqi+1:])
+		}
+	}
+	// Concat all --header flags (renamed to --match) with --match flags
+	// All agent versions can handle --match.
+	if hs, ok := m["header"]; ok {
+		delete(m, "header")
+		m["match"] = append(m["match"], hs...)
+	}
+	if agentVer.LE(semver.MustParse("1.11.8")) {
+		for ma := range m {
+			switch ma {
+			case "meta", "path-equal", "path-prefix", "path-regex":
+				return nil, errcat.User.New("--http-" + ma)
+			}
+		}
+		if agentVer.LE(semver.MustParse("1.11.7")) {
+			if pt, ok := m["plaintext"]; ok {
+				if len(pt) > 0 && pt[0] == "true" {
+					return nil, errcat.User.New("--http-plaintext")
+				}
+				delete(m, "plaintext")
+			}
+		}
+	}
+	args = make([]string, 0, len(args))
+	sort.Strings(ks)
+	for _, k := range ks {
+		for _, v := range m[k] {
+			args = append(args, "--"+k+"="+v)
+		}
+	}
+	return args, nil
 }
 
 // AddIntercept adds one intercept

--- a/pkg/client/userd/trafficmgr/intercept_test.go
+++ b/pkg/client/userd/trafficmgr/intercept_test.go
@@ -19,8 +19,8 @@ func Test_makeFlagsCompatible(t *testing.T) {
 		{
 			"1.11.7",
 			semver.MustParse("1.11.7"),
-			[]string{"--match=a=b", "--header=b=c", "--plaintext=false", "--meta=", "--path-prefix="},
-			[]string{"--match=a=b", "--match=b=c"},
+			[]string{"--match=auto", "--header=b=c", "--plaintext=false", "--meta=", "--path-prefix="},
+			[]string{"--match=b=c"},
 			assert.NoError,
 		},
 		{
@@ -51,9 +51,34 @@ func Test_makeFlagsCompatible(t *testing.T) {
 			[]string{"--meta=a=b", "--path-prefix=/api"},
 			assert.NoError,
 		},
+		{
+			"no agent version, one auto",
+			semver.Version{},
+			[]string{"--match=auto", "--header=auto"},
+			[]string{"--match=auto"},
+			assert.NoError,
+		},
+		{
+			"no agent version, strip header=auto",
+			semver.Version{},
+			[]string{"--header=auto", "--match=a=b"},
+			[]string{"--match=a=b"},
+			assert.NoError,
+		},
+		{
+			"no agent version, strip match=auto",
+			semver.Version{},
+			[]string{"--match=auto", "--header=a=b"},
+			[]string{"--match=a=b"},
+			assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ver := &tt.agentVer
+			if ver.Major == 0 {
+				ver = nil
+			}
 			got, err := makeFlagsCompatible(&tt.agentVer, tt.args)
 			if !tt.wantErr(t, err, fmt.Sprintf("makeFlagsCompatible(%v, %v)", tt.agentVer, tt.args)) {
 				return

--- a/pkg/client/userd/trafficmgr/intercept_test.go
+++ b/pkg/client/userd/trafficmgr/intercept_test.go
@@ -1,0 +1,64 @@
+package trafficmgr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_makeFlagsCompatible(t *testing.T) {
+	tests := []struct {
+		name     string
+		agentVer semver.Version
+		args     []string
+		want     []string
+		wantErr  assert.ErrorAssertionFunc
+	}{
+		{
+			"1.11.7",
+			semver.MustParse("1.11.7"),
+			[]string{"--match=a=b", "--header=b=c", "--plaintext=false", "--meta=", "--path-prefix="},
+			[]string{"--match=a=b", "--match=b=c"},
+			assert.NoError,
+		},
+		{
+			"1.11.7-plaintext",
+			semver.MustParse("1.11.7"),
+			[]string{"--plaintext=true"},
+			nil,
+			assert.Error,
+		},
+		{
+			"1.11.8",
+			semver.MustParse("1.11.8"),
+			[]string{"--plaintext=true"},
+			[]string{"--plaintext=true"},
+			assert.NoError,
+		},
+		{
+			"1.11.8-meta",
+			semver.MustParse("1.11.8"),
+			[]string{"--meta=a=b"},
+			nil,
+			assert.Error,
+		},
+		{
+			"1.11.9",
+			semver.MustParse("1.11.9"),
+			[]string{"--path-prefix=/api", "--meta=a=b"},
+			[]string{"--meta=a=b", "--path-prefix=/api"},
+			assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeFlagsCompatible(&tt.agentVer, tt.args)
+			if !tt.wantErr(t, err, fmt.Sprintf("makeFlagsCompatible(%v, %v)", tt.agentVer, tt.args)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "makeFlagsCompatible(%v, %v)", tt.agentVer, tt.args)
+		})
+	}
+}

--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -557,7 +557,7 @@ if [ -f "$config_file" ]; then
     $TELEPRESENCE quit > "$output_location"
 fi
 
-$TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=true --http-match=all <<<$'verylargejavaservice.default\n8080\nN\n' >"$output_location"
+$TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=true --http-header=all <<<$'verylargejavaservice.default\n8080\nN\n' >"$output_location"
 sleep 1
 is_prop_traffic_agent true
 
@@ -631,7 +631,7 @@ finish_step
 ###############################################
 
 sleep 5 # avoid known agent mechanism-args race
-output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --http-match=all <<<$'verylargejavaservice.default\n8080\nN\n')
+output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --http-header=all <<<$'verylargejavaservice.default\n8080\nN\n')
 sleep 1
 get_preview_url
 has_intercept_id false
@@ -652,7 +652,7 @@ finish_step
 #### Step 12 - licensed intercept all w/o preview url ####
 ##########################################################
 
-output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --http-match=all --preview-url=false)
+output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --http-header=all --preview-url=false)
 sleep 1
 has_intercept_id false
 has_preview_url false
@@ -723,7 +723,7 @@ if [[ -n $TELEPRESENCE_LICENSE ]]; then
     helm_install "smoke-tests/license-values.yaml"
 
     # Ensure we can intercept a persona intercept and that it works with the license
-    output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=false --http-match=auto)
+    output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=false --http-header=auto)
     sleep 1
     # Ensure we aren't logged in since we are testing air-gapped license support
     verify_logout
@@ -764,7 +764,7 @@ if [[ -n $TELEPRESENCE_LICENSE ]]; then
     helm_install "smoke-tests/license-values.yaml"
 
     # Ensure we can intercept a persona intercept and that it works with the license
-    output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=false --http-match=auto 2>&1)
+    output=$($TELEPRESENCE intercept dataprocessingservice --port 3000 --preview-url=false --http-header=auto 2>&1)
     sleep 1
 
     # Ensure we aren't logged in since we are testing air-gapped license support


### PR DESCRIPTION
## Description

The flag `--http-match` is renamed to `--http-header` to avoid confusion
as the new `--http-path-xxx` flags are introduced. A command line like:

    telepresence intercept --http-match=all --http-path-prefix=/api ...

didn't really make sense. Is it matching all requests, or just the
ones prefix with '/api'? Using `--http-header` makes it clearer:

    telepresence intercept --http-header=all --http-path-prefix=/api ...

The old flag can still be used but will render a deprecation warning
that suggests using the new flag. It no longer shows up in the help.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.