### PR TITLE
WIP - Build multi-arch docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
 
   "vm-linux":
     machine:
-      image: "ubuntu-2004:202010-01"
+      image: "ubuntu-2204:2022.04.2"
 
   "vm-macos":
     macos:
@@ -63,7 +63,7 @@ jobs:
             docker login -u="${DOCKERHUB_USERNAME}" -p="${DOCKERHUB_PASSWORD}"
       - run:
           name: Push Images
-          command: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-images
+          command: TELEPRESENCE_VERSION=$CIRCLE_TAG make push-multi-arch-images
       - run:
           name: "Publish linux (arch amd64)"
           command: TELEPRESENCE_VERSION=$CIRCLE_TAG GOARCH=amd64 make push-executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Change: Add an emptyDir volume and volume mount under `/tmp` on the agent sidecar so it works with `readOnlyRootFileSystem: true`
 
+- Feature: The Docker image is built on both amd64 and arm64 architectures
+
 ### 2.6.8 (June 23, 2022)
 
 - Feature: The name and namespace for the DNS Service that the traffic-manager uses in DNS auto-detection can now be specified.


### PR DESCRIPTION
## Description

During my steward duty last week, an issue that came back was about multi-arch not being properly supported for the traffic-manager and the traffic-agent. It seems mainly to be a use case when running minikube or the equivalent on an arm64 machine.

The requirement to bump up the CircleCI executor VM image was manually tested outside of this repo. `ubuntu-2004` had version 19.03 of Docker, which required to enable experimental features to use `docker buildx`. I decided instead to use `ubuntu-2204`, which comes with Docker 20.10.14, not requiring experimental features.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
