### PR TITLE
Mounts and custom securityContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Change: When upgrading, all workloads with injected agents will have their agent "uninstalled" automatically. The mutating webhook will
   then ensure that their pods will receive an updated traffic-agent.
 
-- Bugfix: Remote mounts will no function correctly with custom `securityContext`.
+- Bugfix: Remote mounts will now function correctly with custom `securityContext`.
 
 - Bugfix: The help for commands that accept kubernetes flags will now display those flags in a separate group. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Change: When upgrading, all workloads with injected agents will have their agent "uninstalled" automatically. The mutating webhook will
   then ensure that their pods will receive an updated traffic-agent.
 
+- Bugfix: Remote mounts will no function correctly with custom `securityContext`.
+
 - Bugfix: The help for commands that accept kubernetes flags will now display those flags in a separate group. 
 
 ### 2.5.8 (April 27, 2022)

--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -182,7 +183,8 @@ func Main(ctx context.Context, args ...string) error {
 				g.Go(fmt.Sprintf("forward-%s:%d", cn.Name, ic.ContainerPort), func(ctx context.Context) error {
 					return fwd.Serve(tunnel.WithPool(ctx, tunnel.NewPool()))
 				})
-				state.AddInterceptState(NewInterceptState(state, fwd, ic, cn.MountPoint, env))
+				cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
+				state.AddInterceptState(NewInterceptState(state, fwd, ic, cnMountPoint, env))
 			}
 		}
 

--- a/cmd/traffic/cmd/agent/agent_test.go
+++ b/cmd/traffic/cmd/agent/agent_test.go
@@ -63,6 +63,7 @@ func testContext(t *testing.T, env dos.MapEnv) context.Context {
 	require.NoError(t, err)
 
 	require.NoError(t, fs.MkdirAll(agentconfig.ConfigMountPoint, 0700))
+	require.NoError(t, fs.MkdirAll(agentconfig.ExportsMountPoint, 0700))
 	require.NoError(t, afero.WriteFile(fs, filepath.Join(agentconfig.ConfigMountPoint, agentconfig.ConfigFile), y, 0600))
 
 	env[agentconfig.EnvPrefixAgent+"POD_IP"] = podIP
@@ -114,7 +115,8 @@ func Test_AppEnvironment(t *testing.T) {
 	}, env)
 
 	// Check symlink to container's remote mount point
-	f, err = dos.Open(ctx, filepath.Join(cn.MountPoint, ksDir, "namespace"))
+	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
+	f, err = dos.Open(ctx, filepath.Join(cnMountPoint, ksDir, "namespace"))
 	require.NoError(t, err, "not symlinked")
 	data, err := io.ReadAll(f)
 	require.NoError(t, err)

