### PR TITLE
Add missing examples and flag renames for http-header

### DIFF
--- a/docs/pre-release/.gitrepo
+++ b/docs/pre-release/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2
-	commit = 9b0c1c85d03412a996e91706d0524a51c7c80c22
-	parent = 283f3becc77e881327be907c8ea8b42aff438e54
+	branch = release/v2
+	commit = 39b1afdcd61042ff525f034f97ef2f664feb5963
+	parent = b1e16e54b8cbe15253772a38255923fd3a8ce748
 	method = merge
 	cmdver = 0.4.3

--- a/docs/pre-release/releaseNotes.yml
+++ b/docs/pre-release/releaseNotes.yml
@@ -38,6 +38,14 @@ docDescription: >-
 changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELOG.md
 
 items:
+  - version: 2.4.11
+    date: "2022-02-10"
+    notes:
+      - type: change
+        title: Add additional logging to troubleshoot intermittent issues with intercepts
+        body: >-
+          We've noticed some issues with intercepts in v2.4.10, so we are releasing a version
+          with enhanced logging to help debug and fix the issue.
   - version: 2.4.10
     date: "2022-01-13"
     notes:

--- a/docs/v2.0/.gitrepo
+++ b/docs/v2.0/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.0
-	commit = 9be503c562b27c4109f46620ec4a9f9d5ae0950e
-	parent = 1637ae514ebc9419154acd595899b3c5b618d2a7
+	branch = release/v2.0
+	commit = b42cf349ea3d535af164a6d7451b61c8e5c543fd
+	parent = a96f7e9bb934879b2e52212c0b6addb91de5cf56
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.1/.gitrepo
+++ b/docs/v2.1/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.1
-	commit = aa0ca4778a606f0e4bda6ee998621d71653bbf1a
-	parent = f0026a0d424a0972c765e55e39e0768d63bcca08
+	branch = release/v2.1
+	commit = df5ad91a746314c396f069374d1e37bbae9d9204
+	parent = 33076f7da1626646051da27275e14658e5c68657
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.2/.gitrepo
+++ b/docs/v2.2/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.2
-	commit = a9b98294b6eac2a45252d7674d0a43504d80187b
-	parent = 9a7824916610136297fa495f32b178d5b0b9e3cf
+	branch = release/v2.2
+	commit = 4545df38c5fd7f809e3ab46c0daec775b93308f0
+	parent = 12685f0268280af7eb2719a92ff3b255039ea424
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.3/.gitrepo
+++ b/docs/v2.3/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.3
-	commit = 57534a36fa6bcf84a3b1bec6367d4f770aa60944
-	parent = f0cd97bc01d769fe3cb266e5166590c1516e782e
+	branch = release/v2.3
+	commit = a60003df7d8dd5825430ef04151cabbb02b774c8
+	parent = 286e8eb00b6e378d298c77e5c193493b0d5430c8
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.4/.gitrepo
+++ b/docs/v2.4/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.4
-	commit = 8dd6084fae2a9299a6348c95a884866f72abc239
-	parent = 7c2fe7a115a4ca28e78fa4ff8af0f197901e1bec
+	branch = release/v2.4
+	commit = 7e3e493443f433e72899e0191c8b773fff738ed8
+	parent = 3a31ead4123a34e366c5c45eb5e9bd1824252580
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.4/releaseNotes.yml
+++ b/docs/v2.4/releaseNotes.yml
@@ -38,6 +38,14 @@ docDescription: >-
 changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELOG.md
 
 items:
+  - version: 2.4.11
+    date: "2022-02-10"
+    notes:
+      - type: change
+        title: Add additional logging to troubleshoot intermittent issues with intercepts
+        body: >-
+          We've noticed some issues with intercepts in v2.4.10, so we are releasing a version
+          with enhanced logging to help debug and fix the issue.
   - version: 2.4.10
     date: "2022-01-13"
     notes:

--- a/docs/v2.5/.gitrepo
+++ b/docs/v2.5/.gitrepo
@@ -5,8 +5,8 @@
 ;
 [subrepo]
 	remote = https://github.com/telepresenceio/docs
