### PR TITLE
Issue the PreferredAgent RPC without credentials.

### DIFF
--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -56,6 +56,7 @@ func NewManager(ctx context.Context) (*Manager, context.Context) {
 		ID:    uuid.New().String(),
 	}
 	ctx = a8rcloud.WithSystemAPool[managerutil.SystemaCRUDClient](ctx, a8rcloud.TrafficManagerConnName, &ReverseConnProvider{ret})
+	ctx = a8rcloud.WithSystemAPool[managerutil.SystemaCRUDClient](ctx, a8rcloud.UnauthdTrafficManagerConnName, &managerutil.UnauthdConnProvider{})
 	ret.ctx = ctx
 	// These are context dependent so build them once the pool is up
 	ret.clusterInfo = cluster.NewInfo(ctx)

--- a/pkg/a8rcloud/systema.go
+++ b/pkg/a8rcloud/systema.go
@@ -21,8 +21,9 @@ const (
 )
 
 const (
-	TrafficManagerConnName = "traffic-manager"
-	UserdConnName          = "userd"
+	TrafficManagerConnName        = "traffic-manager"
+	UnauthdTrafficManagerConnName = "traffic-manager-unauth"
+	UserdConnName                 = "userd"
 )
 
 type Closeable interface {
@@ -152,7 +153,7 @@ func (c *systemACredentials) GetRequestMetadata(ctx context.Context, _ ...string
 	} else if installID != "" {
 		headers[InstallIDHeader] = installID
 	} else if _, ok := headers[ApiKeyHeader]; !ok {
-		return nil, fmt.Errorf("at least one of ApiKey and InstallID must return a non-empty string")
+		dlog.Warnf(ctx, "Issuing a systema request without ApiKey or InstallID may result in an error")
 	}
 	if extra, err := c.headers.GetExtraHeaders(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
It should work anonymously now and we won't always have a logged in user
who can use it.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
