### PR TITLE
Allow ingressL5 to be different from ingressHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Bugfix: Intercepts that fail to create are now consistently removed to prevent non-working dangling intercepts from sticking around.
 
+- Bugfix: The ingress-l5 flag will no longer be forcefully set to equal the --ingress-host flag
+
 ### 2.5.3 (February 25, 2022)
 
 - Feature: Client-side binaries for the arm64 architecture are now available for linux

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -500,7 +500,7 @@ func makeIngressInfo(ingressHost string, ingressPort int32, ingressTLS bool, ing
 			ingress.Port = ingressPort
 			ingress.UseTls = ingressTLS
 
-			if ingress.L5Host == "" { // if L5Host is not present
+			if ingressL5 == "" { // if L5Host is not present
 				ingress.L5Host = ingressHost
 				return ingress, nil
 			} else { // if L5Host is present


### PR DESCRIPTION
Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
