### PR TITLE
Configure traffic-agent shutdown timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Bugfix: Telepresence will no longer forward DNS requests for "wpad" to the cluster.
 
+- Bugfix: The traffic-agent will properly shut down if one of its goroutines errors.
+
 ### 2.6.6 (June 9, 2022)
 
 - Bugfix: The propagation of the `TELEPRESENCE_API_PORT` environment variable now works correctly.

--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -124,7 +124,10 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 		return err
 	}
 
-	wg := dgroup.NewGroup(ctx, dgroup.GroupConfig{})
+	wg := dgroup.NewGroup(ctx, dgroup.GroupConfig{
+		SoftShutdownTimeout: time.Second * 10,
+		HardShutdownTimeout: time.Second * 10,
+	})
 	wg.Go("lookupHostWait", func(ctx context.Context) error {
 		return lookupHostWaitLoop(ctx, manager, session, lrStream)
 	})


### PR DESCRIPTION
## Description

Configure traffic-agent shutdown timeouts

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
