### PR TITLE
A mechanism for different test profiles

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -254,7 +254,7 @@ check-integration: tools/bin/helm ## (QA) Run the test suite
 	# We run the test suite with TELEPRESENCE_LOGIN_DOMAIN set to localhost since that value
 	# is only used for extensions. Therefore, we want to validate that our tests, and
 	# telepresence, run without requiring any outside dependencies.
-	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 go test -v -run='Test_Integration/Test_Namespaces.*' -timeout=29m ./integration_test/...
+	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 go test -v -run='Test_Integration/Test_Namespaces.*' -timeout=39m ./integration_test/...
 
 .PHONY: _login
 _login:

--- a/integration_test/headless_test.go
+++ b/integration_test/headless_test.go
@@ -16,9 +16,8 @@ import (
 )
 
 func (s *connectedSuite) Test_SuccessfullyInterceptsHeadlessService() {
-	// GKE Autopilot does not support NET_ADMIN containers which means headless services can't be intercepted
 	if itest.GetProfile(s.Context()) == itest.GkeAutopilotProfile {
-		s.T().SkipNow()
+		s.T().Skip("GKE Autopilot does not support NET_ADMIN containers which means headless services can't be intercepted")
 	}
 	ctx, cancel := context.WithCancel(dcontext.WithSoftness(s.Context()))
 	defer cancel()

--- a/integration_test/headless_test.go
+++ b/integration_test/headless_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func (s *connectedSuite) Test_SuccessfullyInterceptsHeadlessService() {
+	// GKE Autopilot does not support NET_ADMIN containers which means headless services can't be intercepted
+	if itest.GetProfile(s.Context()) == itest.GkeAutopilotProfile {
+		s.T().SkipNow()
+	}
 	ctx, cancel := context.WithCancel(dcontext.WithSoftness(s.Context()))
 	defer cancel()
 	const svc = "echo-headless"

--- a/integration_test/podscaling_test.go
+++ b/integration_test/podscaling_test.go
@@ -96,7 +96,7 @@ func (s *interceptMountSuite) Test_StopInterceptedPodOfMany() {
 	}()
 
 	// Wait for second pod to arrive
-	assert.Eventually(func() bool { return len(s.runningPods(ctx)) == 2 }, 20*time.Second, 2*time.Second)
+	assert.Eventually(func() bool { return len(s.runningPods(ctx)) == 2 }, itest.PodCreateTimeout(ctx), 2*time.Second)
 	s.CapturePodLogs(ctx, "app=echo", "traffic-agent", s.AppNamespace())
 
 	// Delete the currently intercepted pod

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -49,7 +49,7 @@ func (s *notConnectedSuite) Test_Uninstall() {
 		}
 		match, err := regexp.MatchString(jobname+`-[a-z0-9]+-[a-z0-9]+\s+1/1\s+Running`, stdout)
 		return err == nil && match
-	}, 10*time.Second, 2*time.Second)
+	}, itest.PodCreateTimeout(ctx), 2*time.Second)
 
 	require.Eventually(
 		func() bool {


### PR DESCRIPTION
This is intended to encode differences in clusters that we test on.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
