### PR TITLE
Add more data to the "connector_<verb>_intercept_<outcome>" reports

### DIFF
--- a/pkg/client/userd/grpc.go
+++ b/pkg/client/userd/grpc.go
@@ -133,19 +133,48 @@ func (s *service) Status(c context.Context, _ *empty.Empty) (result *rpc.Connect
 	return
 }
 
-func (s *service) CanIntercept(c context.Context, ir *rpc.CreateInterceptRequest) (result *rpc.InterceptResult, err error) {
-	defer func() {
-		var msg string
+func scoutInterceptEntries(spec *manager.InterceptSpec, result *rpc.InterceptResult, err error) ([]scout.Entry, bool) {
+	// The scout belongs to the session and can only contain session specific meta-data
+	// so we don't want to use scout.SetMetadatum() here.
+	entries := make([]scout.Entry, 0, 7)
+	if spec != nil {
+		entries = append(entries,
+			scout.Entry{Key: "service_name", Value: spec.ServiceName},
+			scout.Entry{Key: "service_namespace", Value: spec.Namespace},
+			scout.Entry{Key: "intercept_mechanism", Value: spec.Mechanism},
+			scout.Entry{Key: "intercept_mechanism_numargs", Value: len(spec.Mechanism)},
+		)
+	}
+	var msg string
+	if result != nil {
+		entries = append(entries,
+			scout.Entry{Key: "service_uid", Value: len(result.ServiceUid)},
+			scout.Entry{Key: "workload_kind", Value: len(result.WorkloadKind)},
+		)
 		if result.Error != rpc.InterceptError_UNSPECIFIED {
 			msg = result.Error.String()
-		} else if err != nil {
-			msg = err.Error()
 		}
-		if msg != "" {
-			s.scout.Report(c, "connector_can_intercept_fail", scout.Entry{Key: "error", Value: msg})
+	}
+	if err != nil && msg == "" {
+		msg = err.Error()
+	}
+	if msg != "" {
+		entries = append(entries, scout.Entry{Key: "error", Value: msg})
+		return entries, false
+	}
+	return entries, true
+}
+
+func (s *service) CanIntercept(c context.Context, ir *rpc.CreateInterceptRequest) (result *rpc.InterceptResult, err error) {
+	defer func() {
+		entries, ok := scoutInterceptEntries(ir.Spec, result, err)
+		var action string
+		if ok {
+			action = "connector_can_intercept_success"
 		} else {
-			s.scout.Report(c, "connector_can_intercept_success")
+			action = "connector_can_intercept_fail"
 		}
+		s.scout.Report(c, action, entries...)
 	}()
 	err = s.withSession(c, "CanIntercept", func(c context.Context, session trafficmgr.Session) error {
 		var wl k8sapi.Workload
@@ -166,17 +195,14 @@ func (s *service) CanIntercept(c context.Context, ir *rpc.CreateInterceptRequest
 
 func (s *service) CreateIntercept(c context.Context, ir *rpc.CreateInterceptRequest) (result *rpc.InterceptResult, err error) {
 	defer func() {
-		var msg string
-		if result.Error != rpc.InterceptError_UNSPECIFIED {
-			msg = result.Error.String()
-		} else if err != nil {
-			msg = err.Error()
-		}
-		if msg != "" {
-			s.scout.Report(c, "connector_create_intercept_fail", scout.Entry{Key: "error", Value: msg})
+		entries, ok := scoutInterceptEntries(ir.Spec, result, err)
+		var action string
+		if ok {
+			action = "connector_create_intercept_success"
 		} else {
-			s.scout.Report(c, "connector_create_intercept_success")
+			action = "connector_create_intercept_fail"
 		}
+		s.scout.Report(c, action, entries...)
 	}()
 	err = s.withSession(c, "CreateIntercept", func(c context.Context, session trafficmgr.Session) error {
 		result, err = session.AddIntercept(c, ir)
@@ -186,21 +212,24 @@ func (s *service) CreateIntercept(c context.Context, ir *rpc.CreateInterceptRequ
 }
 
 func (s *service) RemoveIntercept(c context.Context, rr *manager.RemoveInterceptRequest2) (result *rpc.InterceptResult, err error) {
+	var spec *manager.InterceptSpec
 	defer func() {
-		var msg string
-		if result.Error != rpc.InterceptError_UNSPECIFIED {
-			msg = result.Error.String()
-		} else if err != nil {
-			msg = err.Error()
-		}
-		if msg != "" {
-			s.scout.Report(c, "connector_remove_intercept_fail", scout.Entry{Key: "error", Value: msg})
+		entries, ok := scoutInterceptEntries(spec, result, err)
+		var action string
+		if ok {
+			action = "connector_remove_intercept_success"
 		} else {
-			s.scout.Report(c, "connector_remove_intercept_success")
+			action = "connector_remove_intercept_fail"
 		}
+		s.scout.Report(c, action, entries...)
 	}()
 	err = s.withSession(c, "RemoveIntercept", func(c context.Context, session trafficmgr.Session) error {
 		result = &rpc.InterceptResult{}
+		spec = session.GetInterceptSpec(rr.Name)
+		if spec != nil {
+			result.ServiceUid = spec.ServiceUid
+			result.WorkloadKind = spec.WorkloadKind
+		}
 		if err := session.RemoveIntercept(c, rr.Name); err != nil {
 			if grpcStatus.Code(err) == grpcCodes.NotFound {
 				result.Error = rpc.InterceptError_NOT_FOUND
@@ -214,7 +243,7 @@ func (s *service) RemoveIntercept(c context.Context, rr *manager.RemoveIntercept
 		}
 		return nil
 	})
-	return
+	return result, err
 }
 
 func (s *service) List(c context.Context, lr *rpc.ListRequest) (result *rpc.WorkloadInfoSnapshot, err error) {

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -656,6 +656,19 @@ func (tm *TrafficManager) RemoveIntercept(c context.Context, name string) error 
 	return err
 }
 
+// GetInterceptSpec returns the InterceptSpec for the given name, or nil if no such spec exists
+func (tm *TrafficManager) GetInterceptSpec(name string) *manager.InterceptSpec {
+	if ns, ok := tm.localIntercepts[name]; ok {
+		return &manager.InterceptSpec{Name: name, Namespace: ns, WorkloadKind: "local"}
+	}
+	for _, cept := range tm.getCurrentIntercepts() {
+		if cept.Spec.Name == name {
+			return cept.Spec
+		}
+	}
+	return nil
+}
+
 // clearIntercepts removes all intercepts
 func (tm *TrafficManager) clearIntercepts(c context.Context) error {
 	for _, cept := range tm.getCurrentIntercepts() {

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -56,6 +56,7 @@ type Session interface {
 	restapi.AgentState
 	AddIntercept(context.Context, *rpc.CreateInterceptRequest) (*rpc.InterceptResult, error)
 	CanIntercept(context.Context, *rpc.CreateInterceptRequest) (*rpc.InterceptResult, k8sapi.Workload, *ServiceProps)
+	GetInterceptSpec(string) *manager.InterceptSpec
 	Status(context.Context) *rpc.ConnectInfo
 	IngressInfos(c context.Context) ([]*manager.IngressInfo, error)
 	RemoveIntercept(context.Context, string) error


### PR DESCRIPTION
Adds intercept data, such as `service_name`, `service_namespace`,
`intercept_mechanism`, `intercept_mechanism_numargs`, `service_uid`,
and `workload_kind` to the `connector_<verb>_intercept_<outcome>`
traits.