### PR TITLE
Allow connecting to traffic managers not installed via helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 - Change: The default port for the mutating webhook is now `443`. It used to be `8443`.
 
+- Bugfix: `telepresence connect` now works as long as the traffic manager is installed, even if
+  it wasn't installed via `helm install`
+
 ### 2.8.2 (October 15, 2022)
 
 - Feature: The Telepresence DNS resolver is now capable of resolving queries of type `A`, `AAAA`, `CNAME`,

--- a/pkg/install/helm/install.go
+++ b/pkg/install/helm/install.go
@@ -145,7 +145,7 @@ func uninstallExisting(ctx context.Context, helmConfig *action.Configuration, na
 	})
 }
 
-func IsTrafficManager(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace string) (*release.Release, *action.Configuration, error) {
+func isTrafficManager(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace string) (*release.Release, *action.Configuration, error) {
 	dlog.Debug(ctx, "getHelmConfig")
 	helmConfig, err := getHelmConfig(ctx, configFlags, namespace)
 	if err != nil {
@@ -191,7 +191,7 @@ func IsTrafficManager(ctx context.Context, configFlags *genericclioptions.Config
 
 // EnsureTrafficManager ensures the traffic manager is installed.
 func EnsureTrafficManager(ctx context.Context, configFlags *genericclioptions.ConfigFlags, namespace string, req *connector.HelmRequest) error {
-	existing, helmConfig, err := IsTrafficManager(ctx, configFlags, namespace)
+	existing, helmConfig, err := isTrafficManager(ctx, configFlags, namespace)
 	if err != nil {
 		return fmt.Errorf("err detecting traffic manager: %w", err)
 	}


### PR DESCRIPTION
There's lots of ways to set up a helm chart, and not all set up the helm metadata the same way the helm command does. With this change, as long as the traffic-manager service is present, all will be good.

Signed-off-by: Jose Cortes <josecortes@datawire.io>

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
