### PR TITLE
Make telepresence list command work without preceeding connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change: The traffic-manager now requires permissions to read pods across namespaces even if installed with limited permissions
 
+- Bugfix: The `telepresence list` command will produce a correct listing even when not preceded by a `telepresence connect`.
+
 - Bugfix: The root daemon will no longer get into a bad state when a disconnect is rapidly followed by a new connect.
 
 - Bugfix: The client will now only watch agents from accessible namespaces, and is also constrained to namespaces  explicitly mapped 

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -277,8 +277,7 @@ func interceptError(tp rpc.InterceptError, err error) *rpc.InterceptResult {
 // only if the returned rpc.InterceptResult is nil. The returned runtime.Object is either nil, indicating a local
 // intercept, or the workload for the intercept.
 func (tm *TrafficManager) CanIntercept(c context.Context, ir *rpc.CreateInterceptRequest) (*rpc.InterceptResult, k8sapi.Workload, *ServiceProps) {
-	tm.WaitForNSSync(c)
-	tm.wlWatcher.waitForSync(c)
+	tm.waitForSync(c)
 	spec := ir.Spec
 	spec.Namespace = tm.ActualNamespace(spec.Namespace)
 	if spec.Namespace == "" {


### PR DESCRIPTION
## Description

The `telepresence list` command would produce an empty list unless it
was preceded by a `telepresence connect`. This commit ensures that the
needed synchronization always takes place so that the list output is
correct at all times.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
