### PR TITLE
Ensure that stdout/stderr are synchronized at the end of remote command

### DIFF
--- a/pkg/client/stdio.go
+++ b/pkg/client/stdio.go
@@ -1,10 +1,10 @@
 package client
 
 import (
-	"context"
 	"io"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
 )
 
 // StdOutput sends everything written to its Stdout and Stderr to its
@@ -14,6 +14,7 @@ type StdOutput interface {
 	Stdout() io.Writer
 	Stderr() io.Writer
 	ResultChannel() <-chan *connector.StreamResult
+	Finish(error)
 }
 
 type dispatchToCh struct {
@@ -50,6 +51,18 @@ func (d dispatchToCh) Write(p []byte) (n int, err error) {
 
 type stdioHandler chan *connector.StreamResult
 
+func (h stdioHandler) Finish(err error) {
+	r := connector.StreamResult{Final: true}
+	if err != nil {
+		r.Data = &connector.Result{
+			Data:          []byte(err.Error()),
+			ErrorCategory: connector.Result_ErrorCategory(errcat.GetCategory(err)),
+		}
+	}
+	h <- &r
+	close(h)
+}
+
 func (h stdioHandler) Stdout() io.Writer {
 	return dispatchToCh{
 		out:    h,
@@ -68,13 +81,7 @@ func (h stdioHandler) ResultChannel() <-chan *connector.StreamResult {
 	return h
 }
 
-// NewStdOutput returns a new instance of StdOutput which is closed when the
-// given context is done.
-func NewStdOutput(ctx context.Context) StdOutput {
-	so := make(stdioHandler)
-	go func() {
-		<-ctx.Done()
-		close(so)
-	}()
-	return so
+// NewStdOutput returns a new instance of StdOutput
+func NewStdOutput() StdOutput {
+	return make(stdioHandler)
 }

--- a/pkg/client/stdio_test.go
+++ b/pkg/client/stdio_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"io"
 	"testing"
 	"time"
@@ -10,13 +9,12 @@ import (
 )
 
 func TestClosedChannel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	so := NewStdOutput(ctx)
+	so := NewStdOutput()
 	go func() {
 		for range so.ResultChannel() {
 		}
 	}()
-	cancel()
+	so.Finish(nil)
 	time.Sleep(time.Millisecond)
 	_, err := so.Stdout().Write([]byte("boom"))
 	require.Error(t, err, io.ErrClosedPipe)


### PR DESCRIPTION
A remote command would sometimes never print the last output sent to stdout/stderr because the channel that they were sent to wasn't drained before the command ended. This commit ensures that the drain is made.