### PR TITLE
Manual merge from the getambassador.io docs/telepresence/release/v2.5

### DIFF
--- a/docs/v2.6/doc-links.yml
+++ b/docs/v2.6/doc-links.yml
@@ -90,3 +90,5 @@
   link: community
 - title: Release Notes
   link: release-notes
+- title: Licenses
+  link: licenses

--- a/docs/v2.6/quick-start/index.md
+++ b/docs/v2.6/quick-start/index.md
@@ -1,7 +1,7 @@
 ---
-   description: Telepresence Quick Start.
+description: Telepresence Quick Start.
 ---
 
-import TelepresenceQuickStartLanding from './TelepresenceQuickStartLanding'
+import NewTelepresenceQuickStartLanding from './TelepresenceQuickStartLanding'
 
-<TelepresenceQuickStartLanding/>
+<NewTelepresenceQuickStartLanding/>

--- a/docs/v2.6/quick-start/qs-go.md
+++ b/docs/v2.6/quick-start/qs-go.md
@@ -184,7 +184,7 @@ Telepresence connects your local workstation to a remote Kubernetes cluster.
 
 ## 3. Install a sample Go application
 
-Your local workstation may not have the compute or memory resources necessary to run all the services in a multiservice application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
+Your local workstation may not have the compute or memory resources necessary to run all the services in a multi-service application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
 
 <Alert severity="info">
     While Telepresence works with any language, this guide uses a sample app written in Go. We have versions in <a href="../qs-python/">Python (Flask)</a>, <a href="../qs-python-fastapi/">Python (FastAPI)</a>, <a href="../qs-java/">Java</a>, and <a href="../qs-node/">NodeJS</a> if you prefer.

--- a/docs/v2.6/quick-start/qs-java.md
+++ b/docs/v2.6/quick-start/qs-java.md
@@ -182,7 +182,7 @@ Telepresence connects your local workstation to a remote Kubernetes cluster.
 
 ## 3. Install a sample Java application
 
-Your local workstation may not have the compute or memory resources necessary to run all the services in a multiservice application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
+Your local workstation may not have the compute or memory resources necessary to run all the services in a multi-service application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
 
 <Alert severity="info">
   While Telepresence works with any language, this guide uses a sample app written in Java. We have versions in <a href="../qs-python-fastapi/">Python (FastAPI)</a>, <a href="../qs-python/">Python (Flask)</a>, <a href="../qs-go/">Go</a>, and <a href="../qs-node/">NodeJS</a> if you prefer.

--- a/docs/v2.6/quick-start/qs-node.md
+++ b/docs/v2.6/quick-start/qs-node.md
@@ -170,7 +170,7 @@ Telepresence connects your local workstation to a remote Kubernetes cluster.
 
 ## 3. Install a sample Node.js application
 
-Your local workstation may not have the compute or memory resources necessary to run all the services in a multiservice application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
+Your local workstation may not have the compute or memory resources necessary to run all the services in a multi-service application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
 
 <Alert severity="info">
     While Telepresence works with any language, this guide uses a sample app written in Node.js. We have versions in <a href="../qs-go/">Go</a>, <a href="../qs-java/">Java</a>,<a href="../qs-python/">Python using Flask</a>, and <a href="../qs-python-fastapi/">Python using FastAPI</a> if you prefer.

--- a/docs/v2.6/quick-start/qs-python-fastapi.md
+++ b/docs/v2.6/quick-start/qs-python-fastapi.md
@@ -172,7 +172,7 @@ Telepresence connects your local workstation to a remote Kubernetes cluster.
 
 ## 3. Install a sample Python application
 
-Your local workstation may not have the compute or memory resources necessary to run all the services in a multiservice application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
+Your local workstation may not have the compute or memory resources necessary to run all the services in a multi-service application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
 
 <Alert severity="info">
   While Telepresence works with any language, this guide uses a sample app written in Python using the FastAPI framework. We have versions in <a href="../qs-python/">Python (Flask)</a>, <a href="../qs-go/">Go</a>, <a href="../qs-java/">Java</a>, and <a href="../qs-node/">NodeJS</a> if you prefer.

