### PR TITLE
Use the cluster lookup timeout for fallback queries as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Change: The status command includes the install id, user id, account id, and user email in its result, and can print output as JSON
 
+- Change: The lookup-timeout config flag used to set timeouts for DNS queries resolved by a cluster now also configures the timeout for fallback queries (i.e. queries not resolved by the cluster) when connected to the cluster.
+
 - Bugfix: Client and agent sessions no longer leaves dangling waiters in the traffic-manager when they depart.
 
 - Bugfix: An advice to "see logs for details" is no longer printed when the argument count is incorrect in a CLI command.

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -92,7 +92,7 @@ func NewServer(config *rpc.DNSConfig, clusterLookup func(context.Context, string
 		}
 	}
 	if config.LookupTimeout.AsDuration() <= 0 {
-		config.LookupTimeout = durationpb.New(4 * time.Second)
+		config.LookupTimeout = durationpb.New(8 * time.Second)
 	}
 	s := &Server{
 		config:        config,
@@ -451,7 +451,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	pfx = func() string { return fmt.Sprintf("(%s) ", s.fallback.RemoteAddr()) }
-	dc := dns.Client{Net: "udp", Timeout: 2 * time.Second}
+	dc := dns.Client{Net: "udp", Timeout: s.config.LookupTimeout.AsDuration()}
 	msg, _, err = dc.ExchangeWithConn(r, s.fallback)
 	if err != nil {
 		msg = new(dns.Msg)


### PR DESCRIPTION
This means that there's a single configurable timeout for all outbound
dns from the root daemon

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
