### PR TITLE
Let WatchAgentsNS watch only active namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bugfix: The `gather-logs` command will no longer send any logs through `gRPC`.
 
+- Change: Telepresence agents watcher will now only watch namespaces that the user has accessed since the last `connect`.
+
 ### 2.5.5 (April 8, 2022)
 
 - Change: The traffic-manager now requires permissions to read pods across namespaces even if installed with limited permissions

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -87,7 +87,7 @@ RBAC rules required to create an intercept in a namespace; excludes any rules th
 - apiGroups:
   - "apps"
   resources: ["deployments", "replicasets", "statefulsets"]
-  verbs: ["get", "list", "update", "patch"]
+  verbs: ["get", "watch", "list", "update", "patch"]
 - apiGroups:
   - "getambassador.io"
   resources: ["hosts", "mappings"]

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -16,7 +16,7 @@ webhooks:
 {{- end }}
   clientConfig:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-    caBundle: {{ get $secretData "ca.pem" }}
+    caBundle: {{ get $secretData "ca.crt" }}
 {{- else }}
     caBundle: {{ $genCA.Cert | b64enc }}
 {{- end }}
@@ -60,9 +60,9 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-  ca.crt: {{ get $secretData "ca.pem" }}
-  tls.crt: {{ get $secretData "crt.pem" }}
-  tls.key: {{ get $secretData "key.pem" }}
+  ca.crt: {{ get $secretData "ca.crt" }}
+  tls.crt: {{ get $secretData "tls.crt" }}
+  tls.key: {{ get $secretData "tls.key" }}
 {{- else }}
   ca.crt: {{ $genCA.Cert | b64enc }}
   tls.crt: {{ $genCert.Cert | b64enc }}

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -60,12 +60,12 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-  ca.pem: {{ get $secretData "ca.pem" }}
-  crt.pem: {{ get $secretData "crt.pem" }}
-  key.pem: {{ get $secretData "key.pem" }}
+  ca.crt: {{ get $secretData "ca.pem" }}
+  tls.crt: {{ get $secretData "crt.pem" }}
+  tls.key: {{ get $secretData "key.pem" }}
 {{- else }}
-  ca.pem: {{ $genCA.Cert | b64enc }}
-  crt.pem: {{ $genCert.Cert | b64enc }}
-  key.pem: {{ $genCert.Key | b64enc }}
+  ca.crt: {{ $genCA.Cert | b64enc }}
+  tls.crt: {{ $genCert.Cert | b64enc }}
+  tls.key: {{ $genCert.Key | b64enc }}
 {{- end }}
 {{- end }}

--- a/cmd/traffic/cmd/manager/internal/mutator/service.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/service.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	tlsDir          = `/var/run/secrets/tls`
-	tlsCertFile     = `crt.pem`
-	tlsKeyFile      = `key.pem`
+	tlsCertFile     = `tls.crt`
+	tlsKeyFile      = `tls.key`
 	jsonContentType = `application/json`
 )
 

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -252,7 +252,10 @@ func (m *Manager) WatchAgentsNS(request *rpc.AgentsRequest, stream rpc.Manager_W
 		return err
 	}
 
