### PR TITLE
Only consider last session when counting the number of errors in the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 - Bugfix: The command help will only show Kubernetes flags on the commands that supports them
 
+- Bugfix: Only the errors from the last session will be considered when counting the number of errors in the log after
+  a command failure.
+
 ### 2.6.4 (May 23, 2022)
 
 - Bugfix: The traffic-manager RBAC grants permissions to update services, deployments, replicatsets, and statefulsets. Those

--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -83,9 +83,19 @@ func SummarizeLog(ctx context.Context, name string) (string, error) {
 	errorCount := 0
 	for scanner.Scan() {
 		// XXX: is there a better way to detect error lines?
-		parts := strings.Fields(scanner.Text())
-		if len(parts) > 2 && parts[2] == "error" {
+		txt := scanner.Text()
+		parts := strings.Fields(txt)
+		if len(parts) < 3 {
+			continue
+		}
+		switch parts[2] {
+		case "error":
 			errorCount++
+		case "info":
+			if strings.Contains(txt, "-- Starting new session") {
+				// Start over. No use counting errors from previous sessions
+				errorCount = 0
+			}
 		}
 	}
 	if errorCount == 0 {

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -203,6 +203,7 @@ func convertNeverProxySubnets(c context.Context, ms []*manager.IPNet) []routing.
 
 // newSession returns a new properly initialized session object.
 func newSession(c context.Context, scout *scout.Reporter, mi *rpc.OutboundInfo) (*session, error) {
+	dlog.Info(c, "-- Starting new session")
 	conn, mc, err := connectToManager(c)
 	if mc == nil || err != nil {
 		return nil, err
@@ -459,6 +460,8 @@ func (s *session) checkConnectivity(ctx context.Context, info *manager.ClusterIn
 }
 
 func (s *session) run(c context.Context) error {
+	defer dlog.Info(c, "-- Session ended")
+
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 
 	cancelDNSLock := sync.Mutex{}

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -187,6 +187,7 @@ type interceptResult struct {
 var firstAgentConfigMapVersion = semver.MustParse("2.6.0-alpha.64")
 
 func NewSession(c context.Context, sr *scout.Reporter, cr *rpc.ConnectRequest, svc Service, extraServices []SessionService) (Session, *connector.ConnectInfo) {
+	dlog.Info(c, "-- Starting new session")
 	sr.Report(c, "connect")
 
 	rootDaemon, err := svc.RootDaemonClient(c)
@@ -477,6 +478,8 @@ func (tm *TrafficManager) updateDaemonNamespaces(c context.Context) {
 //      Services, and
 //    + (4) mount the appropriate remote volumes.
 func (tm *TrafficManager) Run(c context.Context) error {
+	defer dlog.Info(c, "-- Session ended")
+
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 	g.Go("remain", tm.remain)
 	g.Go("intercept-port-forward", tm.workerPortForwardIntercepts)


### PR DESCRIPTION
## Description

The log can grow quite large over a day and contain a lot of sessions
but only the errors from the last one are relevant when reporting the
number of errors found after a command has been issued. If that command
(or the current session) has zero errors, then there's really no point
in telling the user to go have a look in the logs in case it fails.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