--- a/docs/v2.6/quick-start/qs-python.md
+++ b/docs/v2.6/quick-start/qs-python.md
@@ -182,7 +182,7 @@ Telepresence connects your local workstation to a remote Kubernetes cluster.
 
 ## 3. Install a sample Python application
 
-Your local workstation may not have the compute or memory resources necessary to run all the services in a multiservice application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
+Your local workstation may not have the compute or memory resources necessary to run all the services in a multi-service application. In this example, we’ll show you how Telepresence can give you a fast development loop, even in this situation.
 
 <Alert severity="info">
   While Telepresence works with any language, this guide uses a sample app written in Python using the Flask framework. We have versions in <a href="../qs-python-fastapi/">Python (FastAPI)</a>, <a href="../qs-go/">Go</a>, <a href="../qs-java/">Java</a>, and <a href="../qs-node/">NodeJS</a> if you prefer.

--- a/docs/v2.6/reference/client/login.md
+++ b/docs/v2.6/reference/client/login.md
@@ -32,7 +32,7 @@ login` with the `--apikey` flag.
 ## Telepresence
 
 When you run `telepresence login`, the CLI installs
-a Telepresence binary.  The Telepresence enhanced free client of the [User
+the Telepresence binary.  The Telepresence enhanced free client [User
 Daemon](../../architecture) communicates with the Ambassador Cloud to
 provide fremium features including the ability to create intercepts from
 Ambassador Cloud.

--- a/docs/v2.6/releaseNotes.yml
+++ b/docs/v2.6/releaseNotes.yml
@@ -187,6 +187,12 @@ items:
           API endpoint <code>/intercept-info</code>
         docs: reference/restapi#intercept-info
       - type: change
+        title: --http-match renamed to --http-header
+        body: >-
+          The `telepresence intercept` command line flag <code>--http-match</code> was renamed to <code>--http-header</code>. The old flag
+          still works, but it is deprecated and doesn't show up in the help.
+        docs: concepts/intercepts#creating-and-using-personal-intercepts
+      - type: change
         title: Client RBAC watch
         body: >-
           The verb "watch" was added to the set of required verbs when accessing services and workloads for the client RBAC

--- a/docs/v2.6/troubleshooting/index.md
+++ b/docs/v2.6/troubleshooting/index.md
@@ -80,7 +80,7 @@ to reach out to the owner.
 Once approval is granted, you will have to log out of Ambassador Cloud
 then back in to select the organization.
 
-### Volume mounts are not working on macOS
+## Volume mounts are not working on macOS
 
 It's necessary to have `sshfs` installed in order for volume mounts to work correctly during intercepts. Lately there's been some issues using `brew install sshfs` a macOS workstation because the required component `osxfuse` (now named `macfuse`) isn't open source and hence, no longer supported. As a workaround, you can now use `gromgit/fuse/sshfs-mac` instead. Follow these steps:
 
@@ -101,3 +101,11 @@ but one more thing must be done before it works OK:
 5. Try a mount (or an intercept that performs a mount). It will fail because you need to give permission to “Benjamin Fleischer” to execute a kernel extension (a pop-up appears that takes you to the system preferences).
 6. Approve the needed permission
 7. Reboot your computer.
+
+## Authorization for Preview URLs
+Services that require authentication may not function correctly with preview URLs. When accessing a preview URL, it is necessary to configure your intercept to use custom authentication headers for the preview URL. If you don't, you may receive an unauthorized response or be redirected to the login page for Ambassador Cloud.
+
+You can accomplish this by using a browser extension such as the `ModHeader extension` for [Chrome](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj) 
+or [Firefox](https://addons.mozilla.org/en-CA/firefox/addon/modheader-firefox/).
+
+It is important to note that Ambassador Cloud does not support OAuth browser flows when accessing a preview URL, but other auth schemes such as Basic access authentication and session cookies will work.


### PR DESCRIPTION
The merge does not include changes to stylesheets or links relative to
the getambassador.io repository.

The `extension` directory containing the Docker Extension docs was not
merged.
