### PR TITLE
Don't print "see logs for details" when the argument count is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change: The status command includes the install id, user id and account id in its result, and can print output as JSON
 
+- Bugfix: An advice to "see logs for details" is no longer printed when the argument count is incorrect in a CLI command.
+
 - Bugfix: Removed a bad concatenation that corrupted the output path of `telepresence gather-logs`.
 
 - Bugfix: Agent container is no longer sensitive to a random UID or an UID imposed by a SecurityContext.

--- a/pkg/client/cli/cmd_loglevel.go
+++ b/pkg/client/cli/cmd_loglevel.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -26,15 +27,15 @@ type logLevelSetter struct {
 
 func logLevelArg(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
-		return errcat.User.New("accepts exactly one argument (the log level)")
+		return errors.New("accepts exactly one argument (the log level)")
 	}
 	lvl, err := logrus.ParseLevel(args[0])
 	if err != nil {
-		return errcat.User.New(err)
+		return err
 	}
 	switch lvl {
 	case logrus.PanicLevel, logrus.FatalLevel:
-		return errcat.User.Newf("unsupported log level: %s", lvl)
+		return fmt.Errorf("unsupported log level: %s", lvl)
 	}
 	return nil
 }

--- a/pkg/client/cli/cmd_uninstall.go
+++ b/pkg/client/cli/cmd_uninstall.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 
@@ -39,16 +40,16 @@ func uninstallCommand() *cobra.Command {
 
 func (u *uninstallInfo) args(cmd *cobra.Command, args []string) error {
 	if u.agent && u.allAgents || u.agent && u.everything || u.allAgents && u.everything {
-		return errcat.User.New("--agent, --all-agents, or --everything are mutually exclusive")
+		return errors.New("--agent, --all-agents, or --everything are mutually exclusive")
 	}
 	if !(u.agent || u.allAgents || u.everything) {
-		return errcat.User.New("please specify --agent, --all-agents, or --everything")
+		return errors.New("please specify --agent, --all-agents, or --everything")
 	}
 	switch {
 	case u.agent && len(args) == 0:
-		return errcat.User.New("at least one argument (the name of an agent) is expected")
+		return errors.New("at least one argument (the name of an agent) is expected")
 	case !u.agent && len(args) != 0:
-		return errcat.User.New("unexpected argument(s)")
+		return errors.New("unexpected argument(s)")
 	}
 	return nil
 }


### PR DESCRIPTION
Adds a generic wrapper for `cobra.Command.Args` to all sub-commands that
suppresses the "see logs for detail" message.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
