### PR TITLE
Never use an agent-image default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 - Change: The default port for the mutating webhook is now `443`. It used to be `8443`.
 
+- Change: The traffic-manager will no longer default to use the `tel2` image for the traffic-agent when it is
+  unable to connect to Ambassador Cloud. Air-gapped environments must declare what image to use in the Helm chart.
+
 - Bugfix: `telepresence connect` now works as long as the traffic manager is installed, even if
   it wasn't installed via `helm install`
 

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -113,6 +113,11 @@ func (a *agentInjector) inject(ctx context.Context, req *admission.AdmissionRequ
 		}
 		fallthrough
 	case "enabled":
+		img := managerutil.GetAgentImage(ctx)
+		if img == "" {
+			dlog.Debug(ctx, "Skipping webhook injection because the traffic-manager is unable to determine what image to use for injected traffic-agents.")
+			return nil, nil
+		}
 		config, err = a.findConfigMapValue(ctx, pod, nil)
 		if err != nil {
 			if isDelete {
@@ -149,7 +154,7 @@ func (a *agentInjector) inject(ctx context.Context, req *admission.AdmissionRequ
 			return nil, nil
 		}
 		var gc *agentmap.GeneratorConfig
-		if gc, err = env.GeneratorConfig(managerutil.GetAgentImage(ctx)); err != nil {
+		if gc, err = env.GeneratorConfig(img); err != nil {
 			return nil, err
 		}
 		if config, err = agentmap.Generate(ctx, wl, gc); err != nil {

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -1653,7 +1653,8 @@ func TestTrafficAgentInjector(t *testing.T) {
 			ctx := dlog.NewTestContext(t, false)
 			ctx = managerutil.WithEnv(ctx, env)
 			ctx = k8sapi.WithK8sInterface(ctx, clientset)
-			ctx = managerutil.WithAgentImageRetriever(ctx, nil)
+			ctx, err := managerutil.WithAgentImageRetriever(ctx, func(context.Context, string) error { return nil })
+			require.NoError(t, err)
 			if test.envAdditions != nil {
 				env := managerutil.GetEnv(ctx)
 				newEnv := *env

--- a/cmd/traffic/cmd/manager/internal/mutator/service.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/service.go
@@ -119,11 +119,6 @@ func ServeMutator(ctx context.Context) error {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-
-	// Existing telepresence-agent config maps must be regenerated. Conditions might have changed.
-	if err := RegenerateAgentMaps(ctx, managerutil.GetAgentImage(ctx)); err != nil {
-		return err
-	}
 	cw, err := Load(ctx)
 	if err != nil {
 		return err

--- a/cmd/traffic/cmd/manager/internal/state/intercept.go
+++ b/cmd/traffic/cmd/manager/internal/state/intercept.go
@@ -185,6 +185,10 @@ func (s *State) loadAgentConfig(
 	} else {
 		agentImage = managerutil.GetAgentImage(ctx)
 	}
+	if agentImage == "" {
+		return nil, errcat.User.Newf(
+			"intercepts are disabled because the traffic-manager is unable to determine what image to use for injected traffic-agents.")
+	}
 	span.SetAttributes(
 		attribute.String("tel2.agent-image", agentImage),
 	)

--- a/cmd/traffic/cmd/manager/managerutil/agentimage.go
+++ b/cmd/traffic/cmd/manager/managerutil/agentimage.go
@@ -27,25 +27,18 @@ func logAgentImageInfo(ctx context.Context, img string) {
 func (p *imagePoller) poll(ctx context.Context) {
 	r, err := AgentImageFromSystemA(ctx)
 	if err != nil {
-		dlog.Errorf(ctx, "unable to get Ambassador Cloud preferred agent image: %v", err)
+		dlog.Warnf(ctx, "unable to get Ambassador Cloud preferred agent image: %v", err)
+		return
 	}
 	diff := false
 	p.Lock()
-	if p.img == "" {
-		// First time. Default to environment if fetch from SystemA failed.
-		if r == "" {
-			r = GetEnv(ctx).QualifiedAgentImage()
-		}
-		logAgentImageInfo(ctx, r)
-		p.img = r
-	} else if r != "" && r != p.img {
-		// Subsequent times only updates if r is valid and if it differs from p.img
+	if p.img != r {
 		diff = true
-		logAgentImageInfo(ctx, r)
 		p.img = r
 	}
 	p.Unlock()
-	if diff && p.onChange != nil {
+	if diff {
+		logAgentImageInfo(ctx, r)
 		if err := p.onChange(ctx, r); err != nil {
 			dlog.Error(ctx, err)
 		}
@@ -53,18 +46,21 @@ func (p *imagePoller) poll(ctx context.Context) {
 }
 
 func (p *imagePoller) start(ctx context.Context) {
-	p.poll(ctx)
 	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				p.poll(ctx)
+		var timer *time.Timer
+		defer timer.Stop()
+		duration := func() time.Duration {
+			if p.img == "" {
+				// More aggressive poll until we have an image.
+				return 20 * time.Second
 			}
+			return 5 * time.Minute
 		}
+		timer = time.AfterFunc(duration(), func() {
+			p.poll(ctx)
+			timer.Reset(duration())
+		})
+		<-ctx.Done()
 	}()
 }
 
@@ -83,34 +79,67 @@ func (p imageFromEnv) getImage() string {
 
 type irKey struct{}
 
-func WithAgentImageRetriever(ctx context.Context, onChange func(context.Context, string) error) context.Context {
+// WithAgentImageRetriever returns a context that is configured with an agent image retriever which will
+// retrieve the agent image from the environment variable AGENT_IMAGE or from the Ambassador Cloud, if
+// that environment variable is empty. An error is returned if the environment variable is empty and
+// access to Ambassador Cloud has not been configured.
+//
+// The Ambassador Cloud retriever might return an empty string when used, due to inability to contact
+// Ambassador Cloud.
+func WithAgentImageRetriever(ctx context.Context, onChange func(context.Context, string) error) (context.Context, error) {
 	env := GetEnv(ctx)
 	var ir imageRetriever
+	var img string
 	if env.AgentImage == "" {
-		ip := new(imagePoller)
-		ip.onChange = onChange
+		var err error
+		img, err = AgentImageFromSystemA(ctx)
+		if err != nil {
+			if strings.Contains(err.Error(), "not configured") {
+				// No use polling when access isn't configured. This is normally prohibited by a Helm chart
+				// assertion that either systemA is configured or AGENT_IMAGE is set.
+				return ctx, err
+			}
+			dlog.Warnf(ctx, "unable to get Ambassador Cloud preferred agent image: %v", err)
+		}
+
+		// Set up an imagePoller to track changes in the preferred agent image
+		ip := &imagePoller{img: img, onChange: onChange}
 		ip.start(ctx)
 		ir = ip
 	} else {
-		ir = imageFromEnv(env.QualifiedAgentImage())
-		logAgentImageInfo(ctx, ir.getImage())
+		img = env.QualifiedAgentImage()
+		ir = imageFromEnv(img)
 	}
-	return context.WithValue(ctx, irKey{}, ir)
+	ctx = context.WithValue(ctx, irKey{}, ir)
+	if img != "" {
+		logAgentImageInfo(ctx, img)
+		if err := onChange(ctx, img); err != nil {
+			dlog.Error(ctx, err)
+		}
+	}
+	return ctx, nil
 }
 
-// GetAgentImage returns the fully qualified name of the traffic-agent image, i.e. "docker.io/tel2:2.7.4".
+// GetAgentImage returns the fully qualified name of the traffic-agent image, i.e. "docker.io/tel2:2.7.4",
+// or an empty string if no agent image has been configured.
 func GetAgentImage(ctx context.Context) string {
 	if ir, ok := ctx.Value(irKey{}).(imageRetriever); ok {
 		return ir.getImage()
 	}
+	// The code isn't doing what it's supposed to do during startup.
 	panic("no ImageRetriever has been configured")
 }
 
 // GetExtendedAgentImage returns the fully qualified name of the extended traffic-agent image, e.g.
 // "docker.io/datawire/ambassador-telepresence-agent:1.12.8", or error indicating that the image name
 // doesn't match.
+// An empty string will be returned when no image has been configured.
 func GetExtendedAgentImage(ctx context.Context) (string, error) {
 	img := GetAgentImage(ctx)
+	if img == "" {
+		// We treat the "no image" condition the same as GetAgentImage, i.e. it's OK to return an empty string
+		return "", nil
+	}
 	if si := strings.LastIndexByte(img, '/'); si > 0 && strings.HasPrefix(img[si:], "/ambassador-telepresence-agent:") {
 		return img, nil
 	}

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -18,7 +18,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
-	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 // Env is the traffic-manager's environment. It does not define any defaults because all
@@ -90,7 +89,7 @@ func (e *Env) GeneratorConfig(qualifiedAgentImage string) (*agentmap.GeneratorCo
 func (e *Env) QualifiedAgentImage() string {
 	img := e.AgentImage
 	if img == "" {
-		img = "tel2:" + strings.TrimPrefix(version.Version, "v")
+		return ""
 	}
 	return e.AgentRegistry + "/" + img
 }

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -2,9 +2,7 @@ package managerutil_test
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,7 +13,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
-	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 func TestEnvconfig(t *testing.T) {
@@ -100,12 +97,7 @@ func TestEnvconfig(t *testing.T) {
 			require.NoError(t, err)
 			actual := managerutil.GetEnv(ctx)
 			assert.Equal(t, &expected, actual)
-			assert.Equal(t,
-				fmt.Sprintf(
-					"%s/tel2:%s",
-					actual.AgentRegistry,
-					strings.TrimPrefix(version.Version, "v")),
-				actual.QualifiedAgentImage())
+			assert.Equal(t, "", actual.QualifiedAgentImage())
 		})
 	}
 }

--- a/cmd/traffic/cmd/manager/managerutil/systema.go
+++ b/cmd/traffic/cmd/manager/managerutil/systema.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/common"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/rpc/v2/systema"
@@ -62,14 +63,16 @@ func AgentImageFromSystemA(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		if err := systemaPool.Done(ctx); err != nil {
+			dlog.Errorf(ctx, "unexpected error when returning to systemA pool: %v", err)
+		}
+	}()
 	resp, err := systemaClient.PreferredAgent(ctx, &common.VersionInfo{
 		ApiVersion: client.APIVersion,
 		Version:    client.Version(),
 	})
 	if err != nil {
-		return "", err
-	}
-	if err = systemaPool.Done(ctx); err != nil {
 		return "", err
 	}
 	return resp.GetImageName(), nil

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -128,11 +128,9 @@ func (is *installSuite) Test_EnsureManager_toleratesFailedInstall() {
 	defer restoreVersion()
 	defer is.UninstallTrafficManager(ctx, is.ManagerNamespace())
 
-	ctx = itest.WithConfig(ctx, &client.Config{
-		Timeouts: client.Timeouts{
-			PrivateHelm: 30 * time.Second,
-		},
-	})
+	cfg := client.GetDefaultConfig()
+	cfg.Timeouts.PrivateHelm = 30 * time.Second
+	ctx = itest.WithConfig(ctx, &cfg)
 	ctx, kc := is.cluster(ctx, "default", is.ManagerNamespace())
 	require.Error(ensureTrafficManager(ctx, kc))
 	restoreVersion()

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -689,10 +689,10 @@ func (c Cloud) MarshalYAML() (any, error) {
 	if c.SkipLogin {
 		cm["skipLogin"] = true
 	}
-	if c.SystemaHost != "" && c.SystemaHost != defaultCloudSystemAHost {
+	if c.SystemaHost != defaultCloudSystemAHost {
 		cm["systemaHost"] = c.SystemaHost
 	}
-	if c.SystemaPort != "" && c.SystemaPort != defaultCloudSystemAPort {
+	if c.SystemaPort != defaultCloudSystemAPort {
 		cm["systemaPort"] = c.SystemaPort
 	}
 	return cm, nil
@@ -817,7 +817,7 @@ func (ic Intercept) IsZero() bool {
 // MarshalYAML is not using pointer receiver here, because Intercept is not pointer in the Config struct.
 func (ic Intercept) MarshalYAML() (any, error) {
 	im := make(map[string]any)
-	if ic.DefaultPort != 0 && ic.DefaultPort != defaultInterceptDefaultPort {
+	if ic.DefaultPort != defaultInterceptDefaultPort {
 		im["defaultPort"] = ic.DefaultPort
 	}
 	if ic.AppProtocolStrategy != k8sapi.Http2Probe {


### PR DESCRIPTION
## Description

This PR ensures that the traffic-manager can determine what image
to use for the traffic-agent, so that it never uses a default. The
image is either picked from the `AGENT_IMAGE` environment variable,
or if that is unset, retrieved from Ambassador Cloud.

If the Ambassador Cloud retrieval fails although access is configured,
it will be retried indefinitely, and injections and intercepts will be
disabled until the retrieval succeeds.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
