### PR TITLE
Only use ipv4 addresses for the resolv.conf override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 - Bugfix: Fixed a bug where the `--json` flag did not output json for `telepresence list` when there were no workloads.
 
+- Bugfix: Fixed a bug where the overriding DNS resolver would break down in Linux if /etc/resolv.conf listed an ipv6 resolver
+
 ### 2.4.11 (February 10, 2022)
 
 - Change: Include goarch metadata for reporting to distinguish between Intel and Apple Silicon Macs

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -105,8 +105,12 @@ func (s *Server) runOverridingServer(c context.Context, dev *vif.Device) error {
 		for _, line := range strings.Split(string(dat), "\n") {
 			if strings.HasPrefix(strings.TrimSpace(line), "nameserver") {
 				fields := strings.Fields(line)
-				s.config.LocalIp = net.ParseIP(fields[1])
-				dlog.Infof(c, "Automatically set -dns=%s", net.IP(s.config.LocalIp))
+				ip := net.ParseIP(fields[1])
+				if ip.To4() != nil {
+					s.config.LocalIp = ip.To4()
+					dlog.Infof(c, "Automatically set -dns=%s", net.IP(s.config.LocalIp))
+					break
+				}
 			}
 
 			// The search entry in /etc/resolv.conf is not intended for this resolver so

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -109,7 +109,6 @@ func (s *Server) runOverridingServer(c context.Context, dev *vif.Device) error {
 				if ip.To4() != nil {
 					s.config.LocalIp = ip.To4()
 					dlog.Infof(c, "Automatically set -dns=%s", net.IP(s.config.LocalIp))
-					break
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
