### PR TITLE
Exclude the traffic-manager from list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   in the `config.yml` file using `timeouts.connectivityCheck`. The default timeout was
   changed from 5 seconds to 500 milliseconds to speed up the actual connect.
 
+- Feature: Adds cli autocompletion for the `--namespace` flag on the `list` and `intercept` commands,
+  autocompletion for interceptable workloads on the `intercept` command, and autocompletion for
+  active intercepts on the `leave` command.
+
 - Change: The command `telepresence gather-traces` now prints out a message on success.
 - Change: The command `telepresence upload-traces` now prints out a message on success.
 - Change: The command `telepresence gather-traces` now traces itself and reports errors with trace gathering
@@ -16,9 +20,7 @@
   a large number of attempts to connect to a non-existing interceptor would cause stream congestion
   and an unresponsive intercept.
 
-- Feature: Adds cli autocompletion for the `--namespace` flag on the `list` and `intercept` commands,
-  autocompletion for interceptable workloads on the `intercept` command, and autocompletion for
-  active intercepts on the `leave` command.
+- Bugfix: The `telepresence list` command no longer includes the `traffic-manager` deployment.
 
 ### 2.7.1 (August 10, 2022)
 

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -20,6 +20,11 @@ func init() {
 	})
 }
 
+func (s *connectedSuite) Test_ListExcludesTM() {
+	stdout := itest.TelepresenceOk(s.Context(), "list", "-n", s.ManagerNamespace())
+	s.NotContains(stdout, "traffic-manager")
+}
+
 func (s *connectedSuite) Test_ReportsVersionFromDaemon() {
 	stdout := itest.TelepresenceOk(s.Context(), "version")
 	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))

--- a/pkg/client/userd/trafficmgr/traffic_manager.go
+++ b/pkg/client/userd/trafficmgr/traffic_manager.go
@@ -609,7 +609,7 @@ func (tm *TrafficManager) getInfosForWorkloads(
 ) ([]*rpc.WorkloadInfo, error) {
 	wiMap := make(map[types.UID]*rpc.WorkloadInfo)
 	var err error
-	tm.wlWatcher.eachService(ctx, namespaces, func(svc *core.Service) {
+	tm.wlWatcher.eachService(ctx, tm.GetManagerNamespace(), namespaces, func(svc *core.Service) {
 		var wls []k8sapi.Workload
 		if wls, err = tm.wlWatcher.findMatchingWorkloads(ctx, svc); err != nil {
 			return


### PR DESCRIPTION
## Description

The `telepresence list` command will exclude the `traffic-manager`
service from the list output because it's not a valid candidate for an
intercept.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
