### PR TITLE
Hide unsupported Kubernetes flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Bugfix: UDP based communication with services in the cluster now works as expected.
 
+- Bugfix: The command help will only show Kubernetes flags on the commands that supports them
+
 ### 2.6.4 (May 23, 2022)
 
 - Bugfix: The traffic-manager RBAC grants permissions to update services, deployments, replicatsets, and statefulsets. Those

--- a/pkg/client/cli/command_group.go
+++ b/pkg/client/cli/command_group.go
@@ -31,7 +31,7 @@ func init() {
 		if a == nil || b == nil {
 			return false
 		}
-		return a.Name == b.Name && a.Usage == b.Usage
+		return a.Name == b.Name && a.Usage == b.Usage && a.Hidden == b.Hidden
 	}
 
 	cobra.AddTemplateFunc("commandGroups", func(cmd *cobra.Command) cliutil.CommandGroups {


### PR DESCRIPTION
## Description

The kubernetes flags are accepted by all commands, but hidden,
deprecated, and meaningless to several of them. Nevertheless, they were
displayed when using `--help`. This commit ensures that these flags are
listed only by those commands that truly support them.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.