### PR TITLE
Speed up getOsMetadata() on macOS

### DIFF
--- a/pkg/client/scout/os_metadata_darwin.go
+++ b/pkg/client/scout/os_metadata_darwin.go
@@ -1,6 +1,8 @@
 package scout
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"strings"
 
@@ -8,22 +10,31 @@ import (
 	"github.com/datawire/dlib/dlog"
 )
 
-func runSwVers(ctx context.Context, versionName string) string {
-	cmd := dexec.CommandContext(ctx, "sw_vers", "-"+versionName)
-	cmd.DisableLogging = true
-	r, err := cmd.Output()
-	if err != nil {
-		dlog.Warnf(ctx, "Could not get os metadata %s: %v", versionName, err)
-		return "unknown"
-	}
-	return strings.TrimSpace(string(r))
-}
-
 func getOsMetadata(ctx context.Context) map[string]interface{} {
 	osMeta := map[string]interface{}{
-		"os_version":       runSwVers(ctx, "productVersion"),
-		"os_build_version": runSwVers(ctx, "buildVersion"),
-		"os_name":          runSwVers(ctx, "productName"),
+		"os_version":       "unknown",
+		"os_build_version": "unknown",
+		"os_name":          "unknown",
+	}
+	cmd := dexec.CommandContext(ctx, "sw_vers")
+	cmd.DisableLogging = true
+	if r, err := cmd.Output(); err != nil {
+		dlog.Warnf(ctx, "Could not get os metadata: %v", err)
+	} else {
+		sc := bufio.NewScanner(bytes.NewReader(r))
+		for sc.Scan() {
+			fs := strings.Fields(sc.Text())
+			if len(fs) == 2 {
+				switch fs[0] {
+				case "ProductName:":
+					osMeta["os_name"] = fs[1]
+				case "ProductVersion:":
+					osMeta["os_version"] = fs[1]
+				case "BuildVersion:":
+					osMeta["os_build_version"] = fs[1]
+				}
+			}
+		}
 	}
 	return osMeta
 }


### PR DESCRIPTION
Shell out to `sw_vers` once instead of three times.