### PR TITLE
Add reports for pro connector upgrade

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -5,27 +5,30 @@ These metrics help us understand usage and improve the product; they include inf
 
 The following metrics are collected:
 
-|              Metric Name              | Description                                                                                                                                         |
-| ------------------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `intercept_fail`                      | An attempt to create an intercept has failed. Includes an `error` trait detailing the error.                                                        |
-| `intercept_validation_fail`           | There has been an attempt to creat an invalid intercept. Includes an `error` trait detailing the error.                                             |
-| `intercept_success`                   | An attempt to create an intercept has succeeded.                                                                                                    |
-| `preview_domain_create_fail`          | An attempt to create an intercept with a preview URL has failed. Includes an `error` trait                                                          |
-| `Used legacy syntax`                  | A [legacy command](https://www.telepresence.io/docs/latest/install/migrate-from-legacy/#using-legacy-telepresence-commands) has been used           |
-| `incluster_dns_queries`               | Number of queries made by Telepresence to resolve a name to a cluster service (e.g. `kubernetes.default`). Inclues a `total` and a `failures` trait.|
-| `connect`                             | Telepresence has attempted to connect to the cluster.                                                                                               |
-| `connecting_traffic_manager`          | Telepresence has attempted to connect to the Traffic Manager.                                                                                       |
-| `finished_connecting_traffic_manager` | Telepresence has succeeded at connecting to the Traffic Manager.                                                                                    |
-| `login_failure`                       | A `telepresence login` has failed. Includes an `error` trait detailing the error, and a `method` trait detailing the login method.                  |
-| `login_interrupted`                   | A `telepresence login` has been interrupted by the user, includes a `method` trait detailing the login method.                                      |
-| `login_success`                       | A `telepresence login` has succeded, includes a `method` trait detailing the login method.                                                          |
-| `used_gather_logs`                    | A `telepresence gather-logs` command has been used.                                                                                                 |
-| `vpn_diag_error`                      | A `telepresence test-vpn` command has been used and has resulted in an error.                                                                       |
-| `vpn_diag_fail`                       | A `telepresence test-vpn` command has been used; no error, but it reports a misconfigured network. Includes traits detailing the failure.           |
-| `vpn_diag_pass`                       | A `telepresence test-vpn` command has been used and reported no misconfigurations.                                                                  |
-| `connector_remove_intercept_success`  | The user daemon has successfully removed an intercept                                                                                               |
-| `connector_remove_intercept_fail`     | The user daemon has failed to remove an intercept. Includes an `error` trait describing the failure.                                                |
-| `connector_create_intercept_success`  | The user daemon has successfully created an intercept                                                                                               |
-| `connector_create_intercept_fail`     | The user daemon has failed to create an intercept. Includes an `error` trait describing the failure.                                                |
-| `connector_can_intercept_success`     | The user daemon has validated that an intercept can be created.                                                                                     |
-| `connector_can_intercept_fail`        | The user daemon has determined that an intercept can't be created. Includes an `error` trait describing the reason.                                 |
+| Metric Name                           | Description                                                                                                                                          |
+|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `intercept_fail`                      | An attempt to create an intercept has failed. Includes an `error` trait detailing the error.                                                         |
+| `intercept_validation_fail`           | There has been an attempt to creat an invalid intercept. Includes an `error` trait detailing the error.                                              |
+| `intercept_success`                   | An attempt to create an intercept has succeeded.                                                                                                     |
+| `preview_domain_create_fail`          | An attempt to create an intercept with a preview URL has failed. Includes an `error` trait                                                           |
+| `Used legacy syntax`                  | A [legacy command](https://www.telepresence.io/docs/latest/install/migrate-from-legacy/#using-legacy-telepresence-commands) has been used            |
+| `incluster_dns_queries`               | Number of queries made by Telepresence to resolve a name to a cluster service (e.g. `kubernetes.default`). Inclues a `total` and a `failures` trait. |
+| `connect`                             | Telepresence has attempted to connect to the cluster.                                                                                                |
+| `connecting_traffic_manager`          | Telepresence has attempted to connect to the Traffic Manager.                                                                                        |
+| `finished_connecting_traffic_manager` | Telepresence has succeeded at connecting to the Traffic Manager.                                                                                     |
+| `login_failure`                       | A `telepresence login` has failed. Includes an `error` trait detailing the error, and a `method` trait detailing the login method.                   |
+| `login_interrupted`                   | A `telepresence login` has been interrupted by the user, includes a `method` trait detailing the login method.                                       |
+| `login_success`                       | A `telepresence login` has succeded, includes a `method` trait detailing the login method.                                                           |
+| `used_gather_logs`                    | A `telepresence gather-logs` command has been used.                                                                                                  |
+| `vpn_diag_error`                      | A `telepresence test-vpn` command has been used and has resulted in an error.                                                                        |
+| `vpn_diag_fail`                       | A `telepresence test-vpn` command has been used; no error, but it reports a misconfigured network. Includes traits detailing the failure.            |
+| `vpn_diag_pass`                       | A `telepresence test-vpn` command has been used and reported no misconfigurations.                                                                   |
+| `connector_remove_intercept_success`  | The user daemon has successfully removed an intercept                                                                                                |
+| `connector_remove_intercept_fail`     | The user daemon has failed to remove an intercept. Includes an `error` trait describing the failure.                                                 |
+| `connector_create_intercept_success`  | The user daemon has successfully created an intercept                                                                                                |
+| `connector_create_intercept_fail`     | The user daemon has failed to create an intercept. Includes an `error` trait describing the failure.                                                 |
+| `connector_can_intercept_success`     | The user daemon has validated that an intercept can be created.                                                                                      |
+| `connector_can_intercept_fail`        | The user daemon has determined that an intercept can't be created. Includes an `error` trait describing the reason.                                  |
+| `pro_connector_upgrade_refusal`       | The upgrade to the pro connector was refused by the user. Includes an `first_install` boolean trait.                                                 |
+| `pro_connector_upgrade_success`       | The upgrade to the pro connector succeeded. Includes an `first_install` boolean trait.                                                               |
+| `pro_connector_upgrade_fail`          | The upgrade to the pro connector failed. Includes an `error` trait describing the failure and a `first_install` boolean trait.                       |

--- a/pkg/client/cli/cliutil/systema.go
+++ b/pkg/client/cli/cliutil/systema.go
@@ -160,11 +160,12 @@ func GetTelepresencePro(ctx context.Context) error {
 	defer sc.Close()
 	installRefused := false
 	defer func() {
-		if err != nil {
+		switch {
+		case err != nil:
 			sc.Report(ctx, "pro_connector_upgrade_fail", scout.Entry{Key: "error", Value: err.Error()})
-		} else if installRefused {
+		case installRefused:
 			sc.Report(ctx, "pro_connector_upgrade_refusal")
-		} else {
+		default:
 			sc.Report(ctx, "pro_connector_upgrade_success")
 		}
 	}()


### PR DESCRIPTION
## Description

This PR adds 3 report types for the pro connector upgrade:
- `pro_connector_upgrade_refusal`
- `pro_connector_upgrade_success`
- `pro_connector_upgrade_fail`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
