### PR TITLE
Restore the _TEL_AGENT_NAME to the traffic-agent's set of env vars

### DIFF
--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -844,6 +844,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:
@@ -920,6 +925,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:
@@ -1043,6 +1053,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:
@@ -1132,6 +1147,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:
@@ -1221,6 +1241,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:
@@ -1302,15 +1327,26 @@ func TestTrafficAgentInjector(t *testing.T) {
 								Protocol:      "TCP",
 							}},
 							EnvFrom: nil,
-							Env: []core.EnvVar{{
-								Name: "_TEL_AGENT_POD_IP",
-								ValueFrom: &core.EnvVarSource{
-									FieldRef: &core.ObjectFieldSelector{
-										APIVersion: "v1",
-										FieldPath:  "status.podIP",
+							Env: []core.EnvVar{
+								{
+									Name: "_TEL_AGENT_POD_IP",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "status.podIP",
+										},
 									},
 								},
-							}},
+								{
+									Name: "_TEL_AGENT_NAME",
+									ValueFrom: &core.EnvVarSource{
+										FieldRef: &core.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "metadata.name",
+										},
+									},
+								},
+							},
 							Resources:                core.ResourceRequirements{},
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: "File",
@@ -1374,6 +1410,11 @@ func TestTrafficAgentInjector(t *testing.T) {
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: _TEL_AGENT_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: docker.io/datawire/tel2:2.6.0
     name: traffic-agent
     ports:

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -40,6 +40,15 @@ func AgentContainer(
 					FieldPath:  "status.podIP",
 				},
 			},
+		},
+		core.EnvVar{
+			Name: EnvPrefixAgent + "NAME",
+			ValueFrom: &core.EnvVarSource{
+				FieldRef: &core.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
+				},
+			},
 		})
 
 	mounts := make([]core.VolumeMount, 0, len(config.Containers)*3)


### PR DESCRIPTION
Some customers use this environment variable to inject the TLS secret
annotations and give it a unique name although the configuration is
static. That works since telepresence always expand those annotations
with the current set of environment variables. Or well, it did work
until `_TEL_AGENT_NAME` was removed. That's why it is restored in this
commit.