### PR TITLE
Remove the TCP recursion blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Feature: Client-side binaries for the arm64 architecture are now available for linux
 
+- Bugfix: Fixed bug in the TCP stack causing timeouts after repeated connects to the same address
+
 ### 2.5.2 (February 23, 2022)
 
 - Bugfix: Fixed a bug where Telepresence would use the last server in resolv.conf

--- a/pkg/client/rootd/router.go
+++ b/pkg/client/rootd/router.go
@@ -183,9 +183,9 @@ func (s *session) tcp(c context.Context, pkt tcp.Packet) {
 		return
 	}
 
-	wf, _, err := s.handlers.GetOrCreateTCP(c, connID, func(c context.Context, remove func()) (tunnel.Handler, error) {
+	wf, _, err := s.handlers.GetOrCreate(c, connID, func(c context.Context, remove func()) (tunnel.Handler, error) {
 		return tcp.NewHandler(s.streamCreator(connID), &s.closing, vifWriter{s.dev}, connID, remove, s.rndSource), nil
-	}, pkt)
+	})
 	if err != nil {
 		dlog.Error(c, err)
 		pkt.Release()

--- a/pkg/tunnel/pool.go
+++ b/pkg/tunnel/pool.go
@@ -4,32 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/datawire/dlib/dlog"
-	"github.com/telepresenceio/telepresence/v2/pkg/vif/ip"
 )
