### PR TITLE
Have traffic-manager use channels instead of conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Change: The status command includes the install id, user id, account id, and user email in its result, and can print output as JSON
 
+- Bugfix: Client and agent sessions no longer leaves dangling waiters in the traffic-manager when they depart.
+
 - Bugfix: An advice to "see logs for details" is no longer printed when the argument count is incorrect in a CLI command.
 
 - Bugfix: Removed a bad concatenation that corrupted the output path of `telepresence gather-logs`.

--- a/cmd/traffic/cmd/manager/internal/cluster/subscriber.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/subscriber.go
@@ -1,0 +1,107 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+type clusterInfoSubscribers struct {
+	sync.Mutex
+	idGen       int
+	current     *rpc.ClusterInfo
+	subscribers map[int]chan *rpc.ClusterInfo
+}
+
+func newClusterInfoSubscribers() *clusterInfoSubscribers {
+	return &clusterInfoSubscribers{
+		current:     &rpc.ClusterInfo{},
+		subscribers: make(map[int]chan *rpc.ClusterInfo),
+	}
+}
+
+func (ss *clusterInfoSubscribers) notify(ctx context.Context, ci *rpc.ClusterInfo) {
+	ss.Lock()
+	defer ss.Unlock()
+	if clusterInfoEqual(ss.current, ci) {
+		return
+	}
+	ss.current = ci
+	for _, ch := range ss.subscribers {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- ci:
+		default:
+		}
+	}
+}
+
+func (ss *clusterInfoSubscribers) subscribe() (int, <-chan *rpc.ClusterInfo) {
+	ch := make(chan *rpc.ClusterInfo, 3)
+	ss.Lock()
+	id := ss.idGen
+	ss.idGen++
+	ss.subscribers[id] = ch
+	curr := ss.current
+	ss.Unlock()
+	if curr.KubeDnsIp != nil {
+		// Post initial state
+		ch <- curr
+	}
+	return id, ch
+}
+
+func (ss *clusterInfoSubscribers) unsubscribe(id int) {
+	ss.Lock()
+	ch, ok := ss.subscribers[id]
+	if ok {
+		delete(ss.subscribers, id)
+	}
+	ss.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (ss *clusterInfoSubscribers) subscriberLoop(ctx context.Context, rec interface {
+	Send(request *rpc.ClusterInfo) error
+}) error {
+	id, ch := ss.subscribe()
+	defer ss.unsubscribe(id)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ll := <-ch:
+			if ll == nil {
+				return nil
+			}
+			if err := rec.Send(ll); err != nil {
+				if ctx.Err() == nil {
+					return fmt.Errorf("WatchLogLevel.Send() failed: %w", err)
+				}
+				return nil
+			}
+		}
+	}
+}
+
+func clusterInfoEqual(a, b *rpc.ClusterInfo) bool {
+	if len(a.PodSubnets) != len(b.PodSubnets) ||
+		a.ServiceSubnet != b.ServiceSubnet ||
+		a.ClusterDomain != b.ClusterDomain ||
+		!net.IP(a.KubeDnsIp).Equal(b.KubeDnsIp) {
+		return false
+	}
+	for i, aps := range a.PodSubnets {
+		bps := b.PodSubnets[i]
+		if !net.IP(aps.Ip).Equal(bps.Ip) || aps.Mask != bps.Mask {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/traffic/cmd/manager/internal/cluster/subscriber.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/subscriber.go
@@ -82,7 +82,7 @@ func (ss *clusterInfoSubscribers) subscriberLoop(ctx context.Context, rec interf
 			}
 			if err := rec.Send(ll); err != nil {
 				if ctx.Err() == nil {
-					return fmt.Errorf("WatchLogLevel.Send() failed: %w", err)
+					return fmt.Errorf("WatchCusterInfo.Send() failed: %w", err)
 				}
 				return nil
 			}

--- a/cmd/traffic/cmd/manager/internal/state/llsubscriber.go
+++ b/cmd/traffic/cmd/manager/internal/state/llsubscriber.go
@@ -1,0 +1,89 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+type loglevelSubscribers struct {
+	sync.Mutex
+	idGen       int
+	current     *rpc.LogLevelRequest
+	subscribers map[int]chan *rpc.LogLevelRequest
+}
+
+func newLoglevelSubscribers() *loglevelSubscribers {
+	return &loglevelSubscribers{
+		current:     &rpc.LogLevelRequest{},
+		subscribers: make(map[int]chan *rpc.LogLevelRequest),
+	}
+}
+func (ss *loglevelSubscribers) notify(ctx context.Context, ll *rpc.LogLevelRequest) {
+	ss.Lock()
+	defer ss.Unlock()
+	if ss.current.LogLevel == ll.LogLevel && ss.current.Duration.AsDuration() == ll.Duration.AsDuration() {
+		return
+	}
+	ss.current = ll
+	for _, ch := range ss.subscribers {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- ll:
+		default:
+		}
+	}
+}
+
+func (ss *loglevelSubscribers) subscribe() (int, <-chan *rpc.LogLevelRequest) {
+	ch := make(chan *rpc.LogLevelRequest, 3)
+	ss.Lock()
+	id := ss.idGen
+	ss.idGen++
+	ss.subscribers[id] = ch
+	curr := ss.current
+	ss.Unlock()
+	if curr.Duration != nil {
+		// Post initial state
+		ch <- curr
+	}
+	return id, ch
+}
+
+func (ss *loglevelSubscribers) unsubscribe(id int) {
+	ss.Lock()
+	ch, ok := ss.subscribers[id]
+	if ok {
+		delete(ss.subscribers, id)
+	}
+	ss.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (ss *loglevelSubscribers) subscriberLoop(ctx context.Context, rec interface {
+	Send(request *rpc.LogLevelRequest) error
+}) error {
+	id, ch := ss.subscribe()
+	defer ss.unsubscribe(id)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ll := <-ch:
+			if ll == nil {
+				return nil
+			}
+			if err := rec.Send(ll); err != nil {
+				if ctx.Err() == nil {
+					return fmt.Errorf("WatchLogLevel.Send() failed: %w", err)
+				}
+				return nil
+			}
+		}
+	}
+}

--- a/cmd/traffic/cmd/manager/internal/state/state.go
+++ b/cmd/traffic/cmd/manager/internal/state/state.go
@@ -180,17 +180,18 @@ type State struct {
 	interceptAPIKeys map[string]string                    // InterceptIDs mapped to the APIKey used to create them
 	agentsByName     map[string]map[string]*rpc.AgentInfo // indexed copy of `agents`
 	timedLogLevel    log.TimedLevel
-	logLevelCond     sync.Cond
+	llSubs           *loglevelSubscribers
 }
 
 func NewState(ctx context.Context) *State {
+	loglevel := os.Getenv("LOG_LEVEL")
 	return &State{
 		ctx:              ctx,
 		sessions:         make(map[string]SessionState),
 		interceptAPIKeys: make(map[string]string),
 		agentsByName:     make(map[string]map[string]*rpc.AgentInfo),
-		timedLogLevel:    log.NewTimedLevel(os.Getenv("LOG_LEVEL"), log.SetLevel),
-		logLevelCond:     sync.Cond{L: &sync.Mutex{}},
+		timedLogLevel:    log.NewTimedLevel(loglevel, log.SetLevel),
+		llSubs:           newLoglevelSubscribers(),
 	}
 }
 
@@ -839,7 +840,7 @@ func (s *State) SetTempLogLevel(ctx context.Context, logLevelRequest *rpc.LogLev
 		duration = gd.AsDuration()
 	}
 	s.timedLogLevel.Set(ctx, logLevelRequest.LogLevel, duration)
-	s.logLevelCond.Broadcast()
+	s.llSubs.notify(ctx, logLevelRequest)
 }
 
 // InitialTempLogLevel returns the temporary log-level if it exists, along with the remaining
