### PR TITLE
Ensure that remote command flags occur once

### DIFF
--- a/pkg/shellquote/shellstring_unix.go
+++ b/pkg/shellquote/shellstring_unix.go
@@ -4,6 +4,7 @@
 package shellquote
 
 import (
+	"io"
 	"regexp"
 	"strings"
 )
@@ -49,4 +50,108 @@ func quoteArg(arg string) string {
 		}
 	}
 	return b.String()
+}
+
+// Split the given string into an array, using shell quote semantics
+func Split(line string) ([]string, error) {
+	if line == "" {
+		return nil, nil
+	}
+
+	sb := strings.Builder{}
+	parseDQSegment := func(s string) (string, int) {
+		escaped := false
+		for i, r := range s {
+			if escaped {
+				escaped = false
+				switch r {
+				case '"', '$', '\\':
+					sb.WriteRune(r)
+				// Skip escape character and write this one verbatim
+				case '\n': // Escaped newline means concatenate the lines
+				default:
+					sb.WriteByte('\\') // Not known escape, so retain the escape character
+					sb.WriteRune(r)
+				}
+			} else {
+				if r == '"' {
+					return sb.String(), i + 2
+				}
+				if r == '\\' {
+					escaped = true
+				} else {
+					sb.WriteRune(r)
+				}
+			}
+		}
+		return "", -1
+	}
+	parseSQSegment := func(s string) (string, int) {
+		for i, r := range s {
+			if r == '\'' {
+				return sb.String(), i + 2
+			}
+			sb.WriteRune(r)
+		}
+		return "", -1
+	}
+
+	parseUQSegment := func(s string) (string, int) {
+		escaped := false
+		for i, r := range s {
+			if escaped {
+				escaped = false
+				switch r {
+				case '\n': // Escaped newline means concatenate the lines
+				default: // For all other cases, just skip the escape character and write the rune verbatim
+					sb.WriteRune(r)
+				}
+			} else {
+				switch r {
+				case '"', '\'', ' ', '\t', '\r', '\n': // start of quoted string or whitespace ends this segment
+					return sb.String(), i
+				case '\\':
+					escaped = true
+				default:
+					sb.WriteRune(r)
+				}
+			}
+		}
+		return sb.String(), len(s)
+	}
+
+	var ss []string
+	e := -1
+	newArg := true
+	for i, r := range line {
+		if i < e {
+			continue
+		}
+		var s string
+		var x int
+		switch r {
+		case ' ', '\t', '\r', '\n':
+			// skip whitespace
+			sb.Reset()
+			newArg = true
+			continue
+		case '"':
+			s, x = parseDQSegment(line[i+1:])
+		case '\'':
+			s, x = parseSQSegment(line[i+1:])
+		default:
+			s, x = parseUQSegment(line[i:])
+		}
+		if x < 0 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		e = i + x
+		if newArg {
+			ss = append(ss, s)
+			newArg = false
+		} else {
+			ss[len(ss)-1] = s
+		}
+	}
+	return ss, nil
 }

