### PR TITLE
Configurable securityContext, podSecurityContext and resources for helm chart hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Bugfix: Telepresence no longer fails to inject the traffic agent into the pod generated for workloads that have no
   volumes and `automountServiceAccountToken: false`.
 
+- Feature: The helm-chart now supports settings resources, securityContext and podSecurityContext for use with chart hooks.
+
 ### 2.6.7 (June 22, 2022)
 
 - Bugfix: The Telepresence client will remember and reuse the traffic-manager session after a network failure

--- a/charts/telepresence/CHANGELOG.md
+++ b/charts/telepresence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.6.8 (TBD)
+
+- Feature: The helm-chart now supports settings resources, securityContext and podSecurityContext for use with chart hooks.
+
 ### v2.3.3-rc.0
 
 - Feature: Add AgentInjectorWebhook yaml files, newly introduced in 2.3.1.

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -79,9 +79,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | managerRbac.namespaced                         | Whether the traffic manager should be restricted to specific namespaces                                                   | `false`                                                                     |
 | managerRbac.namespaces                         | Which namespaces the traffic manager should be restricted to                                                              | `[]`                                                                        |
 | telepresenceAPI.port                           | The port on agent's localhost where the Telepresence API server can be found                                              |                                                                             |
-| hooks.podSecurityContext | The Kubernetes SecurityContext for the chart hooks `Pod` | `{}` |  |
-| hooks.securityContext |  The Kubernetes SecurityContext for the chart hooks `Container` | securityContext |  |
-| hooks.resources |  Define resource requests and limits for the chart hooks                | `{}` |  |
+| hooks.podSecurityContext                       | The Kubernetes SecurityContext for the chart hooks `Pod`                                                                  | `{}`                                                                        |
+| hooks.securityContext                          | The Kubernetes SecurityContext for the chart hooks `Container`                                                            | securityContext                                                             |
+| hooks.resources                                | Define resource requests and limits for the chart hooks                                                                   | `{}`                                                                        |
 
 ## License Key
 

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -79,7 +79,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | managerRbac.namespaced                         | Whether the traffic manager should be restricted to specific namespaces                                                   | `false`                                                                     |
 | managerRbac.namespaces                         | Which namespaces the traffic manager should be restricted to                                                              | `[]`                                                                        |
 | telepresenceAPI.port                           | The port on agent's localhost where the Telepresence API server can be found                                              |                                                                             |
-
+| hooks.podSecurityContext | The Kubernetes SecurityContext for the chart hooks `Pod` | `{}` |  |
+| hooks.securityContext |  The Kubernetes SecurityContext for the chart hooks `Container` | securityContext |  |
+| hooks.resources |  Define resource requests and limits for the chart hooks                | `{}` |  |
 
 ## License Key
 

--- a/charts/telepresence/templates/post-upgrade-hook.yaml
+++ b/charts/telepresence/templates/post-upgrade-hook.yaml
@@ -23,10 +23,16 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.hooks.podSecurityContext | nindent 8 }}
       containers:
         - name: upgrade-legacy
           securityContext:
+            {{- if .Values.hooks.securityContext }}
+            {{- toYaml .Values.hooks.securityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "curlimages/curl"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
@@ -35,6 +41,8 @@ spec:
           env:
             - name: CURL_CA_BUNDLE
               value: /secret/ca.crt
+          resources:
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
           # Helm considers applying a deployment a success. It doesn't wait for readinessProbes
           # unless explicitly told to do so by passing --wait and there's no guarantee that's
           # been done. Therefore, a retry is needed here to ensure proper upgrade.

--- a/charts/telepresence/templates/pre-delete-hook.yaml
+++ b/charts/telepresence/templates/pre-delete-hook.yaml
@@ -20,6 +20,8 @@ spec:
   template:
     metadata:
       name: uninstall-agents
+      securityContext:
+        {{- toYaml .Values.hooks.podSecurityContext | nindent 8 }}
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -29,7 +31,11 @@ spec:
       containers:
         - name: uninstall-agents
           securityContext:
+            {{- if .Values.hooks.securityContext }}
+            {{- toYaml .Values.hooks.securityContext | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: curlimages/curl
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
@@ -38,6 +44,8 @@ spec:
           env:
             - name: CURL_CA_BUNDLE
               value: /secret/ca.crt
+          resources:
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
           command:
             - sh
             - -c

--- a/charts/telepresence/templates/pre-delete-hook.yaml
+++ b/charts/telepresence/templates/pre-delete-hook.yaml
@@ -20,13 +20,13 @@ spec:
   template:
     metadata:
       name: uninstall-agents
-      securityContext:
-        {{- toYaml .Values.hooks.podSecurityContext | nindent 8 }}
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      securityContext:
+        {{- toYaml .Values.hooks.podSecurityContext | nindent 8 }}
       restartPolicy: Never
       containers:
         - name: uninstall-agents

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -253,3 +253,25 @@ rbac:
   #
   # Default: false
   only: false
+
+# Values specific to the helm chart hooks for managing upgrade/deleting
+hooks:
+  podSecurityContext:
+    {}
+    # fsGroup: 2000
+
+  # Falls back to the root securityContext if not supplied
+  securityContext:
+    {}
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources:
+    {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi


### PR DESCRIPTION
## Description

Add optional chart values to allow configuring the securityContext, podSecurityContext and resources used by Jobs that are part of the chart upgrade and delete hooks.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
