### PR TITLE
Don't forward DNS requests to "wpad" to the cluster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Bugfix: The Telepresence client will remember and reuse the traffic-manager session after a network failure
   or other reason that caused an unclean disconnect.
 
+- Bugfix: Telepresence will no longer forward DNS requests for "wpad" to the cluster.
+
 ### 2.6.6 (June 9, 2022)
 
 - Bugfix: The propagation of the `TELEPRESENCE_API_PORT` environment variable now works correctly.

--- a/integration_test/wpad_test.go
+++ b/integration_test/wpad_test.go
@@ -1,0 +1,116 @@
+package integration_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+// Test_WpadNotForwarded tests that DNS request aren't forwarded
+// to the cluster.
+func (s *connectedSuite) Test_WpadNotForwarded() {
+	require := s.Require()
+	ctx := s.Context()
+
+	// Ensure that DNS has full functionality
+	s.Eventually(func() bool {
+		short, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		as, err := net.DefaultResolver.LookupIPAddr(short, "kubernetes.default")
+		return err == nil && len(as) > 0
+	}, 30*time.Second, time.Second, "DNS is not functional")
+
+	logDir, err := filelocation.AppUserLogDir(ctx)
+	require.NoError(err)
+	logFile := filepath.Join(logDir, "daemon.log")
+
+	tests := []struct {
+		qn      string
+		forward bool
+	}{
+		{
+			"wpad",
+			false,
+		},
+		{
+			"wpad.default",
+			false,
+		},
+		{
+			"wpad.cluster.local",
+			false,
+		},
+		{
+			"wpad.svc.cluster.local",
+			false,
+		},
+		{
+			"wpad.default.svc.cluster.local",
+			false,
+		},
+		{
+			"wpad.bogus.org",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.qn, func() {
+			require := s.Require()
+			ctx := s.Context()
+
+			// Figure out where the current end of the logfile is
+			s, err := os.Stat(logFile)
+			require.NoError(err)
+			pos := s.Size()
+
+			// Make an attempt to resolve the host
+			short, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+			defer cancel()
+			_, _ = net.DefaultResolver.LookupIPAddr(short, tt.qn)
+
+			// Seek to the end of the log as it were before the lookup
+			rootLog, err := os.Open(logFile)
+			require.NoError(err)
+			defer rootLog.Close()
+			_, err = rootLog.Seek(pos, 0)
+			require.NoError(err)
+
+			// Ensure that there's an A record with an NXDOMAIN but no LookupHost call
+			// with a "wpad." prefix. The host may not match exactly due to how the
+			// OS handles search paths.
+			hasNX := false
+			hasLookup := false
+			scn := bufio.NewScanner(rootLog)
+			for scn.Scan() {
+				txt := scn.Text()
+				if strings.Contains(txt, "wpad") {
+					if !hasLookup {
+						hasLookup = strings.Contains(txt, "LookupHost ")
+					}
+					if !hasNX {
+						hasNX = strings.Contains(txt, "-> NXDOMAIN")
+					}
+				}
+			}
+			if (tt.qn == "wpad" || tt.qn == "wpad.bogus.org") && !hasNX && !hasLookup {
+				// this is very likely OK because our DNS server never received the request. It
+				// was filtered by the OS DNS framework. Those tests are only relevant when the overriding
+				// DNS resolver is used.
+				return
+			}
+			require.Truef(hasNX, "No NXDOMAIN record found for %s", tt.qn)
+			if tt.forward {
+				require.Truef(hasLookup, "Missing expected LookupHost log for %s", tt.qn)
+			} else {
+				require.Falsef(hasLookup, "Found unexpected LookupHost log for %s", tt.qn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The __Web Proxy Auto-Discovery protocol__ relies on DNS requests to
"wpad" (with possible domain suffixes). Telepresence must not forward
such requests to the cluster.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