-
-// RecursionBlocker is implemented by handlers that may experience recursive calls
-// back into the TUN device for IP addresses that have not been forwarded by the cluster.
-// This typically happens when running a cluster in a docker container on the local host
-// and making attempts to connect to an existing IP on a port that no service is
-// listening to.
-type RecursionBlocker interface {
-	InitDone() <-chan struct{}
-	Proceed() bool
-	Reset(context.Context, ip.Packet) error
-	Discard(ip.Packet) bool
-}
-
-// The error returned when recursion is encountered
-var errRecursion = errors.New("connection recursion")
 
 type Pool struct {
 	handlers map[ConnID]Handler
-	blockers map[ip.AddrKey]RecursionBlocker
-
-	lock sync.RWMutex
+	lock     sync.RWMutex
 }
 
 type Handler interface {
@@ -40,31 +21,12 @@ type Handler interface {
 }
 
 func NewPool() *Pool {
-	return &Pool{handlers: make(map[ConnID]Handler), blockers: make(map[ip.AddrKey]RecursionBlocker)}
+	return &Pool{handlers: make(map[ConnID]Handler)}
 }
 
 func (p *Pool) release(ctx context.Context, id ConnID) {
 	p.lock.Lock()
-	if h, ok := p.handlers[id]; ok {
-		delete(p.handlers, id)
-		if b, ok := h.(RecursionBlocker); ok {
-			destKey := ip.MakeAddrKey(id.Destination(), id.DestinationPort())
-			if p.blockers[destKey] == b {
-				if !b.Proceed() {
-					// Delete after a delay to ensure that all recursive attempts to
-					// establish have ceased.
-					time.AfterFunc(20*time.Second, func() {
-						p.lock.Lock()
-						delete(p.blockers, destKey)
-						p.lock.Unlock()
-					})
-				} else {
-					// Delete now (using the current lock)
-					delete(p.blockers, destKey)
-				}
-			}
-		}
-	}
+	delete(p.handlers, id)
 	count := len(p.handlers)
 	p.lock.Unlock()
 	dlog.Debugf(ctx, "-- POOL %s, count now is %d", id, count)
@@ -112,71 +74,6 @@ func (p *Pool) GetOrCreate(ctx context.Context, id ConnID, createHandler Handler
 	var old Handler
 	if old, ok = p.handlers[id]; !ok {
 		p.handlers[id] = handler
-	}
-	count := len(p.handlers)
-	p.lock.Unlock()
-	if ok {
-		// Toss newly created handler. It's not started anyway.
-		return old, true, nil
-	}
-	handler.Start(handlerCtx)
-	dlog.Debugf(ctx, "++ POOL %s, count now is %d", id, count)
-	return handler, false, nil
-}
-
-// GetOrCreateTCP is like GetOrCreate but with the addition that it detects and delays attempts to
-// create handlers for the same destination IP and port until the first attempt has either succeeded
-// or failed. If it fails, then attempts made during between the start and end of that attempt will
-// fail too.
-//
-func (p *Pool) GetOrCreateTCP(ctx context.Context, id ConnID, createHandler HandlerCreator, initialPacket ip.Packet) (Handler, bool, error) {
-	var blocker RecursionBlocker
-	p.lock.RLock()
-	if handler, ok := p.handlers[id]; ok {
-		p.lock.RUnlock()
-		return handler, true, nil
-	}
-
-	blocker = p.blockers[ip.MakeAddrKey(id.Destination(), id.DestinationPort())]
-	if blocker != nil {
-		p.lock.RUnlock()
-		if blocker.Discard(initialPacket) {
-			return nil, false, nil
-		}
-		<-blocker.InitDone()
-		if blocker.Proceed() {
-			return p.GetOrCreate(ctx, id, createHandler)
-		}
-		if err := blocker.Reset(ctx, initialPacket); err != nil {
-			dlog.Errorf(ctx, "failed to send RST after recursion block: %v", err)
-		}
-		return nil, false, errRecursion
-	}
-
-	handlerCtx, cancel := context.WithCancel(ctx)
-	release := func() {
-		p.release(ctx, id)
-		cancel()
-	}
-
-	handler, err := createHandler(handlerCtx, release)
-	p.lock.RUnlock()
-	if err != nil {
-		return nil, false, err
-	}
-	if handler == nil {
-		return nil, false, errors.New("createHandler function did not produce a handler")
-	}
-
-	p.lock.Lock()
-	var old Handler
-	var ok bool
-	if old, ok = p.handlers[id]; !ok {
-		p.handlers[id] = handler
-		var isBlocker bool
-		if blocker, isBlocker = handler.(RecursionBlocker); isBlocker {
-			p.blockers[ip.MakeAddrKey(id.Destination(), id.DestinationPort())] = blocker
-		}
 	}
 	count := len(p.handlers)
 	p.lock.Unlock()

--- a/pkg/vif/tcp/handler.go
+++ b/pkg/vif/tcp/handler.go
@@ -101,12 +101,6 @@ type handler struct {
 	toTun   ip.Writer
 	fromTun chan Packet
 
-	// recursionWaiter blocks connects to the same destination during connect to prevent endless
-	// recursions when the destination runs on the local host (in a Docker container) and forwards
-	// connects that aren't routed to Telepresence TUN-device
-	establishedCh chan struct{}
-	establishedOk bool
-
 	// the dispatcher signals its intent to close in dispatcherClosing. 0 == running, 1 == closing, 2 == closed
 	dispatcherClosing *int32
 
@@ -180,8 +174,6 @@ type handler struct {
 
 	// random generator for initial sequence number
 	rnd *rand.Rand
-
-	synDiscardCount int
 }
 
 func NewHandler(
@@ -201,7 +193,6 @@ func NewHandler(
 		fromTun:           make(chan Packet, ioChannelSize),
 		toMgrCh:           make(chan Packet, ioChannelSize),
 		toMgrMsgCh:        make(chan tunnel.Message),
-		establishedCh:     make(chan struct{}),
 		myWindow:          maxReceiveWindow,
 		wfState:           stateIdle,
 		rnd:               rand.New(rndSource),
@@ -232,34 +223,11 @@ func (h *handler) Close(ctx context.Context) {
 	}
 	// Wake up if waiting for larger window size (ends processPayload)
 	h.sendCondition.Broadcast()
-	select {
-	case <-h.establishedCh:
-		// already closed
-	default:
-		close(h.establishedCh)
-	}
-}
-
-func (h *handler) InitDone() <-chan struct{} {
-	return h.establishedCh
-}
-
-func (h *handler) Proceed() bool {
-	return h.establishedOk // This isn't a state. It's a permanent indication that the connection attempt succeeded.
 }
 
 // Reset replies to the sender of the initialPacket with a RST packet.
 func (h *handler) Reset(ctx context.Context, initialPacket ip.Packet) error {
 	return h.toTun.Write(ctx, initialPacket.(Packet).Reset())
-}
-
-// Discard returns true if the package should be discarded
-func (h *handler) Discard(initialPacket ip.Packet) bool {
-	if initialPacket.(Packet).Header().SYN() {
-		h.synDiscardCount++
-		return h.synDiscardCount > 1 // Keep initial SYN packet
-	}
-	return false
 }
 
 func (h *handler) Start(ctx context.Context) {

--- a/pkg/vif/tcp/tmgr.go
+++ b/pkg/vif/tcp/tmgr.go
@@ -12,8 +12,6 @@ import (
 func (h *handler) handleStreamControl(ctx context.Context, ctrl tunnel.Message) {
 	switch ctrl.Code() {
 	case tunnel.DialOK:
-		h.establishedOk = true
-		close(h.establishedCh)
 	case tunnel.DialReject, tunnel.Disconnect:
 		h.Close(ctx)
 	case tunnel.KeepAlive:


### PR DESCRIPTION
## Description

The recursion blocker for TCP traffic was too intrusive and caused
timeouts and is therefore removed in this commit. Recursions that may
occur when the cluster has access to the workstation's network need to
be dealt with using other network control mechanisms such as
`never_proxy` or by configuring container network so that it cannot
reach the host network.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
 