### PR TITLE
Restore ability to do manual injection of traffic-agent

### DIFF
--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -114,7 +113,7 @@ func SftpServer(ctx context.Context, sftpPortCh chan<- uint16) error {
 }
 
 func Main(ctx context.Context, args ...string) error {
-	dlog.Infof(ctx, "Traffic Agent %s [pid:%d]", version.Version, os.Getpid())
+	dlog.Infof(ctx, "Traffic Agent %s", version.Version)
 
 	// Handle configuration
 	config, err := LoadConfig(ctx)

--- a/k8s/echo-manual-inject-deploy.yaml
+++ b/k8s/echo-manual-inject-deploy.yaml
@@ -18,5 +18,5 @@ spec:
         - name: echo-container
           image: jmalloc/echo-server
           ports:
-            - containerPort: 8080
+            - containerPort: 80
           resources: {}

--- a/k8s/echo-manual-inject-svc.yaml
+++ b/k8s/echo-manual-inject-svc.yaml
@@ -8,5 +8,3 @@ spec:
     service: manual-inject
   ports:
     - port: 80
-      # This port is not defined in k8s/echo-manual-inject-deploy.yaml because it will be the port used by the manually added traffic-agent
-      targetPort: 9900

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -3,21 +3,21 @@ package agentconfig
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	core "k8s.io/api/core/v1"
 )
 
 // AgentContainer will return a configured traffic-agent
 func AgentContainer(
-	pod *v1.Pod,
+	pod *core.Pod,
 	config *Sidecar,
-) *v1.Container {
-	ports := make([]v1.ContainerPort, 0, 5)
+) *core.Container {
+	ports := make([]core.ContainerPort, 0, 5)
 	for _, cc := range config.Containers {
 		for _, ic := range cc.Intercepts {
-			ports = append(ports, v1.ContainerPort{
+			ports = append(ports, core.ContainerPort{
 				Name:          ic.ContainerPortName,
 				ContainerPort: int32(ic.AgentPort),
-				Protocol:      v1.Protocol(ic.Protocol),
+				Protocol:      core.Protocol(ic.Protocol),
 			})
 		}
 	}
@@ -25,38 +25,38 @@ func AgentContainer(
 		return nil
 	}
 
-	evs := make([]v1.EnvVar, 0, len(config.Containers)*5)
-	efs := make([]v1.EnvFromSource, 0, len(config.Containers)*3)
-	EachContainer(pod, config, func(app *v1.Container, cc *Container) {
+	evs := make([]core.EnvVar, 0, len(config.Containers)*5)
+	efs := make([]core.EnvFromSource, 0, len(config.Containers)*3)
+	EachContainer(pod, config, func(app *core.Container, cc *Container) {
 		evs = appendAppContainerEnv(app, cc, evs)
 		efs = appendAppContainerEnvFrom(app, cc, efs)
 	})
 	evs = append(evs,
-		v1.EnvVar{
+		core.EnvVar{
 			Name: EnvPrefixAgent + "POD_IP",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
+			ValueFrom: &core.EnvVarSource{
+				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: "v1",
 					FieldPath:  "status.podIP",
 				},
 			},
 		})
 
-	mounts := make([]v1.VolumeMount, 0, len(config.Containers)*3)
-	EachContainer(pod, config, func(app *v1.Container, cc *Container) {
+	mounts := make([]core.VolumeMount, 0, len(config.Containers)*3)
+	EachContainer(pod, config, func(app *core.Container, cc *Container) {
 		mounts = appendAppContainerVolumeMounts(app, cc, mounts)
 	})
 
 	mounts = append(mounts,
-		v1.VolumeMount{
+		core.VolumeMount{
 			Name:      AnnotationVolumeName,
 			MountPath: AnnotationMountPoint,
 		},
-		v1.VolumeMount{
+		core.VolumeMount{
 			Name:      ConfigVolumeName,
 			MountPath: ConfigMountPoint,
 		},
-		v1.VolumeMount{
+		core.VolumeMount{
 			Name:      ExportsVolumeName,
 			MountPath: ExportsMountPoint,
 		},
@@ -65,7 +65,7 @@ func AgentContainer(
 	if len(efs) == 0 {
 		efs = nil
 	}
-	return &v1.Container{
+	return &core.Container{
 		Name:         ContainerName,
 		Image:        config.AgentImage,
 		Args:         []string{"agent"},
@@ -73,9 +73,9 @@ func AgentContainer(
 		Env:          evs,
 		EnvFrom:      efs,
 		VolumeMounts: mounts,
-		ReadinessProbe: &v1.Probe{
-			ProbeHandler: v1.ProbeHandler{
-				Exec: &v1.ExecAction{
+		ReadinessProbe: &core.Probe{
+			ProbeHandler: core.ProbeHandler{
+				Exec: &core.ExecAction{
 					Command: []string{"/bin/stat", "/tmp/agent/ready"},
 				},
 			},
@@ -83,9 +83,69 @@ func AgentContainer(
 	}
 }
 
+func InitContainer(qualifiedAgentImage string) *core.Container {
+	return &core.Container{
+		Name:  InitContainerName,
+		Image: qualifiedAgentImage,
+		Args:  []string{"agent-init"},
+		VolumeMounts: []core.VolumeMount{{
+			Name:      ConfigVolumeName,
+			MountPath: ConfigMountPoint,
+		}},
+		SecurityContext: &core.SecurityContext{
+			Capabilities: &core.Capabilities{
+				Add: []core.Capability{"NET_ADMIN"},
+			},
+		},
+	}
+}
+
+func AgentVolumes(agentName string) []core.Volume {
+	var items []core.KeyToPath
+	if agentName != "" {
+		items = []core.KeyToPath{{
+			Key:  agentName,
+			Path: ConfigFile,
+		}}
+	}
+	return []core.Volume{
+		{
+			Name: AnnotationVolumeName,
+			VolumeSource: core.VolumeSource{
+				DownwardAPI: &core.DownwardAPIVolumeSource{
+					Items: []core.DownwardAPIVolumeFile{
+						{
+							FieldRef: &core.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.annotations",
+							},
+							Path: "annotations",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: ConfigVolumeName,
+			VolumeSource: core.VolumeSource{
+				ConfigMap: &core.ConfigMapVolumeSource{
+					LocalObjectReference: core.LocalObjectReference{Name: ConfigMap},
+					Items:                items,
+				},
+			},
+		},
+		{
+			Name: ExportsVolumeName,
+			VolumeSource: core.VolumeSource{
+				EmptyDir: &core.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
 // EachContainer will find each container in the given config and match it against a container
 // in the pod using its name. The given function is called once for each match.
-func EachContainer(pod *v1.Pod, config *Sidecar, f func(*v1.Container, *Container)) {
+func EachContainer(pod *core.Pod, config *Sidecar, f func(*core.Container, *Container)) {
 	cns := pod.Spec.Containers
 	for _, cc := range config.Containers {
 		for i := range pod.Spec.Containers {
@@ -97,7 +157,7 @@ func EachContainer(pod *v1.Pod, config *Sidecar, f func(*v1.Container, *Containe
 	}
 }
 
-func appendAppContainerVolumeMounts(app *v1.Container, cc *Container, mounts []v1.VolumeMount) []v1.VolumeMount {
+func appendAppContainerVolumeMounts(app *core.Container, cc *Container, mounts []core.VolumeMount) []core.VolumeMount {
 	for _, m := range app.VolumeMounts {
 		if !strings.HasPrefix(m.MountPath, "/var/run/secrets/") {
 			m.MountPath = cc.MountPoint + "/" + strings.TrimPrefix(m.MountPath, "/")
@@ -107,7 +167,7 @@ func appendAppContainerVolumeMounts(app *v1.Container, cc *Container, mounts []v
 	return mounts
 }
 
-func appendAppContainerEnv(app *v1.Container, cc *Container, es []v1.EnvVar) []v1.EnvVar {
+func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar) []core.EnvVar {
 	for _, e := range app.Env {
 		e.Name = EnvPrefixApp + cc.EnvPrefix + e.Name
 		es = append(es, e)
@@ -115,7 +175,7 @@ func appendAppContainerEnv(app *v1.Container, cc *Container, es []v1.EnvVar) []v
 	return es
 }
 
-func appendAppContainerEnvFrom(app *v1.Container, cc *Container, es []v1.EnvFromSource) []v1.EnvFromSource {
+func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.EnvFromSource) []core.EnvFromSource {
 	for _, e := range app.EnvFrom {
 		e.Prefix = EnvPrefixApp + cc.EnvPrefix + e.Prefix
 		es = append(es, e)

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -86,6 +86,9 @@ type Sidecar struct {
 	// If Create is true, then this Config has not yet been filled in.
 	Create bool `json:"create,omitempty" yaml:"create,omitempty"`
 
+	// If Manual is true, then this Config is created manually
+	Manual bool `json:"manual,omitempty" yaml:"manual,omitempty"`
+
 	// The fully qualified name of the traffic-agent image, i.e. "docker.io/tel2:2.5.4"
 	AgentImage string `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
 

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -1,32 +1,36 @@
 package cli
 
 import (
-	"encoding/json"
-	"fmt"
+	"context"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
-	"github.com/telepresenceio/telepresence/v2/pkg/client/userd/k8s"
-	"github.com/telepresenceio/telepresence/v2/pkg/install"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
-	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type genYAMLInfo struct {
-	outputFile string
-	inputFile  string
+	outputFile   string
+	inputFile    string
+	configFile   string
+	workloadName string
+	namespace    string
 }
 
 func genYAMLCommand() *cobra.Command {
@@ -38,22 +42,44 @@ func genYAMLCommand() *cobra.Command {
 		Short: "Generate YAML for use in kubernetes manifests.",
 		Long: `Generate traffic-agent yaml for use in kubernetes manifests.
 This allows the traffic agent to be injected by hand into existing kubernetes manifests.
-For your modified workload to be valid, you'll have to manually inject both the container and the volume; you can do this by running "genyaml container" or "genyaml volume"
-It is recommended that you not do this unless strictly necessary. Instead, we suggest use of the webhook injector to configure traffic agents.`,
+For your modified workload to be valid, you'll have to manually inject a container and a
+volume into the workload, and a corresponding configmap entry into the "telelepresence-agents"
+configmap; you can do this by running "genyaml config", "genyaml container", and "genyaml volume".
+
+NOTE: It is recommended that you not do this unless strictly necessary. Instead, we suggest letting
+telepresence's webhook injector configure the traffic agents on demand.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("please run genyaml as \"genyaml container\" or \"genyaml volume\"")
+			return errcat.User.New("please run genyaml as \"genyaml config\", \"genyaml container\", \"genyaml initcontainer\", or \"genyaml volume\"")
 		},
 	}
-	cmd.PersistentFlags().StringVar(&info.inputFile, "input", "",
-		"Path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc). Pass '-' for stdin.")
-	cmd.PersistentFlags().StringVar(&info.outputFile, "output", "-",
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&info.outputFile, "output", "o", "-",
 		"Path to the file to place the output in. Defaults to '-' which means stdout.")
-	_ = cmd.MarkPersistentFlagRequired("input")
 	cmd.AddCommand(
+		genConfigMapSubCommand(&info),
 		genContainerSubCommand(&info),
+		genInitContainerSubCommand(&info),
 		genVolumeSubCommand(&info),
 	)
 	return cmd
+}
+
+func getInput(inputFile string) ([]byte, error) {
+	var f io.ReadCloser
+	if inputFile == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		if f, err = os.Open(inputFile); err != nil {
+			return nil, errcat.User.Newf("unable to open input file %q: %w", inputFile, err)
+		}
+		defer f.Close()
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, errcat.User.Newf("error reading from %s: %w", inputFile, err)
+	}
+	return b, nil
 }
 
 func (i *genYAMLInfo) getOutputWriter() (io.WriteCloser, error) {
@@ -62,32 +88,89 @@ func (i *genYAMLInfo) getOutputWriter() (io.WriteCloser, error) {
 	}
 	f, err := os.Create(i.outputFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open output file %s: %w", i.outputFile, err)
+		return nil, errcat.User.Newf("unable to open output file %s: %w", i.outputFile, err)
 	}
 	return f, nil
 }
 
+func (i *genYAMLInfo) loadConfigMapEntry(ctx context.Context) (*agentconfig.Sidecar, error) {
+	if i.configFile != "" {
+		b, err := getInput(i.configFile)
+		if err != nil {
+			return nil, err
+		}
+		var cfg agentconfig.Sidecar
+		if err = yaml.Unmarshal(b, &cfg); err != nil {
+			return nil, errcat.User.Newf("unable to parse config %s: %w", i.configFile, err)
+		}
+		return &cfg, nil
+	}
+	if i.workloadName == "" {
+		return nil, errcat.User.New("either --config or --workload must be provided")
+	}
+
+	// Load configmap entry from the telepresence-agents configmap
+	cm, err := k8sapi.GetK8sInterface(ctx).CoreV1().ConfigMaps(i.namespace).Get(ctx, agentconfig.ConfigMap, meta.GetOptions{})
+	if err != nil {
+		return nil, errcat.User.New(err)
+	}
+	var yml string
+	ok := false
+	if cm.Data != nil {
+		yml, ok = cm.Data[i.workloadName]
+	}
+	if !ok {
+		return nil, errcat.User.Newf("Unable to load entry for %q in configmap %q: %w", i.workloadName, agentconfig.ConfigMap, err)
+	}
+	var cfg agentconfig.Sidecar
+	if err = yaml.Unmarshal([]byte(yml), &cfg); err != nil {
+		return nil, errcat.User.Newf("Unable to parse entry for %q in configmap %q: %w", i.workloadName, agentconfig.ConfigMap, err)
+	}
+	return &cfg, nil
+}
+
+func (i *genYAMLInfo) loadWorkload(ctx context.Context) (k8sapi.Workload, error) {
+	if i.inputFile == "" {
+		if i.workloadName == "" {
+			return nil, errcat.User.New("either --input or --workload must be provided")
+		}
+		return k8sapi.GetWorkload(ctx, i.workloadName, i.namespace, "")
+	}
+	b, err := getInput(i.inputFile)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(schema.GroupVersion{Group: apps.GroupName, Version: "v1"}, &apps.StatefulSet{}, &apps.Deployment{}, &apps.ReplicaSet{})
+	codecFactory := serializer.NewCodecFactory(scheme)
+	deserializer := codecFactory.UniversalDeserializer()
+
+	obj, kind, err := deserializer.Decode(b, nil, nil)
+	if err != nil {
+		return nil, errcat.User.Newf("unable to parse yaml in %s: %w", i.inputFile, err)
+	}
+	wl, err := k8sapi.WrapWorkload(obj)
+	if err != nil {
+		return nil, errcat.User.Newf("unexpected object of kind %s; please pass in a Deployment, ReplicaSet, or StatefulSet", kind)
+	}
+	if wl.GetNamespace() == "" {
+		if d, ok := k8sapi.DeploymentImpl(wl); ok {
+			d.Namespace = i.namespace
+		} else if r, ok := k8sapi.ReplicaSetImpl(wl); ok {
+			r.Namespace = i.namespace
+		} else if s, ok := k8sapi.StatefulSetImpl(wl); ok {
+			s.Namespace = i.namespace
+		}
+	}
+	return wl, nil
+}
+
 func (i *genYAMLInfo) writeObjToOutput(obj interface{}) error {
-	// So this sucks: Kubernetes structs don't have yaml serialization tags!
-	// This means that we can't just yaml.Marshal the object. Now, we could use
-	// the client-go to marshal it, but that's actually really hard given that
-	// we're dealing with partial objects (e.g. containers, not pods).
-	// However, it turns out that since k8s sends objects over the wire in json,
-	// the structs do have json serialization tags; so if we serialize the object to json,
-	// read it back as a plain old map, and then re-serialize to yaml, we'll get a reasonable result.
-	doc, err := json.Marshal(obj)
+	// We use sigs.ks8.io/yaml because it treats json serialization tags as if they were yaml tags.
+	doc, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Errorf("unable to marshal agent container: %w", err)
-	}
-	temp := map[string]interface{}{}
-	err = json.Unmarshal(doc, &temp)
-	if err != nil {
-		// Be a bit weird if this happened, but okay.
-		return fmt.Errorf("unable to unmarshal intermediate representation: %w", err)
-	}
-	doc, err = yaml.Marshal(&temp)
-	if err != nil {
-		return fmt.Errorf("unable to marshal intermediate representation to yaml: %w", err)
+		return errcat.User.Newf("unable to marshal agent container: %w", err)
 	}
 	w, err := i.getOutputWriter()
 	if err != nil {
@@ -96,34 +179,131 @@ func (i *genYAMLInfo) writeObjToOutput(obj interface{}) error {
 	defer w.Close()
 	_, err = w.Write(doc)
 	if err != nil {
-		return fmt.Errorf("unable to write to output %s: %w", i.outputFile, err)
+		return errcat.User.Newf("unable to write to output %s: %w", i.outputFile, err)
 	}
 	return nil
 }
 
-func (i *genYAMLInfo) getInputReader() (io.ReadCloser, error) {
-	if i.inputFile == "-" {
-		return os.Stdin, nil
+func (i *genYAMLInfo) withK8sInterface(ctx context.Context, flagMap map[string]string) (context.Context, error) {
+	configFlags := genericclioptions.NewConfigFlags(false)
+	flags := pflag.NewFlagSet("", 0)
+	configFlags.AddFlags(flags)
+	for k, v := range flagMap {
+		if err := flags.Set(k, v); err != nil {
+			return nil, errcat.User.Newf("error processing kubectl flag --%s=%s: %w", k, v, err)
+		}
 	}
-	f, err := os.Open(i.inputFile)
+
+	configLoader := configFlags.ToRawKubeConfigLoader()
+	restConfig, err := configLoader.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("unable to open input file %s: %w", i.inputFile, err)
+		return nil, errcat.Config.New(err)
 	}
-	return f, nil
+
+	config, err := configLoader.RawConfig()
+	if err != nil {
+		return nil, errcat.Config.New(err)
+	}
+	if len(config.Contexts) == 0 {
+		return nil, errcat.Config.New("kubeconfig has no context definition")
+	}
+
+	ctxName := flagMap["context"]
+	if ctxName == "" {
+		ctxName = config.CurrentContext
+	}
+	c, ok := config.Contexts[ctxName]
+	if !ok {
+		return nil, errcat.Config.Newf("context %q does not exist in the kubeconfig", ctxName)
+	}
+	i.namespace = c.Namespace
+	if i.namespace == "" {
+		i.namespace = flagMap["namespace"]
+		if i.namespace == "" {
+			i.namespace = "default"
+		}
+	}
+	cs, err := kubernetes.NewForConfig(restConfig)
+	if err == nil {
+		ctx = k8sapi.WithK8sInterface(ctx, cs)
+	}
+	return ctx, err
+}
+
+type genConfigMap struct {
+	agentmap.GeneratorConfig
+	*genYAMLInfo
+}
+
+func allKubeFlags() *pflag.FlagSet {
+	kubeFlags := pflag.NewFlagSet("Kubernetes flags", 0)
+	kubeConfig := genericclioptions.NewConfigFlags(false)
+	kubeConfig.AddFlags(kubeFlags)
+	return kubeFlags
+}
+
+func genConfigMapSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
+	kubeFlags := allKubeFlags()
+	info := genConfigMap{genYAMLInfo: yamlInfo}
+	cmd := &cobra.Command{
+		Use:   "config",
+		Args:  cobra.NoArgs,
+		Short: "Generate YAML for the agent's entry in the telepresence-agents configmap.",
+		Long:  "Generate YAML for the agent's entry in the telepresence-agents configmap. See genyaml for more info on what this means",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return info.run(cmd, kubeFlagMap(kubeFlags))
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&info.inputFile, "input", "i", "",
+		"Path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc). Pass '-' for stdin.. Mutually exclusive to --workload")
+	flags.StringVarP(&info.workloadName, "workload", "w", "",
+		"Name of the workload. If given, the workload will be retrieved from the cluster, mutually exclusive to --input")
+	flags.Uint16Var(&info.AgentPort, "agent-port", 9900,
+		"The port number you wish the agent to listen on.")
+	flags.StringVar(&info.QualifiedAgentImage, "agent-image", "docker.io/datawire/tel2:"+strings.TrimPrefix(client.Version(), "v"),
+		`The qualified name of the agent image`)
+	flags.StringVar(&info.ManagerNamespace, "manager-namespace", "ambassador",
+		`The traffic-manager namespace`)
+	flags.StringVar(&info.LogLevel, "loglevel", "info",
+		`The loglevel for the generated traffic-agent sidecar`)
+	flags.AddFlagSet(kubeFlags)
+	return cmd
+}
+
+func (i *genConfigMap) generateConfigMap(ctx context.Context, wl k8sapi.Workload) (*agentconfig.Sidecar, error) {
+	ac, err := agentmap.Generate(ctx, wl, &i.GeneratorConfig)
+	if err != nil {
+		return nil, errcat.NoDaemonLogs.New(err)
+	}
+	return ac, nil
+}
+
+func (g *genConfigMap) run(cmd *cobra.Command, kubeFlags map[string]string) error {
+	ctx, err := g.withK8sInterface(cmd.Context(), kubeFlags)
+	if err != nil {
+		return err
+	}
+
+	wl, err := g.loadWorkload(ctx)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := g.generateConfigMap(ctx, wl)
+	if err != nil {
+		return err
+	}
+	cfg.Manual = true
+	return g.writeObjToOutput(cfg)
 }
 
 type genContainerInfo struct {
 	*genYAMLInfo
-	containerName string
-	serviceName   string
-	port          int
-	proto         string
-	agentPort     int
-	appProto      string
 }
 
 func genContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
-	kubeFlags := pflag.NewFlagSet("Kubernetes flags", 0)
+	kubeFlags := allKubeFlags()
 	info := genContainerInfo{genYAMLInfo: yamlInfo}
 	cmd := &cobra.Command{
 		Use:   "container",
@@ -135,103 +315,100 @@ func genContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.StringVar(&info.containerName, "container-name", "",
-		"The name of the container hosting the application you wish to intercept.")
-	flags.IntVar(&info.port, "port", 0,
-		"The port number you wish to intercept")
-	flags.StringVar(&info.proto, "protocol", string(corev1.ProtocolTCP),
-		`The transport protocol the port speaks, i.e. "tcp" or "udp"`)
-	flags.StringVar(&info.appProto, "app-protocol", "",
-		`The application protocol the port speaks, i.e. "http", "grpc", "https", ...`)
-	flags.IntVar(&info.agentPort, "agent-port", 9900,
-		"The port number you wish the agent to listen on.")
-	flags.StringVar(&info.serviceName, "service-name", "",
-		`The name of the service that's exposing this deployment and that you will wish to intercept.
-Defaults to the name of the deployment.`)
-	_ = cmd.MarkFlagRequired("container-name")
-	_ = cmd.MarkFlagRequired("port")
-
-	kubeConfig := genericclioptions.NewConfigFlags(false)
-	kubeConfig.Namespace = nil // "connect", don't take --namespace
-	kubeConfig.AddFlags(kubeFlags)
+	flags.StringVarP(&info.inputFile, "input", "i", "",
+		"Optional path to the yaml containing the workload definition (i.e. Deployment, StatefulSet, etc). Pass '-' for stdin. Loaded from cluster by default")
+	flags.StringVarP(&info.workloadName, "workload", "w", "",
+		"Name of the workload. If given, the configmap entry will be retrieved telepresence-agents configmap, mutually exclusive to --config")
+	flags.StringVarP(&info.configFile, "config", "c", "", "Path to the yaml containing the generated configmap entry, mutually exclusive to --workload")
 	flags.AddFlagSet(kubeFlags)
 	return cmd
 }
 
-func (i *genContainerInfo) run(cmd *cobra.Command, kubeFlags map[string]string) error {
-	ctx := cmd.Context()
-
-	f, err := i.getInputReader()
+func (g *genContainerInfo) run(cmd *cobra.Command, kubeFlags map[string]string) error {
+	ctx, err := g.withK8sInterface(cmd.Context(), kubeFlags)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
-	b, err := io.ReadAll(f)
+	cm, err := g.loadConfigMapEntry(ctx)
 	if err != nil {
-		return fmt.Errorf("error reading from %s: %w", i.inputFile, err)
+		return err
+	}
+	if g.inputFile == "" {
+		g.workloadName = cm.WorkloadName
 	}
 
-	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(schema.GroupVersion{Group: appsv1.GroupName, Version: "v1"}, &appsv1.StatefulSet{}, &appsv1.Deployment{}, &appsv1.ReplicaSet{})
-	codecFactory := serializer.NewCodecFactory(scheme)
-	deserializer := codecFactory.UniversalDeserializer()
+	wl, err := g.loadWorkload(ctx)
+	if err != nil {
+		return err
+	}
 
-	obj, kind, err := deserializer.Decode(b, nil, nil)
-	if err != nil {
-		return fmt.Errorf("unable to parse yaml in %s: %w", i.inputFile, err)
+	// Sanity check
+	if wl.GetName() != cm.WorkloadName {
+		return errcat.User.Newf("name %q of loaded workload is different from %q loaded configmap entry", wl.GetName(), cm.WorkloadName)
 	}
-	wl, err := k8sapi.WrapWorkload(obj)
-	if err != nil {
-		return fmt.Errorf("unexpected object of kind %s; please pass in a Deployment, ReplicaSet, or StatefulSet", kind)
+	if wl.GetKind() != cm.WorkloadKind {
+		return errcat.User.Newf("kind %q of loaded workload is different from %q loaded configmap entry", wl.GetKind(), cm.WorkloadKind)
 	}
-	containers := wl.GetPodTemplate().Spec.Containers
-	containerIdx := -1
-	for j, c := range containers {
-		if c.Name == i.containerName {
-			containerIdx = j
-			break
+
+	podTpl := wl.GetPodTemplate()
+	agentContainer := agentconfig.AgentContainer(
+		&core.Pod{
+			TypeMeta: meta.TypeMeta{
+				Kind:       "pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: podTpl.ObjectMeta,
+			Spec:       podTpl.Spec,
+		},
+		cm,
+	)
+	return g.writeObjToOutput(agentContainer)
+}
+
+type genInitContainerInfo struct {
+	*genYAMLInfo
+}
+
+func genInitContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
+	kubeFlags := allKubeFlags()
+	info := genInitContainerInfo{genYAMLInfo: yamlInfo}
+	cmd := &cobra.Command{
+		Use:   "initcontainer",
+		Args:  cobra.NoArgs,
+		Short: "Generate YAML for the traffic-agent init container.",
+		Long:  "Generate YAML for the traffic-agent init container. See genyaml for more info on what this means",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return info.run(cmd, kubeFlagMap(kubeFlags))
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&info.workloadName, "workload", "w", "",
+		"Name of the workload. If given, the configmap entry will be retrieved telepresence-agents configmap, mutually exclusive to --config")
+	flags.StringVarP(&info.configFile, "config", "c", "", "Path to the yaml containing the generated configmap entry, mutually exclusive to --workload")
+	flags.AddFlagSet(kubeFlags)
+	return cmd
+}
+
+func (g *genInitContainerInfo) run(cmd *cobra.Command, kubeFlags map[string]string) error {
+	ctx, err := g.withK8sInterface(cmd.Context(), kubeFlags)
+	if err != nil {
+		return err
+	}
+
+	cm, err := g.loadConfigMapEntry(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, cc := range cm.Containers {
+		for _, ic := range cc.Intercepts {
+			if ic.Headless || ic.ContainerPortName == "" {
+				return g.writeObjToOutput(agentconfig.InitContainer(cm.AgentImage))
+			}
 		}
 	}
-	if containerIdx < 0 {
-		return fmt.Errorf("container %s not found in %s given", i.containerName, kind)
-	}
-	container := &containers[containerIdx]
-
-	if i.serviceName == "" {
-		i.serviceName = wl.GetName()
-	}
-
-	cfg := client.GetConfig(ctx)
-	k8sConfig, err := k8s.NewConfig(ctx, kubeFlags)
-	if err != nil {
-		return fmt.Errorf("unable to get k8s config: %w", err)
-	}
-
-	registry := cfg.Images.Registry(ctx)
-	agentImage := cfg.Images.AgentImage(ctx)
-	// Use sane defaults if the user hasn't configured the registry and/or image
-	if registry == "" {
-		registry = "datawire"
-	}
-	if agentImage == "" {
-		agentImage = "tel2:" + strings.TrimPrefix(version.Version, "v")
-	}
-	agentContainer := install.AgentContainer(
-		i.serviceName,
-		fmt.Sprintf("%s/%s", registry, agentImage),
-		container,
-		corev1.ContainerPort{
-			Protocol:      corev1.Protocol(i.proto),
-			ContainerPort: int32(i.agentPort),
-		},
-		i.port,
-		i.appProto,
-		cfg.TelepresenceAPI.Port,
-		k8sConfig.GetManagerNamespace(),
-	)
-
-	return i.writeObjToOutput(&agentContainer)
+	return errcat.User.New("deployment does not need an init container")
 }
 
 type genVolumeInfo struct {
@@ -247,10 +424,15 @@ func genVolumeSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Long:  "Generate YAML for the traffic-agent volume. See genyaml for more info on what this means",
 		RunE:  info.run,
 	}
+	flags := cmd.Flags()
+	flags.StringVarP(&info.workloadName, "workload", "w", "", "Name of the workload.")
 	return cmd
 }
 
-func (i *genVolumeInfo) run(_ *cobra.Command, _ []string) error {
-	volume := install.AgentVolume()
-	return i.writeObjToOutput(&volume)
+func (g *genVolumeInfo) run(*cobra.Command, []string) error {
+	if g.workloadName == "" {
+		return errcat.User.New("missing required flag --workload")
+	}
+	volumes := agentconfig.AgentVolumes(g.workloadName)
+	return g.writeObjToOutput(&volumes)
 }


### PR DESCRIPTION
The ability to inject a traffic-agent into a workload manually was lost
when the way the traffic-agent is installed and configured was changed
to rely solely on the agent-injector and a configmap. This commit
restores that functionality and also re-enables the test to prove that
it works as expected.
