### PR TITLE
Raphaelreyna/guard against nil intercept env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.7.3 (TBD)
+
+- Bugfix: Graciously handle nil intercept environment from the traffic-manager.
+
 ### 2.7.2 (TBD)
 
 - Feature: The timeout for the initial connectivity check that Telepresence performs

--- a/pkg/client/userd/commands/intercept.go
+++ b/pkg/client/userd/commands/intercept.go
@@ -948,6 +948,9 @@ func (is *interceptState) EnsureState(ctx context.Context) (acquired bool, err e
 	is.scout.SetMetadatum(ctx, "intercept_id", intercept.Id)
 
 	is.env = intercept.Environment
+	if is.env == nil {
+		is.env = make(map[string]string)
+	}
 	is.env["TELEPRESENCE_INTERCEPT_ID"] = intercept.Id
 	is.env["TELEPRESENCE_ROOT"] = intercept.ClientMountPoint
 	if args.envFile != "" {


### PR DESCRIPTION
## Description

Graciously handle nil intercept environment map from the traffic-manager by setting it to an empty non-nil map if nil.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] My change is adequately tested.
