### PR TITLE
Fix problem with failed login creating false positives

### DIFF
--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -211,7 +211,7 @@ func (r *Reporter) Close() {
 	case r.buffer <- bufEntry{}:
 	default:
 	}
-	// Wait for the done channel to close. Give up after 2 seconds (that
+	// Wait for the done channel to close. Give up after 3 seconds (that
 	// should be plenty)
 	select {
 	case <-r.done:


### PR DESCRIPTION
The errors encountered in the `Login()` function of the `loginExecutor`
was reported as successes to metriton (with an empty `user_id`) even
though they were in fact failures.