### PR TITLE
Add 'z' prefix to SHA in version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 TELEPRESENCE_REGISTRY ?= docker.io/datawire
 ifdef GITHUB_SHA
-  TELEPRESENCE_VERSION ?= v2.4.5-gotest.$(shell bash -c 'echo $${GITHUB_SHA:0:7}')
+  TELEPRESENCE_VERSION ?= v2.4.5-gotest.z$(shell bash -c 'echo $${GITHUB_SHA:0:7}')
 else
   TELEPRESENCE_VERSION ?= $(shell unset GOOS GOARCH; go run ./build-aux/genversion)
 endif

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -121,7 +121,7 @@ push-image: tel2 ## (Build) Push the manager/agent container image to $(TELEPRES
 	docker push $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION))
 
 tel2-image: tel2
-	docker save $(TELEPRESENCE_REGISTRY)/$@:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/tel2-image.tar
+	docker save $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/tel2-image.tar
 
 .PHONY: clobber
 clobber: ## (Build) Remove all build artifacts and tools

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -88,7 +88,7 @@ func WithCluster(ctx context.Context, f func(ctx context.Context)) {
 	}
 	s.testVersion, s.prePushed = os.LookupEnv("DEV_TELEPRESENCE_VERSION")
 	if !s.prePushed {
-		s.testVersion = "v2.4.5-gotest." + s.suffix
+		s.testVersion = "v2.4.5-gotest.z" + s.suffix
 	}
 	version.Version = s.testVersion
 


### PR DESCRIPTION
An unprefixed SHA starting with zero results in invalid semver version,
so a 'z' is added in front of the sha when creating the test version.
