### PR TITLE
Fix broken gather-logs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.4 (TBD)
+
+- Bugfix: Removed a bad concatenation that corrupted the output path of `telepresence gather-logs`.
+
 ### 2.5.3 (February 25, 2022)
 
 - Feature: Client-side binaries for the arm64 architecture are now available for linux

--- a/pkg/client/cli/cmd_gatherlogs.go
+++ b/pkg/client/cli/cmd_gatherlogs.go
@@ -104,7 +104,7 @@ func (gl *gatherLogsArgs) gatherLogs(ctx context.Context, cmd *cobra.Command, st
 		if err != nil {
 			return errcat.User.New(err)
 		}
-		gl.outputFile = filepath.Join(pwd, "telepresence_logs.zip", pwd)
+		gl.outputFile = filepath.Join(pwd, "telepresence_logs.zip")
 	} else if !strings.HasSuffix(gl.outputFile, ".zip") {
 		return errcat.User.New("output file must end in .zip")
 	}


### PR DESCRIPTION
The path of the final log had an extra full path appended to it. This
commit removes that path.