### PR TITLE
Ensure that the destination folder for the enhanced free client exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.8 (TBD)
+
+- Bugfix: Telepresence now ensures that the download folder for the enhanced free client is created prior to downloading it.
+
 ### 2.5.7 (April 25, 2022)
 
 - Change: A namespaced traffic-manager will no longer require cluster wide RBAC. Only Roles and RoleBindings are now used.

--- a/pkg/client/cli/cliutil/systema.go
+++ b/pkg/client/cli/cliutil/systema.go
@@ -272,6 +272,10 @@ func installTelepresencePro(ctx context.Context, telProLocation string) error {
 // temporary file as the new binary
 func downloadProDaemon(downloadURL string, from io.Reader, telProLocation string) (err error) {
 	dir := filepath.Dir(telProLocation)
+	if err = os.MkdirAll(dir, 0777); err != nil {
+		return errcat.NoDaemonLogs.Newf("error creating directory %q: %w", dir, err)
+	}
+
 	name := filepath.Base(telProLocation)
 	var tmp *os.File
 	if tmp, err = os.CreateTemp(dir, name); err != nil {


### PR DESCRIPTION
## Description

A flow starting with the `telepresence login` after installing the
client would not create the directory where the enhanced free client was
installed before attempting to download it. This resulted in "error
installing updated enhanced free client: unable to create temporary
file in ...".

This commit ensures that the directory is present before the download
attempt is made.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
