### PR TITLE
Include traffic-manager version in version command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.8.4 (TBD)
+
+- Feature: The traffic-manager version is now included in the output from the `telepresence version` command.
+
 ### 2.8.3 (October 27, 2022)
 
 - Feature: The traffic-manager can be configured to disable global (non-http) intercepts using the

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -25,11 +25,12 @@ func (s *connectedSuite) Test_ListExcludesTM() {
 	s.NotContains(stdout, "traffic-manager")
 }
 
-func (s *connectedSuite) Test_ReportsVersionFromDaemon() {
+func (s *connectedSuite) Test_ReportsAllVersions() {
 	stdout := itest.TelepresenceOk(s.Context(), "version")
 	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
 	s.Contains(stdout, fmt.Sprintf("Root Daemon: %s", s.TelepresenceVersion()))
 	s.Contains(stdout, fmt.Sprintf("User Daemon: %s", s.TelepresenceVersion()))
+	s.Contains(stdout, fmt.Sprintf("Traffic Manager: %s", s.TelepresenceVersion()))
 }
 
 func (s *connectedSuite) Test_Status() {

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -33,6 +33,17 @@ func (s *connectedSuite) Test_ReportsAllVersions() {
 	s.Contains(stdout, fmt.Sprintf("Traffic Manager: %s", s.TelepresenceVersion()))
 }
 
+func (s *connectedSuite) Test_ReportsNotConnected() {
+	ctx := s.Context()
+	itest.TelepresenceDisconnectOk(ctx)
+	defer itest.TelepresenceOk(itest.WithUser(ctx, "default"), "connect")
+	stdout := itest.TelepresenceOk(ctx, "version")
+	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
+	s.Contains(stdout, fmt.Sprintf("Root Daemon: %s", s.TelepresenceVersion()))
+	s.Contains(stdout, fmt.Sprintf("User Daemon: %s", s.TelepresenceVersion()))
+	s.Contains(stdout, fmt.Sprintf("Traffic Manager: not connected"))
+}
+
 func (s *connectedSuite) Test_Status() {
 	stdout := itest.TelepresenceOk(s.Context(), "status")
 	s.Contains(stdout, "Root Daemon: Running")

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -41,7 +41,7 @@ func (s *connectedSuite) Test_ReportsNotConnected() {
 	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
 	s.Contains(stdout, fmt.Sprintf("Root Daemon: %s", s.TelepresenceVersion()))
 	s.Contains(stdout, fmt.Sprintf("User Daemon: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("Traffic Manager: not connected"))
+	s.Contains(stdout, "Traffic Manager: not connected")
 }
 
 func (s *connectedSuite) Test_Status() {

--- a/pkg/client/cli/cmd_version.go
+++ b/pkg/client/cli/cmd_version.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/common"
@@ -44,7 +46,7 @@ func printVersion(cmd *cobra.Command, _ []string) error {
 	case err == nil:
 		fmt.Fprintf(cmd.OutOrStdout(), "Root Daemon: %s (api v%d)\n", version.Version, version.ApiVersion)
 	case err == cliutil.ErrNoRootDaemon:
-		fmt.Fprintf(cmd.OutOrStdout(), "Root Daemon: not running\n")
+		fmt.Fprintln(cmd.OutOrStdout(), "Root Daemon: not running")
 	default:
 		fmt.Fprintf(cmd.OutOrStdout(), "Root Daemon: error: %v\n", err)
 	}
@@ -58,11 +60,13 @@ func printVersion(cmd *cobra.Command, _ []string) error {
 		switch {
 		case err == nil:
 			fmt.Fprintf(cmd.OutOrStdout(), "Traffic Manager: %s\n", mgrVer.Version)
+		case status.Code(err) == codes.Unavailable:
+			fmt.Fprintln(cmd.OutOrStdout(), "Traffic Manager: not connected")
 		default:
 			fmt.Fprintf(cmd.OutOrStdout(), "Traffic Manager: error: %v\n", err)
 		}
 	case err == cliutil.ErrNoUserDaemon:
-		fmt.Fprintf(cmd.OutOrStdout(), "User Daemon: not running\n")
+		fmt.Fprintln(cmd.OutOrStdout(), "User Daemon: not running")
 	default:
 		fmt.Fprintf(cmd.OutOrStdout(), "User Daemon: error: %v\n", err)
 	}

--- a/pkg/client/userd/service.go
+++ b/pkg/client/userd/service.go
@@ -182,6 +182,7 @@ nextSession:
 		wg.Add(1)
 		go func(cr *rpc.ConnectRequest) {
 			defer wg.Done()
+			defer s.SetManagerClient(nil)
 			if err := s.session.Run(s.sessionContext); err != nil {
 				if errors.Is(err, trafficmgr.ErrSessionExpired) {
 					// Session has expired. We need to cancel the owner session and reconnect


### PR DESCRIPTION
## Description

Include the version of the traffic-manager in the output from `telepresence version` when connected.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