-	branch = max/from-telepresence.io-2022-02-19/release/v2.5
-	commit = b04eac85b6328cdfbcae58b0a1033c82b0b3c3a8
-	parent = 2e774781b0f53fad8920bec37fc1e639f820e11a
+	branch = release/v2.5
+	commit = f5993d69d2311cbbc3401f52df4edf234d6d1560
+	parent = 708d610d1d5f1501b4de061002e0cf6868e48b7d
 	method = merge
 	cmdver = 0.4.3

--- a/docs/v2.5/concepts/intercepts.md
+++ b/docs/v2.5/concepts/intercepts.md
@@ -98,7 +98,7 @@ with all your dev tools.
  1. Creating the intercept: Intercept your service from your CLI:
 
     ```shell
-    telepresence intercept SERVICENAME --http-match=all
+    telepresence intercept SERVICENAME --http-header=all
     ```
 
     <Alert severity="info">
@@ -142,13 +142,13 @@ while sharing the rest of the development environment.
  1. Creating the intercept: Intercept your service from your CLI:
 
     ```shell
-    telepresence intercept SERVICENAME --http-match=Personal-Intercept=126a72c7-be8b-4329-af64-768e207a184b
+    telepresence intercept SERVICENAME --http-header=Personal-Intercept=126a72c7-be8b-4329-af64-768e207a184b
     ```
 
     We're using
     `Personal-Intercept=126a72c7-be8b-4329-af64-768e207a184b` as the
     header for the sake of the example, but you can use any
-    `key=value` pair you want, or `--http-match=auto` to have it
+    `key=value` pair you want, or `--http-header=auto` to have it
     choose something automatically.
 
     <Alert severity="info">
@@ -187,8 +187,8 @@ while sharing the rest of the development environment.
 
 It's not uncommon to have one service serving several endpoints. Telepresence is capable of limiting an
 intercept to only affect the endpoints you want to work with by using one of the `--http-path-xxx`
-flags below in addition to using `--http-match` flags. Only one such flag can be used in an intercept
-and, contrary to the `--http-match` flag, it cannot be repeated.
+flags below in addition to using `--http-header` flags. Only one such flag can be used in an intercept
+and, contrary to the `--http-header` flag, it cannot be repeated.
 
 The following flags are available:
 
@@ -197,6 +197,30 @@ The following flags are available:
 | `--http-path-equal <path>`    | Only intercept the endpoint for this exact path                  |
 | `--http-path-prefix <prefix>` | Only intercept endpoints with a matching path prefix             |
 | `--http-path-regex <regex>`   | Only intercept endpoints that match the given regular expression |
+
+#### Examples:
+
+1. A personal intercept using the header "Coder: Bob" limited to all endpoints that start with "/api':
+
+    ```shell
+    telepresence intercept SERVICENAME --http-path-prefix=/api --http-header=Coder=Bob
+    ```
+
+2. A personal intercept using the auto generated header that applies only to the endpoint "/api/version":
+
+    ```shell
+    telepresence intercept SERVICENAME --http-path-equal=/api/version --http-header=auto
+    ```
+   or, since `--http-header=auto` is the implicit when using `--http` options, just:
+    ```shell
+    telepresence intercept SERVICENAME --http-path-equal=/api/version
+    ```
+
+3. A personal intercept using the auto generated header limited to all endpoints matching the regular expression "(staging-)?api/.*":
+
+    ```shell
+    telepresence intercept SERVICENAME --http-path-regex='/(staging-)?api/.*'
+    ```
 
 </TabPanel>
 </TabsContainer>

--- a/docs/v2.5/reference/intercepts/index.md
+++ b/docs/v2.5/reference/intercepts/index.md
@@ -15,7 +15,7 @@ that traffic-agent supports, and command-line flags to expose to the
 user to configure that mechanism.  You may tell Telepresence which
 known mechanism to use with the `--mechanism=${mechanism}` flag or by
 setting one of the `--${mechansim}-XXX` flags, which implicitly set
-the mechanism; for example, setting `--http-match=auto` implicitly
+the mechanism; for example, setting `--http-header=auto` implicitly
 sets `--mechanism=http`.
 
 The default open-source traffic-agent only supports the `tcp`
