### PR TITLE
Remove generation of unhelpful messages in the traffic-manager logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
   `docker run -it` to allocate a TTY and will also give other commands like `bash read` the
   same behavior as when executed directly in a terminal.
 
+- Bugfix: The traffic-manager will no longer log numerous warnings saying: "Issuing a 
+  systema request without ApiKey or InstallID may result in an error".
+
+- Bugfix: The traffic-manager will no longer log an error saying: "Unable to derive subnets
+  from nodes" when the `podCIDRStrategy` is `auto` and it chooses to instead derive the
+  subnets from the pod IPs.
+
 ### 2.7.2 (August 25, 2022)
 
 - Bugfix: Standard I/O is restored when using `telepresence intercept <opts> -- <command>`.

--- a/pkg/a8rcloud/systema.go
+++ b/pkg/a8rcloud/systema.go
@@ -163,8 +163,6 @@ func (c *systemACredentials) GetRequestMetadata(ctx context.Context, _ ...string
 		return nil, err
 	} else if installID != "" {
 		headers[InstallIDHeader] = installID
-	} else if _, ok := headers[ApiKeyHeader]; !ok {
-		dlog.Warnf(ctx, "Issuing a systema request without ApiKey or InstallID may result in an error")
 	}
 	if extra, err := c.headers.GetExtraHeaders(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This commit removes two log statements:
- "Issuing a systema request without ApiKey or InstallID may result
  in an error". This warning was potentially logged many times per
  second and was confusing to the user. If an error indeed does occur
  because both an APiKey and an InstallID is missing, then that error is
  relevant and will be logged, but informing the user that it might
  (or might not) happen doesn't bring any clarity.
- "Unable to derive subnets from nodes". This error should be silent
  when the podCIDRStrategy is auto, because the logic then falls back
  to deriving the subnets from the pods, and logs that.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
