### PR TITLE
Revert "Modify TLS secret key names to conform with Kubernetes standard"

### DIFF
--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -60,12 +60,12 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-  ca.crt: {{ get $secretData "ca.pem" }}
-  tls.crt: {{ get $secretData "crt.pem" }}
-  tls.key: {{ get $secretData "key.pem" }}
+  ca.pem: {{ get $secretData "ca.pem" }}
+  crt.pem: {{ get $secretData "crt.pem" }}
+  key.pem: {{ get $secretData "key.pem" }}
 {{- else }}
-  ca.crt: {{ $genCA.Cert | b64enc }}
-  tls.crt: {{ $genCert.Cert | b64enc }}
-  tls.key: {{ $genCert.Key | b64enc }}
+  ca.pem: {{ $genCA.Cert | b64enc }}
+  crt.pem: {{ $genCert.Cert | b64enc }}
+  key.pem: {{ $genCert.Key | b64enc }}
 {{- end }}
 {{- end }}

--- a/cmd/traffic/cmd/manager/internal/mutator/service.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/service.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	tlsDir          = `/var/run/secrets/tls`
-	tlsCertFile     = `tls.crt`
-	tlsKeyFile      = `tls.key`
+	tlsCertFile     = `crt.pem`
+	tlsKeyFile      = `key.pem`
 	jsonContentType = `application/json`
 )
 


### PR DESCRIPTION
Reverts telepresenceio/telepresence#2485

Reverting this one since it breaks some use-cases. Will investigate.