### PR TITLE
Ensure that root daemon session terminates before another is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change: The traffic-manager now requires permissions to read pods across namespaces even if installed with limited permissions
 
+- Bugfix: The root daemon will no longer get into a bad state when a disconnect is rapidly followed by a new connect.
+
 - Bugfix: The client will now only watch agents from accessible namespaces, and is also constrained to namespaces  explicitly mapped 
   using the `connect` command's `--mapped-namespaces` flag.
 

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -383,6 +383,9 @@ func (s *session) watchClusterInfo(ctx context.Context, cfgComplete chan<- struc
 			}
 			if cfgComplete != nil {
 				s.checkConnectivity(ctx, mgrInfo)
+				if ctx.Err() != nil {
+					return
+				}
 				remoteIp := net.IP(mgrInfo.KubeDnsIp)
 				dlog.Infof(ctx, "Setting cluster DNS to %s", remoteIp)
 				dlog.Infof(ctx, "Setting cluster domain to %q", mgrInfo.ClusterDomain)
@@ -411,9 +414,7 @@ func (s *session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInf
 			dlog.Infof(ctx, "Adding service subnet %s", cidr)
 			subnets = append(subnets, cidr)
 		}
-	}
 
-	if s.proxyCluster {
 		for _, sn := range mgrInfo.PodSubnets {
 			cidr := iputil.IPNetFromRPC(sn)
 			dlog.Infof(ctx, "Adding pod subnet %s", cidr)

--- a/pkg/vif/routing/routing_darwin.go
+++ b/pkg/vif/routing/routing_darwin.go
@@ -13,7 +13,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
-const findInterfaceRegex = "gateway:\\s+([0-9.]+)\\s+.*interface:\\s+([a-z0-9]+)"
+const findInterfaceRegex = "(?:gateway:\\s+([0-9.]+)\\s+.*)?interface:\\s+([a-z0-9]+)"
 
 var findInterfaceRe = regexp.MustCompile(findInterfaceRegex)
 
@@ -126,10 +126,12 @@ func GetRoute(ctx context.Context, routedNet *net.IPNet) (Route, error) {
 	if err != nil {
 		return Route{}, fmt.Errorf("unable to get interface object for interface %s: %w", ifaceName, err)
 	}
-	gateway := match[1]
-	gatewayIp := iputil.Parse(gateway)
-	if gatewayIp == nil {
-		return Route{}, fmt.Errorf("unable to parse gateway %s", gateway)
+	var gatewayIp net.IP
+	if gateway := match[1]; gateway != "" {
+		gatewayIp = iputil.Parse(gateway)
+		if gatewayIp == nil {
+			return Route{}, fmt.Errorf("unable to parse gateway %s", gateway)
+		}
 	}
 	localIP, err := interfaceLocalIP(iface, ip.To4() != nil)
 	if err != nil {


### PR DESCRIPTION
## Description

Ensure that root daemon session terminates before another is started

The root daemon risked entering a bad state when a disconnect was
rapidly followed by a new connect. The change in this commit ensures
that the disconnect completes before the new session can start.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
