### PR TITLE
Move gathering of logs from the traffic-manager to the client

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - name: Build dev image
         run: |
           TAG="2.4.5-gotest.${GITHUB_SHA:0:7}"
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - uses: azure/setup-kubectl@v1
         if: steps.get_last_run.outputs.passed != 'success'
         with:
@@ -109,7 +109,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - uses: azure/setup-kubectl@v1
         if: steps.get_last_run.outputs.passed != 'success'
         with:
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - uses: azure/setup-kubectl@v1
         if: steps.get_last_run.outputs.passed != 'success'
         with:

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -15,7 +15,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - name: "Generate dependency information"
         shell: bash
         run: make generate

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
             #- uses: azure/setup-kubectl@v1
             #if: steps.get_last_run.outputs.passed != 'success'
             #with:
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - run: |
           choco install make
         if: steps.get_last_run.outputs.passed != 'success'
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - run: |
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.x'
+          go-version: '1.17'
       - run: |
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.5.5 (TBD)
+
+- Bugfix: The `gather-logs` command will only gather traffic-agent logs from accessible namespaces, and is also constrained to namespaces
+  explicitly mapped using the `connect` command's `--mapped-namespaces` flag.
+
 ### 2.5.4 (March 29, 2022)
 
 - Change: The list command, when used with the `--intercepts` flag, will list the users intercepts from all namespaces

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
@@ -94,15 +96,53 @@ func (s *multipleInterceptsSuite) TestGatherLogs_NoK8sLogs() {
 	require.Equal(0, yamlCount, fileNames)
 }
 
