### PR TITLE
Don't dup stdio to logger

### DIFF
--- a/pkg/client/logging/initcontext_test.go
+++ b/pkg/client/logging/initcontext_test.go
@@ -107,8 +107,8 @@ func TestInitContext(t *testing.T) {
 		bs, err := os.ReadFile(logFile)
 		check.NoError(err)
 		s := string(bs)
-		check.Contains(s, fmt.Sprintf("info    stdout : %s\n", infoMsg))
-		check.Contains(s, fmt.Sprintf("info    stderr : %s\n", errMsg))
+		check.Contains(s, infoMsg)
+		check.Contains(s, errMsg)
 	})
 
 	t.Run("captures output of builtin functions", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestInitContext(t *testing.T) {
 		time.Sleep(30 * time.Millisecond)
 		bs, err := os.ReadFile(logFile)
 		check.NoError(err)
-		check.Contains(string(bs), fmt.Sprintf("info    stderr : %s\n", msg))
+		check.Contains(string(bs), msg)
 	})
 
 	t.Run("captures output of standard logger", func(t *testing.T) {


### PR DESCRIPTION
The change in 2.7.6 where stdout and stderr was duped to the logrus only worked for normal IO. Things like panics, or stack trace output from a QUIT signal, just caused everything to hang, only killable with a `kill -9`.

This commit removes the extra step, and just dups the file descriptor of the log file itself (back to how it was prior to 2.7.6).
