### PR TITLE
feat: allow users to use an annotation to ignore specified volume mounts during injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.9 (TBD)
+
+- Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-ignore-volume-mounts`, that can be used to make the injector ignore specified volume mounts denoted by a comma-separated string.
+
 ### 2.6.8 (June 23, 2022)
 
 - Feature: The name and namespace for the DNS Service that the traffic-manager uses in DNS auto-detection can now be specified.


### PR DESCRIPTION
## Description

Allow users to set annotation `telepresence.getambassador.io/inject-ignore-volume-mounts: "foo,bar"` to instruct the mutating webhook to ignore certain volume mounts to "be copied" during injection. 

This WIP PR is currently more of a proposal or PoC to address an issue discovered in https://github.com/telepresenceio/telepresence/issues/2596#issuecomment-1164617536

Our application unfortunately has a host path mount on `/var/xyz/spam` (xyz owned by root and spam owned by 1001). When it gets mounted by the agent sidecar and all the symlinks in place, `/tel_app_mounts/app/var` becomes owned by root, and hence cause error why the sidecar tries to `mkdir /tel_app_mounts/app/var/run`
```
ls -la /tel_app_exports/app
lrwxrwxrwx    1 1001     1001            24 Jun 23 16:00 var -> /tel_app_mounts/app/var

ls -la /tel_app_mounts/app/var
drwxr-xr-x    3 root     root          4096 Jun 23 16:15 .
drwxr-xr-x    3 root     root          4096 Jun 23 16:15 xyz
``` 
I wonder if this is actually a proper fix or there is other alternatives (we don't really want to manually generate the yamls).

Thanks!

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
