### PR TITLE
Fix agent-injector misbehaviour when owner is an unsupported workload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 2.6.2 (TBD)
 
-- Bugfix: Workoads controlled by workloads like Argo `Rollout` are injected correctly
+- Bugfix: Workloads controlled by workloads like Argo `Rollout` are injected correctly.
+
+- Bugfix: Multiple services appointing the same container port no longer result in duplicated ports in an injected pod.
 
 ### 2.6.1 (May 16, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.2 (TBD)
+
+- Bugfix: Workoads controlled by workloads like Argo `Rollout` are injected correctly
+
 ### 2.6.1 (May 16, 2022)
 
 - Bugfix: Telepresence will now handle multiple path entries in the KUBECONFIG environment correctly.

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -12,8 +12,15 @@ func AgentContainer(
 	config *Sidecar,
 ) *core.Container {
 	ports := make([]core.ContainerPort, 0, 5)
+	pNumbers := make(map[uint16]struct{})
 	for _, cc := range config.Containers {
 		for _, ic := range cc.Intercepts {
+			if _, ok := pNumbers[ic.AgentPort]; ok {
+				// Multiple services may use the same port. Just skip here when
+				// that happens. It's guaranteed that the rest is equal
+				continue
+			}
+			pNumbers[ic.AgentPort] = struct{}{}
 			ports = append(ports, core.ContainerPort{
 				Name:          ic.ContainerPortName,
 				ContainerPort: int32(ic.AgentPort),

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -59,11 +59,15 @@ func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (*a
 	}
 
 	var ccs []*agentconfig.Container
-	pns := make(map[int32]struct{})
+	pns := make(map[int32]uint16)
 	portNumber := func(cnPort int32) uint16 {
-		// Increase the agent's port number only for unique container ports
-		pns[cnPort] = struct{}{}
-		return cfg.AgentPort + uint16(len(pns)-1)
+		if p, ok := pns[cnPort]; ok {
+			// Port already mapped. Reuse that mapping
+			return p
+		}
+		p := cfg.AgentPort + uint16(len(pns))
+		pns[cnPort] = p
+		return p
 	}
 
 	for _, svc := range svcs {

--- a/pkg/k8sapi/workload.go
+++ b/pkg/k8sapi/workload.go
@@ -21,6 +21,12 @@ type Workload interface {
 	Updated(int64) bool
 }
 
+type UnsupportedWorkloadKindError string
+
+func (u UnsupportedWorkloadKindError) Error() string {
+	return fmt.Sprintf("unsupported workload kind: %q", string(u))
+}
+
 // GetWorkload returns a workload for the given name, namespace, and workloadKind. The workloadKind
 // is optional. A search is performed in the following order if it is empty:
 //
@@ -48,7 +54,7 @@ func GetWorkload(c context.Context, name, namespace, workloadKind string) (obj W
 		}
 		err = errors2.NewNotFound(core.Resource("workload"), name+"."+namespace)
 	default:
-		return nil, fmt.Errorf("unsupported workload kind: %q", workloadKind)
+		return nil, UnsupportedWorkloadKindError(workloadKind)
 	}
 	return obj, err
 }


### PR DESCRIPTION
## Description

Some workloads have owners of unsupported type. One example is Argo's
`Rollout`. The agent-injector doesn't handle this correctly. Instead
of generating a `ConfigMap` entry for the controlled workload
(typically a`ReplicaSet`), it attempts to use the `Rollout` and fails.
The correct action must be to actually use the `ReplicaSet` and don't
look further for an owner.

This PR ensures that objets controlled by a `Rollout` are
considered unowned with respect to Telepresence notion of an owner.

The PR also contains a fix for the use-case when multiple services
appoint the same container and containerPort.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
