### PR TITLE
Fix connector report metadatum

### DIFF
--- a/pkg/client/userd/grpc.go
+++ b/pkg/client/userd/grpc.go
@@ -148,8 +148,8 @@ func scoutInterceptEntries(spec *manager.InterceptSpec, result *rpc.InterceptRes
 	var msg string
 	if result != nil {
 		entries = append(entries,
-			scout.Entry{Key: "service_uid", Value: len(result.ServiceUid)},
-			scout.Entry{Key: "workload_kind", Value: len(result.WorkloadKind)},
+			scout.Entry{Key: "service_uid", Value: result.ServiceUid},
+			scout.Entry{Key: "workload_kind", Value: result.WorkloadKind},
 		)
 		if result.Error != rpc.InterceptError_UNSPECIFIED {
 			msg = result.Error.String()


### PR DESCRIPTION
## Description

The growth team has reached out to me to investigate wrong service IDs reported for the connector_create_intercept_* reports. They all had `36` as `service_uid` extra trait, which is the length of a UUID. This PR is fixing this by setting the value for both `service_uid` and `workload_kind` instead of the length of the string (I suspect a bad copy/paste from the `intercept_mechanism_numargs` line).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
