### PR TITLE
Ensure that tunnel streams are closed when connection attempts fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Change: The command `telepresence upload-traces` now prints out a message on success.
 - Change: The command `telepresence gather-traces` now traces itself and reports errors with trace gathering
 
+- Bugfix: Streams created between the traffic-agent and the workstation are now properly closed
+  when no interceptor process has been started on the workstation. This fixes a potential problem where
+  a large number of attempts to connect to a non-existing interceptor would cause stream congestion
+  and an unresponsive intercept.
+
 ### 2.7.1 (August 10, 2022)
 
 

--- a/cmd/traffic/cmd/manager/internal/state/state.go
+++ b/cmd/traffic/cmd/manager/internal/state/state.go
@@ -736,7 +736,7 @@ func (s *State) Tunnel(ctx context.Context, stream tunnel.Stream) error {
 			return err
 		}
 	} else {
-		endPoint = tunnel.NewDialer(stream)
+		endPoint = tunnel.NewDialer(stream, func() {})
 		endPoint.Start(ctx)
 	}
 	<-endPoint.Done()

--- a/integration_test/to_pod_test.go
+++ b/integration_test/to_pod_test.go
@@ -30,7 +30,7 @@ func (s *connectedSuite) Test_ToPodPortForwarding() {
 		defer wg.Done()
 		s.Eventually(func() bool {
 			return itest.Run(ctx, "curl", "--silent", "--max-time", "0.5", "localhost:8081") == nil
-		}, 15*time.Second, 2*time.Second, "Forwarded port is not reachable as localhost:8081")
+		}, 30*time.Second, 2*time.Second, "Forwarded port is not reachable as localhost:8081")
 	}()
 	wg.Add(1)
 	go func() {

--- a/pkg/client/rootd/router.go
+++ b/pkg/client/rootd/router.go
@@ -21,7 +21,7 @@ func (s *session) streamCreator() tunnel.StreamCreator {
 			pipeId := tunnel.NewConnID(p, id.Source(), s.dnsLocalAddr.IP, id.SourcePort(), uint16(s.dnsLocalAddr.Port))
 			dlog.Debugf(c, "Intercept DNS %s to %s", id, pipeId.DestinationAddr())
 			from, to := tunnel.NewPipe(pipeId, s.session.SessionId)
-			tunnel.NewDialer(to).Start(c)
+			tunnel.NewDialer(to, func() {}).Start(c)
 			return from, nil
 		}
 		dlog.Debugf(c, "Opening tunnel for id %s", id)

--- a/pkg/vif/stack.go
+++ b/pkg/vif/stack.go
@@ -278,13 +278,15 @@ func newConnID(proto tcpip.TransportProtocolNumber, id stack.TransportEndpointID
 }
 
 func dispatchToStream(ctx context.Context, id tunnel.ConnID, conn net.Conn, streamCreator tunnel.StreamCreator) {
+	ctx, cancel := context.WithCancel(ctx)
 	stream, err := streamCreator(ctx, id)
 	if err != nil {
 		if err != nil {
 			dlog.Errorf(ctx, "forward %s: %s", id, err)
 		}
+		cancel()
 		return
 	}
-	ep := tunnel.NewConnEndpoint(stream, conn)
+	ep := tunnel.NewConnEndpoint(stream, conn, cancel)
 	ep.Start(ctx)
 }


### PR DESCRIPTION
## Description

If a traffic-agent makes an attempt to connect to an interceptor process
on the workstation, and no such process exists, that results in the
dial being rejected, which is correctly propagated, but unfortunately,
the stream between the traffic-manager and the workstation is not being
closed. This commit ensures that the close happens and also adds some
additional security around canceling of streams.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
