### PR TITLE
bugfix: appPortStrategy -> appProtocolStrategy

### DIFF
--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -200,7 +200,7 @@ agentInjector:
     reinvocationPolicy: Never
     sideEffects: None
     timeoutSeconds: 5
-  appPortStrategy: http2Probe
+  appProtocolStrategy: http2Probe
 
 ################################################################################
 ## Telepresence API Server Configuration


### PR DESCRIPTION
## Description

The deployment.yaml manifest, looks for `appProtocolStrategy` which doesn't exist in the values.yaml, but `appPortStrategy` does. I believe the original is the intended one so updated it within the `values.yaml` so that I can override it where appropriate

https://github.com/telepresenceio/telepresence/blob/1d55ef689fcf5d9dd17b44d9b3ba6326f1aadede/charts/telepresence/templates/deployment.yaml#L83

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
