### PR TITLE
Handle missing cloud config.

### DIFF
--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -152,6 +152,9 @@ func (m *Manager) CanConnectAmbassadorCloud(ctx context.Context, _ *empty.Empty)
 // GetCloudConfig returns the SystemA Host and Port to the caller (currently just used by
 // the agents).
 func (m *Manager) GetCloudConfig(ctx context.Context, _ *empty.Empty) (*rpc.AmbassadorCloudConfig, error) {
+	if m.cloudConfig == nil {
+		return nil, status.Error(codes.Unavailable, "access to Ambassador Cloud is not configured")
+	}
 	return proto.Clone(m.cloudConfig).(*rpc.AmbassadorCloudConfig), nil
 }
 


### PR DESCRIPTION
## Description

If access to Ambassador Cloud was disabled, the traffic-manager would return an "error while marshaling: proto: Marshal called with nil" error from the gRPC method `GetCloudConfig`, which in turn terminated services in the enhanced user daemon.

This commit ensures that the proper gRPC error code `Unavailable` is returned with a descriptive message.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
