### PR TITLE
Refactor intercept cleanup logic to be done on removeIntercept.

### DIFF
--- a/cmd/traffic/cmd/manager/internal/state/intercept.go
+++ b/cmd/traffic/cmd/manager/internal/state/intercept.go
@@ -412,23 +412,21 @@ func findIntercept(ac *agentconfig.Sidecar, spec *managerrpc.InterceptSpec) (fou
 }
 
 type InterceptFinalizer func(ctx context.Context, interceptInfo *managerrpc.InterceptInfo) error
-type interceptRefresher func() (*managerrpc.InterceptInfo, bool)
 
 type interceptState struct {
 	sync.Mutex
-	lastInfoCh       chan *managerrpc.InterceptInfo
-	finalizers       []InterceptFinalizer
-	refreshIntercept interceptRefresher
-	interceptID      string
+	lastInfoCh  chan *managerrpc.InterceptInfo
+	finalizers  []InterceptFinalizer
+	interceptID string
+	clientCtx   context.Context
 }
 
-func newInterceptState(clientCtx context.Context, tmCtx context.Context, interceptID string, refreshIntercept interceptRefresher) *interceptState {
+func newInterceptState(clientCtx context.Context, tmCtx context.Context, interceptID string) *interceptState {
 	is := &interceptState{
-		lastInfoCh:       make(chan *managerrpc.InterceptInfo),
-		interceptID:      interceptID,
-		refreshIntercept: refreshIntercept,
+		lastInfoCh:  make(chan *managerrpc.InterceptInfo),
+		interceptID: interceptID,
+		clientCtx:   clientCtx,
 	}
-	go is.monitor(clientCtx, tmCtx)
 	return is
 }
 
@@ -438,34 +436,14 @@ func (is *interceptState) addFinalizer(finalizer InterceptFinalizer) {
 	is.finalizers = append(is.finalizers, finalizer)
 }
 
-func (is *interceptState) terminate(info *managerrpc.InterceptInfo) {
-	is.lastInfoCh <- info
-}
-
-func (is *interceptState) monitor(clientCtx context.Context, tmCtx context.Context) {
-	for {
-		select {
-		case <-tmCtx.Done():
-			dlog.Warnf(tmCtx, "Traffic manager is closing but intercept %s is still open", is.interceptID)
-			return
-		case interceptInfo := <-is.lastInfoCh:
-			parentCtx := clientCtx
-			if parentCtx.Err() != nil {
-				// Currently this has no implications, but in future it may mean that the operations below happen
-				// with the API key of a user other than the intercept's owner
-				dlog.Warnf(tmCtx, "Intercept %s will be closed with global context", is.interceptID)
-				parentCtx = tmCtx
-			}
-			is.Lock()
-			defer is.Unlock()
-			for i := len(is.finalizers) - 1; i >= 0; i-- {
-				f := is.finalizers[i]
-				err := f(parentCtx, interceptInfo)
-				if err != nil {
-					dlog.Errorf(parentCtx, "Error cleaning up intercept %s: %v", is.interceptID, err)
-				}
-			}
-			return
+func (is *interceptState) terminate(interceptInfo *managerrpc.InterceptInfo) {
+	is.Lock()
+	defer is.Unlock()
+	for i := len(is.finalizers) - 1; i >= 0; i-- {
+		f := is.finalizers[i]
+		err := f(is.clientCtx, interceptInfo)
+		if err != nil {
+			dlog.Errorf(is.clientCtx, "Error cleaning up intercept %s: %v", is.interceptID, err)
 		}
 	}
 }

--- a/cmd/traffic/cmd/manager/internal/state/state.go
+++ b/cmd/traffic/cmd/manager/internal/state/state.go
@@ -565,7 +565,7 @@ func (s *State) AddInterceptFinalizer(interceptID string, finalizer InterceptFin
 	defer s.mu.RUnlock()
 	state, ok := s.interceptStates[interceptID]
 	if !ok {
-		return fmt.Errorf("no such intercept %s", interceptID)
+		return status.Errorf(codes.NotFound, "no such intercept %s", interceptID)
 	}
 	state.addFinalizer(finalizer)
 	return nil

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -17,11 +17,8 @@ import (
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
-	"github.com/telepresenceio/telepresence/rpc/v2/systema"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/mutator"
-	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/watchable"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/a8rcloud"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
@@ -55,13 +52,7 @@ func Main(ctx context.Context, _ ...string) error {
 
 	g.Go("agent-injector", mutator.ServeMutator)
 
-	g.Go("intercept-gc", mgr.runInterceptGCLoop)
-
-	// This goroutine is responsible for informing System A of intercepts (and
-	// relevant metadata like domains) that have been garbage collected. This
-	// ensures System A doesn't list preview URLs + intercepts that no longer
-	// exist.
-	g.Go("systema-gc", mgr.runSystemAGCLoop)
+	g.Go("session-gc", mgr.runSessionGCLoop)
 
 	// Wait for exit
 	return g.Wait()
@@ -96,7 +87,7 @@ func (m *Manager) serveHTTP(ctx context.Context) error {
 	return sc.ListenAndServe(ctx, host+":"+port)
 }
 
-func (m *Manager) runInterceptGCLoop(ctx context.Context) error {
+func (m *Manager) runSessionGCLoop(ctx context.Context) error {
 	// Loop calling Expire
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -109,92 +100,4 @@ func (m *Manager) runInterceptGCLoop(ctx context.Context) error {
 			return nil
 		}
 	}
-}
-
-func (m *Manager) runSystemAGCLoop(ctx context.Context) error {
-	for snapshot := range m.state.WatchIntercepts(ctx, nil) {
-		func() {
-			for _, update := range snapshot.Updates {
-				// Since all intercepts with a domain require a login, we can use
-				// presence of the ApiKey in the interceptInfo to determine all
-				// intercepts that we need to inform System A of their deletion
-				if update.Delete && update.Value.ApiKey != "" {
-					systema := a8rcloud.GetSystemAPool[managerutil.SystemaCRUDClient](ctx, a8rcloud.TrafficManagerConnName)
-					if update.Value.PreviewDomain != "" {
-						// If we get here, it'll be because an earlier call to UpdateIntercept succeeded in creating a preview domain
-						// In this case, the intercept has an associated systema connection open to allow serving the preview domain, which now needs to be cleaned up
-						// This is deferred because if we drop the last connection it'll have to be reacquired by the Get() below
-						defer func(systema a8rcloud.SystemAPool[managerutil.SystemaCRUDClient]) {
-							if err := systema.Done(ctx); err != nil {
-								dlog.Errorln(ctx, "systema: release reverse connection:", err)
-							}
-						}(systema)
-					}
-					if sa, err := systema.Get(ctx); err != nil {
-						dlog.Errorln(ctx, "systema: acquire connection:", err)
-					} else {
-						// First we remove the PreviewDomain if it exists
-						if update.Value.PreviewDomain != "" {
-							err = m.reapDomain(ctx, sa, update)
-							if err != nil {
-								dlog.Errorln(ctx, "systema: remove domain:", err)
-							}
-						}
-						// Now we inform SystemA of the intercepts removal
-						dlog.Debugf(ctx, "systema: remove intercept: %q", update.Value.Id)
-						err = m.reapIntercept(ctx, sa, update)
-						if err != nil {
-							dlog.Errorln(ctx, "systema: remove intercept:", err)
-						}
-
-						// Release the connection we got to delete the domain + intercept
-						if err := systema.Done(ctx); err != nil {
-							dlog.Errorln(ctx, "systema: release management connection:", err)
-						}
-					}
-				}
-			}
-		}()
-	}
-	return nil
-}
-
-// reapDomain informs SystemA that an intercept with a domain has been garbage collected
-func (m *Manager) reapDomain(ctx context.Context, sa systema.SystemACRUDClient, interceptUpdate watchable.InterceptMapUpdate) error {
-	// we only reapDomains for intercepts that have been deleted
-	if !interceptUpdate.Delete {
-		return fmt.Errorf("%s is not being deleted, so the domain was not reaped", interceptUpdate.Value.Id)
-	}
-	dlog.Debugf(ctx, "systema: removing domain: %q", interceptUpdate.Value.PreviewDomain)
-	_, err := sa.RemoveDomain(ctx, &systema.RemoveDomainRequest{
-		Domain: interceptUpdate.Value.PreviewDomain,
-	})
-
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// reapIntercept informs SystemA that an intercept has been garbage collected
-func (m *Manager) reapIntercept(ctx context.Context, sa systema.SystemACRUDClient, interceptUpdate watchable.InterceptMapUpdate) error {
-	// we only reapIntercept for intercepts that have been deleted
-	if !interceptUpdate.Delete {
-		return fmt.Errorf("%s is not being deleted, so the intercept was not reaped", interceptUpdate.Value.Id)
-	}
-	dlog.Debugf(ctx, "systema: remove intercept: %q", interceptUpdate.Value.Id)
-	_, err := sa.RemoveIntercept(ctx, &systema.InterceptRemoval{
-		InterceptId: interceptUpdate.Value.Id,
-	})
-
-	// We remove the APIKey whether or not the RemoveIntercept call was successful, so
-	// let's do that before we check the error.
-	if wasRemoved := m.state.RemoveInterceptAPIKey(interceptUpdate.Value.Id); !wasRemoved {
-		dlog.Debugf(ctx, "Intercept ID %s had no APIKey", interceptUpdate.Value.Id)
-	}
-
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/traffic/cmd/manager/systema.go
+++ b/cmd/traffic/cmd/manager/systema.go
@@ -46,12 +46,6 @@ func (p *ReverseConnProvider) GetAPIKey(ctx context.Context) (string, error) {
 				break
 			}
 		}
-
-		// If there were no other clients using telepresence, we try to find an APIKey
-		// used for creating an intercept.
-		if apikey == "" {
-			apikey = p.mgr.state.GetInterceptAPIKey()
-		}
 	}
 	if apikey == "" {
 		return "", errors.New("no apikey has been provided by a client")


### PR DESCRIPTION
## Description

It really made no sense to do it in a separate GC goroutine when the
user's session may already be terminated and it may be no longer be
possible to use the user's credentials to contact systema for cleanup.

Signed-off-by: Jose Cortes <josecortes@datawire.io>


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
