### PR TITLE
license bundle seg fault fix

### DIFF
--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -79,10 +79,10 @@ func (m *Manager) GetLicense(ctx context.Context, _ *empty.Empty) (*rpc.License,
 	lb := license.BundleFromContext(ctx)
 	if lb == nil {
 		resp.ErrMsg = "license not found"
+	} else {
+		resp.License = lb.License()
+		resp.Host = lb.Host()
 	}
-
-	resp.License = lb.License()
-	resp.Host = lb.Host()
 
 	return &resp, nil
 }


### PR DESCRIPTION
## Description

Add check if license bundle is nil before pulling out license and host strings.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
