### PR TITLE
use buildx to build for linux/amd64 cluster

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -134,7 +134,7 @@ endif
 tel2:
 	mkdir -p $(BUILDDIR)
 	printf $(TELEPRESENCE_VERSION) > $(BUILDDIR)/version.txt ## Pass version in a file instead of a --build-arg to maximize cache usage
-	docker build --target $@ --tag $@ --tag $(TELEPRESENCE_REGISTRY)/$@:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f base-image/Dockerfile .
+	docker buildx build --platform linux/amd64 --target $@ --tag "$@" --tag $(TELEPRESENCE_REGISTRY)/$@:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f base-image/Dockerfile .
 
 .PHONY: push-image
 push-image: tel2 ## (Build) Push the manager/agent container image to $(TELEPRESENCE_REGISTRY)


### PR DESCRIPTION
Signed-off-by: Christian Moser <christian.moser@starmind.com>

## Description

This would allow building the telepresence docker image for different architectures especially if the build is triggered locally on an arm64 architecture.
I don't have any deep knowledge about the telepresence CI architecture if this is already possible via a specific CirceCi config or some prerequisites on my local machine so I can build a docker image for an amd64 k8s cluster.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
