### PR TITLE
fix-unit-testing-issues

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -76,7 +76,7 @@ following Free and Open Source software:
     github.com/imdario/mergo                                            v0.3.11                                    3-clause BSD license
     github.com/inconshreveable/mousetrap                                v1.0.0                                     Apache License 2.0
     github.com/jmoiron/sqlx                                             v1.3.1                                     MIT license
-    github.com/json-iterator/go                                         v1.1.10                                    MIT license
+    github.com/json-iterator/go                                         v1.1.12                                    MIT license
     github.com/kr/fs                                                    v0.1.0                                     3-clause BSD license
     github.com/lann/builder                                             v0.0.0-20180802200727-47ae307949d0         MIT license
     github.com/lann/ps                                                  v0.0.0-20150810152359-62de8c46ede0         MIT license
@@ -94,7 +94,7 @@ following Free and Open Source software:
     github.com/moby/spdystream                                          v0.2.0                                     Apache License 2.0
     github.com/moby/term                                                v0.0.0-20201216013528-df9cb8a40635         Apache License 2.0
     github.com/modern-go/concurrent                                     v0.0.0-20180306012644-bacd9c7ef1dd         Apache License 2.0
-    github.com/modern-go/reflect2                                       v1.0.1                                     Apache License 2.0
+    github.com/modern-go/reflect2                                       v1.0.2                                     Apache License 2.0
     github.com/monochromegane/go-gitignore                              v0.0.0-20200626010858-205db1a8cc00         MIT license
     github.com/morikuni/aec                                             v1.0.0                                     MIT license
     github.com/opencontainers/go-digest                                 v1.0.0                                     Apache License 2.0

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.3.1 // indirect
-	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
@@ -122,7 +122,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,9 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -624,8 +625,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=

--- a/pkg/client/scout/reporter_test.go
+++ b/pkg/client/scout/reporter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datawire/dlib/dcontext"
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 func TestInstallID(t *testing.T) {
@@ -256,9 +257,17 @@ func TestInstallID(t *testing.T) {
 		}
 	}
 	origEnv := os.Environ()
+	version.Version = "testing"
+	defer func() { version.Version = "" }()
+
 	for tcName, tcData := range testcases {
 		tcData := tcData
 		t.Run(tcName, func(t *testing.T) {
+			if tcData.InputGOOS != runtime.GOOS {
+				t.Skip()
+				return
+			}
+
 			ctx := dlog.NewTestContext(t, true)
 			homedir := t.TempDir()
 			defer func() {

--- a/pkg/client/scout/reporter_test.go
+++ b/pkg/client/scout/reporter_test.go
@@ -256,9 +256,12 @@ func TestInstallID(t *testing.T) {
 			},
 		}
 	}
+
 	origEnv := os.Environ()
-	version.Version = "testing"
-	defer func() { version.Version = "" }()
+
+	ov := version.Version
+	version.Version = "v0.0.0"
+	defer func() { version.Version = ov }()
 
 	for tcName, tcData := range testcases {
 		tcData := tcData


### PR DESCRIPTION
## Description

Fixes 3 issues with unit tests

1. Skips OS specific tests if OS does not match `runtime.GOOS`.
2. Fixes panic while serializing `core.Secret` by updating `github.com/json-iterator/go` to latest version.
3. Removes dependency on the `TELEPRESENCE_VERSION` environment variable.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
