### PR TITLE
Fill out description fields for poddaemon cmd args

### DIFF
--- a/cmd/traffic/cmd/poddaemon/main.go
+++ b/cmd/traffic/cmd/poddaemon/main.go
@@ -94,13 +94,13 @@ func Main(ctx context.Context, argStrs ...string) error {
 	})
 
 	cmd.Flags().StringVar(&args.WorkloadKind, "workload-kind", "Deployment",
-		"TODO")
+		"Target workload kind to intercept (Deployment, ReplicaSet)")
 	cmd.Flags().StringVar(&args.WorkloadName, "workload-name", "",
-		"TODO")
+		"Name of workload to intercept")
 	cmd.Flags().StringVar(&args.WorkloadNamespace, "workload-namespace", PodNamespace(),
-		"TODO")
+		"Namespace of workload to intercept")
 	cmd.Flags().Int32Var(&args.Port, "port", 8080,
-		"TODO")
+		"Workload port to forward to")
 
 	args.PreviewSpec.Ingress = &rpc_manager.IngressInfo{}
 	cmd.Flags().StringVar(&args.PreviewSpec.Ingress.Host, "ingress-host", "",
@@ -113,7 +113,7 @@ func Main(ctx context.Context, argStrs ...string) error {
 		"Hostname to put in requests (TLS-SNI and the HTTP \"Host\" header) (default is to use the L3 hostname)")
 
 	cmd.Flags().StringVar(&args.PreviewSpec.PullRequestUrl, "pull-request", "",
-		"TODO")
+		"GitHub Pull Request URL to link and notify when generating a preview domain for this intercept")
 	cli.AddPreviewFlags("preview-url-", cmd.Flags(), &args.PreviewSpec)
 
 	cmd.SetArgs(argStrs)


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

## Description

Replace a bunch of "TODO" descriptions in poddaemon cmd args with something significant and use wording similar to the `telepresence intercept --help` descriptions.

I'm not sure if this is worth mentioning in the CHANGELOG, but I'm happy to do so if necessary.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
