### PR TITLE
improve: allow resolving <service-name>.<namespace>.svc by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Feature: The agent injector now supports a new annotation, `telepresence.getambassador.io/inject-ignore-volume-mounts`, that can be used to make the injector ignore specified volume mounts denoted by a comma-separated string.
 
+- Change: Allow resolving `<service-name>.<namespace>.svc` by default.
+
 ### 2.6.8 (June 23, 2022)
 
 - Feature: The name and namespace for the DNS Service that the traffic-manager uses in DNS auto-detection can now be specified.

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -155,6 +155,9 @@ func (s *Server) shouldDoClusterLookup(query string) bool {
 		case n == 2 && strings.HasPrefix(query, wpadDot):
 			// Reject "wpad.<namespace>."
 			return false
+		case n == 3 && strings.HasSuffix(query, ".svc"):
+			// Accept "<service-name>.<namespace>.svc"
+			return true
 		}
 	}
 


### PR DESCRIPTION
## Description

By default telepresence only resolves `<service-name>.<namespace>` and FQDN `<service-name>.<namespace>.svc.cluster.local`. Currently, in order to resolve address like `<service-name>.<namespace>.svc`, I have to add to all clusters in my kube config file.
```
    extensions:
    - name: telepresence.io
      extension:
        dns:
          include-suffixes:
           - .svc
```

If there isn't a specific reason to not resolve this by default, this PR will make the resolution work.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
