### PR TITLE
Use PreRunE instead of PostRun to deprecate k8s flags

### DIFF
--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -160,8 +160,8 @@ func argsCheck(f cobra.PositionalArgs) cobra.PositionalArgs {
 
 func initDeprecatedPersistentFlags(cmd *cobra.Command) {
 	cmd.Flags().AddFlagSet(deprecatedGlobalFlags)
-	opf := cmd.PostRun
-	cmd.PostRun = func(cmd *cobra.Command, args []string) {
+	opf := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// Allow deprecated global flags so that scripts using them don't break, but print
 		// a warning that their values are ignored.
 		deprecatedGlobalFlags.VisitAll(func(f *pflag.Flag) {
@@ -171,8 +171,9 @@ func initDeprecatedPersistentFlags(cmd *cobra.Command) {
 			}
 		})
 		if opf != nil {
-			opf(cmd, args)
+			return opf(cmd, args)
 		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
The error telling the user that the k8s flags are deprecated was never
printed. This is because the code used `PostRun` which never runs
when `RunE` is used (which it is). This commit changes that to instead
use `PreRunE`.