### PR TITLE
Increase the gRPC max receive size for the telepresence list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Bugfix: Multiple services appointing the same container port no longer result in duplicated ports in an injected pod.
 
+- Bugfix: The `telepresence list` command no longer errors out with "grpc: received message larger than max" when listing namespaces
+  with a large number of workloads.
+
 ### 2.6.1 (May 16, 2022)
 
 - Bugfix: Telepresence will now handle multiple path entries in the KUBECONFIG environment correctly.


### PR DESCRIPTION
## Description

When listing really large namespaces, the gRPC entry received by the
CLI from the user daemon could be larger than the default gRPC max
receive size. This commit changes the default size (for this command)
to 20Mi, overridable to larger by the maxReceiveSize gRPC option.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.