### PR TITLE
Disable cgo for linux again.

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -24,6 +24,15 @@ BINDIR=$(BUILDDIR)/bin
 
 bindir ?= $(or $(shell go env GOBIN),$(shell go env GOPATH|cut -d: -f1)/bin)
 
+# Build statically on linux platforms so that the binary can be used in
+# alpine containers and the like, where libc is different.
+ifeq ($(GOHOSTOS),linux)
+CGO_ENABLED=0
+else
+CGO_ENABLED=1
+endif
+
+
 .PHONY: FORCE
 FORCE:
 


### PR DESCRIPTION
This would break all alpine containers which represent a big proportion
of users using telepresence inside docker

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
