### PR TITLE
add manual cloud intercept step

### DIFF
--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -618,7 +618,6 @@ verify_output_empty "${output}" true
 
 finish_step
 
-
 ###############################################
 #### Step 7 - Verify login prompted        ####
 ###############################################
@@ -861,11 +860,26 @@ if [[ -n $TELEPRESENCE_LICENSE ]]; then
         echo "Intercept should have errored since the license is invalid"
         exit 1
     fi
+    finish_step
+
+    ##########################################################
+    ###########  Step 18 - Verify Cloud Intercept  ###########
+    ##########################################################
+    echo "Step 18: log into https://getambassador.io/cloud and start an intercept."
+    read -p "Success(y|n): " yn
+    case $yn in
+        [Yy]* ) echo "Step 18 sucess!"; break;;
+        [Nn]* ) echo "Should be able to initiate intercept from the cloud"; exit 1;;
+        * ) echo "invalid input"; exit 1;;
+    esac
+    finish_step
+
 
     $TELEPRESENCE helm uninstall >"$output_location"
     finish_step
     restore_config
     trap - EXIT
+
 fi
 ##########################################################
 #### The end :)                                       ####

--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -866,7 +866,7 @@ if [[ -n $TELEPRESENCE_LICENSE ]]; then
     ###########  Step 18 - Verify Cloud Intercept  ###########
     ##########################################################
     echo "Step ${STEP}: log into https://getambassador.io/cloud and start an intercept."
-    read -p "Success(y/n)? " yn
+    read -r -p "Success(y/n)? " yn
     case $yn in
         [Yy]* )	finish_step;; 
         [Nn]* ) echo "Should be able to initiate intercept from the cloud"; exit 1;;

--- a/smoke-tests/run_smoke_test.sh
+++ b/smoke-tests/run_smoke_test.sh
@@ -865,14 +865,13 @@ if [[ -n $TELEPRESENCE_LICENSE ]]; then
     ##########################################################
     ###########  Step 18 - Verify Cloud Intercept  ###########
     ##########################################################
-    echo "Step 18: log into https://getambassador.io/cloud and start an intercept."
-    read -p "Success(y|n): " yn
+    echo "Step ${STEP}: log into https://getambassador.io/cloud and start an intercept."
+    read -p "Success(y/n)? " yn
     case $yn in
-        [Yy]* ) echo "Step 18 sucess!"; break;;
+        [Yy]* )	finish_step;; 
         [Nn]* ) echo "Should be able to initiate intercept from the cloud"; exit 1;;
         * ) echo "invalid input"; exit 1;;
     esac
-    finish_step
 
 
     $TELEPRESENCE helm uninstall >"$output_location"


### PR DESCRIPTION
## Description
Adds a step to the smoke tests asking the tester to manually initiate an intercept in the cloud.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
