### PR TITLE
Fix environment variable interpolation in generated traffic-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Change: The Helm chart `dnsConfig` was deprecated but retained for backward compatibility. The fields
   `alwaysProxySubnets` and `neverProxySubnets` can now be found under `routing` in the `client` struct.
 
+- Bugfix: Environment variable interpolation now works for all definitions that are copied from pod containers
+  into the injected traffic-agent container.
+
 - Bugfix: An attempt to create simultaneous intercepts that span multiple namespace on the same workstation
   is detected early and prohibited instead of resulting in failing DNS lookups later on.
 

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -357,7 +357,7 @@ func addAgentContainer(
 	config *agentconfig.Sidecar,
 	patches patchOps,
 ) patchOps {
-	acn := agentconfig.AgentContainer(pod, config)
+	acn := agentconfig.AgentContainer(ctx, pod, config)
 	if acn == nil {
 		return patches
 	}

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -1512,19 +1512,29 @@ func TestTrafficAgentInjector(t *testing.T) {
 					Containers: []core.Container{{
 						Name:  "some-container",
 						Image: "some-app-image",
+						Env: []core.EnvVar{
+							{
+								Name:  "TOKEN_VOLUME",
+								Value: "default-token-vol",
+							},
+							{
+								Name:  "SECRET_NAME",
+								Value: "default-secret-name",
+							},
+						},
 						Ports: []core.ContainerPort{{
 							Name: "http", ContainerPort: 8888},
 						},
 						VolumeMounts: []core.VolumeMount{
-							{Name: "default-token-nkspp", ReadOnly: true, MountPath: serviceAccountMountPath},
+							{Name: "$(TOKEN_VOLUME)", ReadOnly: true, MountPath: serviceAccountMountPath},
 						}},
 					},
 					Volumes: []core.Volume{
 						{
-							Name: "default-token-nkspp",
+							Name: "default-token-vol",
 							VolumeSource: core.VolumeSource{
 								Secret: &core.SecretVolumeSource{
-									SecretName:  "default-token-nkspp",
+									SecretName:  "default-secret-name",
 									DefaultMode: &secretMode,
 								},
 							},
@@ -1539,6 +1549,10 @@ func TestTrafficAgentInjector(t *testing.T) {
     args:
     - agent
     env:
+    - name: _TEL_APP_A_TOKEN_VOLUME
+      value: default-token-vol
+    - name: _TEL_APP_A_SECRET_NAME
+      value: default-secret-name
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1563,7 +1577,7 @@ func TestTrafficAgentInjector(t *testing.T) {
     resources: {}
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-nkspp
+      name: $(_TEL_APP_A_TOKEN_VOLUME)
       readOnly: true
     - mountPath: /tel_pod_info
       name: traffic-annotations

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -1,14 +1,20 @@
 package agentconfig
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 
 	core "k8s.io/api/core/v1"
+
+	"github.com/datawire/dlib/dlog"
 )
 
 // AgentContainer will return a configured traffic-agent
 func AgentContainer(
+	ctx context.Context,
 	pod *core.Pod,
 	config *Sidecar,
 ) *core.Container {
@@ -28,9 +34,10 @@ func AgentContainer(
 
 	evs := make([]core.EnvVar, 0, len(config.Containers)*5)
 	efs := make([]core.EnvFromSource, 0, len(config.Containers)*3)
+	subst := make(map[string]string, len(evs)+len(efs))
 	EachContainer(pod, config, func(app *core.Container, cc *Container) {
-		evs = appendAppContainerEnv(app, cc, evs)
-		efs = appendAppContainerEnvFrom(app, cc, efs)
+		evs = appendAppContainerEnv(app, cc, evs, subst)
+		efs = appendAppContainerEnvFrom(app, cc, efs, subst)
 	})
 	if config.APIPort > 0 {
 		evs = append(evs, core.EnvVar{
@@ -85,6 +92,7 @@ func AgentContainer(
 	if len(efs) == 0 {
 		efs = nil
 	}
+
 	ac := &core.Container{
 		Name:         ContainerName,
 		Image:        config.AgentImage,
@@ -103,6 +111,20 @@ func AgentContainer(
 	}
 	if r := config.Resources; r != nil {
 		ac.Resources = *r
+	}
+
+	// Replace all occurrences of "$(ENV" with "$(PFX_ENV"
+	aj, err := json.Marshal(&ac)
+	if err != nil {
+		dlog.Error(ctx, err)
+		return nil
+	}
+	for k, pk := range subst {
+		aj = bytes.ReplaceAll(aj, []byte("$("+k), []byte("$("+pk))
+	}
+	if err = json.Unmarshal(aj, &ac); err != nil {
+		dlog.Error(ctx, err)
+		return nil
 	}
 	return ac
 }
@@ -219,22 +241,27 @@ func appendAppContainerVolumeMounts(app *core.Container, cc *Container, mounts [
 		} else {
 			m.MountPath = cc.MountPoint + "/" + strings.TrimPrefix(m.MountPath, "/")
 		}
+
 		mounts = append(mounts, m)
 	}
 	return mounts
 }
 
-func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar) []core.EnvVar {
+func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar, subst map[string]string) []core.EnvVar {
 	for _, e := range app.Env {
-		e.Name = EnvPrefixApp + cc.EnvPrefix + e.Name
+		pn := EnvPrefixApp + cc.EnvPrefix + e.Name
+		subst[e.Name] = pn
+		e.Name = pn
 		es = append(es, e)
 	}
 	return es
 }
 
-func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.EnvFromSource) []core.EnvFromSource {
+func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.EnvFromSource, subst map[string]string) []core.EnvFromSource {
 	for _, e := range app.EnvFrom {
-		e.Prefix = EnvPrefixApp + cc.EnvPrefix + e.Prefix
+		pn := EnvPrefixApp + cc.EnvPrefix + e.Prefix
+		subst[e.Prefix] = pn
+		e.Prefix = pn
 		es = append(es, e)
 	}
 	return es

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -353,6 +353,7 @@ func (g *genContainerInfo) run(cmd *cobra.Command, kubeFlags map[string]string) 
 
 	podTpl := wl.GetPodTemplate()
 	agentContainer := agentconfig.AgentContainer(
+		ctx,
 		&core.Pod{
 			TypeMeta: meta.TypeMeta{
 				Kind:       "pod",


### PR DESCRIPTION
## Description

Environment variables that are defined in a pod's container can be interpolated in other values using a `$(<env name>)` syntax. This commit ensures that such interpolation works with the env-vars that are copied, and prefixed into the traffic agent by also prefixing the actual interpolation. E.g.
```
volumeMounts:
  - name: $(TOKEN_VOLUME)
```
becomes:
```
volumeMounts:
  - name: $(_TEL_APP_A_TOKEN_VOLUME)
```
when copied into the agent container definition.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
