### PR TITLE
Make regex in smoke tests only match preview urls

### DIFF
--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -87,7 +87,7 @@ has_intercept_id() {
 
 # Puts preview url in a variable
 get_preview_url() {
-    preview_url=$(echo "$output" | grep -Eo 'https://[^ >]+')
+    preview_url=$(echo "$output" | grep -Eo 'https://[^ >]+.preview.edgestack.me')
     if [[ -z $preview_url ]]; then
         echo "No Preview URL found"
         exit 1


### PR DESCRIPTION
Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
