### PR TITLE
Update community meeting information

### DIFF
--- a/MEETING_SCHEDULE.md
+++ b/MEETING_SCHEDULE.md
@@ -1,20 +1,16 @@
 # Community Meeting Schedule
 
-## Meet the Maintainers
+## Weekly Troubleshooting
 
-Every four to six weeks we dedicate one session to meeting the maintainers of Telepresence.  These sessions are a way to connect in person to share updates and listen to feedback from the community. 
+We hold troubleshooting sessions once a week on Tuesdays, at 2:30 pm Eastern.  These sessions are a way to connect in person with project maintainers and get help with any problems you might be encountering while using Telepresence.
 
-For the latest information, [visit the website](https://www.getambassador.io/about-us/events/meet-the-maintainers/).
+**Zoom Meeting Link**: https://us02web.zoom.us/j/81514139559?pwd=M3g3dzV4cytQV0IrMVpuZWFyU2ZDQT09
 
 
-**Zoom Meeting Link**: https://us02web.zoom.us/j/81261393224
-
-**Recordings**: http://bit.ly/AmbassadorOfficeHoursRecordings
-
-## Contributors Meeting
+## Monthly Contributors Meeting
 
 The Telepresence Contributors Meeting is held on the first Wednesday of every month at 11am Eastern.  The focus of this meeting is discussion of technical issues related to development of Telepresence.
 
 New contributors are always welcome! Check out our [contributor's guide](DEVELOPING.md) to learn how you can help make Telepresence better.
 
-**Zoom Meeting Link**: https://us02web.zoom.us/j/83490763112
+**Zoom Meeting Link**: https://us02web.zoom.us/j/6297823847


### PR DESCRIPTION
## Description

This pull request updates information about community meetings by 1) removing Meet the Maintainers meetings, 2) adding weekly troubleshooting sessions, and 3) correcting the Zoom link for monthly contributors meetings.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
