### PR TITLE
Add missing DNS flush to the DNS resolver used with systemd-resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change: The traffic-manager now requires permissions to read pods across namespaces even if installed with limited permissions
 
+- Bugfix: The DNS resolver used on Linux with systemd-resolved now flushes the cache when the search path changes.
+
 - Bugfix: The `telepresence list` command will produce a correct listing even when not preceded by a `telepresence connect`.
 
 - Bugfix: The root daemon will no longer get into a bad state when a disconnect is rapidly followed by a new connect.

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -124,6 +124,7 @@ func (s *Server) updateLinkDomains(c context.Context, paths []string, dev *vif.D
 	if err := dbus.SetLinkDomains(dcontext.HardContext(c), int(dev.Index()), paths...); err != nil {
 		return fmt.Errorf("failed to set link domains on %q: %w", dev.Name(), err)
 	}
+	s.flushDNS()
 	dlog.Debugf(c, "Link domains on device %q set to [%s]", dev.Name(), strings.Join(paths, ","))
 	return nil
 }


### PR DESCRIPTION
## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