--- a/cmd/traffic/cmd/agent/config.go
+++ b/cmd/traffic/cmd/agent/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
+	"github.com/telepresenceio/telepresence/v2/pkg/log"
 )
 
 type Config interface {
@@ -44,6 +45,9 @@ func LoadConfig(ctx context.Context) (Config, error) {
 	}
 	c.podIP = dos.Getenv(ctx, "_TEL_AGENT_POD_IP")
 	for _, cn := range c.Containers {
+		if err := addAppMounts(ctx, cn); err != nil {
+			return nil, err
+		}
 		if err := addSecretsMounts(ctx, cn); err != nil {
 			return nil, err
 		}
@@ -72,10 +76,39 @@ func (c *config) PodIP() string {
 	return c.podIP
 }
 
+// addAppMounts adds each of the mounts present under the containers MountPoint as a
+// symlink under the agentconfig.ExportsMountPoint/<container mount>/
+func addAppMounts(ctx context.Context, ag *agentconfig.Container) error {
+	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(ag.MountPoint))
+	if err := dos.Mkdir(ctx, cnMountPoint, 0700); err != nil {
+		return err
+	}
+	appMountsDir, err := dos.Open(ctx, ag.MountPoint)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil // Nothing is mounted from this app container. That's ok
+		}
+		return err
+	}
+	defer appMountsDir.Close()
+	mounts, err := appMountsDir.ReadDir(-1)
+	if err != nil {
+		return err
+	}
+	for _, mount := range mounts {
+		if err = dos.Symlink(ctx, filepath.Join(ag.MountPoint, mount.Name()), filepath.Join(cnMountPoint, mount.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // addSecretsMounts adds any token-rotating system secrets directories if they exist
 // e.g. /var/run/secrets/kubernetes.io or /var/run/secrets/eks.amazonaws.com
 // to the TELEPRESENCE_MOUNTS environment variable
 func addSecretsMounts(ctx context.Context, ag *agentconfig.Container) error {
+	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(ag.MountPoint))
+
 	// This will attempt to handle all the secrets dirs, but will return the first error we encountered.
 	secretsDir, err := dos.Open(ctx, "/var/run/secrets")
 	if err != nil {
@@ -85,10 +118,10 @@ func addSecretsMounts(ctx context.Context, ag *agentconfig.Container) error {
 		return err
 	}
 	fileInfo, err := secretsDir.ReadDir(-1)
+	secretsDir.Close()
 	if err != nil {
 		return err
 	}
-	secretsDir.Close()
 
 	mm := make(map[string]struct{})
 	for _, m := range ag.Mounts {
@@ -113,7 +146,7 @@ func addSecretsMounts(ctx context.Context, ag *agentconfig.Container) error {
 			continue
 		}
 
-		appMountsPath := filepath.Join(ag.MountPoint, dirPath)
+		appMountsPath := filepath.Join(cnMountPoint, dirPath)
 		dlog.Debugf(ctx, "checking appmounts directory: %s", dirPath)
 		// Make sure the path doesn't already exist
 		_, err = dos.Stat(ctx, appMountsPath)

--- a/cmd/traffic/cmd/agent/config.go
+++ b/cmd/traffic/cmd/agent/config.go
@@ -48,6 +48,10 @@ func LoadConfig(ctx context.Context) (Config, error) {
 			return nil, err
 		}
 	}
+	if c.LogLevel != "" {
+		// Override default from environment
+		log.SetLevel(ctx, c.LogLevel)
+	}
 	return &c, nil
 }
 

--- a/cmd/traffic/cmd/agent/state_test.go
+++ b/cmd/traffic/cmd/agent/state_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/agent"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/forwarder"
 )
 
@@ -39,7 +41,8 @@ func makeFS(t *testing.T, ctx context.Context) (*forwarder.Forwarder, agent.Stat
 	require.NoError(t, err)
 	s := agent.NewSimpleState(c)
 	cn := c.AgentConfig().Containers[0]
-	s.AddInterceptState(agent.NewInterceptState(s, f, cn.Intercepts[0], cn.MountPoint, map[string]string{}))
+	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
+	s.AddInterceptState(agent.NewInterceptState(s, f, cn.Intercepts[0], cnMountPoint, map[string]string{}))
 
 	return f, s
 }

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -113,7 +113,7 @@ func (a *agentInjector) inject(ctx context.Context, req *admission.AdmissionRequ
 	var patches patchOps
 	patches = addInitContainer(ctx, pod, config, patches)
 	patches = addAgentContainer(ctx, pod, config, patches)
-	patches = addAgentVolume(pod, config, patches)
+	patches = addAgentVolumes(pod, config, patches)
 	patches = hidePorts(pod, config, patches)
 	patches = addPodAnnotations(ctx, pod, patches)
 
@@ -214,7 +214,7 @@ func addInitContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Si
 	})
 }
 
-func addAgentVolume(pod *core.Pod, ag *agentconfig.Sidecar, patches patchOps) patchOps {
+func addAgentVolumes(pod *core.Pod, ag *agentconfig.Sidecar, patches patchOps) patchOps {
 	for _, vol := range pod.Spec.Volumes {
 		if vol.Name == agentconfig.AnnotationVolumeName {
 			return patches
@@ -254,6 +254,16 @@ func addAgentVolume(pod *core.Pod, ag *agentconfig.Sidecar, patches patchOps) pa
 							Path: agentconfig.ConfigFile,
 						}},
 					},
+				},
+			},
+		},
+		patchOperation{
+			Op:   "add",
+			Path: "/spec/volumes/-",
+			Value: core.Volume{
+				Name: agentconfig.ExportsVolumeName,
+				VolumeSource: core.VolumeSource{
+					EmptyDir: &core.EmptyDirVolumeSource{},
 				},
 			},
 		},

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -859,6 +859,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -878,6 +880,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -928,6 +935,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -947,6 +956,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -1044,6 +1058,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -1063,6 +1079,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -1125,6 +1146,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -1144,6 +1167,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 `,
 			"",
 			nil,
@@ -1207,6 +1235,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -1226,6 +1256,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 `,
 			"",
 			nil,