-	var lastSnap map[string]*rpc.AgentInfo
+	// Ensure that initial snapshot is not equal to lastSnap even if it is empty so
+	// that an initial snapshot is sent even when it's empty.
+	lastSnap := make(map[string]*rpc.AgentInfo)
+	lastSnap[""] = nil
 	snapEqual := func(snap []*rpc.AgentInfo) bool {
 		if len(snap) != len(lastSnap) {
 			return false

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -123,15 +123,15 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 }
 
 func (s *notConnectedSuite) Test_ConflictingProxies() {
-	topCtx := s.Context()
-	itest.TelepresenceQuitOk(topCtx)
+	ctx := s.Context()
+	itest.TelepresenceQuitOk(ctx)
 
 	testIP := &net.IPNet{
 		IP:   net.ParseIP("10.128.0.32"),
 		Mask: net.CIDRMask(32, 32),
 	}
 	// We don't really care if we can't route this with TP disconnected provided the result is the same once we connect
-	originalRoute, _ := routing.GetRoute(topCtx, testIP)
+	originalRoute, _ := routing.GetRoute(ctx, testIP)
 	for name, t := range map[string]struct {
 		alsoProxy  []string
 		neverProxy []string
@@ -150,7 +150,7 @@ func (s *notConnectedSuite) Test_ConflictingProxies() {
 	} {
 		s.Run(name, func() {
 			require := s.Require()
-			ctx := itest.WithKubeConfigExtension(topCtx, func(cluster *api.Cluster) map[string]interface{} {
+			ctx := itest.WithKubeConfigExtension(s.Context(), func(cluster *api.Cluster) map[string]interface{} {
 				return map[string]interface{}{
 					"never-proxy": t.neverProxy,
 					"also-proxy":  t.alsoProxy,

--- a/pkg/client/userd/k8s/watcher.go
+++ b/pkg/client/userd/k8s/watcher.go
@@ -28,15 +28,16 @@ const resyncPeriod = 2 * time.Minute
 // Watcher watches some resource and can be cancelled
 type Watcher struct {
 	sync.Mutex
-	cancel     context.CancelFunc
-	resource   string
-	namespace  string
-	getter     cache.Getter
-	objType    runtime.Object
-	cond       *sync.Cond
-	controller cache.Controller
-	store      cache.Store
-	equals     func(runtime.Object, runtime.Object) bool
+	cancel         context.CancelFunc
+	resource       string
+	namespace      string
+	getter         cache.Getter
+	objType        runtime.Object
+	cond           *sync.Cond
+	controller     cache.Controller
+	store          cache.Store
+	equals         func(runtime.Object, runtime.Object) bool
+	stateListeners []func()
 }
 
 func newListerWatcher(c context.Context, getter cache.Getter, resource, namespace string) cache.ListerWatcher {
@@ -71,11 +72,23 @@ func NewWatcher(resource, namespace string, getter cache.Getter, objType runtime
 	}
 }
 
+// AddStateListener adds a listener function that will be called when the watcher
+// changes its state (starts or is cancelled)
+func (w *Watcher) AddStateListener(l func()) {
+	w.Lock()
+	w.stateListeners = append(w.stateListeners, l)
+	w.Unlock()
+}
+
 func (w *Watcher) Cancel() {
 	w.Lock()
 	defer w.Unlock()
 	if w.cancel != nil {
 		w.cancel()
+		w.cancel = nil
+		for _, l := range w.stateListeners {
+			l()
+		}
 	}
 }
 
@@ -98,6 +111,14 @@ func (w *Watcher) Get(c context.Context, obj interface{}) (interface{}, bool, er
 	return w.store.Get(obj)
 }
 
+func (w *Watcher) EnsureStarted(c context.Context) {
+	w.Lock()
+	defer w.Unlock()
+	if w.store == nil {
+		w.startOnDemand(c)
+	}
+}
+
 func (w *Watcher) List(c context.Context) []interface{} {
 	w.Lock()
 	defer w.Unlock()
@@ -105,6 +126,14 @@ func (w *Watcher) List(c context.Context) []interface{} {
 		w.startOnDemand(c)
 	}
 	return w.store.List()
+}
+
+// Active returns true if the watcher has been started and not yet cancelled
+func (w *Watcher) Active() bool {
+	w.Lock()
+	active := w.cancel != nil
+	w.Unlock()
+	return active
 }
 
 func (w *Watcher) Watch(c context.Context, ready *sync.WaitGroup) {
@@ -123,6 +152,9 @@ func (w *Watcher) startOnDemand(c context.Context) {
 	rdy.Wait()
 	go w.run(c)
 	cache.WaitForCacheSync(c.Done(), w.controller.HasSynced)
+	for _, l := range w.stateListeners {
+		l()
+	}
 }
 
 func (w *Watcher) startLocked(c context.Context, ready *sync.WaitGroup) {

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -148,6 +148,10 @@ type TrafficManager struct {
 	// agentWaiters contains chan *manager.AgentInfo keyed by agent <name>.<namespace>
 	agentWaiters sync.Map
 
+	// agentInitWaiters  is protected by the currentAgentsLock. The contained channels are closed
+	// and the slice is cleared when an agent snapshot arrives.
+	agentInitWaiters []chan<- struct{}
+
 	sessionServices []SessionService
 	sr              *scout.Reporter
 }
@@ -580,6 +584,38 @@ func (tm *TrafficManager) workloadInfoSnapshot(
 	includeLocalIntercepts bool,
 ) (*rpc.WorkloadInfoSnapshot, error) {
 	is := tm.getCurrentIntercepts()
+
+	// If a watcher is started, we better wait for the next snapshot from WatchAgentsNS
+	waitCh := make(chan struct{}, 1)
+	tm.currentAgentsLock.Lock()
+	tm.agentInitWaiters = append(tm.agentInitWaiters, waitCh)
+	tm.currentAgentsLock.Unlock()
+	needWait := false
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(namespaces))
+	for _, ns := range namespaces {
+		if ns == "" {
+			// Don't use tm.ActualNamespace here because the accessibility of the namespace
+			// is actually determined once the watcher starts
+			ns = tm.Namespace
+		}
+		tm.wlWatcher.ensureStarted(ctx, ns, func(started bool) {
+			if started {
+				needWait = true
+			}
+			wg.Done()
+		})
+	}
+	wg.Wait()
+	wc, cancel := client.GetConfig(ctx).Timeouts.TimeoutContext(ctx, client.TimeoutRoundtripLatency)
+	defer cancel()
+	if needWait {
+		select {
+		case <-wc.Done():
+		case <-waitCh:
+		}
+	}
 
 	var nss []string
 	if filter == rpc.ListRequest_INTERCEPTS {

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -530,6 +530,15 @@ func (tm *TrafficManager) waitForSync(ctx context.Context) {
 	tm.wlWatcher.waitForSync(ctx)
 }
 
+func (tm *TrafficManager) getActiveNamespaces(ctx context.Context) []string {
+	tm.waitForSync(ctx)
+	return tm.wlWatcher.getActiveNamespaces()
+}
+
+func (tm *TrafficManager) addActiveNamespaceListener(l func()) {
+	tm.wlWatcher.addActiveNamespaceListener(l)
+}
+
 func (tm *TrafficManager) WatchWorkloads(c context.Context, wr *rpc.WatchWorkloadsRequest, stream WatchWorkloadsStream) error {
 	tm.waitForSync(c)
 	sCtx, sCancel := context.WithCancel(c)


### PR DESCRIPTION
## Description

An active namespace in this context, is a namespace that the user has
done some explicit action on such as `list` or `intercept`. The client
has no reason to watch agents in any other namespace. Limiting the
watch this way will decrease network traffic significantly on large
clusters when the user doesn't `connect` using `--mapped-namespaces`.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