--- a/pkg/shellquote/shellstring_unix_test.go
+++ b/pkg/shellquote/shellstring_unix_test.go
@@ -1,0 +1,131 @@
+//go:build !windows
+// +build !windows
+
+package shellquote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "Empty",
+			line:    "",
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "single quoted",
+			line:    `'one quoted' 'two quoted'`,
+			want:    []string{`one quoted`, `two quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "escape in single quoted",
+			line:    `'\one'`,
+			want:    []string{`\one`},
+			wantErr: false,
+		},
+		{
+			name:    "escape in single quoted",
+			line:    `'\'one'`, // unbalanced. There's no escape in single quote
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "single quoted concat",
+			line:    `'one quoted''two quoted'`,
+			want:    []string{`one quotedtwo quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted",
+			line:    `"one quoted" "two quoted"`,
+			want:    []string{`one quoted`, `two quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted concat",
+			line:    `"one quoted""two quoted"`,
+			want:    []string{`one quotedtwo quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with escaped quote",
+			line:    `"one \"quoted\"" "two quoted"`,
+			want:    []string{`one "quoted"`, `two quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with unbalanced escaped quote",
+			line:    `"one \"quoted\" "two quoted"`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "double quoted with escaped dollar",
+			line:    `"\$32.0"`,
+			want:    []string{`$32.0`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with escaped escape",
+			line:    `"the \\ character"`,
+			want:    []string{`the \ character`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with escaped newline",
+			line:    "\"the line \\\ncontinues here\"",
+			want:    []string{`the line continues here`},
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with escaped newline",
+			line:    "\"the line \\\ncontinues here\"",
+			want:    []string{`the line continues here`},
+			wantErr: false,
+		},
+		{
+			name:    "not quoted",
+			line:    `not quoted`,
+			want:    []string{`not`, `quoted`},
+			wantErr: false,
+		},
+		{
+			name:    "backslash escape",
+			line:    `one\ two three\ four`,
+			want:    []string{`one two`, `three four`},
+			wantErr: false,
+		},
+		{
+			name:    "double and singe quoted concat",
+			line:    `"one quoted"'two quoted'`,
+			want:    []string{`one quotedtwo quoted`},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Split(tt.line)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+				got, err := Split(ShellArgsString(got))
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/shellquote/shellstring_windows.go
+++ b/pkg/shellquote/shellstring_windows.go
@@ -1,62 +1,163 @@
 package shellquote
 
 import (
+	"io"
 	"strings"
 )
 
-// quoteArg is heavy influenced by appendEscapeArg() in exec_windows.go in the syscall package
 func quoteArg(arg string) string {
 	if arg == "" {
 		return `""`
 	}
 	needsBackslash := false
-	hasSpace := false
+	needsQuote := false
 	for _, c := range arg {
 		switch c {
 		case '"', '\\':
 			needsBackslash = true
 		case ' ', '\t':
-			hasSpace = true
+			needsQuote = true
 		}
 	}
-
-	if !needsBackslash && !hasSpace {
-		// No special handling required; normal case.
+	if !(needsBackslash || needsQuote) {
 		return arg
 	}
 
 	b := strings.Builder{}
-	if !needsBackslash {
-		// hasSpace is true, so we need to quote the string.
+	slashes := 0
+	slashOut := func() {
+		for ; slashes > 0; slashes-- {
+			b.WriteByte('\\')
+		}
+	}
+	slashOutBeforeQuote := func(escape bool) {
+		slashes <<= 1
+		if escape {
+			slashes++
+		}
+		slashOut()
+	}
+
+	if needsQuote {
 		b.WriteByte('"')
+	}
+
+	if !needsBackslash {
 		b.WriteString(arg)
 		b.WriteByte('"')
 		return b.String()
 	}
 
-	if hasSpace {
-		b.WriteByte('"')
-	}
-	slashes := 0
 	for _, c := range arg {
 		switch c {
 		default:
-			slashes = 0
+			slashOut()
+			b.WriteRune(c)
 		case '\\':
 			slashes++
 		case '"':
-			for ; slashes > 0; slashes-- {
-				b.WriteByte('\\')
-			}
-			b.WriteByte('\\')
+			slashOutBeforeQuote(true)
+			b.WriteByte('"')
 		}
-		b.WriteRune(c)
 	}
-	if hasSpace {
-		for ; slashes > 0; slashes-- {
-			b.WriteByte('\\')
-		}
+	if needsQuote {
+		slashOutBeforeQuote(false)
 		b.WriteByte('"')
+	} else {
+		slashOut()
 	}
 	return b.String()
+}
+
+// Split the given string into an array, using shell quote semantics
+func Split(line string) ([]string, error) {
+	if line == "" {
+		return nil, nil
+	}
+
+	sb := strings.Builder{}
+	slashes := 0
+	slashOut := func() {
+		for ; slashes > 0; slashes-- {
+			sb.WriteByte('\\')
+		}
+	}
+	slashOutBeforeQuote := func() bool {
+		even := slashes&1 == 0
+		slashes >>= 1
+		slashOut()
+		return even
+	}
+	parseDQSegment := func(s string) (string, int) {
+		slashes = 0
+		for i, r := range s {
+			switch r {
+			case '"':
+				if slashOutBeforeQuote() {
+					return sb.String(), i + 2
+				}
+				sb.WriteRune(r)
+			case '\\':
+				slashes++
+			default:
+				slashOut()
+				sb.WriteRune(r)
+			}
+		}
+		return "", -1
+	}
+	parseUQSegment := func(s string) (string, int) {
+		slashes = 0
+		for i, r := range s {
+			switch r {
+			case ' ', '\t', '\r', '\n': // start of quoted string or whitespace ends this segment
+				slashOut()
+				return sb.String(), i
+			case '"':
+				if slashOutBeforeQuote() {
+					return sb.String(), i
+				}
+				sb.WriteByte('"')
+			case '\\':
+				slashes++
+			default:
+				slashOut()
+				sb.WriteRune(r)
+			}
+		}
+		return sb.String(), len(s)
+	}
+
+	var ss []string
+	e := -1
+	newArg := true
+	for i, r := range line {
+		if i < e {
+			continue
+		}
+		var s string
+		var x int
+		switch r {
+		case ' ', '\t', '\r', '\n':
+			// skip whitespace
+			sb.Reset()
+			newArg = true
+			continue
+		case '"':
+			s, x = parseDQSegment(line[i+1:])
+		default:
+			s, x = parseUQSegment(line[i:])
+		}
+		if x < 0 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		e = i + x
+		if newArg {
+			ss = append(ss, s)
+			newArg = false
+		} else {
+			ss[len(ss)-1] = s
+		}
+	}
+	return ss, nil
 }

--- a/pkg/shellquote/shellstring_windows_test.go
+++ b/pkg/shellquote/shellstring_windows_test.go
@@ -1,0 +1,121 @@
+package shellquote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplit(t *testing.T) {
+	// Tests inspired by https://docs.microsoft.com/en-us/previous-versions/ms880421(v=msdn.10)?redirectedfrom=MSDN
+	tests := []struct {
+		name    string
+		line    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "Empty",
+			line:    "",
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "double quoted with unbalanced escaped quote",
+			line:    `"one \"quoted\" "two quoted"`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    `"a b c" d e`,
+			line:    `"a b c" d e`,
+			want:    []string{`a b c`, `d`, `e`},
+			wantErr: false,
+		},
+		{
+			name:    `"ab\"c" "\\" d`,
+			line:    `"ab\"c" "\\" d`,
+			want:    []string{`ab"c`, `\`, `d`},
+			wantErr: false,
+		},
+		{
+			name:    `a\\\b d"e f"g h`,
+			line:    `a\\\b d"e f"g h`,
+			want:    []string{`a\\\b`, `de fg`, `h`},
+			wantErr: false,
+		},
+		{
+			name:    `a\\\"b c d`,
+			line:    `a\\\"b c d`,
+			want:    []string{`a\"b`, `c`, `d`},
+			wantErr: false,
+		},
+		{
+			name:    `a\\\\"b c" d e`,
+			line:    `a\\\\"b c" d e`,
+			want:    []string{`a\\b c`, `d`, `e`},
+			wantErr: false,
+		},
+		{
+			name:    `"a\\b c" d e`,
+			line:    `"a\\b c" d e`,
+			want:    []string{`a\\b c`, `d`, `e`},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Split(tt.line)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+				joined := ShellArgsString(got)
+				got, err := Split(joined)
+				require.NoError(t, err, joined)
+				assert.Equal(t, tt.want, got, joined)
+			}
+		})
+	}
+}
+
+func Test_quoteArg(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: `\`,
+			arg:  `\`,
+			want: `\`,
+		},
+		{
+			name: `\ \`,
+			arg:  `\ \`,
+			want: `"\ \\"`,
+		},
+		{
+			name: `\ \"`,
+			arg:  `\ \"`,
+			want: `"\ \\\""`,
+		},
+		{
+			name: `\\ \\`,
+			arg:  `\\ \\`,
+			want: `"\\ \\\\"`,
+		},
+		{
+			name: `\" \\`,
+			arg:  `\" \\`,
+			want: `"\\\" \\\\"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, []byte(tt.want), []byte(quoteArg(tt.arg)), "quoteArg(%v)", tt.arg)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Ensures that remote command flags are parsed only once by the user daemon, and that the `cliutil.Value` implements `pflag.SliceValue`.

## Checklist

 - [x] My change is adequately tested.