### PR TITLE
Ensure that user's config directory exists before starting the daemons

### DIFF
--- a/pkg/client/cli/cliutil/connector.go
+++ b/pkg/client/cli/cliutil/connector.go
@@ -70,6 +70,9 @@ func withConnector(ctx context.Context, maybeStart bool, withNotify bool, fn fun
 			err = ErrNoUserDaemon
 			if maybeStart {
 				fmt.Println("Launching Telepresence User Daemon")
+				if _, err = ensureAppUserConfigDir(ctx); err != nil {
+					return err
+				}
 				if err = proc.StartInBackground(connectorDaemon, "connector-foreground"); err != nil {
 					return fmt.Errorf("failed to launch the connector service: %w", err)
 				}


### PR DESCRIPTION
The daemons will start file watchers on this directory. That fails with
an error unless the directory exists. It's important that the directory
is created by the user and not by root so this cannot be done in the
root daemon.