### PR TITLE
Grant traffic-manager permissions to update services and workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.6.4 (TBD)
+
+- Bugfix: The traffic-manager RBAC grants permissions to update services, deployments, replicatsets, and statefulsets. Those
+  permissions are needed when the traffic-manager upgrades from versions < 2.6.0 and can be revoked after the upgrade.
+
 ### 2.6.3 (May 20, 2022)
 
 - Bugfix: The `--mount` intercept flag now handles relative mount points correctly on non-windows platforms. Windows

--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -16,6 +16,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - update # Only needed for upgrade of older versions
+- apiGroups:
+  - ""
+  resources:
   - nodes
   - pods
   - services
@@ -59,6 +65,7 @@ rules:
   - get
   - list
   - patch
+  - update # Only needed for upgrade of older versions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -23,6 +23,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - update # Only needed for upgrade of older versions
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:
@@ -57,6 +63,7 @@ rules:
   - get
   - list
   - patch
+  - update # Only needed for upgrade of older versions
 {{- if eq . (include "telepresence.namespace" $) }}
 # Must be able to get the manager namespace in order to get the cluster-id
 - apiGroups:


### PR DESCRIPTION
## Description

When upgrading to 2.6.x, Telepresence must uninstall older versions of
injected traffic-agents by modifying (restoring really) services,
deployments, replicasets, and statefulsets to their original shape,
because in 2.6.x, where the mutating webhook is always used, those
manifests are never modified.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.