### PR TITLE
l5 typo

### DIFF
--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -660,7 +660,7 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 				Host:   ingressInfo.Host,
 				Port:   ingressInfo.Port,
 				UseTls: ingressInfo.UseTls,
-				L5Host: ingressInfo.Host,
+				L5Host: ingressInfo.L5Host,
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
1 Line PR
Due to a typo, the L5 host was hardcoded to be the same as the host when intercepted using the cli.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
