### PR TITLE
Improve error message on failure to parse JSON files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.8.0 (TBD)
 
 - Bugfix: The Helm chart value `appProtocolStrategy` is now correctly named (used to be `appPortStategy`)
+- Bugfix: Include file name in error message when failing to parse JSON file.
 
 ### 2.7.6 (September 16, 2022)
 

--- a/pkg/client/cache/cache.go
+++ b/pkg/client/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -39,12 +40,13 @@ func LoadFromUserCache(ctx context.Context, dest any, file string) error {
 	if err != nil {
 		return err
 	}
-	jsonContent, err := os.ReadFile(filepath.Join(dir, file))
+	path := filepath.Join(dir, file)
+	jsonContent, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	if err := json.Unmarshal(jsonContent, &dest); err != nil {
-		return err
+		return fmt.Errorf("failed to parse JSON from file %s: %w", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Include the path to the file in the error message when JSON parse errors occur. This should make it easier to diagnose these errors.

Fixes: #2804

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
