### PR TITLE
Change mutating webhook port to 443 and make it configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 2.8.3 (TBD)
+
+- Feature: The port used for the mutating webhook can be configured using the Helm chart setting
+  `agentInjector.webhook.port`.
+
+- Change: The default port for the mutating webhook is now `443`. It used to be `8443`.
+
 ### 2.8.2 (October 15, 2022)
 
 - Feature: The Telepresence DNS resolver is now capable of resolving queries of type `A`, `AAAA`, `CNAME`,

--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM golang:alpine3.15 as tel2-build
 
-RUN apk add --no-cache gcc musl-dev fuse-dev
+RUN apk add --no-cache gcc musl-dev fuse-dev libcap
 
 WORKDIR telepresence
 COPY go.mod go.sum .
@@ -31,7 +31,10 @@ RUN \
     --mount=type=cache,target=/go/pkg/mod \
     go build -o /usr/local/bin/ -trimpath -ldflags=-X=$(go list ./pkg/version).Version=$(cat version.txt) ./cmd/traffic/...
 
-# The tel2 targer is the one that gets published. It aims to be a small as possible.
+# setcap is necessary because the process will listen to privileged ports
+RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/traffic
+
+# The tel2 target is the one that gets published. It aims to be a small as possible.
 FROM alpine:3.15 as tel2
 
 RUN apk add --no-cache ca-certificates iptables

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
             value: {{ .systemaHost }}
           - name: SYSTEMA_PORT
             value: {{ .systemaPort | quote }}
+          - name: MUTATOR_WEBHOOK_PORT
+            value: {{ .agentInjector.webhook.port | quote }}
           {{- with .tracing }}
           {{- if .grpcPort }}
           - name: TRACING_GRPC_PORT
@@ -217,7 +219,7 @@ spec:
           - name: api
             containerPort: {{ .apiPort }}
           - name: https
-            containerPort: 8443
+            containerPort: {{ .agentInjector.webhook.port }}
           {{- if .prometheus.port }}  # 0 is false
           - name: prometheus
             containerPort: {{ .prometheus.port }}

--- a/charts/telepresence/templates/service.yaml
+++ b/charts/telepresence/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - name: https
-    port: 443
+    port: {{ .Values.agentInjector.webhook.port }}
     targetPort: https
   selector:
     {{- include "telepresence.selectorLabels" . | nindent 4 }}

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -159,12 +159,6 @@ managerRbac:
 ################################################################################
 agentInjector:
   name: agent-injector
-  service:
-    type: ClusterIP
-    ports:
-    - name: https
-      port: 443
-      targetPort: https
   secret:
     name: mutator-webhook-tls
   certificate:

--- a/cmd/traffic/cmd/manager/internal/mutator/service.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/service.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -25,7 +24,6 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/install"
 )
 
 const (
@@ -140,7 +138,7 @@ func ServeMutator(ctx context.Context) error {
 		return operation + r.URL.Path
 	}))
 	server := &dhttp.ServerConfig{Handler: wrapped}
