### PR TITLE
Add install id, user id, account id and json flag to status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.5.4 (TBD)
 
+- Change: The status command includes the install id, user id and account id in its result, and can print output as JSON
+
 - Bugfix: Removed a bad concatenation that corrupted the output path of `telepresence gather-logs`.
 
 ### 2.5.3 (February 25, 2022)

--- a/docs/v2.5/releaseNotes.yml
+++ b/docs/v2.5/releaseNotes.yml
@@ -39,6 +39,13 @@ docDescription: >-
 changelog: https://github.com/telepresenceio/telepresence/blob/$branch$/CHANGELOG.md
 
 items:
+  - version: 2.5.4
+    date: "TBD"
+    notes:
+      - type: change
+        title: Update status command output
+        body: >-
+          The status command includes the install id, user id and account id in its result, and can print output as JSON.
   - version: 2.5.1
     date: "2022-02-19"
     notes:

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/stretchr/testify/suite"
@@ -40,4 +41,36 @@ func (s *cliSuite) Test_Status() {
 	s.Empty(stderr)
 	s.Contains(stdout, "Root Daemon: Not running")
 	s.Contains(stdout, "User Daemon: Not running")
+}
+
+func (s *cliSuite) Test_StatusWithJSON() {
+	itest.TelepresenceQuitOk(s.Context())
+	stdout, stderr, err := itest.Telepresence(s.Context(), "status", "--json")
+	if err != nil {
+		s.SetGeneralError(fmt.Errorf("bailing out. If telepresence status isn't working, nothing will: %w", err))
+		s.Require().NoError(err)
+	}
+	s.NoError(err)
+	s.Empty(stderr)
+
+	var status statusResponse
+	s.NoError(json.Unmarshal([]byte(stdout), &status))
+	s.False(status.RootDaemon.Running)
+	s.False(status.UserDaemon.Running)
+}
+
+type statusResponseRootDaemon struct {
+	Running           bool     `json:"running,omitempty"`
+	AlsoProxySubnets  []string `json:"also_proxy_subnets,omitempty"`
+	NeverProxySubnets []string `json:"never_proxy_subnets,omitempty"`
+}
+
+type statusResponseUserDaemon struct {
+	Running           bool   `json:"running,omitempty"`
+	KubernetesContext string `json:"kubernetes_context,omitempty"`
+}
+
+type statusResponse struct {
+	RootDaemon statusResponseRootDaemon `json:"root_daemon,omitempty"`
+	UserDaemon statusResponseUserDaemon `json:"user_daemon,omitempty"`
 }

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -68,6 +68,7 @@ type statusResponseRootDaemon struct {
 type statusResponseUserDaemon struct {
 	Running           bool   `json:"running,omitempty"`
 	KubernetesContext string `json:"kubernetes_context,omitempty"`
+	InstallID         string `json:"install_id,omitempty"`
 }
 
 type statusResponse struct {

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/stretchr/testify/suite"
@@ -31,4 +32,13 @@ func (s *connectedSuite) Test_Status() {
 	s.Contains(stdout, "Root Daemon: Running")
 	s.Contains(stdout, "User Daemon: Running")
 	s.Contains(stdout, "Kubernetes context:")
+}
+
+func (s *connectedSuite) Test_StatusWithJSON() {
+	stdout := itest.TelepresenceOk(s.Context(), "status", "--json")
+	var status statusResponse
+	s.NoError(json.Unmarshal([]byte(stdout), &status))
+	s.True(status.RootDaemon.Running)
+	s.True(status.UserDaemon.Running)
+	s.NotEmpty(status.UserDaemon.KubernetesContext)
 }

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -41,4 +41,5 @@ func (s *connectedSuite) Test_StatusWithJSON() {
 	s.True(status.RootDaemon.Running)
 	s.True(status.UserDaemon.Running)
 	s.NotEmpty(status.UserDaemon.KubernetesContext)
+	s.NotEmpty(status.UserDaemon.InstallID)
 }

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -104,7 +104,7 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 		stdout := itest.TelepresenceOk(ctx, "status")
 		s.T().Log("Actual status output: ", stdout)
 		expected := fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount)
-		s.T().Log("Looking for string: %s", expected)
+		s.T().Log("Looking for string: ", expected)
 		return strings.Contains(stdout, expected)
 	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
 

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -102,12 +102,15 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 	neverProxiedCount := len(ips) + 1
 	s.Eventually(func() bool {
 		stdout := itest.TelepresenceOk(ctx, "status")
+		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount))
+	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
+
+	s.Eventually(func() bool {
 		jsonStdout := itest.TelepresenceOk(ctx, "status", "--json")
 		var status statusResponse
-		require.NoError(json.Unmarshal([]byte(jsonStdout), &status))
-		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount)) &&
-			len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
-	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
+		err := json.Unmarshal([]byte(jsonStdout), &status)
+		return err == nil && len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
+	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		return itest.Run(ctx, "curl", "--silent", "--max-time", "0.5", ip) != nil

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -102,19 +102,15 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 	neverProxiedCount := len(ips) + 1
 	s.Eventually(func() bool {
 		stdout := itest.TelepresenceOk(ctx, "status")
-		s.T().Log("Actual status output: ", stdout)
-		expected := fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount)
-		s.T().Log("Looking for string: ", expected)
-		return strings.Contains(stdout, expected)
-	}, 10*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
+		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount))
+	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		jsonStdout := itest.TelepresenceOk(ctx, "status", "--json")
 		var status statusResponse
 		require.NoError(json.Unmarshal([]byte(jsonStdout), &status))
