### PR TITLE
Improve quit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,12 @@ End the service with `<ctrl>-C` and then try `curl hello.default` or `http://hel
 
 Now end the session too. Your desktop no longer has access to the cluster internals.
 ```console
-$ telepresence quit
-Telepresence Daemon quitting...done
+$ telepresence quit -u
+Telepresence Network is already disconnected
+Telepresence Traffic Manager had already quit
+$ telepresence quit -r
+Telepresence Network quitting...done
+Telepresence Traffic Manager is already disconnected
 $ curl hello.default
 curl: (6) Could not resolve host: hello.default
 ```

--- a/pkg/client/cli/cliutil/version_check.go
+++ b/pkg/client/cli/cliutil/version_check.go
@@ -18,17 +18,27 @@ func versionCheck(ctx context.Context, daemonType string, daemonBinary string, c
 	if ctx.Value(quitting{}) != nil {
 		return nil
 	}
+	var quitFlag string
+	switch {
+	case daemonType == "Root":
+		quitFlag = "-r"
+	case daemonType == "User":
+		quitFlag = "-u"
+	default:
+		return fmt.Errorf("unknown daemonType: %s", daemonType)
+	}
 	// Ensure that the already running daemon has the correct version
 	vi, err := client.Version(ctx, &empty.Empty{})
 	if err != nil {
 		return fmt.Errorf("unable to retrieve version of %s Daemon: %w", daemonType, err)
 	}
 	if version.Version != vi.Version {
-		return errcat.User.Newf("version mismatch. Client %s != %s Daemon %s, please quit telepresence and reconnect", version.Version, daemonType, vi.Version)
+		return errcat.User.Newf("version mismatch. Client %s != %s Daemon %s, please run 'telepresence quit %s' and reconnect", version.Version, daemonType, vi.Version, quitFlag)
 	}
 	if daemonBinary != "" {
 		if vi.Executable != daemonBinary {
-			return errcat.User.Newf("executable mismatch. Connector using %s, configured to use %s, please quit telepresence and reconnect", vi.Executable, daemonBinary)
+			return errcat.User.Newf("executable mismatch. Connector using %s, configured to use %s, please run 'telepresence quit %s' and reconnect",
+				vi.Executable, daemonBinary, quitFlag)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Donny Yung <donaldyung@datawire.io>

## Description

Updating the quit messages so users know how to quit the long running daemon when they are using incompatible versions

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
