### PR TITLE
Ensure that genversion bumps patch version of released tags only

### DIFF
--- a/build-aux/genversion/main.go
+++ b/build-aux/genversion/main.go
@@ -17,12 +17,12 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
-	"time"
 
 	//nolint:depguard // This short script has no logging and no Contexts.
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/blang/semver"
 )
@@ -39,7 +39,11 @@ func Main() error {
 	if err != nil {
 		return fmt.Errorf("unable to parse semver %s: %w", gitDescStr, err)
 	}
-	gitDescVer.Patch++
+
+	// Bump to next patch version only if we found a release, i.e. no pre-version and no build suffix.
+	if len(gitDescVer.Pre) == 0 && len(gitDescVer.Build) == 0 {
+		gitDescVer.Patch++
+	}
 
 	// If an additional arg has been used, we include it in the tag
 	if len(os.Args) >= 2 {


### PR DESCRIPTION
A tag like `v2.6.0-alpha.1` must not result in `v2.6.1-xxx` when used
with the `genversion` command. Bumping the patch version is only
relevant when the last found tag is a release tag.