@@ -858,9 +859,6 @@ func (s *State) InitialTempLogLevel() *rpc.LogLevelRequest {
 
 // WaitForTempLogLevel waits for a new temporary log-level request. It returns the values
 // of the last request that was made.
-func (s *State) WaitForTempLogLevel() *rpc.LogLevelRequest {
-	s.logLevelCond.L.Lock()
-	defer s.logLevelCond.L.Unlock()
-	s.logLevelCond.Wait()
-	return s.InitialTempLogLevel()
+func (s *State) WaitForTempLogLevel(stream rpc.Manager_WatchLogLevelServer) error {
+	return s.llSubs.subscriberLoop(stream.Context(), stream)
 }

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -718,22 +718,8 @@ func (m *Manager) SetLogLevel(ctx context.Context, request *rpc.LogLevelRequest)
 }
 
 func (m *Manager) WatchLogLevel(_ *empty.Empty, stream rpc.Manager_WatchLogLevelServer) error {
-	ctx := stream.Context()
-	dlog.Debugf(ctx, "WatchLogLevel called")
-
-	ll := m.state.InitialTempLogLevel()
-	dlog.Debugf(ctx, "InitialLogLevel %v", ll)
-	for m.ctx.Err() == nil {
-		if ll != nil {
-			if err := stream.Send(ll); err != nil {
-				dlog.Errorf(ctx, "WatchLogLevel.Send() failed: %v", err)
-				break
-			}
-		}
-		ll = m.state.WaitForTempLogLevel()
-		dlog.Debugf(ctx, "AwaitedLogLevel %v", ll)
-	}
-	return nil
+	dlog.Debugf(stream.Context(), "WatchLogLevel called")
+	return m.state.WaitForTempLogLevel(stream)
 }
 
 func (m *Manager) WatchClusterInfo(session *rpc.SessionInfo, stream rpc.Manager_WatchClusterInfoServer) error {


### PR DESCRIPTION
Clients and agents can't wait on conditions because the
condition won't release the wait until the condition is
notified. So even if a client or agent departs, their calls
to wait will not end which causes an ever-growing demand
of resources.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
