### PR TITLE
Ensure that zero entries in the Config are omitted during marshal

### DIFF
--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -226,7 +226,7 @@ func (s *cluster) ensureCluster(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *cluster) withBasicConfig(c context.Context, t *testing.T) context.Context {
-	config := client.GetDefaultConfig(c)
+	config := client.GetDefaultConfig()
 	config.LogLevels.UserDaemon = logrus.DebugLevel
 	config.LogLevels.RootDaemon = logrus.DebugLevel
 
@@ -243,8 +243,8 @@ func (s *cluster) withBasicConfig(c context.Context, t *testing.T) context.Conte
 	to.PrivateTrafficManagerConnect = 180 * time.Second
 
 	registry := s.Registry()
-	config.Images.Registry = registry
-	config.Images.WebhookRegistry = registry
+	config.Images.PrivateRegistry = registry
+	config.Images.PrivateWebhookRegistry = registry
 
 	config.Grpc.MaxReceiveSize, _ = resource.ParseQuantity("10Mi")
 	config.Cloud.SystemaHost = "127.0.0.1"

--- a/integration_test/webhook_test.go
+++ b/integration_test/webhook_test.go
@@ -57,8 +57,8 @@ func (s *notConnectedSuite) Test_WebhookAgentImageFromConfig() {
 	// latter that is used in the traffic-manager
 	ctxAI := itest.WithConfig(ctx, &client.Config{
 		Images: client.Images{
-			AgentImage:        "notUsed:0.0.1",
-			WebhookAgentImage: "imageFromConfig:0.0.1",
+			PrivateAgentImage:        "notUsed:0.0.1",
+			PrivateWebhookAgentImage: "imageFromConfig:0.0.1",
 		},
 	})
 

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -208,8 +208,8 @@ func (i *genContainerInfo) run(cmd *cobra.Command, kubeFlags map[string]string) 
 		return fmt.Errorf("unable to get k8s config: %w", err)
 	}
 
-	registry := cfg.Images.Registry
-	agentImage := cfg.Images.AgentImage
+	registry := cfg.Images.Registry(ctx)
+	agentImage := cfg.Images.AgentImage(ctx)
 	// Use sane defaults if the user hasn't configured the registry and/or image
 	if registry == "" {
 		registry = "datawire"

--- a/pkg/client/cli/extensions/builtin.go
+++ b/pkg/client/cli/extensions/builtin.go
@@ -13,7 +13,7 @@ import (
 // CLI version number, which might not be initialized yet at init-time (esp. during `go test`).
 func builtinExtensions(ctx context.Context) map[string]ExtensionInfo {
 	cfg := client.GetConfig(ctx)
-	registry := cfg.Images.Registry
+	registry := cfg.Images.Registry(ctx)
 	cloud := cfg.Cloud
 	version := strings.TrimPrefix(client.Version(), "v")
 	image := fmt.Sprintf("%s/tel2:%s", registry, version)

--- a/pkg/client/cli/extensions/extensions.go
+++ b/pkg/client/cli/extensions/extensions.go
@@ -314,8 +314,8 @@ func urlSchemeIsOneOf(urlStr string, schemes ...string) bool {
 // image attribute.
 func (es *ExtensionsState) AgentImage(ctx context.Context) (string, error) {
 	cfg := client.GetConfig(ctx)
-	if cfg.Images.AgentImage != "" {
-		return fmt.Sprintf("%s/%s", cfg.Images.Registry, cfg.Images.AgentImage), nil
+	if ai := cfg.Images.AgentImage(ctx); ai != "" {
+		return fmt.Sprintf("%s/%s", cfg.Images.Registry(ctx), ai), nil
 	}
 	if es.cachedImage.Image != "" || es.cachedImage.Err != nil {
 		return es.cachedImage.Image, es.cachedImage.Err

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -80,12 +80,12 @@ intercept:
 	assert.Equal(t, logrus.DebugLevel, cfg.LogLevels.UserDaemon) // from sys2
 	assert.Equal(t, logrus.TraceLevel, cfg.LogLevels.RootDaemon) // from user
 
-	assert.Equal(t, "testregistry.io", cfg.Images.Registry)                                      // from user
-	assert.Equal(t, "ambassador-telepresence-client-image:0.0.1", cfg.Images.AgentImage)         // from user
-	assert.Equal(t, "ambassador-telepresence-webhook-image:0.0.2", cfg.Images.WebhookAgentImage) // from user
-	assert.Equal(t, 1234, cfg.TelepresenceAPI.Port)                                              // from user
-	assert.Equal(t, k8sapi.PortName, cfg.Intercept.AppProtocolStrategy)                          // from user
-	assert.Equal(t, 9080, cfg.Intercept.DefaultPort)                                             // from user
+	assert.Equal(t, "testregistry.io", cfg.Images.PrivateRegistry)                                      // from user
+	assert.Equal(t, "ambassador-telepresence-client-image:0.0.1", cfg.Images.PrivateAgentImage)         // from user
+	assert.Equal(t, "ambassador-telepresence-webhook-image:0.0.2", cfg.Images.PrivateWebhookAgentImage) // from user
+	assert.Equal(t, 1234, cfg.TelepresenceAPI.Port)                                                     // from user
+	assert.Equal(t, k8sapi.PortName, cfg.Intercept.AppProtocolStrategy)                                 // from user
+	assert.Equal(t, 9080, cfg.Intercept.DefaultPort)                                                    // from user
 }
 
 func Test_ConfigMarshalYAML(t *testing.T) {
@@ -114,4 +114,10 @@ func Test_ConfigMarshalYAML(t *testing.T) {
 	cfg2, err := LoadConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, &cfg, cfg2)
+}
+
+func Test_ConfigMarshalYAMLDefaults(t *testing.T) {
+	cfgBytes, err := yaml.Marshal(GetDefaultConfig())
+	require.NoError(t, err)
+	require.Equal(t, "{}\n", string(cfgBytes))
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -93,8 +93,8 @@ func Test_ConfigMarshalYAML(t *testing.T) {
 	env, err := LoadEnv(ctx)
 	require.NoError(t, err)
 	ctx = WithEnv(ctx, env)
-	cfg := GetDefaultConfig(ctx)
-	cfg.Images.AgentImage = "something:else"
+	cfg := GetDefaultConfig()
+	cfg.Images.PrivateAgentImage = "something:else"
 	cfg.Timeouts.PrivateTrafficManagerAPI = defaultTimeoutsTrafficManagerAPI + 20*time.Second
 	cfg.Cloud.RefreshMessages += 10 * time.Minute
 	cfg.LogLevels.UserDaemon = logrus.TraceLevel

--- a/pkg/client/userd/trafficmgr/install.go
+++ b/pkg/client/userd/trafficmgr/install.go
@@ -50,7 +50,7 @@ func NewTrafficManagerInstaller(kc *k8s.Cluster) (Installer, error) {
 const annTelepresenceActions = install.DomainPrefix + "actions"
 
 func managerImageName(ctx context.Context) string {
-	return fmt.Sprintf("%s/tel2:%s", client.GetConfig(ctx).Images.Registry, strings.TrimPrefix(client.Version(), "v"))
+	return fmt.Sprintf("%s/tel2:%s", client.GetConfig(ctx).Images.Registry(ctx), strings.TrimPrefix(client.Version(), "v"))
 }
 
 // RemoveManagerAndAgents will remove the agent from all deployments listed in the given agents slice. Unless agentsOnly is true,

--- a/pkg/client/userd/trafficmgr/install_test.go
+++ b/pkg/client/userd/trafficmgr/install_test.go
@@ -104,7 +104,7 @@ func TestAddAgentToWorkload(t *testing.T) {
 		defer func() { version.Version = sv }()
 
 		testCfg := *cfg
-		testCfg.Images.Registry = "localhost:5000"
+		testCfg.Images.PrivateRegistry = "localhost:5000"
 		ctx = client.WithConfig(ctx, &testCfg)
 
 		for tcName, tc := range testcases {

--- a/pkg/install/helm/install.go
+++ b/pkg/install/helm/install.go
@@ -34,7 +34,7 @@ func getHelmConfig(ctx context.Context, configFlags *genericclioptions.ConfigFla
 func getValues(ctx context.Context) map[string]interface{} {
 	clientConfig := client.GetConfig(ctx)
 	imgConfig := clientConfig.Images
-	imageRegistry := imgConfig.Registry
+	imageRegistry := imgConfig.Registry(ctx)
 	cloudConfig := clientConfig.Cloud
 	imageTag := strings.TrimPrefix(client.Version(), "v")
 	values := map[string]interface{}{
@@ -52,11 +52,11 @@ func getValues(ctx context.Context) map[string]interface{} {
 		}
 	}
 	apc := clientConfig.Intercept.AppProtocolStrategy
-	if imgConfig.WebhookAgentImage != "" || imgConfig.WebhookRegistry != "" || apc != k8sapi.Http2Probe {
+	if wai, wr := imgConfig.WebhookAgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" || apc != k8sapi.Http2Probe {
 		agentImage := make(map[string]interface{})
-		if imgConfig.WebhookAgentImage != "" {
-			parts := strings.Split(imgConfig.WebhookAgentImage, ":")
-			image := imgConfig.WebhookAgentImage
+		if wai != "" {
+			parts := strings.Split(wai, ":")
+			image := wai
 			tag := ""
 			if len(parts) > 1 {
 				image = parts[0]
@@ -65,8 +65,8 @@ func getValues(ctx context.Context) map[string]interface{} {
 			agentImage["name"] = image
 			agentImage["tag"] = tag
 		}
-		if imgConfig.WebhookRegistry != "" {
-			agentImage["registry"] = imgConfig.WebhookRegistry
+		if wr != "" {
+			agentImage["registry"] = wr
 		}
 		agentInjector := map[string]interface{}{"agentImage": agentImage}
 		values["agentInjector"] = agentInjector


### PR DESCRIPTION
- Replaces the approach of defining `client.Config` defaults using environment variables with getters.
- Adds an `IsZero()` method to `client.Config` entries that have a default value that is different from the go zero value.
- Save the config.yml as config.yml.bak when updating it