### PR TITLE
Let the telepresence client cache the session-info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.6.7 (TBD)
+
+- Bugfix: The Telepresence client will remember and reuse the traffic-manager session after a network failure
+  or other reason that caused an unclean disconnect.
+
 ### 2.6.6 (June 9, 2022)
 
 - Bugfix: The propagation of the `TELEPRESENCE_API_PORT` environment variable now works correctly.

--- a/pkg/client/userd/trafficmgr/session_cache.go
+++ b/pkg/client/userd/trafficmgr/session_cache.go
@@ -1,0 +1,45 @@
+package trafficmgr
+
+import (
+	"context"
+	"os"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cache"
+)
+
+const sessionInfoFile = "sessions.json"
+
+type SavedSession struct {
+	Host    string
+	Session *manager.SessionInfo `json:"session"`
+}
+
+// SaveSessionToUserCache saves the provided session to user cache and returns an error if
+// something goes wrong while marshalling or persisting.
+func SaveSessionToUserCache(ctx context.Context, host string, session *manager.SessionInfo) error {
+	return cache.SaveToUserCache(ctx, &SavedSession{
+		Host:    host,
+		Session: session,
+	}, sessionInfoFile)
+}
+
+// LoadSessionFromUserCache gets the session from cache or returns an error if something goes
+// wrong while loading or unmarshalling.
+func LoadSessionFromUserCache(ctx context.Context, host string) (*manager.SessionInfo, error) {
+	var ss *SavedSession
+	err := cache.LoadFromUserCache(ctx, &ss, sessionInfoFile)
+	if err == nil && ss.Host == host {
+		return ss.Session, nil
+	}
+	if err != nil && os.IsNotExist(err) {
+		err = nil
+	}
+	return nil, err
+}
+
+// DeleteSessionFromUserCache removes user info cache if existing or returns an error. An attempt
+// to remove a non-existing cache is a no-op and the function returns nil.
+func DeleteSessionFromUserCache(ctx context.Context) error {
+	return cache.DeleteFromUserCache(ctx, sessionInfoFile)
+}


### PR DESCRIPTION
## Description

Prior to this change, the client would forget its session-id when it
was forcefully disconnected and reconnecting to the traffic-manager
would create a new session. As a result, the old session was lost and
all intercepts belonging to it was unavailable. The traffic-manager
would however keep the session alive for 24 hours, and during that time
the intercepts would remain active. An active tcp intercept effectively
blocks all other intercepts to the same workload.

This commit stores the session-id in the client's cache and removes it
only after a successful `Depart`. If the session-id is found in the
cache when the client connects, then the client will use that in an
attempted call to `Remain`. If the call succeeds, the client will reuse the
session and not call `ArriveAsClient` to create a new session.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.