### PR TITLE
add global flags to remote commands

### DIFF
--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -253,7 +253,11 @@ func initGlobalFlagGroups() {
 		flag.Hidden = true
 	})
 
-	globalFlagGroups = []cliutil.FlagGroup{{
+	globalFlagGroups = GlobalFlagGroups()
+}
+
+func GlobalFlagGroups() []cliutil.FlagGroup {
+	return []cliutil.FlagGroup{{
 		Name: "other Telepresence flags",
 		Flags: func() *pflag.FlagSet {
 			flags := pflag.NewFlagSet("", 0)


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description

I ran into a problem updating the docker extension where the remote commands would not use the global flags. This small PR should add the global flags to the userD commands.

Tested with `--output json`

TODO i didnt figure out how to get the global flags to show up in the help text for remote commands