### PR TITLE
Use objectSelector functionality of MutatingWebhookConfiguration to filter objects

### DIFF
--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -40,6 +40,9 @@ webhooks:
   name: agent-injector.getambassador.io
   sideEffects: {{ .Values.agentInjector.webhook.sideEffects }}
   timeoutSeconds: {{ .Values.agentInjector.webhook.timeoutSeconds }}
+  objectSelector:
+    matchLabels:
+      telepresence.getambassador.io/inject-traffic-agent: enabled
 {{- if .Values.managerRbac.namespaced }}
   namespaceSelector:
     matchExpressions:

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -62,12 +62,6 @@ func agentInjector(ctx context.Context, req *admission.AdmissionRequest) ([]patc
 		return nil, nil
 	}
 
-	if pod.Annotations[install.InjectAnnotation] != "enabled" {
-		dlog.Debugf(ctx, `The %s pod has not enabled %s container injection through %q annotation; skipping`,
-			refPodName, install.AgentContainerName, install.InjectAnnotation)
-		return nil, nil
-	}
-
 	svcName := pod.Annotations[install.ServiceNameAnnotation]
 	svc, err := findMatchingService(ctx, "", svcName, podNamespace, pod.Labels)
 	if err != nil {

--- a/docs/pre-release/reference/cluster-config.md
+++ b/docs/pre-release/reference/cluster-config.md
@@ -202,7 +202,7 @@ To solve this issue, you can use Telepresence's Mutating Webhook alternative mec
 workloads will then stay untouched and only the underlying pods will be modified to inject the Traffic
 Agent sidecar container and update the port definitions.
 
-Simply add the `telepresence.getambassador.io/inject-traffic-agent: enabled` annotation to your
+Simply add the `telepresence.getambassador.io/inject-traffic-agent: enabled` label to your
 workload template's annotations:
 
 ```diff
@@ -211,7 +211,6 @@ workload template's annotations:
      metadata:
        labels:
          service: your-service
-+      annotations:
 +        telepresence.getambassador.io/inject-traffic-agent: enabled
      spec:
        containers:
@@ -228,8 +227,8 @@ in the service. This is necessary when the service has multiple ports.
      metadata:
        labels:
          service: your-service
-       annotations:
          telepresence.getambassador.io/inject-traffic-agent: enabled
+       annotations:
 +        telepresence.getambassador.io/inject-service-port: https
      spec:
        containers:
@@ -246,8 +245,8 @@ This is necessary when the workload is exposed by multiple services.
      metadata:
        labels:
          service: your-service
-       annotations:
          telepresence.getambassador.io/inject-traffic-agent: enabled
+       annotations:
 +        telepresence.getambassador.io/inject-service-name: my-service
      spec:
        containers:
@@ -299,11 +298,9 @@ spec:
       service: your-service
   template:
     metadata:
-      annotations:
-        telepresence.getambassador.io/inject-traffic-agent: enabled
       labels:
         service: your-service
-    spec:
+        telepresence.getambassador.io/inject-traffic-agent: enabled
       containers:
         - name: your-container
           image: jmalloc/echo-server


### PR DESCRIPTION
Kubernetes MutatingWebhookConfiguration supports specifying an `objectSelector` which filters whether tor un the webhook based on if the object has matching labels.

Currently this field is left out of the configuration and the filtering is handled in the agent injector code itself. This present a problem if you decided to set the failurePolicy too fail, in that if the traffic agent restarts it will never restart because it will fail mutation.

PR to resolve #2486 