@@ -43,7 +43,7 @@ login`](../client/login/)) changes the Telepresence defaults in two
 ways.
 
 First, being logged in to Ambassador Cloud causes Telepresence to
-default to `--mechanism=http --http-match=auto --http-path-prefix=/` (
+default to `--mechanism=http --http-header=auto --http-path-prefix=/` (
 `--mechanism=http` is redundant. It is implied by other `--http-xxx` flags).
 If you hadn't been logged in it would have defaulted to
 `--mechanism=tcp`.  This tells Telepresence to use the Ambassador
@@ -52,7 +52,7 @@ intercept a subset of HTTP requests, rather than just intercepting the
 entirety of all TCP connections.  This is important for working in a
 shared cluster with teammates, and is important for the preview URL
 functionality below.  See `telepresence intercept --help` for
-information on using the `--http-match` and `--http-path-xxx` flags to
+information on using the `--http-header` and `--http-path-xxx` flags to
 customize which requests that are intercepted.
 
 Secondly, being logged in causes Telepresence to default to

--- a/docs/v2.5/reference/restapi.md
+++ b/docs/v2.5/reference/restapi.md
@@ -43,7 +43,7 @@ $ curl -v localhost:9980/healthz
 `http://localhost:<TELEPRESENCE_API_PORT>/consume-here` will respond with "true" (consume the message) or "false" (leave the message on the queue). When running in the cluster, this endpoint will respond with `false` if the headers match an ongoing intercept for the same workload because it's assumed that it's up to the intercept to consume the message. When running locally, the response is inverted. Matching headers means that the message should be consumed.
 
 #### test endpoint using curl
-Assuming that the API-server runs on port 9980, that the intercept was started with `--http-match x=y --http-path-prefix=/api`, we can now check that the "/consume-here" returns "true" for the path "/api" and given headers.
+Assuming that the API-server runs on port 9980, that the intercept was started with `--http-header x=y --http-path-prefix=/api`, we can now check that the "/consume-here" returns "true" for the path "/api" and given headers.
 ```console
 $ curl -v localhost:9980/consume-here?path=/api -H 'x-telepresence-caller-intercept-id: 4392d394-100e-4f15-a89b-426012f10e05:apitest' -H 'x: y'
 *   Trying ::1:9980...
@@ -71,7 +71,7 @@ If you can run curl from the pod, you can try the exact same URL. The result sho
 `http://localhost:<TELEPRESENCE_API_PORT>/intercept-info` is intended to be queried with an optional path query and a set of headers, typically obtained from a Kafka message or similar, and will respond with a JSON structure containing the two booleans `clientSide` and `intercepted`, and a `metadata` map which corresponds to the `--http-meta` key pairs used when the intercept was created. This field is always omitted in case `intercepted` is `false`.
 
 #### test endpoint using curl
-Assuming that the API-server runs on port 9980, that the intercept was started with `--http-match x=y --http-path-prefix=/api --http-meta a=b --http-meta b=c`, we can now check that the "/intercept-info" returns information for the given path and headers.
+Assuming that the API-server runs on port 9980, that the intercept was started with `--http-header x=y --http-path-prefix=/api --http-meta a=b --http-meta b=c`, we can now check that the "/intercept-info" returns information for the given path and headers.
 ```console
 $ curl -v localhost:9980/intercept-info?path=/api -H 'x-telepresence-caller-intercept-id: 4392d394-100e-4f15-a89b-426012f10e05:apitest' -H 'x: y'
 *   Trying ::1:9980...* Connected to localhost (127.0.0.1) port 9980 (#0)

--- a/docs/v2.5/releaseNotes.yml
+++ b/docs/v2.5/releaseNotes.yml
@@ -69,6 +69,12 @@ items:
           API endpoint <code>/intercept-info</code>
         docs: reference/restapi#intercept-info
       - type: change
+        title: --http-match renamed to --http-header
+        body: >-
+          The `telepresence intercept` command line flag <code>--http-match</code> was renamed to <code>--http-header</code>. The old flag
+          still works, but it is deprecated and doesn't show up in the help.
+        docs: concepts/intercepts#creating-and-using-personal-intercepts
+      - type: change
         title: Client RBAC watch
         body: >-
           The verb "watch" was added to the set of required verbs when accessing services and workloads for the client RBAC


### PR DESCRIPTION
## Description

This is adding some missing docs that I added directly in getambassador.io. I'll merge these changes in telepresence.io once completed here.

I also noticed that I had messed up the docs subrepos, which were pointing to my branches instead of the release ones. I pulled from the release branches before applying my changes. After updating, it looks like the pre-release is still linked to the v2.4 docs, although the pre-release docs in telepresence.io reflect the 2.5. I left that part out of this PR and will address it in another one.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