-func (s *multipleInterceptsSuite) cleanLogDir(ctx context.Context) {
+func (s *singleServiceSuite) TestGatherLogs_OnlyMappedLogs() {
 	require := s.Require()
+	ctx := s.Context()
+	otherNS := fmt.Sprintf("other-ns-%s", s.Suffix())
+	itest.CreateNamespaces(ctx, otherNS)
+	itest.ApplyEchoService(ctx, s.ServiceName(), otherNS, 8083)
+	itest.TelepresenceOk(ctx, "intercept", "--namespace", otherNS, "--mount", "false", s.ServiceName())
+	itest.TelepresenceOk(ctx, "leave", s.ServiceName()+"-"+otherNS)
+	itest.TelepresenceOk(ctx, "intercept", "--namespace", s.AppNamespace(), "--mount", "false", s.ServiceName())
+	itest.TelepresenceOk(ctx, "leave", s.ServiceName()+"-"+s.AppNamespace())
+
+	bothNsRx := fmt.Sprintf("(?:%s|%s)", s.AppNamespace(), otherNS)
+	outputDir := s.T().TempDir()
+	outputFile := filepath.Join(outputDir, "allLogs.zip")
+	cleanLogDir(ctx, require, bothNsRx, s.ManagerNamespace(), s.ServiceName())
+	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--traffic-manager=False")
+	_, foundAgents, _, fileNames := getZipData(require, outputFile, bothNsRx, s.ManagerNamespace(), s.ServiceName())
+	require.Equal(2, foundAgents, fileNames)
+
+	// Connect using mapped-namespaces
+	itest.TelepresenceDisconnectOk(ctx)
+	stdout := itest.TelepresenceOk(ctx, "connect", "--mapped-namespaces", s.AppNamespace())
+	require.Contains(stdout, "Connected to context default")
+	defer func() {
+		itest.TelepresenceQuitOk(ctx)
+		stdout := itest.TelepresenceOk(ctx, "connect")
+		require.Contains(stdout, "Connected to context default")
+	}()
+
+	cleanLogDir(ctx, require, bothNsRx, s.ManagerNamespace(), s.ServiceName())
+	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--traffic-manager=False")
+	_, foundAgents, _, fileNames = getZipData(require, outputFile, bothNsRx, s.ManagerNamespace(), s.ServiceName())
+	require.Equal(1, foundAgents, fileNames)
+}
+
+func (s *multipleInterceptsSuite) cleanLogDir(ctx context.Context) {
+	cleanLogDir(ctx, s.Require(), s.AppNamespace(), s.ManagerNamespace(), s.svcRegex())
+}
+
+func cleanLogDir(ctx context.Context, require *require.Assertions, appNamespace, mgrNamespace, svcNameRx string) {
 	logDir, err := filelocation.AppUserLogDir(ctx)
 	require.NoError(err)
 	files, err := os.ReadDir(logDir)
 	require.NoError(err)
 	match := regexp.MustCompile(
-		fmt.Sprintf(`^(:?traffic-manager-[0-9a-z-]+\.%s|hello-[0-%d]-[0-9a-z-]+\.%s)\.(:?log|yaml)$`,
-			s.ManagerNamespace(), s.ServiceCount()-1, s.AppNamespace()))
+		fmt.Sprintf(`^(?:traffic-manager-[0-9a-z-]+\.%s|%s-[0-9a-z-]+\.%s)\.(?:log|yaml)$`,
+			mgrNamespace, svcNameRx, appNamespace))
 
 	for _, file := range files {
 		if match.MatchString(file.Name()) {
@@ -112,17 +152,24 @@ func (s *multipleInterceptsSuite) cleanLogDir(ctx context.Context) {
 	}
 }
 
+func (s *multipleInterceptsSuite) svcRegex() string {
+	return fmt.Sprintf("hello-[0-%d]", s.ServiceCount())
+}
+
 func (s *multipleInterceptsSuite) getZipData(outputFile string) (bool, int, int, []string) {
-	require := s.Require()
+	return getZipData(s.Require(), outputFile, s.AppNamespace(), s.ManagerNamespace(), s.svcRegex())
+}
+
+func getZipData(require *require.Assertions, outputFile, appNamespace, mgrNamespace, svcNameRx string) (bool, int, int, []string) {
 	zipReader, err := zip.OpenReader(outputFile)
 	require.NoError(err)
 	defer func() {
-		s.NoError(zipReader.Close())
+		require.NoError(zipReader.Close())
 	}()
 	// we collect and return the fileNames so that it makes it easier
 	// to debug if tests fail
-	helloMatch := regexp.MustCompile(fmt.Sprintf(`^hello-[0-%d]-[0-9a-z-]+\.%s\.(:?log|yaml)$`, s.ServiceCount()-1, s.AppNamespace()))
-	tmMatch := regexp.MustCompile(fmt.Sprintf(`^traffic-manager-[0-9a-z-]+\.%s\.(:?log|yaml)$`, s.ManagerNamespace()))
+	helloMatch := regexp.MustCompile(fmt.Sprintf(`^%s-[0-9a-z-]+\.%s\.(?:log|yaml)$`, svcNameRx, appNamespace))
+	tmMatch := regexp.MustCompile(fmt.Sprintf(`^traffic-manager-[0-9a-z-]+\.%s\.(?:log|yaml)$`, mgrNamespace))
 	tmHdrMatch := regexp.MustCompile(`Traffic Manager v\d+\.\d+\.\d+`)
 	agHdrMatch := regexp.MustCompile(`Traffic Agent v\d+\.\d+\.\d+`)
 	foundManager, foundAgents, yamlCount := false, 0, 0
@@ -135,7 +182,7 @@ func (s *multipleInterceptsSuite) getZipData(outputFile string) (bool, int, int,
 				continue
 			}
 			foundManager = true
-			fileContent := s.readZip(f)
+			fileContent := readZip(require, f)
 			// We can be fairly certain we actually got a traffic-manager log
 			// if we see the following
 			require.Regexp(tmHdrMatch, string(fileContent))
@@ -146,7 +193,7 @@ func (s *multipleInterceptsSuite) getZipData(outputFile string) (bool, int, int,
 				continue
 			}
 			foundAgents++
-			fileContent := s.readZip(f)
+			fileContent := readZip(require, f)
 			// We can be fairly certain we actually got a traffic-manager log
 			// if we see the following
 			require.Regexp(agHdrMatch, string(fileContent))
@@ -158,10 +205,10 @@ func (s *multipleInterceptsSuite) getZipData(outputFile string) (bool, int, int,
 // readZip reads a zip file and returns the []byte string. Used in tests for
 // checking that a zipped file's contents are correct. Exported since it is
 // also used in telepresence_test.go
-func (s *multipleInterceptsSuite) readZip(zippedFile *zip.File) []byte {
+func readZip(require *require.Assertions, zippedFile *zip.File) []byte {
 	fileReader, err := zippedFile.Open()
-	s.Require().NoError(err)
+	require.NoError(err)
 	fileContent, err := io.ReadAll(fileReader)
-	s.Require().NoError(err)
+	require.NoError(err)
 	return fileContent
 }

--- a/pkg/client/cli/cmd_gatherlogs_test.go
+++ b/pkg/client/cli/cmd_gatherlogs_test.go
@@ -226,6 +226,8 @@ func Test_gatherLogsNoK8s(t *testing.T) {
 			}
 			stdout := dlog.StdLogger(ctx, dlog.LogLevelInfo).Writer()
 			stderr := dlog.StdLogger(ctx, dlog.LogLevelError).Writer()
+			cmd.SetOut(stdout)
+			cmd.SetErr(stderr)
 			gl := &gatherLogsArgs{
 				outputFile: tc.outputFile,
 				daemons:    tc.daemons,
@@ -236,7 +238,7 @@ func Test_gatherLogsNoK8s(t *testing.T) {
 			}
 
 			// Ensure we can create a zip of the logs
-			err := gl.gatherLogs(ctx, cmd, stdout, stderr)
+			err := gl.gatherLogs(ctx, cmd)
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errMsg)
@@ -372,10 +374,8 @@ func Test_gatherLogsAnonymizeLogs(t *testing.T) {
 		},
 	}
 
-	ctx := dlog.NewTestContext(t, false)
 	testLogDir := "testdata/testLogDir"
 	outputDir := t.TempDir()
-	stdout := dlog.StdLogger(ctx, dlog.LogLevelInfo).Writer()
 	files := []string{"echo-auto-inject-6496f77cbd-n86nc", "traffic-manager-5c69859f94-g4ntj"}
 	for _, file := range files {
 		// The anonymize function edits files in place
@@ -385,7 +385,7 @@ func Test_gatherLogsAnonymizeLogs(t *testing.T) {
 		err := copyFiles(dstFile, srcFile)
 		require.NoError(t, err)
 
-		err = anonymizeLog(stdout, dstFile, anonymizer)
+		err = anonymizeLog(dstFile, anonymizer)
 		require.NoError(t, err)
 
 		// Now verify things have actually been anonymized

--- a/pkg/client/userd/grpc.go
+++ b/pkg/client/userd/grpc.go
@@ -381,6 +381,14 @@ func (s *service) GetIngressInfos(c context.Context, _ *empty.Empty) (result *rp
 	return
 }
 
+func (s *service) GatherLogs(ctx context.Context, request *rpc.LogsRequest) (result *rpc.LogsResponse, err error) {
+	err = s.withSession(ctx, "GatherLogs", func(c context.Context, session trafficmgr.Session) error {
+		result, err = session.GatherLogs(c, request)
+		return err
+	})
+	return
+}
+
 func (s *service) SetLogLevel(ctx context.Context, request *manager.LogLevelRequest) (result *empty.Empty, err error) {
 	s.logCall(ctx, "SetLogLevel", func(c context.Context) {
 		duration := time.Duration(0)

--- a/pkg/client/userd/trafficmgr/gather_logs.go
+++ b/pkg/client/userd/trafficmgr/gather_logs.go
@@ -1,0 +1,156 @@
+package trafficmgr
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+)
+
+// getPodLogs is a helper function for getting the logs from the container
+// of a given pod. If we are unable to get a log for a given pod, we will
+// instead return the error instead of the log, so that:
+// - one failure doesn't prevent us from getting logs from other pods
+// - it is easy to figure out why getting logs for a given pod failed
+func getPodLog(ctx context.Context, podsAPI typed.PodInterface, pod *core.Pod, container string, podYAML bool) (string, string) {
+	req := podsAPI.GetLogs(pod.Name, &core.PodLogOptions{Container: container})
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get log for %s.%s: %v", pod.Name, pod.Namespace, err)
+		dlog.Error(ctx, msg)
+		return msg, ""
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err = io.Copy(buf, podLogs); err != nil {
+		msg := fmt.Sprintf("Failed writing log to buffer: %v", err)
+		dlog.Error(ctx, msg)
+		return msg, ""
+	}
+	podLog := buf.String()
+
+	// Get the pod yaml if the user asked for it
+	if podYAML {
+		var b []byte
+		if b, err = yaml.Marshal(pod); err != nil {
+			msg := fmt.Sprintf("Failed marshaling pod yaml: %v", err)
+			dlog.Error(ctx, msg)
+			return msg, ""
+		}
+		return podLog, string(b)
+	}
+	return podLog, ""
+}
+
+// GatherLogs acquires the logs for the traffic-manager and/or traffic-agents specified by the
+// connector.LogsRequest and returns them to the caller
+func (tm *TrafficManager) GatherLogs(ctx context.Context, request *connector.LogsRequest) (*connector.LogsResponse, error) {
+	logWriteMutex := &sync.Mutex{}
+	coreAPI := k8sapi.GetK8sInterface(ctx).CoreV1()
+	resp := &connector.LogsResponse{
+		PodLogs: make(map[string]string),
+		PodYaml: make(map[string]string),
+	}
+	container := "traffic-agent"
+	hasContainer := func(pod *core.Pod) bool {
+		if strings.EqualFold(request.Agents, "all") || strings.Contains(pod.Name, request.Agents) {
+			cns := pod.Spec.Containers
+			for c := range cns {
+				if cns[c].Name == container {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	if !strings.EqualFold(request.Agents, "none") {
+		for _, ns := range tm.GetCurrentNamespaces(true) {
+			podsAPI := coreAPI.Pods(ns)
+			podList, err := podsAPI.List(ctx, meta.ListOptions{})
+			if err != nil {
+				resp.ErrMsg = err.Error()
+				dlog.Error(ctx, resp.ErrMsg)
+				return resp, nil
+			}
+			pods := podList.Items
+			podsWithContainer := make([]*core.Pod, 0, len(pods))
+			for i := range pods {
+				pod := &pods[i]
+				if hasContainer(pod) {
+					podsWithContainer = append(podsWithContainer, pod)
+				}
+			}
+			wg := sync.WaitGroup{}
+			wg.Add(len(podsWithContainer))
+			for _, pod := range podsWithContainer {
+				go func(pod *core.Pod) {
+					defer wg.Done()
+					// Since the same named workload could exist in multiple namespaces
+					// we add the namespace into the name so that it's easier to make
+					// sense of the logs
+					podAndNs := fmt.Sprintf("%s.%s", pod.Name, pod.Namespace)
+					dlog.Debugf(ctx, "gathering logs for %s, yaml = %t", podAndNs, request.GetPodYaml)
+					logs, yml := getPodLog(ctx, podsAPI, pod, container, request.GetPodYaml)
+					logWriteMutex.Lock()
+					resp.PodLogs[podAndNs] = logs
+					if request.GetPodYaml {
+						resp.PodYaml[podAndNs] = yml
+					}
+					logWriteMutex.Unlock()
+				}(pod)
+			}
+			wg.Wait()
+		}
+	}
+
+	// We want to get the traffic-manager log *last* so that if we generate
+	// any errors in the traffic-manager getting the traffic-agent pods, we
+	// want those logs to appear in what we export
+	if request.TrafficManager {
+		ns := tm.GetManagerNamespace()
+		podAndNs := fmt.Sprintf("traffic-manager.%s", ns)
+		podsAPI := coreAPI.Pods(ns)
+		selector := labels.SelectorFromSet(labels.Set{
+			"app":          "traffic-manager",
+			"telepresence": "manager",
+		})
+		podList, err := podsAPI.List(ctx, meta.ListOptions{LabelSelector: selector.String()})
+		switch {
+		case err != nil:
+			dlog.Errorf(ctx, "failed to gather logs for %s: %v", podAndNs, err)
+			resp.PodLogs[podAndNs] = err.Error()
+		case len(podList.Items) == 1:
+			pod := &podList.Items[0]
+			podAndNs = fmt.Sprintf("%s.%s", pod.Name, ns)
+			dlog.Debugf(ctx, "gathering logs for %s, yaml = %t", podAndNs, request.GetPodYaml)
+			logs, yml := getPodLog(ctx, podsAPI, pod, "traffic-manager", request.GetPodYaml)
+			resp.PodLogs[podAndNs] = logs
+			if request.GetPodYaml {
+				resp.PodYaml[podAndNs] = yml
+			}
+		case len(podList.Items) > 1:
+			msg := fmt.Sprintf("multiple traffic managers found in namespace %s using selector %s", ns, selector.String())
+			dlog.Error(ctx, msg)
+			resp.PodLogs[podAndNs] = msg
+		default:
+			msg := fmt.Sprintf("no traffic manager found in namespace %s using selector %s", ns, selector.String())
+			dlog.Error(ctx, msg)
+			resp.PodLogs[podAndNs] = msg
+		}
+	}
+	return resp, nil
+}

--- a/pkg/client/userd/trafficmgr/service_proxy.go
+++ b/pkg/client/userd/trafficmgr/service_proxy.go
@@ -48,8 +48,7 @@ func (p *mgrProxy) get() (managerrpc.ManagerClient, []grpc.CallOption, error) {
 	p.RLock()
 	defer p.RUnlock()
 	if p.clientX == nil {
-		return nil, nil, status.Error(codes.Unavailable,
-			"telepresence: the userd is not connected to the manager")
+		return nil, nil, status.Error(codes.Unavailable, "telepresence: the userd is not connected to the manager")
 	}
 	return p.clientX, p.callOptionsX, nil
 }
@@ -176,11 +175,11 @@ func (p *mgrProxy) WatchIntercepts(arg *managerrpc.SessionInfo, srv managerrpc.M
 	}
 }
 
-func (p *mgrProxy) CreateIntercept(_ context.Context, _ *managerrpc.CreateInterceptRequest) (*managerrpc.InterceptInfo, error) {
-	return nil, errors.New("must call connector.CreateIntercept instead of manager.CreateIntercept")
+func (p *mgrProxy) CreateIntercept(context.Context, *managerrpc.CreateInterceptRequest) (*managerrpc.InterceptInfo, error) {
+	return nil, status.Error(codes.Unimplemented, "must call connector.CreateIntercept instead of manager.CreateIntercept")
 }
-func (p *mgrProxy) RemoveIntercept(_ context.Context, _ *managerrpc.RemoveInterceptRequest2) (*empty.Empty, error) {
-	return nil, errors.New("must call connector.RemoveIntercept instead of manager.RemoveIntercept")
+func (p *mgrProxy) RemoveIntercept(context.Context, *managerrpc.RemoveInterceptRequest2) (*empty.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "must call connector.RemoveIntercept instead of manager.RemoveIntercept")
 }
 func (p *mgrProxy) UpdateIntercept(ctx context.Context, arg *managerrpc.UpdateInterceptRequest) (*managerrpc.InterceptInfo, error) {
 	client, callOptions, err := p.get()
@@ -197,11 +196,11 @@ func (p *mgrProxy) ReviewIntercept(ctx context.Context, arg *managerrpc.ReviewIn
 	return client.ReviewIntercept(ctx, arg, callOptions...)
 }
 
-func (p *mgrProxy) ClientTunnel(_ managerrpc.Manager_ClientTunnelServer) error {
+func (p *mgrProxy) ClientTunnel(managerrpc.Manager_ClientTunnelServer) error {
 	return status.Error(codes.Unimplemented, "ClientTunnel was deprecated in 2.4.5 and has since been removed")
 }
 
-func (p *mgrProxy) AgentTunnel(_ managerrpc.Manager_AgentTunnelServer) error {
+func (p *mgrProxy) AgentTunnel(managerrpc.Manager_AgentTunnelServer) error {
 	return status.Error(codes.Unimplemented, "AgentTunnel was deprecated in 2.4.5 and has since been removed")
 }
 
@@ -330,8 +329,8 @@ func (p *mgrProxy) AgentLookupHostResponse(ctx context.Context, arg *managerrpc.
 	return client.AgentLookupHostResponse(ctx, arg, callOptions...)
 }
 
-func (p *mgrProxy) WatchLookupHost(_ *managerrpc.SessionInfo, _ managerrpc.Manager_WatchLookupHostServer) error {
-	return errors.New("must call manager.WatchLookupHost from an agent (intercepted Pod), not from a client (workstation)")
+func (p *mgrProxy) WatchLookupHost(*managerrpc.SessionInfo, managerrpc.Manager_WatchLookupHostServer) error {
+	return status.Error(codes.Unimplemented, "must call manager.WatchLookupHost from an agent (intercepted Pod), not from a client (workstation)")
 }
 
 func (p *mgrProxy) WatchClusterInfo(arg *managerrpc.SessionInfo, srv managerrpc.Manager_WatchClusterInfoServer) error {
@@ -365,14 +364,10 @@ func (p *mgrProxy) SetLogLevel(ctx context.Context, request *managerrpc.LogLevel
 	return client.SetLogLevel(ctx, request, callOptions...)
 }
 
-func (p *mgrProxy) GetLogs(ctx context.Context, request *managerrpc.GetLogsRequest) (*managerrpc.LogsResponse, error) {
-	client, callOptions, err := p.get()
-	if err != nil {
-		return nil, err
-	}
-	return client.GetLogs(ctx, request, callOptions...)
+func (p *mgrProxy) GetLogs(context.Context, *managerrpc.GetLogsRequest) (*managerrpc.LogsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, " \"must call connector.GatherLogs instead of manager.GetLogs\"")
 }
 
-func (p *mgrProxy) WatchLogLevel(_ *empty.Empty, _ managerrpc.Manager_WatchLogLevelServer) error {
-	return errors.New("must call manager.WatchLogLevel from an agent (intercepted Pod), not from a client (workstation)")
+func (p *mgrProxy) WatchLogLevel(*empty.Empty, managerrpc.Manager_WatchLogLevelServer) error {
+	return status.Error(codes.Unimplemented, "must call manager.WatchLogLevel from an agent (intercepted Pod), not from a client (workstation)")
 }

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -72,6 +72,7 @@ type Session interface {
 	ActualNamespace(string) string
 	RemainWithToken(context.Context) error
 	AddNamespaceListener(k8s.NamespaceListener)
+	GatherLogs(context.Context, *connector.LogsRequest) (*connector.LogsResponse, error)
 }
 
 type Service interface {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,9 +23,9 @@ func init() {
 			Version = "(unknown version)"
 		}
 		if _, err := semver.ParseTolerant(Version); err != nil {
-			if Version != "(devel)" && Version != "(unknown version)" {
+			if Version != "" && Version != "(devel)" && Version != "(unknown version)" {
 				// If this isn't a parsable semver (enforced by Makefile), isn't
-				// "(devel)" (a special value from runtime/debug), and isn't our own
+				// empty, "(devel)" (a special value from runtime/debug), or our own
 				// special "(unknown version)", then something about the toolchain
 				// has clearly changed and invalidated our assumptions.  That's
 				// worthy of a panic; if this is built using an unsupported

--- a/rpc/connector/connector.pb.go
+++ b/rpc/connector/connector.pb.go
@@ -1748,6 +1748,142 @@ func (x *LicenseData) GetHostDomain() string {
 	return ""
 }
 
+type LogsRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Whether or not logs from the traffic-manager are desired.
+	TrafficManager bool `protobuf:"varint,1,opt,name=traffic_manager,json=trafficManager,proto3" json:"traffic_manager,omitempty"`
+	// The traffic-agent(s) logs are desired from. Can be `all`, `False`,
+	// or substring to filter based on pod names.
+	Agents string `protobuf:"bytes,2,opt,name=agents,proto3" json:"agents,omitempty"`
+	// Whether or not to get the pod yaml deployed to the cluster.
+	GetPodYaml bool `protobuf:"varint,3,opt,name=get_pod_yaml,json=getPodYaml,proto3" json:"get_pod_yaml,omitempty"`
+}
+
+func (x *LogsRequest) Reset() {
+	*x = LogsRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_rpc_connector_connector_proto_msgTypes[23]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *LogsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogsRequest) ProtoMessage() {}
+
+func (x *LogsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_rpc_connector_connector_proto_msgTypes[23]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogsRequest.ProtoReflect.Descriptor instead.
+func (*LogsRequest) Descriptor() ([]byte, []int) {
+	return file_rpc_connector_connector_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *LogsRequest) GetTrafficManager() bool {
+	if x != nil {
+		return x.TrafficManager
+	}
+	return false
+}
+
+func (x *LogsRequest) GetAgents() string {
+	if x != nil {
+		return x.Agents
+	}
+	return ""
+}
+
+func (x *LogsRequest) GetGetPodYaml() bool {
+	if x != nil {
+		return x.GetPodYaml
+	}
+	return false
+}
+
+type LogsResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// The map contains assocations between <podName.namespace> and the logs
+	// from that pod.
+	PodLogs map[string]string `protobuf:"bytes,1,rep,name=pod_logs,json=podLogs,proto3" json:"pod_logs,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// Errors encountered when getting logs from the traffic-manager
+	// and/or traffic-agents.
+	ErrMsg string `protobuf:"bytes,2,opt,name=err_msg,json=errMsg,proto3" json:"err_msg,omitempty"`
+	// The map contains assocations between <podName.namespace> and the pod's
+	// yaml.
+	PodYaml map[string]string `protobuf:"bytes,3,rep,name=pod_yaml,json=podYaml,proto3" json:"pod_yaml,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (x *LogsResponse) Reset() {
+	*x = LogsResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_rpc_connector_connector_proto_msgTypes[24]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *LogsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogsResponse) ProtoMessage() {}
+
+func (x *LogsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_rpc_connector_connector_proto_msgTypes[24]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogsResponse.ProtoReflect.Descriptor instead.
+func (*LogsResponse) Descriptor() ([]byte, []int) {
+	return file_rpc_connector_connector_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *LogsResponse) GetPodLogs() map[string]string {
+	if x != nil {
+		return x.PodLogs
+	}
+	return nil
+}
+
+func (x *LogsResponse) GetErrMsg() string {
+	if x != nil {
+		return x.ErrMsg
+	}
+	return ""
+}
+
+func (x *LogsResponse) GetPodYaml() map[string]string {
+	if x != nil {
+		return x.PodYaml
+	}
+	return nil
+}
+
 type CommandGroups_Flag struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1763,7 +1899,7 @@ type CommandGroups_Flag struct {
 func (x *CommandGroups_Flag) Reset() {
 	*x = CommandGroups_Flag{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_rpc_connector_connector_proto_msgTypes[23]
+		mi := &file_rpc_connector_connector_proto_msgTypes[25]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1776,7 +1912,7 @@ func (x *CommandGroups_Flag) String() string {
 func (*CommandGroups_Flag) ProtoMessage() {}
 
 func (x *CommandGroups_Flag) ProtoReflect() protoreflect.Message {
-	mi := &file_rpc_connector_connector_proto_msgTypes[23]
+	mi := &file_rpc_connector_connector_proto_msgTypes[25]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1841,7 +1977,7 @@ type CommandGroups_Command struct {
 func (x *CommandGroups_Command) Reset() {
 	*x = CommandGroups_Command{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_rpc_connector_connector_proto_msgTypes[24]
+		mi := &file_rpc_connector_connector_proto_msgTypes[26]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1854,7 +1990,7 @@ func (x *CommandGroups_Command) String() string {
 func (*CommandGroups_Command) ProtoMessage() {}
 
 func (x *CommandGroups_Command) ProtoReflect() protoreflect.Message {
-	mi := &file_rpc_connector_connector_proto_msgTypes[24]
+	mi := &file_rpc_connector_connector_proto_msgTypes[26]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1909,7 +2045,7 @@ type CommandGroups_Commands struct {
 func (x *CommandGroups_Commands) Reset() {
 	*x = CommandGroups_Commands{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_rpc_connector_connector_proto_msgTypes[25]
+		mi := &file_rpc_connector_connector_proto_msgTypes[27]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1922,7 +2058,7 @@ func (x *CommandGroups_Commands) String() string {
 func (*CommandGroups_Commands) ProtoMessage() {}
 
 func (x *CommandGroups_Commands) ProtoReflect() protoreflect.Message {
-	mi := &file_rpc_connector_connector_proto_msgTypes[25]
+	mi := &file_rpc_connector_connector_proto_msgTypes[27]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1959,7 +2095,7 @@ type WorkloadInfo_ServiceReference struct {
 func (x *WorkloadInfo_ServiceReference) Reset() {
 	*x = WorkloadInfo_ServiceReference{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_rpc_connector_connector_proto_msgTypes[28]
+		mi := &file_rpc_connector_connector_proto_msgTypes[30]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1972,7 +2108,7 @@ func (x *WorkloadInfo_ServiceReference) String() string {
 func (*WorkloadInfo_ServiceReference) ProtoMessage() {}
 
 func (x *WorkloadInfo_ServiceReference) ProtoReflect() protoreflect.Message {
-	mi := &file_rpc_connector_connector_proto_msgTypes[28]
+	mi := &file_rpc_connector_connector_proto_msgTypes[30]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2164,7 @@ type WorkloadInfo_ServiceReference_Port struct {
 func (x *WorkloadInfo_ServiceReference_Port) Reset() {
 	*x = WorkloadInfo_ServiceReference_Port{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_rpc_connector_connector_proto_msgTypes[29]
+		mi := &file_rpc_connector_connector_proto_msgTypes[31]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2041,7 +2177,7 @@ func (x *WorkloadInfo_ServiceReference_Port) String() string {
 func (*WorkloadInfo_ServiceReference_Port) ProtoMessage() {}
 
 func (x *WorkloadInfo_ServiceReference_Port) ProtoReflect() protoreflect.Message {
-	mi := &file_rpc_connector_connector_proto_msgTypes[29]
+	mi := &file_rpc_connector_connector_proto_msgTypes[31]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2364,7 +2500,34 @@ var file_rpc_connector_connector_proto_rawDesc = []byte{
 	0x18, 0x0a, 0x07, 0x6c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
 	0x52, 0x07, 0x6c, 0x69, 0x63, 0x65, 0x6e, 0x73, 0x65, 0x12, 0x1f, 0x0a, 0x0b, 0x68, 0x6f, 0x73,
 	0x74, 0x5f, 0x64, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a,
-	0x68, 0x6f, 0x73, 0x74, 0x44, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x2a, 0xf1, 0x02, 0x0a, 0x0e, 0x49,
+	0x68, 0x6f, 0x73, 0x74, 0x44, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x22, 0x70, 0x0a, 0x0b, 0x4c, 0x6f,
+	0x67, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a, 0x0f, 0x74, 0x72, 0x61,
+	0x66, 0x66, 0x69, 0x63, 0x5f, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01,
+	0x28, 0x08, 0x52, 0x0e, 0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x4d, 0x61, 0x6e, 0x61, 0x67,
+	0x65, 0x72, 0x12, 0x16, 0x0a, 0x06, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x06, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x73, 0x12, 0x20, 0x0a, 0x0c, 0x67, 0x65,
+	0x74, 0x5f, 0x70, 0x6f, 0x64, 0x5f, 0x79, 0x61, 0x6d, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x08,
+	0x52, 0x0a, 0x67, 0x65, 0x74, 0x50, 0x6f, 0x64, 0x59, 0x61, 0x6d, 0x6c, 0x22, 0xbb, 0x02, 0x0a,
+	0x0c, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4c, 0x0a,
+	0x08, 0x70, 0x6f, 0x64, 0x5f, 0x6c, 0x6f, 0x67, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x31, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x63,
+	0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2e, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x50, 0x6f, 0x64, 0x4c, 0x6f, 0x67, 0x73, 0x45, 0x6e, 0x74,
+	0x72, 0x79, 0x52, 0x07, 0x70, 0x6f, 0x64, 0x4c, 0x6f, 0x67, 0x73, 0x12, 0x17, 0x0a, 0x07, 0x65,
+	0x72, 0x72, 0x5f, 0x6d, 0x73, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x65, 0x72,
+	0x72, 0x4d, 0x73, 0x67, 0x12, 0x4c, 0x0a, 0x08, 0x70, 0x6f, 0x64, 0x5f, 0x79, 0x61, 0x6d, 0x6c,
+	0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x31, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65,
+	0x73, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2e,
+	0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x50, 0x6f, 0x64,
+	0x59, 0x61, 0x6d, 0x6c, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x07, 0x70, 0x6f, 0x64, 0x59, 0x61,
+	0x6d, 0x6c, 0x1a, 0x3a, 0x0a, 0x0c, 0x50, 0x6f, 0x64, 0x4c, 0x6f, 0x67, 0x73, 0x45, 0x6e, 0x74,
+	0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x1a, 0x3a,
+	0x0a, 0x0c, 0x50, 0x6f, 0x64, 0x59, 0x61, 0x6d, 0x6c, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10,
+	0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79,
+	0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x2a, 0xf1, 0x02, 0x0a, 0x0e, 0x49,
 	0x6e, 0x74, 0x65, 0x72, 0x63, 0x65, 0x70, 0x74, 0x45, 0x72, 0x72, 0x6f, 0x72, 0x12, 0x0f, 0x0a,
 	0x0b, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x11,
 	0x0a, 0x0d, 0x4e, 0x4f, 0x5f, 0x43, 0x4f, 0x4e, 0x4e, 0x45, 0x43, 0x54, 0x49, 0x4f, 0x4e, 0x10,
@@ -2387,7 +2550,7 @@ var file_rpc_connector_connector_proto_rawDesc = []byte{
 	0x0e, 0x12, 0x0d, 0x0a, 0x09, 0x4e, 0x4f, 0x54, 0x5f, 0x46, 0x4f, 0x55, 0x4e, 0x44, 0x10, 0x0c,
 	0x12, 0x14, 0x0a, 0x10, 0x4d, 0x4f, 0x55, 0x4e, 0x54, 0x5f, 0x50, 0x4f, 0x49, 0x4e, 0x54, 0x5f,
 	0x42, 0x55, 0x53, 0x59, 0x10, 0x0d, 0x12, 0x10, 0x0a, 0x0c, 0x55, 0x4e, 0x4b, 0x4e, 0x4f, 0x57,
-	0x4e, 0x5f, 0x46, 0x4c, 0x41, 0x47, 0x10, 0x0f, 0x22, 0x04, 0x08, 0x01, 0x10, 0x01, 0x32, 0x8e,
+	0x4e, 0x5f, 0x46, 0x4c, 0x41, 0x47, 0x10, 0x0f, 0x22, 0x04, 0x08, 0x01, 0x10, 0x01, 0x32, 0xe7,
 	0x0f, 0x0a, 0x09, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x12, 0x43, 0x0a, 0x07,
 	0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x1a,
@@ -2508,12 +2671,17 @@ var file_rpc_connector_connector_proto_rawDesc = []byte{
 	0x6e, 0x67, 0x72, 0x65, 0x73, 0x73, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
 	0x74, 0x1a, 0x2c, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65,
 	0x2e, 0x75, 0x73, 0x65, 0x72, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x49, 0x6e, 0x67, 0x72,
-	0x65, 0x73, 0x73, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x42,
-	0x39, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x65,
-	0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x69, 0x6f, 0x2f, 0x74, 0x65, 0x6c,
-	0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x2f, 0x72, 0x70, 0x63, 0x2f, 0x76, 0x32,
-	0x2f, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x33,
+	0x65, 0x73, 0x73, 0x49, 0x6e, 0x66, 0x6f, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
+	0x57, 0x0a, 0x0a, 0x47, 0x61, 0x74, 0x68, 0x65, 0x72, 0x4c, 0x6f, 0x67, 0x73, 0x12, 0x23, 0x2e,
+	0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x63, 0x6f, 0x6e,
+	0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2e, 0x4c, 0x6f, 0x67, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x1a, 0x24, 0x2e, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e, 0x63,
+	0x65, 0x2e, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x2e, 0x4c, 0x6f, 0x67, 0x73,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x42, 0x39, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68,
+	0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65,
+	0x6e, 0x63, 0x65, 0x69, 0x6f, 0x2f, 0x74, 0x65, 0x6c, 0x65, 0x70, 0x72, 0x65, 0x73, 0x65, 0x6e,
+	0x63, 0x65, 0x2f, 0x72, 0x70, 0x63, 0x2f, 0x76, 0x32, 0x2f, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63,
+	0x74, 0x6f, 0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2529,7 +2697,7 @@ func file_rpc_connector_connector_proto_rawDescGZIP() []byte {
 }
 
 var file_rpc_connector_connector_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_rpc_connector_connector_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_rpc_connector_connector_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_rpc_connector_connector_proto_goTypes = []interface{}{
 	(InterceptError)(0),                        // 0: telepresence.connector.InterceptError
 	(ConnectInfo_ErrType)(0),                   // 1: telepresence.connector.ConnectInfo.ErrType
@@ -2559,101 +2727,109 @@ var file_rpc_connector_connector_proto_goTypes = []interface{}{
 	(*KeyData)(nil),                            // 25: telepresence.connector.KeyData
 	(*LicenseRequest)(nil),                     // 26: telepresence.connector.LicenseRequest
 	(*LicenseData)(nil),                        // 27: telepresence.connector.LicenseData
-	(*CommandGroups_Flag)(nil),                 // 28: telepresence.connector.CommandGroups.Flag
-	(*CommandGroups_Command)(nil),              // 29: telepresence.connector.CommandGroups.Command
-	(*CommandGroups_Commands)(nil),             // 30: telepresence.connector.CommandGroups.Commands
-	nil,                                        // 31: telepresence.connector.CommandGroups.CommandGroupsEntry
-	nil,                                        // 32: telepresence.connector.ConnectRequest.KubeFlagsEntry
-	(*WorkloadInfo_ServiceReference)(nil),      // 33: telepresence.connector.WorkloadInfo.ServiceReference
-	(*WorkloadInfo_ServiceReference_Port)(nil), // 34: telepresence.connector.WorkloadInfo.ServiceReference.Port
-	nil,                                     // 35: telepresence.connector.InterceptResult.EnvironmentEntry
-	(*manager.AgentInfoSnapshot)(nil),       // 36: telepresence.manager.AgentInfoSnapshot
-	(*manager.InterceptInfoSnapshot)(nil),   // 37: telepresence.manager.InterceptInfoSnapshot
-	(*manager.SessionInfo)(nil),             // 38: telepresence.manager.SessionInfo
-	(*manager.IngressInfo)(nil),             // 39: telepresence.manager.IngressInfo
-	(*manager.InterceptSpec)(nil),           // 40: telepresence.manager.InterceptSpec
-	(*manager.AgentInfo)(nil),               // 41: telepresence.manager.AgentInfo
-	(*manager.InterceptInfo)(nil),           // 42: telepresence.manager.InterceptInfo
-	(*userdaemon.IngressInfoRequest)(nil),   // 43: telepresence.userdaemon.IngressInfoRequest
-	(*emptypb.Empty)(nil),                   // 44: google.protobuf.Empty
-	(*manager.RemoveInterceptRequest2)(nil), // 45: telepresence.manager.RemoveInterceptRequest2
-	(*manager.LogLevelRequest)(nil),         // 46: telepresence.manager.LogLevelRequest
-	(*common.VersionInfo)(nil),              // 47: telepresence.common.VersionInfo
-	(*userdaemon.IngressInfoResponse)(nil),  // 48: telepresence.userdaemon.IngressInfoResponse
+	(*LogsRequest)(nil),                        // 28: telepresence.connector.LogsRequest
+	(*LogsResponse)(nil),                       // 29: telepresence.connector.LogsResponse
+	(*CommandGroups_Flag)(nil),                 // 30: telepresence.connector.CommandGroups.Flag
+	(*CommandGroups_Command)(nil),              // 31: telepresence.connector.CommandGroups.Command
+	(*CommandGroups_Commands)(nil),             // 32: telepresence.connector.CommandGroups.Commands
+	nil,                                        // 33: telepresence.connector.CommandGroups.CommandGroupsEntry
+	nil,                                        // 34: telepresence.connector.ConnectRequest.KubeFlagsEntry
+	(*WorkloadInfo_ServiceReference)(nil),      // 35: telepresence.connector.WorkloadInfo.ServiceReference
+	(*WorkloadInfo_ServiceReference_Port)(nil), // 36: telepresence.connector.WorkloadInfo.ServiceReference.Port
+	nil,                                     // 37: telepresence.connector.InterceptResult.EnvironmentEntry
+	nil,                                     // 38: telepresence.connector.LogsResponse.PodLogsEntry
+	nil,                                     // 39: telepresence.connector.LogsResponse.PodYamlEntry
+	(*manager.AgentInfoSnapshot)(nil),       // 40: telepresence.manager.AgentInfoSnapshot
+	(*manager.InterceptInfoSnapshot)(nil),   // 41: telepresence.manager.InterceptInfoSnapshot
+	(*manager.SessionInfo)(nil),             // 42: telepresence.manager.SessionInfo
+	(*manager.IngressInfo)(nil),             // 43: telepresence.manager.IngressInfo
+	(*manager.InterceptSpec)(nil),           // 44: telepresence.manager.InterceptSpec
+	(*manager.AgentInfo)(nil),               // 45: telepresence.manager.AgentInfo
+	(*manager.InterceptInfo)(nil),           // 46: telepresence.manager.InterceptInfo
+	(*userdaemon.IngressInfoRequest)(nil),   // 47: telepresence.userdaemon.IngressInfoRequest
+	(*emptypb.Empty)(nil),                   // 48: google.protobuf.Empty
+	(*manager.RemoveInterceptRequest2)(nil), // 49: telepresence.manager.RemoveInterceptRequest2
+	(*manager.LogLevelRequest)(nil),         // 50: telepresence.manager.LogLevelRequest
+	(*common.VersionInfo)(nil),              // 51: telepresence.common.VersionInfo
+	(*userdaemon.IngressInfoResponse)(nil),  // 52: telepresence.userdaemon.IngressInfoResponse
 }
 var file_rpc_connector_connector_proto_depIdxs = []int32{
-	31, // 0: telepresence.connector.CommandGroups.command_groups:type_name -> telepresence.connector.CommandGroups.CommandGroupsEntry
-	32, // 1: telepresence.connector.ConnectRequest.kube_flags:type_name -> telepresence.connector.ConnectRequest.KubeFlagsEntry
+	33, // 0: telepresence.connector.CommandGroups.command_groups:type_name -> telepresence.connector.CommandGroups.CommandGroupsEntry
+	34, // 1: telepresence.connector.ConnectRequest.kube_flags:type_name -> telepresence.connector.ConnectRequest.KubeFlagsEntry
 	1,  // 2: telepresence.connector.ConnectInfo.error:type_name -> telepresence.connector.ConnectInfo.ErrType
-	36, // 3: telepresence.connector.ConnectInfo.agents:type_name -> telepresence.manager.AgentInfoSnapshot
-	37, // 4: telepresence.connector.ConnectInfo.intercepts:type_name -> telepresence.manager.InterceptInfoSnapshot
-	38, // 5: telepresence.connector.ConnectInfo.session_info:type_name -> telepresence.manager.SessionInfo
-	39, // 6: telepresence.connector.IngressInfos.ingress_infos:type_name -> telepresence.manager.IngressInfo
+	40, // 3: telepresence.connector.ConnectInfo.agents:type_name -> telepresence.manager.AgentInfoSnapshot
+	41, // 4: telepresence.connector.ConnectInfo.intercepts:type_name -> telepresence.manager.InterceptInfoSnapshot
+	42, // 5: telepresence.connector.ConnectInfo.session_info:type_name -> telepresence.manager.SessionInfo
+	43, // 6: telepresence.connector.IngressInfos.ingress_infos:type_name -> telepresence.manager.IngressInfo
 	2,  // 7: telepresence.connector.UninstallRequest.uninstall_type:type_name -> telepresence.connector.UninstallRequest.UninstallType
-	40, // 8: telepresence.connector.CreateInterceptRequest.spec:type_name -> telepresence.manager.InterceptSpec
+	44, // 8: telepresence.connector.CreateInterceptRequest.spec:type_name -> telepresence.manager.InterceptSpec
 	3,  // 9: telepresence.connector.ListRequest.filter:type_name -> telepresence.connector.ListRequest.Filter
-	41, // 10: telepresence.connector.WorkloadInfo.agent_info:type_name -> telepresence.manager.AgentInfo
-	42, // 11: telepresence.connector.WorkloadInfo.intercept_info:type_name -> telepresence.manager.InterceptInfo
-	33, // 12: telepresence.connector.WorkloadInfo.service:type_name -> telepresence.connector.WorkloadInfo.ServiceReference
+	45, // 10: telepresence.connector.WorkloadInfo.agent_info:type_name -> telepresence.manager.AgentInfo
+	46, // 11: telepresence.connector.WorkloadInfo.intercept_info:type_name -> telepresence.manager.InterceptInfo
+	35, // 12: telepresence.connector.WorkloadInfo.service:type_name -> telepresence.connector.WorkloadInfo.ServiceReference
 	16, // 13: telepresence.connector.WorkloadInfoSnapshot.workloads:type_name -> telepresence.connector.WorkloadInfo
-	42, // 14: telepresence.connector.InterceptResult.intercept_info:type_name -> telepresence.manager.InterceptInfo
+	46, // 14: telepresence.connector.InterceptResult.intercept_info:type_name -> telepresence.manager.InterceptInfo
 	0,  // 15: telepresence.connector.InterceptResult.error:type_name -> telepresence.connector.InterceptError
-	35, // 16: telepresence.connector.InterceptResult.environment:type_name -> telepresence.connector.InterceptResult.EnvironmentEntry
-	43, // 17: telepresence.connector.InterceptResult.service_props:type_name -> telepresence.userdaemon.IngressInfoRequest
+	37, // 16: telepresence.connector.InterceptResult.environment:type_name -> telepresence.connector.InterceptResult.EnvironmentEntry
+	47, // 17: telepresence.connector.InterceptResult.service_props:type_name -> telepresence.userdaemon.IngressInfoRequest
 	4,  // 18: telepresence.connector.LoginResult.code:type_name -> telepresence.connector.LoginResult.Code
-	28, // 19: telepresence.connector.CommandGroups.Command.flags:type_name -> telepresence.connector.CommandGroups.Flag
-	29, // 20: telepresence.connector.CommandGroups.Commands.commands:type_name -> telepresence.connector.CommandGroups.Command
-	30, // 21: telepresence.connector.CommandGroups.CommandGroupsEntry.value:type_name -> telepresence.connector.CommandGroups.Commands
-	34, // 22: telepresence.connector.WorkloadInfo.ServiceReference.ports:type_name -> telepresence.connector.WorkloadInfo.ServiceReference.Port
-	44, // 23: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
-	8,  // 24: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
-	44, // 25: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
-	44, // 26: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
-	13, // 27: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	13, // 28: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	45, // 29: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	11, // 30: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
-	14, // 31: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
-	15, // 32: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
-	44, // 33: telepresence.connector.Connector.UserNotifications:input_type -> google.protobuf.Empty
-	20, // 34: telepresence.connector.Connector.Login:input_type -> telepresence.connector.LoginRequest
-	44, // 35: telepresence.connector.Connector.Logout:input_type -> google.protobuf.Empty
-	22, // 36: telepresence.connector.Connector.GetCloudUserInfo:input_type -> telepresence.connector.UserInfoRequest
-	24, // 37: telepresence.connector.Connector.GetCloudAPIKey:input_type -> telepresence.connector.KeyRequest
-	26, // 38: telepresence.connector.Connector.GetCloudLicense:input_type -> telepresence.connector.LicenseRequest
-	44, // 39: telepresence.connector.Connector.GetIngressInfos:input_type -> google.protobuf.Empty
-	46, // 40: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	44, // 41: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
-	44, // 42: telepresence.connector.Connector.ListCommands:input_type -> google.protobuf.Empty
-	6,  // 43: telepresence.connector.Connector.RunCommand:input_type -> telepresence.connector.RunCommandRequest
-	43, // 44: telepresence.connector.Connector.ResolveIngressInfo:input_type -> telepresence.userdaemon.IngressInfoRequest
-	47, // 45: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
-	9,  // 46: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
-	44, // 47: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
-	9,  // 48: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
-	18, // 49: telepresence.connector.Connector.CanIntercept:output_type -> telepresence.connector.InterceptResult
-	18, // 50: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.connector.InterceptResult
-	18, // 51: telepresence.connector.Connector.RemoveIntercept:output_type -> telepresence.connector.InterceptResult
-	12, // 52: telepresence.connector.Connector.Uninstall:output_type -> telepresence.connector.UninstallResult
-	17, // 53: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	17, // 54: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	19, // 55: telepresence.connector.Connector.UserNotifications:output_type -> telepresence.connector.Notification
-	21, // 56: telepresence.connector.Connector.Login:output_type -> telepresence.connector.LoginResult
-	44, // 57: telepresence.connector.Connector.Logout:output_type -> google.protobuf.Empty
-	23, // 58: telepresence.connector.Connector.GetCloudUserInfo:output_type -> telepresence.connector.UserInfo
-	25, // 59: telepresence.connector.Connector.GetCloudAPIKey:output_type -> telepresence.connector.KeyData
-	27, // 60: telepresence.connector.Connector.GetCloudLicense:output_type -> telepresence.connector.LicenseData
-	10, // 61: telepresence.connector.Connector.GetIngressInfos:output_type -> telepresence.connector.IngressInfos
-	44, // 62: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
-	44, // 63: telepresence.connector.Connector.Quit:output_type -> google.protobuf.Empty
-	5,  // 64: telepresence.connector.Connector.ListCommands:output_type -> telepresence.connector.CommandGroups
-	7,  // 65: telepresence.connector.Connector.RunCommand:output_type -> telepresence.connector.RunCommandResponse
-	48, // 66: telepresence.connector.Connector.ResolveIngressInfo:output_type -> telepresence.userdaemon.IngressInfoResponse
-	45, // [45:67] is the sub-list for method output_type
-	23, // [23:45] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	38, // 19: telepresence.connector.LogsResponse.pod_logs:type_name -> telepresence.connector.LogsResponse.PodLogsEntry
+	39, // 20: telepresence.connector.LogsResponse.pod_yaml:type_name -> telepresence.connector.LogsResponse.PodYamlEntry
+	30, // 21: telepresence.connector.CommandGroups.Command.flags:type_name -> telepresence.connector.CommandGroups.Flag
+	31, // 22: telepresence.connector.CommandGroups.Commands.commands:type_name -> telepresence.connector.CommandGroups.Command
+	32, // 23: telepresence.connector.CommandGroups.CommandGroupsEntry.value:type_name -> telepresence.connector.CommandGroups.Commands
+	36, // 24: telepresence.connector.WorkloadInfo.ServiceReference.ports:type_name -> telepresence.connector.WorkloadInfo.ServiceReference.Port
+	48, // 25: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
+	8,  // 26: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
+	48, // 27: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
+	48, // 28: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
+	13, // 29: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	13, // 30: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	49, // 31: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	11, // 32: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
+	14, // 33: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
+	15, // 34: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
+	48, // 35: telepresence.connector.Connector.UserNotifications:input_type -> google.protobuf.Empty
+	20, // 36: telepresence.connector.Connector.Login:input_type -> telepresence.connector.LoginRequest
+	48, // 37: telepresence.connector.Connector.Logout:input_type -> google.protobuf.Empty
+	22, // 38: telepresence.connector.Connector.GetCloudUserInfo:input_type -> telepresence.connector.UserInfoRequest
+	24, // 39: telepresence.connector.Connector.GetCloudAPIKey:input_type -> telepresence.connector.KeyRequest
+	26, // 40: telepresence.connector.Connector.GetCloudLicense:input_type -> telepresence.connector.LicenseRequest
+	48, // 41: telepresence.connector.Connector.GetIngressInfos:input_type -> google.protobuf.Empty
+	50, // 42: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	48, // 43: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
+	48, // 44: telepresence.connector.Connector.ListCommands:input_type -> google.protobuf.Empty
+	6,  // 45: telepresence.connector.Connector.RunCommand:input_type -> telepresence.connector.RunCommandRequest
+	47, // 46: telepresence.connector.Connector.ResolveIngressInfo:input_type -> telepresence.userdaemon.IngressInfoRequest
+	28, // 47: telepresence.connector.Connector.GatherLogs:input_type -> telepresence.connector.LogsRequest
+	51, // 48: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
+	9,  // 49: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
+	48, // 50: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
+	9,  // 51: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
+	18, // 52: telepresence.connector.Connector.CanIntercept:output_type -> telepresence.connector.InterceptResult
+	18, // 53: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.connector.InterceptResult
+	18, // 54: telepresence.connector.Connector.RemoveIntercept:output_type -> telepresence.connector.InterceptResult
+	12, // 55: telepresence.connector.Connector.Uninstall:output_type -> telepresence.connector.UninstallResult
+	17, // 56: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	17, // 57: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	19, // 58: telepresence.connector.Connector.UserNotifications:output_type -> telepresence.connector.Notification
+	21, // 59: telepresence.connector.Connector.Login:output_type -> telepresence.connector.LoginResult
+	48, // 60: telepresence.connector.Connector.Logout:output_type -> google.protobuf.Empty
+	23, // 61: telepresence.connector.Connector.GetCloudUserInfo:output_type -> telepresence.connector.UserInfo
+	25, // 62: telepresence.connector.Connector.GetCloudAPIKey:output_type -> telepresence.connector.KeyData
+	27, // 63: telepresence.connector.Connector.GetCloudLicense:output_type -> telepresence.connector.LicenseData
+	10, // 64: telepresence.connector.Connector.GetIngressInfos:output_type -> telepresence.connector.IngressInfos
+	48, // 65: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
+	48, // 66: telepresence.connector.Connector.Quit:output_type -> google.protobuf.Empty
+	5,  // 67: telepresence.connector.Connector.ListCommands:output_type -> telepresence.connector.CommandGroups
+	7,  // 68: telepresence.connector.Connector.RunCommand:output_type -> telepresence.connector.RunCommandResponse
+	52, // 69: telepresence.connector.Connector.ResolveIngressInfo:output_type -> telepresence.userdaemon.IngressInfoResponse
+	29, // 70: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
+	48, // [48:71] is the sub-list for method output_type
+	25, // [25:48] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_rpc_connector_connector_proto_init() }
@@ -2939,7 +3115,7 @@ func file_rpc_connector_connector_proto_init() {
 			}
 		}
 		file_rpc_connector_connector_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CommandGroups_Flag); i {
+			switch v := v.(*LogsRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2951,7 +3127,7 @@ func file_rpc_connector_connector_proto_init() {
 			}
 		}
 		file_rpc_connector_connector_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CommandGroups_Command); i {
+			switch v := v.(*LogsResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2963,6 +3139,30 @@ func file_rpc_connector_connector_proto_init() {
 			}
 		}
 		file_rpc_connector_connector_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CommandGroups_Flag); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_rpc_connector_connector_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CommandGroups_Command); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_rpc_connector_connector_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CommandGroups_Commands); i {
 			case 0:
 				return &v.state
@@ -2974,7 +3174,7 @@ func file_rpc_connector_connector_proto_init() {
 				return nil
 			}
 		}
-		file_rpc_connector_connector_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
+		file_rpc_connector_connector_proto_msgTypes[30].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*WorkloadInfo_ServiceReference); i {
 			case 0:
 				return &v.state
@@ -2986,7 +3186,7 @@ func file_rpc_connector_connector_proto_init() {
 				return nil
 			}
 		}
-		file_rpc_connector_connector_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
+		file_rpc_connector_connector_proto_msgTypes[31].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*WorkloadInfo_ServiceReference_Port); i {
 			case 0:
 				return &v.state
@@ -3006,7 +3206,7 @@ func file_rpc_connector_connector_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_rpc_connector_connector_proto_rawDesc,
 			NumEnums:      5,
-			NumMessages:   31,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/connector/connector.proto
+++ b/rpc/connector/connector.proto
@@ -82,8 +82,12 @@ service Connector {
 
   // ResolveIngressInfo is a temporary rpc intended to allow the cli to ask
   // the cloud for default ingress values
-  rpc ResolveIngressInfo(telepresence.userdaemon.IngressInfoRequest) returns
-  (telepresence.userdaemon.IngressInfoResponse);
+  rpc ResolveIngressInfo(telepresence.userdaemon.IngressInfoRequest)
+      returns(telepresence.userdaemon.IngressInfoResponse);
+
+  // GatherLogs will acquire logs for the various Telepresence components in kubernetes
+  // (pending the request) and return them to the caller
+  rpc GatherLogs(LogsRequest) returns (LogsResponse);
 }
 
 message CommandGroups {
@@ -362,4 +366,31 @@ message LicenseRequest {
 message LicenseData {
   string license = 1;
   string host_domain = 2;
+}
+
+message LogsRequest {
+  // Whether or not logs from the traffic-manager are desired.
+  bool traffic_manager = 1;
+
+  // The traffic-agent(s) logs are desired from. Can be `all`, `False`,
+  // or substring to filter based on pod names.
+  string agents = 2;
+
+  // Whether or not to get the pod yaml deployed to the cluster.
+  bool get_pod_yaml = 3;
+}
+
+message LogsResponse {
+
+  // The map contains assocations between <podName.namespace> and the logs
+  // from that pod.
+  map<string, string> pod_logs = 1;
+
+  // Errors encountered when getting logs from the traffic-manager
+  // and/or traffic-agents.
+  string err_msg = 2;
+
+  // The map contains assocations between <podName.namespace> and the pod's
+  // yaml.
+  map<string, string> pod_yaml = 3;
 }

--- a/rpc/connector/connector_grpc.pb.go
+++ b/rpc/connector/connector_grpc.pb.go
@@ -73,6 +73,9 @@ type ConnectorClient interface {
 	// ResolveIngressInfo is a temporary rpc intended to allow the cli to ask
 	// the cloud for default ingress values
 	ResolveIngressInfo(ctx context.Context, in *userdaemon.IngressInfoRequest, opts ...grpc.CallOption) (*userdaemon.IngressInfoResponse, error)
+	// GatherLogs will acquire logs for the various Telepresence components in kubernetes
+	// (pending the request) and return them to the caller
+	GatherLogs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogsResponse, error)
 }
 
 type connectorClient struct {
@@ -327,6 +330,15 @@ func (c *connectorClient) ResolveIngressInfo(ctx context.Context, in *userdaemon
 	return out, nil
 }
 
+func (c *connectorClient) GatherLogs(ctx context.Context, in *LogsRequest, opts ...grpc.CallOption) (*LogsResponse, error) {
+	out := new(LogsResponse)
+	err := c.cc.Invoke(ctx, "/telepresence.connector.Connector/GatherLogs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ConnectorServer is the server API for Connector service.
 // All implementations must embed UnimplementedConnectorServer
 // for forward compatibility
@@ -382,6 +394,9 @@ type ConnectorServer interface {
 	// ResolveIngressInfo is a temporary rpc intended to allow the cli to ask
 	// the cloud for default ingress values
 	ResolveIngressInfo(context.Context, *userdaemon.IngressInfoRequest) (*userdaemon.IngressInfoResponse, error)
+	// GatherLogs will acquire logs for the various Telepresence components in kubernetes
+	// (pending the request) and return them to the caller
+	GatherLogs(context.Context, *LogsRequest) (*LogsResponse, error)
 	mustEmbedUnimplementedConnectorServer()
 }
 
@@ -454,6 +469,9 @@ func (UnimplementedConnectorServer) RunCommand(context.Context, *RunCommandReque
 }
 func (UnimplementedConnectorServer) ResolveIngressInfo(context.Context, *userdaemon.IngressInfoRequest) (*userdaemon.IngressInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ResolveIngressInfo not implemented")
+}
+func (UnimplementedConnectorServer) GatherLogs(context.Context, *LogsRequest) (*LogsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GatherLogs not implemented")
 }
 func (UnimplementedConnectorServer) mustEmbedUnimplementedConnectorServer() {}
 
@@ -870,6 +888,24 @@ func _Connector_ResolveIngressInfo_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Connector_GatherLogs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LogsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorServer).GatherLogs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/telepresence.connector.Connector/GatherLogs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorServer).GatherLogs(ctx, req.(*LogsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Connector_ServiceDesc is the grpc.ServiceDesc for Connector service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -956,6 +992,10 @@ var Connector_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ResolveIngressInfo",
 			Handler:    _Connector_ResolveIngressInfo_Handler,
+		},
+		{
+			MethodName: "GatherLogs",
+			Handler:    _Connector_GatherLogs_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -1414,6 +1414,7 @@ func (x *LogLevelRequest) GetDuration() *durationpb.Duration {
 	return nil
 }
 
+// Deprecated.
 type GetLogsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1481,6 +1482,7 @@ func (x *GetLogsRequest) GetGetPodYaml() bool {
 	return false
 }
 
+// Deprecated.
 type LogsResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -287,6 +287,7 @@ message LogLevelRequest {
   google.protobuf.Duration duration = 2;
 }
 
+// Deprecated.
 message GetLogsRequest {
   // Whether or not logs from the traffic-manager are desired.
   bool traffic_manager = 1;
@@ -299,6 +300,7 @@ message GetLogsRequest {
   bool get_pod_yaml = 3;
 }
 
+// Deprecated.
 message LogsResponse {
 
   // The map contains assocations between <podName.namespace> and the logs
@@ -453,6 +455,7 @@ service Manager {
 
   // GetLogs will acquire logs for the various Telepresence components in kubernetes
   // (pending the request) and return them to the caller
+  // Deprecated: Will return an empty response
   rpc GetLogs(GetLogsRequest) returns (LogsResponse);
 
   // Watches

--- a/rpc/manager/manager_grpc.pb.go
+++ b/rpc/manager/manager_grpc.pb.go
@@ -46,6 +46,7 @@ type ManagerClient interface {
 	SetLogLevel(ctx context.Context, in *LogLevelRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// GetLogs will acquire logs for the various Telepresence components in kubernetes
 	// (pending the request) and return them to the caller
+	// Deprecated: Will return an empty response
 	GetLogs(ctx context.Context, in *GetLogsRequest, opts ...grpc.CallOption) (*LogsResponse, error)
 	// WatchAgents notifies a client of the set of known Agents.
 	//
@@ -598,6 +599,7 @@ type ManagerServer interface {
 	SetLogLevel(context.Context, *LogLevelRequest) (*emptypb.Empty, error)
 	// GetLogs will acquire logs for the various Telepresence components in kubernetes
 	// (pending the request) and return them to the caller
+	// Deprecated: Will return an empty response
 	GetLogs(context.Context, *GetLogsRequest) (*LogsResponse, error)
 	// WatchAgents notifies a client of the set of known Agents.
 	//


### PR DESCRIPTION
## Description

Having the traffic-manager do it had two problems:
1. There was no way of telling what namespaces to gather logs for.
2. The gathered logs should perhaps not be visible to the caller.

This commit moves the whole process to the client to ensure that the
client's set of accessible namespaces are taken into account and that
no logs can be retrieved unless the user has the permissions needed
to do so.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
