### PR TITLE
remove debug print statement

### DIFF
--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -5,7 +5,6 @@ package output
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -137,8 +136,6 @@ func (o *output) writeStructured(err error) {
 	if response.hasCmdOnly() {
 		return
 	}
-
-	fmt.Printf("response: %+v\n", response)
 
 	_ = o.jsonEncoder.Encode(response)
 }


### PR DESCRIPTION
Signed-off-by: Raphael Reyna <raphaelreyna@protonmail.com>

## Description

Removes double printing of json object along with `response: ` when watching while printing json output.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
