### PR TITLE
improve: make sidecar work with readOnlyRootFileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-ignore-volume-mounts`, that can be used to make the injector ignore specified volume mounts denoted by a comma-separated string.
 
+- Change: Add an emptyDir volume and volume mount under `/tmp` on the agent sidecar so it works with `readOnlyRootFileSystem: true`
+
 ### 2.6.8 (June 23, 2022)
 
 - Feature: The name and namespace for the DNS Service that the traffic-manager uses in DNS auto-detection can now be specified.

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -993,6 +993,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: replace
   path: /spec/volumes
   value:
@@ -1011,6 +1013,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     name: traffic-config
   - emptyDir: {}
     name: export-volume
+  - emptyDir: {}
+    name: tel-agent-tmp
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -1070,6 +1074,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: replace
   path: /spec/volumes
   value:
@@ -1088,6 +1094,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     name: traffic-config
   - emptyDir: {}
     name: export-volume
+  - emptyDir: {}
+    name: tel-agent-tmp
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -1192,6 +1200,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: replace
   path: /spec/volumes
   value:
@@ -1210,6 +1220,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     name: traffic-config
   - emptyDir: {}
     name: export-volume
+  - emptyDir: {}
+    name: tel-agent-tmp
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http
@@ -1279,6 +1291,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: replace
   path: /spec/volumes
   value:
@@ -1297,6 +1311,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     name: traffic-config
   - emptyDir: {}
     name: export-volume
+  - emptyDir: {}
+    name: tel-agent-tmp
 `,
 			"",
 			nil,
@@ -1367,6 +1383,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: replace
   path: /spec/volumes
   value:
@@ -1385,6 +1403,8 @@ func TestTrafficAgentInjector(t *testing.T) {
     name: traffic-config
   - emptyDir: {}
     name: export-volume
+  - emptyDir: {}
+    name: tel-agent-tmp
 `,
 			"",
 			nil,
@@ -1459,6 +1479,10 @@ func TestTrafficAgentInjector(t *testing.T) {
 								{
 									Name:      "export-volume",
 									MountPath: "/tel_app_exports",
+								},
+								{
+									Name:      "tel-agent-tmp",
+									MountPath: "/tmp",
 								},
 							},
 							ReadinessProbe: &core.Probe{
@@ -1545,6 +1569,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       name: traffic-config
     - mountPath: /tel_app_exports
       name: export-volume
+    - mountPath: /tmp
+      name: tel-agent-tmp
 - op: add
   path: /spec/volumes/-
   value:
@@ -1569,6 +1595,11 @@ func TestTrafficAgentInjector(t *testing.T) {
   value:
     emptyDir: {}
     name: export-volume
+- op: add
+  path: /spec/volumes/-
+  value:
+    emptyDir: {}
+    name: tel-agent-tmp
 - op: replace
   path: /spec/containers/0/ports/0/name
   value: tm-http

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -76,6 +76,10 @@ func AgentContainer(
 			Name:      ExportsVolumeName,
 			MountPath: ExportsMountPoint,
 		},
+		core.VolumeMount{
+			Name:      TempVolumeName,
+			MountPath: TempMountPoint,
+		},
 	)
 
 	if len(efs) == 0 {
@@ -152,6 +156,12 @@ func AgentVolumes(agentName string) []core.Volume {
 		},
 		{
 			Name: ExportsVolumeName,
+			VolumeSource: core.VolumeSource{
+				EmptyDir: &core.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: TempVolumeName,
 			VolumeSource: core.VolumeSource{
 				EmptyDir: &core.EmptyDirVolumeSource{},
 			},

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -19,6 +19,8 @@ const (
 	MountPrefixApp       = "/tel_app_mounts"
 	ExportsVolumeName    = "export-volume"
 	ExportsMountPoint    = "/tel_app_exports"
+	TempVolumeName       = "tel-agent-tmp"
+	TempMountPoint       = "/tmp"
 	EnvPrefix            = "_TEL_"
 	EnvPrefixAgent       = EnvPrefix + "AGENT_"
 	EnvPrefixApp         = EnvPrefix + "APP_"


### PR DESCRIPTION
## Description

Add a emptyDir volume mount under `/tmp` on the agent sidecar so it works with `readOnlyRootFileSystem: true`

Current behavior with `readOnlyRootFileSystem` set to `true` on the pod.

```
error: mkdir /tmp/agent: read-only file system
```

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