-	addr := ":" + strconv.Itoa(install.MutatorWebhookPortHTTPS)
+	addr := fmt.Sprintf(":%d", managerutil.GetEnv(ctx).MutatorWebhookPort)
 
 	dlog.Infof(ctx, "Mutating webhook service is listening on %v", addr)
 	defer dlog.Info(ctx, "Mutating webhook service stopped")

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -32,7 +32,7 @@ import (
 
 // Main starts up the traffic manager and blocks until it ends.
 func Main(ctx context.Context, _ ...string) error {
-	dlog.Infof(ctx, "Traffic Manager %s [pid:%d]", version.Version, os.Getpid())
+	dlog.Infof(ctx, "Traffic Manager %s [uid:%d,gid:%d]", version.Version, os.Getuid(), os.Getgid())
 
 	ctx, err := managerutil.LoadEnv(ctx, os.LookupEnv)
 	if err != nil {

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -30,16 +30,17 @@ import (
 // The Env is responsible for all parsing of the environment strings. No parsing of such
 // strings should be made elsewhere in the code.
 type Env struct {
-	LogLevel          string   `env:"LOG_LEVEL,             parser=logLevel"`
-	User              string   `env:"USER,                  parser=string,      default="`
-	ServerHost        string   `env:"SERVER_HOST,           parser=string,      default="`
-	ServerPort        uint16   `env:"SERVER_PORT,           parser=port-number"`
-	PrometheusPort    uint16   `env:"PROMETHEUS_PORT,       parser=port-number, default=0"`
-	SystemAHost       string   `env:"SYSTEMA_HOST,          parser=string,      default="`
-	SystemAPort       uint16   `env:"SYSTEMA_PORT,          parser=port-number, default=0"`
-	ManagerNamespace  string   `env:"MANAGER_NAMESPACE,     parser=string,      default="`
-	ManagedNamespaces []string `env:"MANAGED_NAMESPACES,    parser=split-trim,  default="`
-	APIPort           uint16   `env:"AGENT_REST_API_PORT,   parser=port-number, default=0"`
+	LogLevel           string   `env:"LOG_LEVEL,             parser=logLevel"`
+	User               string   `env:"USER,                  parser=string,      default="`
+	ServerHost         string   `env:"SERVER_HOST,           parser=string,      default="`
+	ServerPort         uint16   `env:"SERVER_PORT,           parser=port-number"`
+	PrometheusPort     uint16   `env:"PROMETHEUS_PORT,       parser=port-number, default=0"`
+	MutatorWebhookPort uint16   `env:"MUTATOR_WEBHOOK_PORT,  parser=port-number, default=0"`
+	SystemAHost        string   `env:"SYSTEMA_HOST,          parser=string,      default="`
+	SystemAPort        uint16   `env:"SYSTEMA_PORT,          parser=port-number, default=0"`
+	ManagerNamespace   string   `env:"MANAGER_NAMESPACE,     parser=string,      default="`
+	ManagedNamespaces  []string `env:"MANAGED_NAMESPACES,    parser=split-trim,  default="`
+	APIPort            uint16   `env:"AGENT_REST_API_PORT,   parser=port-number, default=0"`
 
 	TracingGrpcPort uint16            `env:"TRACING_GRPC_PORT,     parser=port-number,default=0"`
 	MaxReceiveSize  resource.Quantity `env:"GRPC_MAX_RECEIVE_SIZE, parser=quantity"`

--- a/integration_test/testdata/legacyManifests/manifests.yml
+++ b/integration_test/testdata/legacyManifests/manifests.yml
@@ -179,7 +179,7 @@ spec:
         - containerPort: 8081
           name: api
           protocol: TCP
-        - containerPort: 8443
+        - containerPort: 443
           name: https
           protocol: TCP
         resources: {}

--- a/pkg/install/constants.go
+++ b/pkg/install/constants.go
@@ -10,7 +10,6 @@ const (
 	ServiceNameAnnotation     = DomainPrefix + "inject-service-name"
 	ManualInjectAnnotation    = DomainPrefix + "manually-injected"
 	ManagerAppName            = "traffic-manager"
-	MutatorWebhookPortHTTPS   = 8443
 	MutatorWebhookTLSName     = "mutator-webhook-tls"
 	TelAppMountPoint          = "/tel_app_mounts"
 )


### PR DESCRIPTION
## Description

Prior to this commit, the mutating webhook was listening to port `8443`. The port was selected so that it was above the privileged port range, and hence would cause no conflicts when running the container as an unprivileged user. This caused problems with firewalls that enable port `443` but blocks `8443` by default.

The remedy for this problem was to add:

    RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/traffic

to the Dockerfile that builds the tel2 image. This enables the binary to listen to privileged ports without being root.

This commit also fixes a bug in the Helm chart, causing the existing `agentInjector.webhook.port` to be completely ignored. The default setting for that value was incidentally already `443`, and now that value is propagated correctly.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
