### PR TITLE
Make it easier for daemon-side commands to run in sessions.

### DIFF
--- a/pkg/client/userd/commands/commands.go
+++ b/pkg/client/userd/commands/commands.go
@@ -8,6 +8,10 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/cliutil"
 )
 
+const (
+	CommandRequiresSession = "cobra.telepresence.io/with-session"
+)
+
 // GetCommands will return all commands implemented by the connector daemon.
 func GetCommands() cliutil.CommandGroups {
 	return cliutil.CommandGroups{}

--- a/pkg/client/userd/service.go
+++ b/pkg/client/userd/service.go
@@ -159,7 +159,7 @@ nextSession:
 				rsp = s.session.UpdateStatus(s.sessionContext, cr)
 			} else {
 				sCtx, sCancel := context.WithCancel(c)
-				session, rsp = trafficmgr.NewSession(sCtx, s.scout, cr, s, sessionServices)
+				sCtx, session, rsp = trafficmgr.NewSession(sCtx, s.scout, cr, s, sessionServices)
 				sCtx = a8rcloud.WithSystemAPool[*SessionClient](sCtx, a8rcloud.UserdConnName, &SessionClientProvider{session})
 				if sCtx.Err() == nil && rsp.Error == rpc.ConnectInfo_UNSPECIFIED {
 					s.sessionContext = session.WithK8sInterface(sCtx)

--- a/pkg/client/userd/trafficmgr/ctx.go
+++ b/pkg/client/userd/trafficmgr/ctx.go
@@ -1,0 +1,19 @@
+package trafficmgr
+
+import (
+	"context"
+)
+
+type sessionKey struct{}
+
+func WithSession(ctx context.Context, session Session) context.Context {
+	return context.WithValue(ctx, sessionKey{}, session)
+}
+
+func GetSession(ctx context.Context) Session {
+	val := ctx.Value(sessionKey{})
+	if sess, ok := val.(Session); ok {
+		return sess
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Adds some infrastructure to allow commands implemented on the daemon to run with a session. No functionality change here.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
