### PR TITLE
Ensure that TELEPRESENCE_API_PORT is configured and propagated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.6 (TBD)
+
+- Bugfix: The propagation of the `TELEPRESENCE_API_PORT` environment variable now works correctly.
+
 ### 2.6.5 (June 3, 2022)
 
 - Feature: The `reinvocationPolicy` or the traffic-agent injector webhook can now be configured using the Helm chart.

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -155,9 +155,9 @@ func (a *agentInjector) inject(ctx context.Context, req *admission.AdmissionRequ
 	patches = hidePorts(pod, config, patches)
 	patches = addPodAnnotations(ctx, pod, patches)
 
-	if env.APIPort != 0 {
+	if config.APIPort != 0 {
 		tpEnv := make(map[string]string)
-		tpEnv["TELEPRESENCE_API_PORT"] = strconv.Itoa(int(env.APIPort))
+		tpEnv[agentconfig.EnvAPIPort] = strconv.Itoa(int(config.APIPort))
 		patches = addTPEnv(pod, config, tpEnv, patches)
 	}
 

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -921,6 +921,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     args:
     - agent
     env:
+    - name: TELEPRESENCE_API_PORT
+      value: "9981"
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:

--- a/integration_test/testdata/apiserveraccess/main.go
+++ b/integration_test/testdata/apiserveraccess/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/restapi"
@@ -111,14 +112,13 @@ func run(c context.Context) error {
 	return nil
 }
 
-const portEnv = "TELEPRESENCE_API_PORT"
 const interceptIdEnv = "TELEPRESENCE_INTERCEPT_ID"
 
 // apiURL creates the generic URL needed to access the service
 func apiURL() (string, error) {
-	pe := os.Getenv(portEnv)
+	pe := os.Getenv(agentconfig.EnvAPIPort)
 	if _, err := strconv.ParseUint(pe, 10, 16); err != nil {
-		return "", fmt.Errorf("value %q of env %s does not represent a valid port number", pe, portEnv)
+		return "", fmt.Errorf("value %q of env %s does not represent a valid port number", pe, agentconfig.EnvAPIPort)
 	}
 	return "http://localhost:" + pe, nil
 }

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -1,6 +1,7 @@
 package agentconfig
 
 import (
+	"strconv"
 	"strings"
 
 	core "k8s.io/api/core/v1"
@@ -31,6 +32,12 @@ func AgentContainer(
 		evs = appendAppContainerEnv(app, cc, evs)
 		efs = appendAppContainerEnvFrom(app, cc, efs)
 	})
+	if config.APIPort > 0 {
+		evs = append(evs, core.EnvVar{
+			Name:  EnvAPIPort,
+			Value: strconv.Itoa(int(config.APIPort)),
+		})
+	}
 	evs = append(evs,
 		core.EnvVar{
 			Name: EnvPrefixAgent + "POD_IP",

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -26,6 +26,9 @@ const (
 	// EnvInterceptMounts mount points propagated to client during intercept
 	EnvInterceptMounts = "TELEPRESENCE_MOUNTS"
 
+	// EnvAPIPort is the port number of the Telepresence API server, when it is enabled
+	EnvAPIPort = "TELEPRESENCE_API_PORT"
+
 	DomainPrefix     = "telepresence.getambassador.io/"
 	InjectAnnotation = DomainPrefix + "inject-" + ContainerName
 )

--- a/pkg/client/userd/trafficmgr/install.go
+++ b/pkg/client/userd/trafficmgr/install.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd/k8s"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
@@ -681,7 +682,7 @@ func addAgentToWorkload(
 	if telepresenceAPIPort != 0 {
 		addTPEnvAction = &addTPEnvironmentAction{
 			ContainerName: container.Name,
-			Env:           map[string]string{"TELEPRESENCE_API_PORT": strconv.Itoa(int(telepresenceAPIPort))},
+			Env:           map[string]string{agentconfig.EnvAPIPort: strconv.Itoa(int(telepresenceAPIPort))},
 		}
 	}
 

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -31,6 +31,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/rpc/v2/userdaemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/a8rcloud"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd/auth"
@@ -928,7 +929,7 @@ func (tm *TrafficManager) reconcileAPIServers(ctx context.Context) {
 
 	agentAPIPort := func(ii *manager.InterceptInfo) int {
 		is := ii.Spec
-		if ps, ok := ii.Environment["TELEPRESENCE_API_PORT"]; ok {
+		if ps, ok := ii.Environment[agentconfig.EnvAPIPort]; ok {
 			port, err := strconv.ParseUint(ps, 10, 16)
 			if err == nil {
 				return int(port)

--- a/pkg/install/container.go
+++ b/pkg/install/container.go
@@ -173,7 +173,7 @@ func appEnvironment(appContainer *core.Container, apiPort int) []core.EnvVar {
 	copy(envCopy, appEnv)
 	if apiPort != 0 {
 		envCopy = append(envCopy, core.EnvVar{
-			Name:  "TELEPRESENCE_API_PORT",
+			Name:  agentconfig.EnvAPIPort,
 			Value: strconv.Itoa(apiPort),
 		})
 	}


### PR DESCRIPTION
## Description

The propagation of the `TELEPRESENCE_API_PORT` was unintentionally
dropped in the transition to 2.6.x. It's restored by this commit.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
