### PR TITLE
update makefile to generate tgz after chart updates

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -132,7 +132,7 @@ clobber: ## (Build) Remove all build artifacts and tools
 # ===========================================================
 
 .PHONY: prepare-release
-prepare-release: generate pkg/install/helm/telepresence-chart.tgz ## (Release) Update necessary files and tag the release (does not push)
+prepare-release: generate ## (Release) Update necessary files and tag the release (does not push)
 	sed -i.bak "/^### $(patsubst v%,%,$(TELEPRESENCE_VERSION)) (TBD)\$$/s/TBD/$$(date +'%B %-d, %Y')/" CHANGELOG.md
 	rm -f CHANGELOG.md.bak
 	go mod edit -require=github.com/telepresenceio/telepresence/rpc/v2@$(TELEPRESENCE_VERSION)
@@ -143,6 +143,9 @@ prepare-release: generate pkg/install/helm/telepresence-chart.tgz ## (Release) U
 	rm -f charts/telepresence/Chart.yaml.bak
 	sed -i.bak "s/^### (TBD).*/### $(TELEPRESENCE_VERSION)/" charts/telepresence/CHANGELOG.md
 	rm -f charts/telepresence/CHANGELOG.md.bak
+	# copy of pkg/install/helm/telepresence-chart.tgz target
+	GOOS=$(GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) go run ./build-aux/package_embedded_chart/main.go $(TELEPRESENCE_VERSION)
+	git add pkg/install/helm/telepresence-chart.tgz
 	$(if $(findstring -,$(TELEPRESENCE_VERSION)),,cp -a pkg/client/userd/trafficmgr/testdata/addAgentToWorkload/cur pkg/client/userd/trafficmgr/testdata/addAgentToWorkload/$(TELEPRESENCE_VERSION))
 	$(if $(findstring -,$(TELEPRESENCE_VERSION)),,git add pkg/client/userd/trafficmgr/testdata/addAgentToWorkload/$(TELEPRESENCE_VERSION))
 	git commit --signoff --message='Prepare $(TELEPRESENCE_VERSION)'


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description

update the `prepare-release` makefile target to generate `pkg/install/helm/telepresence-chart.tgz` after the other chart updates, and then add it to the git commit

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
