### PR TITLE
Revert tls cert name changes

### DIFF
--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -16,7 +16,7 @@ webhooks:
 {{- end }}
   clientConfig:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-    caBundle: {{ get $secretData "ca.crt" }}
+    caBundle: {{ get $secretData "ca.pem" }}
 {{- else }}
     caBundle: {{ $genCA.Cert | b64enc }}
 {{- end }}
@@ -60,9 +60,9 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-  ca.crt: {{ get $secretData "ca.crt" }}
-  tls.crt: {{ get $secretData "tls.crt" }}
-  tls.key: {{ get $secretData "tls.key" }}
+  ca.crt: {{ get $secretData "ca.pem" }}
+  tls.crt: {{ get $secretData "crt.pem" }}
+  tls.key: {{ get $secretData "key.pem" }}
 {{- else }}
   ca.crt: {{ $genCA.Cert | b64enc }}
   tls.crt: {{ $genCert.Cert | b64enc }}

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -60,12 +60,12 @@ metadata:
     {{- include "telepresence.labels" . | nindent 4 }}
 data:
 {{- if and ($secretData) (not .Values.agentInjector.certificate.regenerate) }}
-  ca.crt: {{ get $secretData "ca.pem" }}
-  tls.crt: {{ get $secretData "crt.pem" }}
-  tls.key: {{ get $secretData "key.pem" }}
+  ca.pem: {{ get $secretData "ca.pem" }}
+  crt.pem: {{ get $secretData "crt.pem" }}
+  key.pem: {{ get $secretData "key.pem" }}
 {{- else }}
-  ca.crt: {{ $genCA.Cert | b64enc }}
-  tls.crt: {{ $genCert.Cert | b64enc }}
-  tls.key: {{ $genCert.Key | b64enc }}
+  ca.pem: {{ $genCA.Cert | b64enc }}
+  crt.pem: {{ $genCert.Cert | b64enc }}
+  key.pem: {{ $genCert.Key | b64enc }}
 {{- end }}
 {{- end }}

--- a/cmd/traffic/cmd/manager/internal/mutator/service.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/service.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	tlsDir          = `/var/run/secrets/tls`
-	tlsCertFile     = `tls.crt`
-	tlsKeyFile      = `tls.key`
+	tlsCertFile     = `crt.pem`
+	tlsKeyFile      = `key.pem`
 	jsonContentType = `application/json`
 )
 


### PR DESCRIPTION
Reverting those commits since they cause the helm upgrade to fail. We'll need to introduce them in a release that forces the secret to be regenerated.