### PR TITLE
Fix crash in test-vpn when command initializtion fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Bugfix: `telepresence connect` now works as long as the traffic manager is installed, even if
   it wasn't installed via `helm install`
 
+- Bugfix. telepresence check-vpn no longer crashes when the daemons don't start properly.
+
 ### 2.8.2 (October 15, 2022)
 
 - Feature: The Telepresence DNS resolver is now capable of resolving queries of type `A`, `AAAA`, `CNAME`,

--- a/pkg/client/cli/cmd_diag_vpn.go
+++ b/pkg/client/cli/cmd_diag_vpn.go
@@ -150,7 +150,9 @@ func (di *vpnDiagInfo) run(cmd *cobra.Command, _ []string) (err error) {
 		return fmt.Errorf("failed to get routing table: %w", err)
 	}
 	subnets := map[string][]*net.IPNet{podType: {}, svcType: {}}
-	err = cliutil.InitCommand(cmd)
+	if err = cliutil.InitCommand(cmd); err != nil {
+		return err
+	}
 	ctx = cmd.Context()
 
 	// If this times out, it's likely to be because the traffic manager never gave us the subnets;


### PR DESCRIPTION
## Description

The test-vpn command would ignore an unsuccessful return from the command initialization and continue processing, assuming that the user daemon would be there. It wasn't, and that caused the command to crash. This commit fixes this by propagating the original error to the user.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
