### PR TITLE
Handle relative mount points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.6.3 (TBD)
 
+- Bugfix: The `--mount` intercept flag now handles relative mount points correctly on non-windows platforms. Windows
+  still require the argument to be a drive letter followed by a colon.
+
 - Bugfix: The traffic-agent's configuration update automatically when services are added, updated or deleted.
 
 - Bugfix: Telepresence will now always inject an initContainer when the service's targetPort is numeric

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -380,6 +380,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 
 	// Use another logger to avoid errors due to logs arriving after the tests complete.
 	ctx = dlog.WithLogger(ctx, dlog.WrapLogrus(logrus.StandardLogger()))
+	dlog.Infof(ctx, "Capturing logs for pods %q", pods)
 	for _, pod := range strings.Split(pods, " ") {
 		if _, ok := s.logCapturingPods.LoadOrStore(pod, present); ok {
 			continue

--- a/pkg/client/cli/prepare_mount_unix.go
+++ b/pkg/client/cli/prepare_mount_unix.go
@@ -5,11 +5,18 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func prepareMount(mountPoint string) (string, error) {
 	if mountPoint == "" {
 		return os.MkdirTemp("", "telfs-")
+	} else {
+		var err error
+		mountPoint, err = filepath.Abs(mountPoint)
+		if err != nil {
+			return "", err
+		}
 	}
 	return mountPoint, os.MkdirAll(mountPoint, 0700)
 }


### PR DESCRIPTION
The `telepresence intercept --mount <mountPoint>` now handles relative
paths on non-windows platforms. Windows will still require the path to
be a drive letter followed by a colon.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.