### PR TITLE
Add "multi_port" and "multi_service" traits to connector metrics

### DIFF
--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -897,6 +897,17 @@ func (tm *TrafficManager) GetInterceptSpec(name string) *manager.InterceptSpec {
 	return nil
 }
 
+// InterceptsForWorkload returns the client's current intercepts on the given namespace and workload combination
+func (tm *TrafficManager) InterceptsForWorkload(workloadName, namespace string) []*manager.InterceptSpec {
+	wlis := make([]*manager.InterceptSpec, 0)
+	for _, cept := range tm.getCurrentIntercepts() {
+		if cept.Spec.Agent == workloadName && cept.Spec.Namespace == namespace {
+			wlis = append(wlis, cept.Spec)
+		}
+	}
+	return wlis
+}
+
 // ClearIntercepts removes all intercepts
 func (tm *TrafficManager) ClearIntercepts(c context.Context) error {
 	for _, cept := range tm.getCurrentIntercepts() {

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -68,6 +68,7 @@ type Session interface {
 	AddInterceptor(string, int) error
 	RemoveInterceptor(string) error
 	GetInterceptSpec(string) *manager.InterceptSpec
+	InterceptsForWorkload(string, string) []*manager.InterceptSpec
 	Status(context.Context) *rpc.ConnectInfo
 	IngressInfos(c context.Context) ([]*manager.IngressInfo, error)
 	ClearIntercepts(context.Context) error


### PR DESCRIPTION
Adds the two boolean traits to the intercept metrics reported by the
connector:
- `multi_port` indicates that the intercept is one of several concurrent
  intercepts on the same workload.
- `multi_service` indicates that the concurrent intercepts on the same
  workload uses different services.

The traits are added to the following actions:
- `connector_can_intercept_success`
- `connector_can_intercept_fail`
- `connector_create_intercept_success`
- `connector_create_intercept_fail`
- `connector_remove_intercept_success`
- `connector_remove_intercept_fail`
