### PR TITLE
Handle KUBECONFIG with multiple path entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.1 (TBD)
+
+- Bugfix: Telepresence will now handle multiple path entries in the KUBECONFIG environment correctly.
+
 ### 2.6.0 (May 13, 2022)
 
 - Feature: Traffic-agent is now capable of intercepting multiple containers and multiple ports per container.

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -100,7 +100,7 @@ func (s *notConnectedSuite) Test_NeverProxy() {
 		require.NoError(err)
 		return map[string]interface{}{"never-proxy": []string{ip + "/32"}}
 	})
-	itest.TelepresenceOk(ctx, "connect")
+	itest.TelepresenceOk(ctx, "connect", "--context", "extra")
 	defer itest.TelepresenceQuitOk(ctx)
 
 	// The cluster's IP address will also be never proxied, so we gotta account for that.
@@ -156,7 +156,7 @@ func (s *notConnectedSuite) Test_ConflictingProxies() {
 					"also-proxy":  t.alsoProxy,
 				}
 			})
-			itest.TelepresenceOk(ctx, "connect")
+			itest.TelepresenceOk(ctx, "connect", "--context", "extra")
 			defer itest.TelepresenceQuitOk(ctx)
 			s.Eventually(func() bool {
 				return itest.Run(ctx, "curl", "--silent", "-k", "--max-time", "0.5", "https://kubernetes.default:443") == nil
@@ -192,7 +192,7 @@ func (s *notConnectedSuite) Test_DNSIncludes() {
 	require.NoError(err)
 	logFile := filepath.Join(logDir, "daemon.log")
 
-	itest.TelepresenceOk(ctx, "connect")
+	itest.TelepresenceOk(ctx, "connect", "--context", "extra")
 	defer itest.TelepresenceQuitOk(ctx)
 
 	retryCount := 0

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -356,11 +356,7 @@ func connectMgr(c context.Context, cluster *k8s.Cluster, installID string, svc S
 	}
 
 	dlog.Debug(c, "traffic-manager started, creating port-forward")
-	restConfig, err := cluster.ConfigFlags.ToRESTConfig()
-	if err != nil {
-		return nil, stacktrace.Wrap(err, "ToRESTConfig")
-	}
-	grpcDialer, err := dnet.NewK8sPortForwardDialer(c, restConfig, k8sapi.GetK8sInterface(c))
+	grpcDialer, err := dnet.NewK8sPortForwardDialer(c, cluster.Config.RestConfig, k8sapi.GetK8sInterface(c))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Since the user daemon is long-running, the client would convert a
setting of the `KUBECONFIG` environment variable to a `--kubeconfig`
flag. This works well in most cases but fails when the `KUBECONFIG`
contains several path entries, because the `--kubeconfig` flag will only
accept one path.

This commit changes so that both the `--kubeconfig` flag and the
`KUBECONFIG` environment are set to the connector daemon verbatim. The
daemon then sets or unsets its os environment accordingly.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
