### PR TITLE
Pass a new kubeconfig to the connector when re-connecting

### DIFF
--- a/integration_test/not_connected_test.go
+++ b/integration_test/not_connected_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"runtime"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
@@ -37,7 +39,11 @@ func (s *notConnectedSuite) Test_ConnectWithCommand() {
 func (s *notConnectedSuite) Test_InvalidKubeconfig() {
 	ctx := s.Context()
 	itest.TelepresenceOk(ctx, "quit", "-ur")
-	badEnvCtx := itest.WithEnv(ctx, map[string]string{"KUBECONFIG": "/dev/null"})
+	path := "/dev/null"
+	if runtime.GOOS == "windows" {
+		path = "C:\\NUL"
+	}
+	badEnvCtx := itest.WithEnv(ctx, map[string]string{"KUBECONFIG": path})
 	_, stderr, err := itest.Telepresence(badEnvCtx, "connect")
 	s.Contains(stderr, "kubeconfig has no context definition")
 	itest.TelepresenceQuitOk(ctx) // process is started with bad env, so get rid of it


### PR DESCRIPTION
Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