-		s.T().Log("Actual never proxy subnet count: ", len(status.RootDaemon.NeverProxySubnets))
 		return len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
-	}, 10*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
+	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		return itest.Run(ctx, "curl", "--silent", "--max-time", "0.5", ip) != nil

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -106,7 +106,7 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 		expected := fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount)
 		s.T().Log("Looking for string: ", expected)
 		return strings.Contains(stdout, expected)
-	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
+	}, 10*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		jsonStdout := itest.TelepresenceOk(ctx, "status", "--json")
@@ -114,7 +114,7 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 		require.NoError(json.Unmarshal([]byte(jsonStdout), &status))
 		s.T().Log("Actual never proxy subnet count: ", len(status.RootDaemon.NeverProxySubnets))
 		return len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
-	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
+	}, 10*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		return itest.Run(ctx, "curl", "--silent", "--max-time", "0.5", ip) != nil

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -70,7 +70,7 @@ func (s *notConnectedSuite) Test_APIServerIsProxied() {
 		copy(rng[:], ip)
 		rng[len(rng)-1] = 0
 		expectedValue := fmt.Sprintf("%s/24", rng)
-		require.Contains(stdout, fmt.Sprintf("- %s", expectedValue), fmt.Sprintf("Expecting to find '- %s/24'", rng))
+		require.Contains(stdout, fmt.Sprintf("- %s", expectedValue), fmt.Sprintf("Expecting to find '- %s'", expectedValue))
 		require.Contains(status.RootDaemon.AlsoProxySubnets, expectedValue)
 	}
 }
