### PR TITLE
Fix panic when using preview URLs with traffic-managers < 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bugfix: Telepresence will now handle multiple path entries in the KUBECONFIG environment correctly.
 
+- Bugfix: Telepresence will no longer panic when using preview URLs with traffic-managers < 2.6.0
+
 ### 2.6.0 (May 13, 2022)
 
 - Feature: Traffic-agent is now capable of intercepting multiple containers and multiple ports per container.

--- a/pkg/client/cli/cmds_intercept.go
+++ b/pkg/client/cli/cmds_intercept.go
@@ -737,6 +737,11 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 			err = fmt.Errorf("creating preview domain: %w", err)
 			return true, err
 		}
+		if is.env == nil {
+			// Some older traffic-managers may return an intercept without an initialized env
+			is.env = r.InterceptInfo.Environment
+		}
+
 		// MountPoint is not returned by the traffic-manager (of course, it has no idea).
 		intercept.ClientMountPoint = r.InterceptInfo.ClientMountPoint
 		is.scout.SetMetadatum(ctx, "preview_url", intercept.PreviewDomain)

--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -181,14 +181,14 @@ get_config() {
     darwin)
         config_file="$HOME/Library/Application Support/telepresence/config.yml"
         ;;
-    Linux)
+    linux)
         config_file="${XDG_CONFIG_HOME:-$HOME/.config}/telepresence/config.yml"
         ;;
     windows)
         config_file="$HOME/AppData/Roaming/telepresence/config.yml"
         ;;
     *)
-        echo "OS is unknown by smoke-tests. Update get_workstation_apikey to include default config location for your OS"
+        echo "OS is unknown by smoke-tests. Update get_config to include default config location for your OS"
         exit 1
         ;;
     esac


### PR DESCRIPTION
## Description

Older traffic-managers would return an InterceptInfo without an
initialized env on calls to `UpdateIntercept`. This caused a panic
message to be printed on the console after the intercept had
been set up.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