@@ -1285,6 +1320,10 @@ func TestTrafficAgentInjector(t *testing.T) {
 								{
 									Name:      "traffic-config",
 									MountPath: "/etc/traffic-agent",
+								},
+								{
+									Name:      "export-volume",
+									MountPath: "/tel_app_exports",
 								},
 							},
 							ReadinessProbe: &core.Probe{
@@ -1353,6 +1392,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-annotations
     - mountPath: /etc/traffic-agent
       name: traffic-config
+    - mountPath: /tel_app_exports
+      name: export-volume
 - op: add
   path: /spec/volumes/-
   value:
@@ -1372,6 +1413,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         path: config.yaml
       name: telepresence-agents
     name: traffic-config
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: export-volume
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Env struct {
+	LogLevel    string `env:"LOG_LEVEL,default=info"`
 	User        string `env:"USER,default="`
 	ServerHost  string `env:"SERVER_HOST,default="`
 	ServerPort  string `env:"SERVER_PORT,default=8081"`
@@ -41,6 +42,7 @@ func (e *Env) GeneratorConfig(qualifiedAgentImage string) *agentmap.GeneratorCon
 		APIPort:             uint16(e.APIPort),
 		QualifiedAgentImage: qualifiedAgentImage,
 		ManagerNamespace:    e.ManagerNamespace,
+		LogLevel:            e.LogLevel,
 	}
 }
 

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -40,6 +40,7 @@ func TestEnvconfig(t *testing.T) {
 		AgentPort:       9900,
 		MaxReceiveSize:  resource.MustParse("4Mi"),
 		PodCIDRStrategy: "auto",
+		LogLevel:        "info",
 	}
 
 	testcases := map[string]struct {

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -143,6 +143,7 @@ func (s *singleServiceSuite) TestGatherLogs_OnlyMappedLogs() {
 	}()
 
 	cleanLogDir(ctx, require, bothNsRx, s.ManagerNamespace(), s.ServiceName())
+	itest.TelepresenceOk(ctx, "list") // To ensure that the mapped namespaces are active
 	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--traffic-manager=False")
 	_, foundAgents, _, fileNames = getZipData(require, outputFile, bothNsRx, s.ManagerNamespace(), s.ServiceName())
 	require.Equal(1, foundAgents, fileNames)

--- a/k8s/hello-w-volume.yaml
+++ b/k8s/hello-w-volume.yaml
@@ -44,6 +44,9 @@ spec:
       labels:
         service: hello
     spec:
+      securityContext:
+        runAsGroup: 11000
+        runAsUser: 11000
       volumes:
         - name: hello-cm-volume
           configMap:

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -47,14 +47,20 @@ func AgentContainer(
 		mounts = appendAppContainerVolumeMounts(app, cc, mounts)
 	})
 
-	mounts = append(mounts, v1.VolumeMount{
-		Name:      AnnotationVolumeName,
-		MountPath: AnnotationMountPoint,
-	})
-	mounts = append(mounts, v1.VolumeMount{
-		Name:      ConfigVolumeName,
-		MountPath: ConfigMountPoint,
-	})
+	mounts = append(mounts,
+		v1.VolumeMount{
+			Name:      AnnotationVolumeName,
+			MountPath: AnnotationMountPoint,
+		},
+		v1.VolumeMount{
+			Name:      ConfigVolumeName,
+			MountPath: ConfigMountPoint,
+		},
+		v1.VolumeMount{
+			Name:      ExportsVolumeName,
+			MountPath: ExportsMountPoint,
+		},
+	)
 
 	if len(efs) == 0 {
 		efs = nil

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -14,6 +14,8 @@ const (
 	ConfigMountPoint     = "/etc/traffic-agent"
 	ConfigFile           = "config.yaml"
 	MountPrefixApp       = "/tel_app_mounts"
+	ExportsVolumeName    = "export-volume"
+	ExportsMountPoint    = "/tel_app_exports"
 	EnvPrefix            = "_TEL_"
 	EnvPrefixAgent       = EnvPrefix + "AGENT_"
 	EnvPrefixApp         = EnvPrefix + "APP_"

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -23,6 +23,7 @@ type GeneratorConfig struct {
 	APIPort             uint16
 	QualifiedAgentImage string
 	ManagerNamespace    string
+	LogLevel            string
 }
 
 func GenerateForPod(ctx context.Context, pod *core.Pod, env *GeneratorConfig) (*agentconfig.Sidecar, error) {
@@ -72,6 +73,7 @@ func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (*a
 	ag := &agentconfig.Sidecar{
 		AgentImage:   cfg.QualifiedAgentImage,
 		AgentName:    wl.GetName(),
+		LogLevel:     cfg.LogLevel,
 		Namespace:    wl.GetNamespace(),
 		WorkloadName: wl.GetName(),
 		WorkloadKind: wl.GetKind(),


### PR DESCRIPTION
## Description

This PR adds an `emptyDir` volume mount to the `traffic-agent`
which can be written to regardless of what security context the pod
is using. The volume is mounted under `/tel_app_exports`. Each
app container will have a directory entry there, and under that
directory, all mounts will be symlinked to their original location.

The `/tel_app_exports/<container-name>` is then what's exported by the
`sftp` server during an intercept involving that container.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
