### PR TITLE
Fix panic when root daemon session creation times out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
 - Bugfix: `telepresence connect` now works as long as the traffic manager is installed, even if
   it wasn't installed via `helm install`
 
-- Bugfix. telepresence check-vpn no longer crashes when the daemons don't start properly.
+- Bugfix: Telepresence check-vpn no longer crashes when the daemons don't start properly.
+
+- Bugfix: The root daemon no longer crashes when the session boot times out before the cluster connection succeeds.
 
 ### 2.8.2 (October 15, 2022)
 

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -627,7 +627,6 @@ func (s *session) run(c context.Context) error {
 	case <-wc.Done():
 		// Time out when waiting for the cluster info to arrive
 		s.vifReady <- wc.Err()
-		close(s.vifReady)
 		s.dnsServer.Stop()
 		return wc.Err()
 	case <-s.vifReady:


### PR DESCRIPTION
## Description

Removes a redundant close of the `vifReady` channel. The close is unnecessary and will sometimes cause a panic in `onFirstClusterInfo`, because at the point where it happened, the cluster info watcher has already been started, and `onFirstClusterInfo` will close the channel when it receives the first cluster info. If that never happens, the whole thing will time out and the session as a whole is cancelled.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