@@ -103,7 +103,9 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 	s.Eventually(func() bool {
 		stdout := itest.TelepresenceOk(ctx, "status")
 		s.T().Log("Actual status output: ", stdout)
-		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount))
+		expected := fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount)
+		s.T().Log("Looking for string: %s", expected)
+		return strings.Contains(stdout, expected)
 	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
 
 	s.Eventually(func() bool {

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -102,14 +102,16 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 	neverProxiedCount := len(ips) + 1
 	s.Eventually(func() bool {
 		stdout := itest.TelepresenceOk(ctx, "status")
+		s.T().Log("Actual status output: ", stdout)
 		return strings.Contains(stdout, fmt.Sprintf("Never Proxy: (%d subnets)", neverProxiedCount))
 	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets", neverProxiedCount))
 
 	s.Eventually(func() bool {
 		jsonStdout := itest.TelepresenceOk(ctx, "status", "--json")
 		var status statusResponse
-		err := json.Unmarshal([]byte(jsonStdout), &status)
-		return err == nil && len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
+		require.NoError(json.Unmarshal([]byte(jsonStdout), &status))
+		s.T().Log("Actual never proxy subnet count: ", len(status.RootDaemon.NeverProxySubnets))
+		return len(status.RootDaemon.NeverProxySubnets) == neverProxiedCount
 	}, 5*time.Second, 1*time.Second, fmt.Sprintf("did not find %d never-proxied subnets in json status", neverProxiedCount))
 
 	s.Eventually(func() bool {

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -107,8 +107,8 @@ func (s *statusInfo) status(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (s *statusInfo) daemonStatus(ctx context.Context) (daemonStatus, error) {
-	ds := daemonStatus{}
+func (s *statusInfo) daemonStatus(ctx context.Context) (*daemonStatus, error) {
+	ds := &daemonStatus{}
 	err := cliutil.WithStartedNetwork(ctx, func(ctx context.Context, daemonClient daemon.DaemonClient) error {
 		ds.Running = true
 		var err error
@@ -154,8 +154,8 @@ func (s *statusInfo) daemonStatus(ctx context.Context) (daemonStatus, error) {
 	return ds, nil
 }
 
-func (s *statusInfo) connectorStatus(ctx context.Context) (connectorStatus, error) {
-	cs := connectorStatus{}
+func (s *statusInfo) connectorStatus(ctx context.Context) (*connectorStatus, error) {
+	cs := &connectorStatus{}
 	err := cliutil.WithStartedConnector(ctx, false, func(ctx context.Context, connectorClient connector.ConnectorClient) error {
 		cs.Running = true
 		version, err := connectorClient.Version(ctx, &empty.Empty{})
@@ -222,10 +222,10 @@ func (s *statusInfo) connectorStatus(ctx context.Context) (connectorStatus, erro
 	return cs, nil
 }
 
-func (s *statusInfo) printJSON(ds daemonStatus, cs connectorStatus) error {
+func (s *statusInfo) printJSON(ds *daemonStatus, cs *connectorStatus) error {
 	output, err := json.Marshal(statusOutput{
-		DaemonStatus: ds,
-		UserDaemon:   cs,
+		DaemonStatus: *ds,
+		UserDaemon:   *cs,
 	})
 	if err != nil {
 		return err
@@ -234,12 +234,12 @@ func (s *statusInfo) printJSON(ds daemonStatus, cs connectorStatus) error {
 	return nil
 }
 
-func (s *statusInfo) printText(ds daemonStatus, cs connectorStatus) {
+func (s *statusInfo) printText(ds *daemonStatus, cs *connectorStatus) {
 	s.printDaemonText(ds)
 	s.printConnectorText(cs)
 }
 
-func (s *statusInfo) printDaemonText(ds daemonStatus) {
+func (s *statusInfo) printDaemonText(ds *daemonStatus) {
 	if ds.Running {
 		s.println("Root Daemon: Running")
 		s.printf("  Version   : %s (api %d)\n", ds.Version, ds.APIVersion)
@@ -266,7 +266,7 @@ func (s *statusInfo) printDaemonText(ds daemonStatus) {
 	}
 }
 
-func (s *statusInfo) printConnectorText(cs connectorStatus) {
+func (s *statusInfo) printConnectorText(cs *connectorStatus) {
 	if cs.Running {
 		s.println("User Daemon: Running")
 		s.printf("  Version         : %s (api %d)\n", cs.Version, cs.APIVersion)

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/rpc/v2/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/cliutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
@@ -164,8 +165,8 @@ func (s *statusInfo) connectorStatus(ctx context.Context) (*connectorStatus, err
 		cs.Version = version.Version
 		cs.APIVersion = version.ApiVersion
 		cs.Executable = version.Executable
-		//reporter := scout.NewReporter(ctx, "cli")
-		//cs.InstallID = reporter.InstallID()
+		reporter := scout.NewReporter(ctx, "cli")
+		cs.InstallID = reporter.InstallID()
 
 		if !cliutil.HasLoggedIn(ctx) {
 			cs.AmbassadorCloud.Status = "Logged out"

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -15,7 +15,6 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/rpc/v2/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/cliutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
@@ -165,8 +164,8 @@ func (s *statusInfo) connectorStatus(ctx context.Context) (*connectorStatus, err
 		cs.Version = version.Version
 		cs.APIVersion = version.ApiVersion
 		cs.Executable = version.Executable
-		reporter := scout.NewReporter(ctx, "cli")
-		cs.InstallID = reporter.InstallID()
+		//reporter := scout.NewReporter(ctx, "cli")
+		//cs.InstallID = reporter.InstallID()
 
 		if !cliutil.HasLoggedIn(ctx) {
 			cs.AmbassadorCloud.Status = "Logged out"

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -136,10 +136,10 @@ func (s *statusInfo) daemonStatus(ctx context.Context) (daemonStatus, error) {
 			ds.DNS.IncludeSuffixes = dns.IncludeSuffixes
 			ds.DNS.LookupTimeout = dns.LookupTimeout.AsDuration()
 			for _, subnet := range obc.AlsoProxySubnets {
-				ds.AlsoProxySubnets = append(ds.AlsoProxySubnets, fmt.Sprintf("%v", iputil.IPNetFromRPC(subnet)))
+				ds.AlsoProxySubnets = append(ds.AlsoProxySubnets, iputil.IPNetFromRPC(subnet).String())
 			}
 			for _, subnet := range obc.NeverProxySubnets {
-				ds.NeverProxySubnets = append(ds.NeverProxySubnets, fmt.Sprintf("%v", iputil.IPNetFromRPC(subnet)))
+				ds.NeverProxySubnets = append(ds.NeverProxySubnets, iputil.IPNetFromRPC(subnet).String())
 			}
 		}
 		return nil

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 	"io"
 	"net"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/rpc/v2/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/cliutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 

--- a/pkg/client/scout/os_metadata_windows.go
+++ b/pkg/client/scout/os_metadata_windows.go
@@ -11,34 +11,36 @@ import (
 )
 
 func getOsMetadata(ctx context.Context) map[string]interface{} {
-	cmd := dexec.CommandContext(ctx, "systeminfo")
+	cmd := dexec.CommandContext(ctx, "wmic", "os", "get", "Caption,Version,BuildNumber", "/value")
 	cmd.DisableLogging = true
 	r, err := cmd.Output()
 	osMeta := map[string]interface{}{}
 	if err != nil {
-		dlog.Warnf(ctx, "Error running systeminfo: %v", err)
+		dlog.Warnf(ctx, "Error running wmic: %v", err)
 		return osMeta
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(r))
 	for scanner.Scan() {
 		line := scanner.Text()
-		parts := strings.Split(line, ":")
+		parts := strings.Split(line, "=")
 		if len(parts) < 2 {
 			// Untagged string (empty line, etc)
 			continue
 		}
-		name, value := strings.TrimSpace(parts[0]), strings.TrimSpace(strings.Join(parts[1:], ":"))
+		name, value := strings.TrimSpace(parts[0]), strings.TrimSpace(strings.Join(parts[1:], "="))
 		// systeminfo doesn't have a concept of an OS Build number, so we'll have to set that to unknown
-		if name == "OS Name" {
+		if name == "Caption" {
 			osMeta["os_name"] = value
 		}
-		if name == "OS Version" {
+		if name == "Version" {
 			osMeta["os_version"] = value
 		}
+		if name == "BuildNumber" {
+			osMeta["os_build_version"] = value
+		}
 	}
-	osMeta["os_build_version"] = "unknown"
 	if err := scanner.Err(); err != nil {
-		dlog.Warnf(ctx, "Unable to scan systeminfo output: %v", err)
+		dlog.Warnf(ctx, "Unable to scan wmic output: %v", err)
 	}
 	return osMeta
 }


### PR DESCRIPTION
## Description

This PR adds the install id, user id and account id as metadata
returned by the status command. It also adds support for a `--json` flag
so that its output can be easily consumed by other processes.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
