### PR TITLE
Workflow for testing server/client compatibility.

### DIFF
--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -40,6 +40,8 @@ jobs:
           ./telepresence-server version
 
           ./telepresence-server helm install
+          # Quit the user and root daemons since they get started by the installation.
+          ./telepresence-server quit
           ./telepresence-client connect
           ./telepresence-client status
           ./telepresence-client list

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -86,9 +86,8 @@ jobs:
           ./telepresence-server helm install
 
           # Quit the user and root daemons since they get started by the installation. Use multiple
-          # different ways since the arguments have changed.
-          ./telepresence-server quit -u || true
-          ./telepresence-server quit -r || true
+          # different ways and ignore failure since the arguments have changed.
+          ./telepresence-server quit -ur || true
           ./telepresence-server quit -s || true
 
           ./telepresence-client connect

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -1,0 +1,46 @@
+# This github workflow tests client and server compatibility for telepresence using nightly builds.
+#
+# See the "matrix" field below for which versions are tested.
+
+name: "Telepresence Test Matrix"
+on:
+  # Run daily at 9am UTC.
+  schedule:
+    - cron: '0 9 * * *'
+  # Run whenever this file is modified.
+  push:
+    paths:
+      - '.github/workflows/compatibility.yaml'
+
+jobs:
+  telepresence_matrix:
+    strategy:
+      matrix:
+        client_version: ["nightly"]
+        server_version:  ["nightly", "2.8.3", "2.7.6", "2.6.8"]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${{ matrix.client_version}}/telepresence -o telepresence-client
+          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${{ matrix.server_version }}/telepresence -o telepresence-server
+          chmod a+x telepresence-client
+          chmod a+x telepresence-server
+
+      # Provision cluster as late as possible so we don't waste resources if any prior steps fail.
+      - uses: datawire/infra-actions/provision-cluster@v0.2.0
+        with:
+          distribution: Kubeception
+          version: 1.23
+          kubeconfig: kubeconfig.yaml
+          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
+          gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - run: |
+          ./telepresence-client version
+          ./telepresence-server version
+
+          ./telepresence-server helm install
+          ./telepresence-client connect
+          ./telepresence-client status
+          ./telepresence-client list
+          curl -v -k https://kubernetes.default.svc.cluster.local

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         client_version: ["nightly"]
-        server_version:  ["nightly", "2.8.3", "2.7.6", "2.6.8"]
+        server_version:  ["nightly", "2.8.3", "2.7.6"]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -41,8 +41,13 @@ jobs:
           ./telepresence-server version
 
           ./telepresence-server helm install
-          # Quit the user and root daemons since they get started by the installation.
-          ./telepresence-server quit
+
+          # Quit the user and root daemons since they get started by the installation. Use multiple
+          # different ways since the arguments have changed.
+          ./telepresence-server quit -u || true
+          ./telepresence-server quit -r || true
+          ./telepresence-server quit -s || true
+
           ./telepresence-client connect
           ./telepresence-client status
           ./telepresence-client list

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   telepresence_matrix:
     strategy:
+      fail-fast: false
       matrix:
         client_version: ["nightly"]
         server_version:  ["nightly", "2.8.3", "2.7.6", "2.6.8"]

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -32,7 +32,7 @@ jobs:
           distribution: Kubeception
           version: 1.23
           kubeconfig: kubeconfig.yaml
-          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
+          kubeceptionToken: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - run: |

--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -17,13 +17,56 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Client and server versions can specify an exact released value like "2.8.3", they can
+        # specify "nightly" to reference nightly builds, and they can specify "-<N>" to reference
+        # the most recent Z release in the N'th most recent minor series of release. So for example
+        # "-1" will always refer to the most recent release, "-2" will always refer to latest Z
+        # release of the minor release prior to the current, "-3" will always refer to the latest Z
+        # release of the minor release *two* releases prior to the current, etc.
+
         client_version: ["nightly"]
-        server_version:  ["nightly", "2.8.3", "2.7.6"]
+        server_version:  ["nightly", "-1", "-2"]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: |
-          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${{ matrix.client_version}}/telepresence -o telepresence-client
-          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${{ matrix.server_version }}/telepresence -o telepresence-server
+          cat << 'EOF' >> get-version
+          # This is the version as specified. A negative number N indicates N minor versions ago, so
+          # -1 is the most recently released minor version, -2 is the one before that, and -3 is the
+          # one before that.
+          VSPEC="${1}"
+
+          # List every version based on tags, most recently listed first.
+          list-versions() {
+            git tag -l 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -u -r -V
+          }
+
+          # List versions with just major.minor, no z version.
+          list-versions-no-z() {
+            list-versions | cut -d. -f 1,2 | sort -u -r -V
+          }
+
+          if [[ "$1" = -* ]]; then
+            # This is a relative version, so strip off the first character to get the index value.
+            IDX="${VSPEC:1}"
+            # Print just then IDX'th line of the sorted no-z versions to find the desired minor version.
+            DESIRED_MINOR=$(list-versions-no-z | sed "${IDX}q;d")
+            # The grep filters the ordered list of all versions down to just the set of desired
+            # minor versions, and the sed picks the most recent from that set of minor versions.
+            DESIRED_EXACT=$(list-versions | grep -F "${DESIRED_MINOR}" | sed '1q;d')
+            # Strip off the "v" that is the first character in the tag.
+            printf  "${DESIRED_EXACT:1}\n"
+          else
+            printf "${VSPEC}\n"
+          fi
+          EOF
+          echo SERVER_VERSION=$(bash ./get-version ${{ matrix.server_version }}) >> ${GITHUB_ENV}
+          echo CLIENT_VERSION=$(bash ./get-version ${{ matrix.client_version }}) >> ${GITHUB_ENV}
+      - run: |
+          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${CLIENT_VERSION}/telepresence -o telepresence-client
+          curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${SERVER_VERSION}/telepresence -o telepresence-server
           chmod a+x telepresence-client
           chmod a+x telepresence-server
 


### PR DESCRIPTION
## Description

This PR includes a workflow for testing nightly builds against older client/server versions. The matrix of versions can reference nightly builds (e.g. "nightly"), absolution versions (e.g. "2.4.1"), and relative versions (e.g. "-1" is the current release, "-2" is the most recent Z release of one minor version prior to the current release).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
