### PR TITLE
Handle pods with no volumes and automountServiceAccountToken == false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Change: The Helm chart will now add the `nodeSelector`, `affinity` and `tolerations` values to the traffic-manager's
   post-upgrade-hook and pre-delete-hook jobs.
 
+- Bugfix: Telepresence no longer fails to inject the traffic agent into the pod generated for workloads that have no
+  volumes and `automountServiceAccountToken: false`.
+
 ### 2.6.7 (June 22, 2022)
 
 - Bugfix: The Telepresence client will remember and reuse the traffic-manager session after a network failure

--- a/integration_test/workloads_test.go
+++ b/integration_test/workloads_test.go
@@ -60,3 +60,7 @@ func (s *connectedSuite) Test_SuccessfullyInterceptsReplicaSet() {
 func (s *connectedSuite) Test_SuccessfullyInterceptsStatefulSet() {
 	s.successfulIntercept("StatefulSet", "ss-echo", "9092")
 }
+
+func (s *connectedSuite) Test_SuccessfullyInterceptsDeploymentWithNoVolumes() {
+	s.successfulIntercept("Deployment", "echo-no-vols", "9093")
+}

--- a/k8s/echo-no-vols.yaml
+++ b/k8s/echo-no-vols.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-no-vols
+spec:
+  type: ClusterIP
+  selector:
+    app: echo-no-vols
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-no-vols
+  labels:
+    app: echo-no-vols
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-no-vols
+  template:
+    metadata:
+      labels:
+        app: echo-no-vols
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: echo-server
+          image: docker.io/thhal/echo-server:latest
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+          resources:
+            limits:
+              cpu: 50m
+              memory: 8Mi


### PR DESCRIPTION
## Description

A workload with `automountServiceAccountToken: false` that has no
volumes, will have `/spec/volumes` unset. The webhook injector would
always assume that `/spec/volumes` was at least an empty list, and thus
create an incorrect patch attempting to add entries to that missing
value. The failing replicaset would show the following:
```
Error creating: Internal error occurred: add operation does not apply: doc is missing path: "/spec/volumes/-": missing value
```
This commit ensures that the patch is correct by first checking if the
value is undefined, and if so, replacing it with a list of volumes
instead of attempting to add them.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.