### PR TITLE
Ensure that WatchAgents respect the grpc.maxReceiveSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Change: The TUN device will no longer route pod or service subnets if it is running in a machine that's already connected to the cluster
 
-- Bugfix: The client's agent watcher will now respect the configured grpc.maxReceiveSize
+- Bugfix: The client's gather logs command and agent watcher will now respect the configured grpc.maxReceiveSize
 
 - Bugfix: Client and agent sessions no longer leaves dangling waiters in the traffic-manager when they depart.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Change: The TUN device will no longer route pod or service subnets if it is running in a machine that's already connected to the cluster
 
+- Bugfix: The client's agent watcher will now respect the configured grpc.maxReceiveSize
+
 - Bugfix: Client and agent sessions no longer leaves dangling waiters in the traffic-manager when they depart.
 
 - Bugfix: An advice to "see logs for details" is no longer printed when the argument count is incorrect in a CLI command.

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -196,7 +196,14 @@ func NewSession(c context.Context, sr *scout.Reporter, cr *rpc.ConnectRequest, s
 
 	// Must call SetManagerClient before calling daemon.Connect which tells the
 	// daemon to use the proxy.
-	svc.SetManagerClient(tmgr.managerClient)
+	var opts []grpc.CallOption
+	cfg := client.GetConfig(c)
+	if !cfg.Grpc.MaxReceiveSize.IsZero() {
+		if mz, ok := cfg.Grpc.MaxReceiveSize.AsInt64(); ok {
+			opts = append(opts, grpc.MaxCallRecvMsgSize(int(mz)))
+		}
+	}
+	svc.SetManagerClient(tmgr.managerClient, opts...)
 
 	// Tell daemon what it needs to know in order to establish outbound traffic to the cluster
 	oi := tmgr.getOutboundInfo(c)

--- a/pkg/vif/routing/routing.go
+++ b/pkg/vif/routing/routing.go
@@ -49,14 +49,15 @@ func interfaceLocalIP(iface *net.Interface, ipv4 bool) (net.IP, error) {
 		if err != nil {
 			return net.IP{}, fmt.Errorf("unable to parse address %s: %v", addr.String(), err)
 		}
-		if ip.To4() != nil {
-			if ipv4 {
-				return ip.To4(), nil
+		if ip4 := ip.To4(); ip4 != nil {
+			if !ipv4 {
+				continue
 			}
+			return ip4, nil
 		} else if ipv4 {
 			continue
 		}
 		return ip, nil
 	}
-	return net.IP{}, fmt.Errorf("interface %s has no addresses", iface.Name)
+	return nil, nil
 }

--- a/pkg/vif/routing/routing_darwin.go
+++ b/pkg/vif/routing/routing_darwin.go
@@ -49,6 +49,9 @@ func GetRoutingTable(ctx context.Context) ([]Route, error) {
 			if err != nil {
 				return nil, err
 			}
+			if localIP == nil {
+				continue
+			}
 			mask, ok := mask.(*route.Inet4Addr)
 			if !ok {
 				continue
@@ -71,6 +74,9 @@ func GetRoutingTable(ctx context.Context) ([]Route, error) {
 			localIP, err := interfaceLocalIP(iface, false)
 			if err != nil {
 				return nil, err
+			}
+			if localIP == nil {
+				continue
 			}
 			mask, ok := mask.(*route.Inet6Addr)
 			if !ok {

--- a/pkg/vif/routing/routing_linux.go
+++ b/pkg/vif/routing/routing_linux.go
@@ -112,6 +112,9 @@ msgLoop:
 				if err != nil {
 					return nil, err
 				}
+				if srcIP == nil {
+					continue
+				}
 				routes = append(routes, Route{
 					LocalIP:   srcIP,
 					RoutedNet: dstNet,

--- a/pkg/vif/routing/routing_test.go
+++ b/pkg/vif/routing/routing_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +22,5 @@ func TestGetRoutingTable_defaultRoute(t *testing.T) {
 		}
 	}
 	assert.NotNil(t, dflt)
+	assert.False(t, dflt.Gateway.Equal(net.IP{0, 0, 0, 0}))
 }


### PR DESCRIPTION
The agent snapshot may grow quite large in a big cluster with many
installed agents.

Closes #2490

 - [x] I made sure to update `./CHANGELOG.md`.
 