### PR TITLE
Deprecate config setting for images.webhookAgentImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Change: Telepresence upgraded its embedded Kubernetes API from version 0.23.4 to 0.24.1
 
+- Change: The configuration setting for `images.webhookAgentImage` is now deprecated. Use `images.agentImage` instead.
+
 - Bugfix: UDP based communication with services in the cluster now works as expected.
 
 - Bugfix: The command help will only show Kubernetes flags on the commands that supports them

--- a/integration_test/webhook_test.go
+++ b/integration_test/webhook_test.go
@@ -45,7 +45,7 @@ func (s *webhookSuite) Test_AutoInjectedAgent() {
 	require.Contains(stdout, "echo-auto-inject: intercepted")
 }
 
-func (s *notConnectedSuite) Test_WebhookAgentImageFromConfig() {
+func (s *notConnectedSuite) Test_AgentImageFromConfig() {
 	// Restore the traffic-manager at the end of this function
 	ctx := itest.WithUser(s.Context(), "default")
 	defer func() {
@@ -57,8 +57,7 @@ func (s *notConnectedSuite) Test_WebhookAgentImageFromConfig() {
 	// latter that is used in the traffic-manager
 	ctxAI := itest.WithConfig(ctx, &client.Config{
 		Images: client.Images{
-			PrivateAgentImage:        "notUsed:0.0.1",
-			PrivateWebhookAgentImage: "imageFromConfig:0.0.1",
+			PrivateAgentImage: "imageFromConfig:0.0.1",
 		},
 	})
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -520,10 +520,9 @@ func (ll *LogLevels) merge(o *LogLevels) {
 }
 
 type Images struct {
-	PrivateRegistry          string `json:"registry,omitempty" yaml:"registry,omitempty"`
-	PrivateAgentImage        string `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
-	PrivateWebhookRegistry   string `json:"webhookRegistry,omitempty" yaml:"webhookRegistry,omitempty"`
-	PrivateWebhookAgentImage string `json:"webhookAgentImage,omitempty" yaml:"webhookAgentImage,omitempty"`
+	PrivateRegistry        string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	PrivateAgentImage      string `json:"agentImage,omitempty" yaml:"agentImage,omitempty"`
+	PrivateWebhookRegistry string `json:"webhookRegistry,omitempty" yaml:"webhookRegistry,omitempty"`
 }
 
 // UnmarshalYAML parses the images YAML
@@ -548,7 +547,8 @@ func (img *Images) UnmarshalYAML(node *yaml.Node) (err error) {
 		case "webhookRegistry":
 			img.PrivateWebhookRegistry = v.Value
 		case "webhookAgentImage":
-			img.PrivateWebhookAgentImage = v.Value
+			dlog.Warn(parseContext, withLoc(fmt.Sprintf(`deprecated key %q, please use "agentImage" instead`, kv), ms[i]))
+			img.PrivateAgentImage = v.Value
 		default:
 			if parseContext != nil {
 				dlog.Warn(parseContext, withLoc(fmt.Sprintf("unknown key %q", kv), ms[i]))
@@ -561,9 +561,6 @@ func (img *Images) UnmarshalYAML(node *yaml.Node) (err error) {
 func (img *Images) merge(o *Images) {
 	if o.PrivateAgentImage != "" {
 		img.PrivateAgentImage = o.PrivateAgentImage
-	}
-	if o.PrivateWebhookAgentImage != "" {
-		img.PrivateWebhookAgentImage = o.PrivateWebhookAgentImage
 	}
 	if o.PrivateRegistry != "" {
 		img.PrivateRegistry = o.PrivateRegistry
@@ -584,19 +581,12 @@ func (img *Images) WebhookRegistry(c context.Context) string {
 	if img.PrivateWebhookRegistry != "" {
 		return img.PrivateWebhookRegistry
 	}
-	return GetEnv(c).Registry
+	return img.Registry(c)
 }
 
 func (img *Images) AgentImage(c context.Context) string {
 	if img.PrivateAgentImage != "" {
 		return img.PrivateAgentImage
-	}
-	return GetEnv(c).AgentImage
-}
-
-func (img *Images) WebhookAgentImage(c context.Context) string {
-	if img.PrivateWebhookAgentImage != "" {
-		return img.PrivateWebhookAgentImage
 	}
 	return GetEnv(c).AgentImage
 }

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -40,8 +40,7 @@ logLevels:
   rootDaemon: trace
 images:
   registry: testregistry.io
-  agentImage: ambassador-telepresence-client-image:0.0.1
-  webhookAgentImage: ambassador-telepresence-webhook-image:0.0.2
+  agentImage: ambassador-telepresence-agent-image:0.0.2
 telepresenceAPI:
   port: 1234
 intercept:
@@ -80,12 +79,11 @@ intercept:
 	assert.Equal(t, logrus.DebugLevel, cfg.LogLevels.UserDaemon) // from sys2
 	assert.Equal(t, logrus.TraceLevel, cfg.LogLevels.RootDaemon) // from user
 
-	assert.Equal(t, "testregistry.io", cfg.Images.PrivateRegistry)                                      // from user
-	assert.Equal(t, "ambassador-telepresence-client-image:0.0.1", cfg.Images.PrivateAgentImage)         // from user
-	assert.Equal(t, "ambassador-telepresence-webhook-image:0.0.2", cfg.Images.PrivateWebhookAgentImage) // from user
-	assert.Equal(t, 1234, cfg.TelepresenceAPI.Port)                                                     // from user
-	assert.Equal(t, k8sapi.PortName, cfg.Intercept.AppProtocolStrategy)                                 // from user
-	assert.Equal(t, 9080, cfg.Intercept.DefaultPort)                                                    // from user
+	assert.Equal(t, "testregistry.io", cfg.Images.PrivateRegistry)                             // from user
+	assert.Equal(t, "ambassador-telepresence-agent-image:0.0.2", cfg.Images.PrivateAgentImage) // from user
+	assert.Equal(t, 1234, cfg.TelepresenceAPI.Port)                                            // from user
+	assert.Equal(t, k8sapi.PortName, cfg.Intercept.AppProtocolStrategy)                        // from user
+	assert.Equal(t, 9080, cfg.Intercept.DefaultPort)                                           // from user
 }
 
 func Test_ConfigMarshalYAML(t *testing.T) {

--- a/pkg/install/helm/install.go
+++ b/pkg/install/helm/install.go
@@ -52,7 +52,7 @@ func getValues(ctx context.Context) map[string]interface{} {
 		}
 	}
 	apc := clientConfig.Intercept.AppProtocolStrategy
-	if wai, wr := imgConfig.WebhookAgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" || apc != k8sapi.Http2Probe {
+	if wai, wr := imgConfig.AgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" || apc != k8sapi.Http2Probe {
 		agentImage := make(map[string]interface{})
 		if wai != "" {
 			parts := strings.Split(wai, ":")


### PR DESCRIPTION
## Description

There is only one type of agent image since 2.6, and that is the one
injected by the webhook, so it no longer serves a purpose to have a
configuration setting for both `agentImage` and `webhookAgentImage`.
This commit deprecates the latter. If set, a warning is logged and the
value ends up in the `agentImage`.

This commit also changes the `images.webhookRegistry` so that it
defaults the setting of `images.registry` which in turn defaults to
the environment variable `TELEPRESENCE_REGISTRY`. Prior to this change,
the `images.webhookRegistry` would default directly to the environment
variable.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
