### PR TITLE
Remove hardcoded test version from github "build-image" workflow job

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -21,15 +21,12 @@ jobs:
           go-version: '1.17'
       - name: Build dev image
         run: |
-          TAG="2.4.5-gotest.${GITHUB_SHA:0:7}"
-          TELEPRESENCE_VERSION="v${TAG}" make tel2
-          mkdir -p /tmp/workspace
-          docker save "datawire/tel2:${TAG}" > tel2-image.tar
+          make tel2-image
       - name: Upload image
         uses: actions/upload-artifact@v2
         with:
           name: image
-          path: tel2-image.tar
+          path: build-output/tel2-image.tar
   "macos_test":
     runs-on: macos-latest
     needs: "build_image"

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 TELEPRESENCE_REGISTRY ?= docker.io/datawire
+ifdef GITHUB_SHA
+  TELEPRESENCE_VERSION ?= v2.4.5-gotest.$(shell bash -c 'echo $${GITHUB_SHA:0:7}')
+else
+  TELEPRESENCE_VERSION ?= $(shell unset GOOS GOARCH; go run ./build-aux/genversion)
+endif
 
-_TELEPRESENCE_VERSION := $(shell unset GOOS GOARCH; go run ./build-aux/genversion)
-TELEPRESENCE_VERSION ?= $(_TELEPRESENCE_VERSION)
 $(if $(filter v2.%,$(TELEPRESENCE_VERSION)),\
   $(info [make] TELEPRESENCE_VERSION=$(TELEPRESENCE_VERSION)),\
   $(error TELEPRESENCE_VERSION variable is invalid: It must be a v2.* string, but is '$(TELEPRESENCE_VERSION)'))

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -110,10 +110,6 @@ build-version: pkg/install/helm/telepresence-chart.tgz ## (Build) Generate a tel
 build: build-version ## (Build)  Generate a telepresence-chart.tgz, build all the source code, then git restore telepresence-chart.tgz
 	git restore pkg/install/helm/telepresence-chart.tgz
 
-# TODO remove the following two lines when we're passed the PR build barrier
-.PHONY: image
-image: tel2
-
 .PHONY: tel2-base tel2
 tel2-base tel2:
 	mkdir -p $(BUILDDIR)
@@ -123,6 +119,9 @@ tel2-base tel2:
 .PHONY: push-image
 push-image: tel2 ## (Build) Push the manager/agent container image to $(TELEPRESENCE_REGISTRY)
 	docker push $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION))
+
+tel2-image: tel2
+	docker save $(TELEPRESENCE_REGISTRY)/$@:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/tel2-image.tar
 
 .PHONY: clobber
 clobber: ## (Build) Remove all build artifacts and tools

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -203,8 +203,8 @@ clientRbac:
   # managed in your cluster.
   # This MUST be set.
   #
-  # Default: {}
-  subjects: {}
+  # Default: []
+  subjects: []
     # - kind: User
     #   name: jane
     #   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Having a hard-coded version in the github workflow makes it impossible
to change, because the actual execution of the workflow will use the
base-version of the workflow files (as a protective measure). This
commit moves the actual version mangling into the makefile so that the
modification takes immediate effect.