### PR TITLE
add shared login

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -34,6 +34,7 @@ following Free and Open Source software:
     github.com/datawire/envconfig                                                v0.0.0-20221012222025-09524dc7d59b        Apache License 2.0
     github.com/datawire/go-ftpserver                                             v0.1.1                                    Apache License 2.0
     github.com/datawire/go-fuseftp/rpc                                           v0.2.0                                    Apache License 2.0
+    github.com/datawire/k8sapi                                                   v0.1.1-0.20221102000402-bab67787b913      Apache License 2.0
     github.com/datawire/metriton-go-client                                       v0.1.1                                    Apache License 2.0
     github.com/davecgh/go-spew                                                   v1.1.1                                    ISC license
     github.com/docker/cli                                                        v20.10.18+incompatible                    Apache License 2.0
@@ -136,13 +137,13 @@ following Free and Open Source software:
     github.com/xlab/treeprint                                                    v1.1.0                                    MIT license
     go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc  v0.36.0                                   Apache License 2.0
     go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp                v0.36.0                                   Apache License 2.0
-    go.opentelemetry.io/otel                                                     v1.10.0                                   Apache License 2.0
+    go.opentelemetry.io/otel                                                     v1.11.1                                   Apache License 2.0
     go.opentelemetry.io/otel/exporters/otlp/internal/retry                       v1.10.0                                   Apache License 2.0
     go.opentelemetry.io/otel/exporters/otlp/otlptrace                            v1.10.0                                   Apache License 2.0
     go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc              v1.10.0                                   Apache License 2.0
     go.opentelemetry.io/otel/metric                                              v0.32.1                                   Apache License 2.0
     go.opentelemetry.io/otel/sdk                                                 v1.10.0                                   Apache License 2.0
-    go.opentelemetry.io/otel/trace                                               v1.10.0                                   Apache License 2.0
+    go.opentelemetry.io/otel/trace                                               v1.11.1                                   Apache License 2.0
     go.opentelemetry.io/proto/otlp                                               v0.19.0                                   Apache License 2.0
     go.starlark.net                                                              v0.0.0-20220817180228-f738f5508c12        3-clause BSD license
     golang.org/x/crypto                                                          v0.0.0-20220924013350-4ba4fb4dd9e7        3-clause BSD license

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -34,7 +34,7 @@ following Free and Open Source software:
     github.com/datawire/envconfig                                                v0.0.0-20221012222025-09524dc7d59b        Apache License 2.0
     github.com/datawire/go-ftpserver                                             v0.1.1                                    Apache License 2.0
     github.com/datawire/go-fuseftp/rpc                                           v0.2.0                                    Apache License 2.0
-    github.com/datawire/k8sapi                                                   v0.1.1-0.20221102000402-bab67787b913      Apache License 2.0
+    github.com/datawire/k8sapi                                                   v0.1.1-0.20221102212418-ff24519a45be      Apache License 2.0
     github.com/datawire/metriton-go-client                                       v0.1.1                                    Apache License 2.0
     github.com/davecgh/go-spew                                                   v1.1.1                                    ISC license
     github.com/docker/cli                                                        v20.10.18+incompatible                    Apache License 2.0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -34,7 +34,7 @@ following Free and Open Source software:
     github.com/datawire/envconfig                                                v0.0.0-20221012222025-09524dc7d59b        Apache License 2.0
     github.com/datawire/go-ftpserver                                             v0.1.1                                    Apache License 2.0
     github.com/datawire/go-fuseftp/rpc                                           v0.2.0                                    Apache License 2.0
-    github.com/datawire/k8sapi                                                   v0.1.1-0.20221102212418-ff24519a45be      Apache License 2.0
+    github.com/datawire/k8sapi                                                   v0.1.1                                    Apache License 2.0
     github.com/datawire/metriton-go-client                                       v0.1.1                                    Apache License 2.0
     github.com/davecgh/go-spew                                                   v1.1.1                                    ISC license
     github.com/docker/cli                                                        v20.10.18+incompatible                    Apache License 2.0

--- a/charts/telepresence/templates/trafficManagerRbac/cloud-token.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cloud-token.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ include "traffic-manager.namespace" . }}
+  name: traffic-manager-cloud-token
+  labels: {{- include "telepresence.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: traffic-manager-cloud-token
+  namespace: {{ include "traffic-manager.namespace" . }}
+  labels: {{- include "telepresence.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: traffic-manager-cloud-token
+subjects:
+  - kind: ServiceAccount
+    name: traffic-manager
+    namespace: {{ include "traffic-manager.namespace" . }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: traffic-manager-agent-cloud-token
+  namespace: {{ include "traffic-manager.namespace" . }}
+  labels: {{- include "telepresence.labels" . | nindent 4 }}

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
@@ -3,72 +3,47 @@ package cloudtoken
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 )
 
 type Service interface {
 	MaybeAddToken(ctx context.Context, apikey string) error
 }
 
-type createConfigmapIfNotPresent struct {
-	createToken func(ctx context.Context, apikey string) error
-	done        <-chan struct{}
+type patchConfigmapIfNotPresent struct {
+	patchConfigmap func(ctx context.Context, apikey string) error
+	done           <-chan struct{}
 }
 
-var (
-	suffix               = "agent-cloud-token"
-	cloudConnectTokenKey = "CLOUD_CONNECT_TOKEN"
+const (
+	CLOUD_TOKEN_NAME_SUFFIX = "agent-cloud-token"
+	CLOUD_TOKEN_KEY         = "CLOUD_CONNECT_TOKEN"
 )
 
-// NewCreateConfigmapIfNotPresent will start up watchers to watch for a configmap or secret
+// NewPatchConfigmapIfNotPresent will start up watchers to watch for a configmap or secret
 // with the apikey. If one is found, the watchers shut down. If MaybeAddToken is called
 // and successfully creates a configmap, the watchers are shut down.
-func NewCreateConfigmapIfNotPresent(ctx context.Context) *createConfigmapIfNotPresent {
+func NewPatchConfigmapIfNotPresent(ctx context.Context) *patchConfigmapIfNotPresent {
 	managerns := managerutil.GetEnv(ctx).ManagerNamespace
 	clientset := k8sapi.GetK8sInterface(ctx)
 	watchers := newTokenWatchers(clientset, managerns)
 
-	// ctx for watchers, cancelled if token is found
+	// ctx for watchers, cancelled if token is found or watcher err
+	// cancelling this ctx also stops MaybeAddToken from adding token
 	cancelCtx, cancel := context.WithCancel(ctx)
 
+	// watch for secrets and configmaps, cancel if an apikey is found
 	go func() {
-		// search checks if apikey token exists, if it does, shut down the watchers
-		search := func() {
-			configmaps, err := watchers.mapsWatcher.List(cancelCtx)
-			if err != nil {
-				dlog.Errorf(ctx, "error watching cloud token configmaps: %s", err.Error())
-				cancel()
-			}
-			for _, cm := range configmaps {
-				_, ok := cm.Data[cloudConnectTokenKey]
-				if strings.HasSuffix(cm.Name, suffix) && ok {
-					dlog.Infof(ctx, "configmap %s found, stopping cloud token watchers", cm.Name)
-					cancel()
-				}
-			}
-			secrets, err := watchers.secretsWatcher.List(cancelCtx)
-			if err != nil {
-				dlog.Errorf(ctx, "error watching cloud token secrets: %s", err.Error())
-				cancel()
-			}
-			for _, s := range secrets {
-				_, ok := s.Data[cloudConnectTokenKey]
-				if strings.HasSuffix(s.Name, suffix) && ok {
-					dlog.Infof(ctx, "secret %s found, stopping cloud token watchers", s.Name)
-					cancel()
-				}
-			}
-		}
-
 		// startup and search
 		dlog.Info(ctx, "starting cloud token watchers")
-		search()
+		watchers.searchMaps(cancelCtx, cancel)
+		watchers.searchSecrets(cancelCtx, cancel)
 
 		// context for subscribe. This has to be different than the watcher context
 		// because cancelling the subscribe ctx will close the channel, and a case
@@ -79,8 +54,10 @@ func NewCreateConfigmapIfNotPresent(ctx context.Context) *createConfigmapIfNotPr
 		// search on broadcast
 		for {
 			select {
-			case <-watchers.subscribe(subCtx):
-				search()
+			case <-watchers.mapsWatcher.Subscribe(subCtx):
+				watchers.searchMaps(cancelCtx, cancel)
+			case <-watchers.secretsWatcher.Subscribe(subCtx):
+				watchers.searchSecrets(cancelCtx, cancel)
 			case <-cancelCtx.Done():
 				subCancel()
 				return
@@ -88,34 +65,38 @@ func NewCreateConfigmapIfNotPresent(ctx context.Context) *createConfigmapIfNotPr
 		}
 	}()
 
-	return &createConfigmapIfNotPresent{
-		createToken: func(ctx context.Context, apikey string) error {
-			dlog.Info(ctx, "patching cloud token configmap with apikey")
-			_, err := clientset.CoreV1().ConfigMaps(managerns).Patch(
-				ctx,
-				"traffic-manager-"+suffix,
-				types.StrategicMergePatchType,
-				[]byte(fmt.Sprintf(`{"data":{"%s":"%s"}}`, cloudConnectTokenKey, apikey)),
-				apiv1.PatchOptions{},
-			)
-			if err == nil {
-				dlog.Info(ctx, "cloud token configmap successfully patched")
-			}
-			return err
-		},
-		done: cancelCtx.Done(),
+	return &patchConfigmapIfNotPresent{
+		patchConfigmap: buildConfigmapPatcher(clientset, managerns),
+		done:           cancelCtx.Done(),
 	}
 }
 
 // MaybeAddToken will add a token if one does not already exist
-func (c *createConfigmapIfNotPresent) MaybeAddToken(ctx context.Context, apikey string) error {
+func (c *patchConfigmapIfNotPresent) MaybeAddToken(ctx context.Context, apikey string) error {
 	select {
 	case <-c.done: // apikey is already present or watcher err, do nothing
 		return nil
 	default: // create token
 		// we could cancel the watchers here, and have a mutex guard this func,
-		// which would prevent multiple calls to MaybeAddToken and therefore c.createToken,
-		// but im pretty sure it would just race and the loser gets logged as err :shrug:
-		return c.createToken(ctx, apikey)
+		// which would prevent multiple simultaneous calls to MaybeAddToken and therefore c.patchToken,
+		// but im pretty sure they would just race and the slower one wins, which is fine
+		return c.patchConfigmap(ctx, apikey)
+	}
+}
+
+func buildConfigmapPatcher(clientset kubernetes.Interface, managerns string) func(ctx context.Context, apikey string) error {
+	return func(ctx context.Context, apikey string) error {
+		dlog.Info(ctx, "patching cloud token configmap with apikey")
+		_, err := clientset.CoreV1().ConfigMaps(managerns).Patch(
+			ctx,
+			"traffic-manager-"+CLOUD_TOKEN_NAME_SUFFIX,
+			types.StrategicMergePatchType,
+			[]byte(fmt.Sprintf(`{"data":{"%s":"%s"}}`, CLOUD_TOKEN_KEY, apikey)),
+			apiv1.PatchOptions{},
+		)
+		if err == nil {
+			dlog.Info(ctx, "cloud token configmap successfully patched")
+		}
+		return err
 	}
 }

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -71,14 +72,14 @@ func NewPatchConfigmapIfNotPresent(ctx context.Context) *patchConfigmapIfNotPres
 	}
 }
 
-// MaybeAddToken will add a token if one does not already exist
+// MaybeAddToken will add a token if one does not already exist.
 func (c *patchConfigmapIfNotPresent) MaybeAddToken(ctx context.Context, apikey string) error {
 	select {
 	case <-c.done: // apikey is already present or watcher err, do nothing
 		return nil
-	default: // create token
+	default: // patch configmap with token
 		// we could cancel the watchers here, and have a mutex guard this func,
-		// which would prevent multiple simultaneous calls to MaybeAddToken and therefore c.patchToken,
+		// which would prevent multiple simultaneous calls to MaybeAddToken and therefore c.patchConfigmap,
 		// but im pretty sure they would just race and the slower one wins, which is fine
 		return c.patchConfigmap(ctx, apikey)
 	}

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
@@ -1,0 +1,121 @@
+package cloudtoken
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type Service interface {
+	MaybeAddToken(ctx context.Context, apikey string) error
+}
+
+type createConfigmapIfNotPresent struct {
+	createToken func(ctx context.Context, apikey string) error
+	done        <-chan struct{}
+}
+
+var (
+	suffix               = "agent-cloud-token"
+	cloudConnectTokenKey = "CLOUD_CONNECT_TOKEN"
+)
+
+// NewCreateConfigmapIfNotPresent will start up watchers to watch for a configmap or secret
+// with the apikey. If one is found, the watchers shut down. If MaybeAddToken is called
+// and successfully creates a configmap, the watchers are shut down.
+func NewCreateConfigmapIfNotPresent(ctx context.Context) *createConfigmapIfNotPresent {
+	managerns := managerutil.GetEnv(ctx).ManagerNamespace
+	clientset := k8sapi.GetK8sInterface(ctx)
+	watchers := newTokenWatchers(clientset, managerns)
+
+	// ctx for watchers, cancelled if token is found
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		// search checks if apikey token exists, if it does, shut down the watchers
+		search := func() {
+			configmaps, err := watchers.mapsWatcher.List(cancelCtx)
+			if err != nil {
+				dlog.Errorf(ctx, "error watching cloud token configmaps: %s", err.Error())
+				cancel()
+			}
+			for _, cm := range configmaps {
+				_, ok := cm.Data[cloudConnectTokenKey]
+				if strings.HasSuffix(cm.Name, suffix) && ok {
+					dlog.Infof(ctx, "configmap %s found, stopping cloud token watchers", cm.Name)
+					cancel()
+				}
+			}
+			secrets, err := watchers.secretsWatcher.List(cancelCtx)
+			if err != nil {
+				dlog.Errorf(ctx, "error watching cloud token secrets: %s", err.Error())
+				cancel()
+			}
+			for _, s := range secrets {
+				_, ok := s.Data[cloudConnectTokenKey]
+				if strings.HasSuffix(s.Name, suffix) && ok {
+					dlog.Infof(ctx, "secret %s found, stopping cloud token watchers", s.Name)
+					cancel()
+				}
+			}
+		}
+
+		// startup and search
+		dlog.Info(ctx, "starting cloud token watchers")
+		search()
+
+		// context for subscribe. This has to be different than the watcher context
+		// because cancelling the subscribe ctx will close the channel, and a case
+		// will activate on a closed channel. we dont want search triggered after
+		// watchers are shut down
+		subCtx, subCancel := context.WithCancel(ctx)
+
+		// search on broadcast
+		for {
+			select {
+			case <-watchers.subscribe(subCtx):
+				search()
+			case <-cancelCtx.Done():
+				subCancel()
+				return
+			}
+		}
+	}()
+
+	return &createConfigmapIfNotPresent{
+		createToken: func(ctx context.Context, apikey string) error {
+			dlog.Info(ctx, "patching cloud token configmap with apikey")
+			_, err := clientset.CoreV1().ConfigMaps(managerns).Patch(
+				ctx,
+				"traffic-manager-"+suffix,
+				types.StrategicMergePatchType,
+				[]byte(fmt.Sprintf(`{"data":{"%s":"%s"}}`, cloudConnectTokenKey, apikey)),
+				apiv1.PatchOptions{},
+			)
+			if err == nil {
+				dlog.Info(ctx, "cloud token configmap successfully patched")
+			}
+			return err
+		},
+		done: cancelCtx.Done(),
+	}
+}
+
+// MaybeAddToken will add a token if one does not already exist
+func (c *createConfigmapIfNotPresent) MaybeAddToken(ctx context.Context, apikey string) error {
+	select {
+	case <-c.done: // apikey is already present or watcher err, do nothing
+		return nil
+	default: // create token
+		// we could cancel the watchers here, and have a mutex guard this func,
+		// which would prevent multiple calls to MaybeAddToken and therefore c.createToken,
+		// but im pretty sure it would just race and the loser gets logged as err :shrug:
+		return c.createToken(ctx, apikey)
+	}
+}

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/service.go
@@ -47,7 +47,7 @@ func NewPatchConfigmapIfNotPresent(ctx context.Context) *patchConfigmapIfNotPres
 		watchers.searchMaps(cancelCtx, cancel)
 		watchers.searchSecrets(cancelCtx, cancel)
 
-		// context for subscribe. This must be seperated from the watcher ctx
+		// context for subscribe. This must be separated from the watcher ctx
 		// because cancelling the subscribe ctx will close the channel, and a case
 		// will activate on a closed channel. we dont want search triggered after
 		// watchers are shut down

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
@@ -2,15 +2,16 @@ package cloudtoken
 
 import (
 	"context"
+	"strings"
 	"sync"
 
+	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 type tokenWatchers struct {
-	cond           *sync.Cond
 	mapsWatcher    *k8sapi.Watcher[*corev1.ConfigMap]
 	secretsWatcher *k8sapi.Watcher[*corev1.Secret]
 }
@@ -18,29 +19,65 @@ type tokenWatchers struct {
 func newTokenWatchers(clientset kubernetes.Interface, watchedNs string) *tokenWatchers {
 	client := clientset.CoreV1().RESTClient()
 
-	cond := &sync.Cond{
-		L: &sync.Mutex{},
-	}
+	mapsWatcher := k8sapi.NewWatcher(
+		"configmaps",
+		client,
+		&sync.Cond{
+			L: &sync.Mutex{},
+		},
+		k8sapi.WithNamespace[*corev1.ConfigMap](watchedNs),
+		k8sapi.WithEquals(func(cm1, cm2 *corev1.ConfigMap) bool {
+			_, ok := cm2.Data[CLOUD_TOKEN_KEY]
+			return cm1.Name == cm2.Name && !ok
+		}),
+	)
+
+	secretsWatcher := k8sapi.NewWatcher(
+		"secrets",
+		client,
+		&sync.Cond{
+			L: &sync.Mutex{},
+		},
+		k8sapi.WithNamespace[*corev1.Secret](watchedNs),
+		k8sapi.WithEquals(func(s1, s2 *corev1.Secret) bool {
+			_, ok := s2.Data[CLOUD_TOKEN_KEY]
+			return s1.Name == s2.Name && !ok
+		}),
+	)
 
 	return &tokenWatchers{
-		mapsWatcher: k8sapi.NewWatcher("configmaps", client, cond,
-			k8sapi.WithNamespace[*corev1.ConfigMap](watchedNs),
-			k8sapi.WithEquals(func(cm1, cm2 *corev1.ConfigMap) bool {
-				_, ok := cm2.Data[cloudConnectTokenKey]
-				return cm1.Name == cm2.Name && !ok
-			}),
-		),
-		secretsWatcher: k8sapi.NewWatcher("secrets", client, cond,
-			k8sapi.WithNamespace[*corev1.Secret](watchedNs),
-			k8sapi.WithEquals(func(s1, s2 *corev1.Secret) bool {
-				_, ok := s2.Data[cloudConnectTokenKey]
-				return s1.Name == s2.Name && !ok
-			}),
-		),
-		cond: cond,
+		mapsWatcher:    mapsWatcher,
+		secretsWatcher: secretsWatcher,
 	}
 }
 
-func (w *tokenWatchers) subscribe(ctx context.Context) <-chan struct{} {
-	return k8sapi.Subscribe(ctx, w.cond)
+// search checks if apikey token exists, if it does, shut down the watchers
+func (w *tokenWatchers) searchMaps(ctx context.Context, cancel context.CancelFunc) {
+	configmaps, err := w.mapsWatcher.List(ctx)
+	if err != nil {
+		dlog.Errorf(ctx, "error watching cloud token configmaps: %s", err.Error())
+		cancel()
+	}
+	for _, cm := range configmaps {
+		_, ok := cm.Data[CLOUD_TOKEN_KEY]
+		if strings.HasSuffix(cm.Name, CLOUD_TOKEN_NAME_SUFFIX) && ok {
+			dlog.Infof(ctx, "configmap %s found, stopping cloud token watchers", cm.Name)
+			cancel()
+		}
+	}
+}
+
+func (w *tokenWatchers) searchSecrets(ctx context.Context, cancel context.CancelFunc) {
+	secrets, err := w.secretsWatcher.List(ctx)
+	if err != nil {
+		dlog.Errorf(ctx, "error watching cloud token secrets: %s", err.Error())
+		cancel()
+	}
+	for _, s := range secrets {
+		_, ok := s.Data[CLOUD_TOKEN_KEY]
+		if strings.HasSuffix(s.Name, CLOUD_TOKEN_NAME_SUFFIX) && ok {
+			dlog.Infof(ctx, "secret %s found, stopping cloud token watchers", s.Name)
+			cancel()
+		}
+	}
 }

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -51,7 +52,7 @@ func newTokenWatchers(clientset kubernetes.Interface, watchedNs string) *tokenWa
 	}
 }
 
-// search checks if apikey token exists, if it does, shut down the watchers
+// search checks if apikey token exists, if it does, shut down the watchers.
 func (w *tokenWatchers) searchMaps(ctx context.Context, cancel context.CancelFunc) {
 	configmaps, err := w.mapsWatcher.List(ctx)
 	if err != nil {

--- a/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
+++ b/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken/watcher.go
@@ -1,0 +1,46 @@
+package cloudtoken
+
+import (
+	"context"
+	"sync"
+
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type tokenWatchers struct {
+	cond           *sync.Cond
+	mapsWatcher    *k8sapi.Watcher[*corev1.ConfigMap]
+	secretsWatcher *k8sapi.Watcher[*corev1.Secret]
+}
+
+func newTokenWatchers(clientset kubernetes.Interface, watchedNs string) *tokenWatchers {
+	client := clientset.CoreV1().RESTClient()
+
+	cond := &sync.Cond{
+		L: &sync.Mutex{},
+	}
+
+	return &tokenWatchers{
+		mapsWatcher: k8sapi.NewWatcher("configmaps", client, cond,
+			k8sapi.WithNamespace[*corev1.ConfigMap](watchedNs),
+			k8sapi.WithEquals(func(cm1, cm2 *corev1.ConfigMap) bool {
+				_, ok := cm2.Data[cloudConnectTokenKey]
+				return cm1.Name == cm2.Name && !ok
+			}),
+		),
+		secretsWatcher: k8sapi.NewWatcher("secrets", client, cond,
+			k8sapi.WithNamespace[*corev1.Secret](watchedNs),
+			k8sapi.WithEquals(func(s1, s2 *corev1.Secret) bool {
+				_, ok := s2.Data[cloudConnectTokenKey]
+				return s1.Name == s2.Name && !ok
+			}),
+		),
+		cond: cond,
+	}
+}
+
+func (w *tokenWatchers) subscribe(ctx context.Context) <-chan struct{} {
+	return k8sapi.Subscribe(ctx, w.cond)
+}

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/license"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/subnet"
 )
 

--- a/cmd/traffic/cmd/manager/internal/cluster/info_test.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/license"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 func TestNewInfo_GetClusterID(t *testing.T) {

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -149,7 +149,7 @@ func (a *agentInjector) inject(ctx context.Context, req *admission.AdmissionRequ
 			}
 			return nil, err
 		}
-		k8sapi.RecordWorkloadInfo(span, wl)
+		RecordWorkloadInfo(span, wl)
 		if isDelete {
 			return nil, nil
 		}
@@ -557,7 +557,7 @@ func (a *agentInjector) findConfigMapValue(ctx context.Context, pod *core.Pod, w
 			if ok && (ag.WorkloadKind == "" || ag.WorkloadKind == or.Kind) {
 				return &ag, nil
 			}
-			wl, err = k8sapi.GetWorkload(ctx, or.Name, pod.GetNamespace(), or.Kind)
+			wl, err = GetWorkload(ctx, or.Name, pod.GetNamespace(), or.Kind)
 			if err != nil {
 				if k8sErrors.IsNotFound(err) {
 					return nil, nil

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector.go
@@ -21,11 +21,11 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 )
 

--- a/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/agent_injector_test.go
@@ -22,11 +22,11 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 const serviceAccountMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"

--- a/cmd/traffic/cmd/manager/internal/mutator/v25uninstall/uninstall.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/v25uninstall/uninstall.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 

--- a/cmd/traffic/cmd/manager/internal/mutator/v25uninstall/uninstall_actions.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/v25uninstall/uninstall_actions.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 // A partialAction is a single change that can be applied to an object.  A partialAction may not be

--- a/cmd/traffic/cmd/manager/internal/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/watcher.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/mutator/v25uninstall"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 type Map interface {

--- a/cmd/traffic/cmd/manager/internal/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/internal/mutator/watcher.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -28,6 +27,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
+	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 )
 
 type Map interface {

--- a/cmd/traffic/cmd/manager/internal/state/intercept.go
+++ b/cmd/traffic/cmd/manager/internal/state/intercept.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	managerrpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/mutator"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
@@ -68,7 +69,7 @@ func (s *State) PrepareIntercept(ctx context.Context, cr *managerrpc.CreateInter
 	}
 
 	spec := cr.InterceptSpec
-	wl, err := k8sapi.GetWorkload(ctx, spec.Agent, spec.Namespace, spec.WorkloadKind)
+	wl, err := mutator.GetWorkload(ctx, spec.Agent, spec.Namespace, spec.WorkloadKind)
 	if err != nil {
 		if errors2.IsNotFound(err) {
 			err = errcat.User.New(err)

--- a/cmd/traffic/cmd/manager/internal/state/intercept.go
+++ b/cmd/traffic/cmd/manager/internal/state/intercept.go
@@ -22,13 +22,13 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	managerrpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/install"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -22,10 +22,10 @@ import (
 	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/mutator"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/datawire/dlib/derror"
 	"github.com/datawire/envconfig"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 // Env is the traffic-manager's environment. It does not define any defaults because all

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
 
 func TestEnvconfig(t *testing.T) {

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/rpc/v2/systema"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/ambassadoragent/cloudtoken"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/cluster"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/internal/state"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/license"
@@ -41,12 +42,13 @@ type Clock interface {
 }
 
 type Manager struct {
-	ctx         context.Context
-	clock       Clock
-	ID          string
-	state       *state.State
-	clusterInfo cluster.Info
-	cloudConfig *rpc.AmbassadorCloudConfig
+	ctx          context.Context
+	clock        Clock
+	ID           string
+	state        *state.State
+	clusterInfo  cluster.Info
+	cloudConfig  *rpc.AmbassadorCloudConfig
+	tokenService cloudtoken.Service
 
 	rpc.UnsafeManagerServer
 }
@@ -89,8 +91,9 @@ func getCloudConfig(ctx context.Context) (*rpc.AmbassadorCloudConfig, error) {
 func NewManager(ctx context.Context) (*Manager, context.Context, error) {
 	ctx = license.WithBundle(ctx, "/home/telepresence")
 	ret := &Manager{
-		clock: wall{},
-		ID:    uuid.New().String(),
+		clock:        wall{},
+		ID:           uuid.New().String(),
+		tokenService: cloudtoken.NewCreateConfigmapIfNotPresent(ctx),
 	}
 	cloudConfig, err := getCloudConfig(ctx)
 	if err != nil {
@@ -174,6 +177,8 @@ func (m *Manager) ArriveAsClient(ctx context.Context, client *rpc.ClientInfo) (*
 
 	sessionID := m.state.AddClient(client, m.clock.Now())
 
+	m.MaybeAddToken(ctx, client.GetApiKey())
+
 	installId := client.GetInstallId()
 	return &rpc.SessionInfo{
 		SessionId: sessionID,
@@ -198,10 +203,20 @@ func (m *Manager) ArriveAsAgent(ctx context.Context, agent *rpc.AgentInfo) (*rpc
 	}, nil
 }
 
+func (m *Manager) MaybeAddToken(ctx context.Context, apikey string) {
+	if apikey != "" {
+		if err := m.tokenService.MaybeAddToken(ctx, apikey); err != nil {
+			dlog.Errorf(ctx, "error creating cloud token: %s", err)
+		}
+	}
+}
+
 // Remain indicates that the session is still valid.
-func (m *Manager) Remain(_ context.Context, req *rpc.RemainRequest) (*empty.Empty, error) {
+func (m *Manager) Remain(ctx context.Context, req *rpc.RemainRequest) (*empty.Empty, error) {
 	// ctx = WithSessionInfo(ctx, req.GetSession())
 	// dlog.Debug(ctx, "Remain called")
+
+	m.MaybeAddToken(ctx, req.GetApiKey())
 
 	if ok := m.state.MarkSession(req, m.clock.Now()); !ok {
 		return nil, status.Errorf(codes.NotFound, "Session %q not found", req.GetSession().GetSessionId())

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -93,7 +93,7 @@ func NewManager(ctx context.Context) (*Manager, context.Context, error) {
 	ret := &Manager{
 		clock:        wall{},
 		ID:           uuid.New().String(),
-		tokenService: cloudtoken.NewCreateConfigmapIfNotPresent(ctx),
+		tokenService: cloudtoken.NewPatchConfigmapIfNotPresent(ctx),
 	}
 	cloudConfig, err := getCloudConfig(ctx)
 	if err != nil {

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/rpc/v2/systema"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager"
@@ -31,7 +32,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	mockmanagerutil "github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil/mocks"
 	"github.com/telepresenceio/telepresence/v2/pkg/a8rcloud"
-	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -33,13 +33,13 @@ require (
 	github.com/telepresenceio/telepresence/rpc/v2 v2.8.3
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.0
-	go.opentelemetry.io/otel v1.10.0
+	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.10.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.10.0
 	go.opentelemetry.io/otel/metric v0.32.1 // indirect
 	go.opentelemetry.io/otel/sdk v1.10.0
-	go.opentelemetry.io/otel/trace v1.10.0
+	go.opentelemetry.io/otel/trace v1.11.1
 	go.opentelemetry.io/proto/otlp v0.19.0
 	golang.org/x/net v0.0.0-20220923203811-8be639271d50
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
@@ -188,6 +188,9 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-require golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
+require (
+	github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913
+	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
+)
 
 replace github.com/telepresenceio/telepresence/rpc/v2 => ./rpc

--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 )
 
 require (
-	github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be
+	github.com/datawire/k8sapi v0.1.1
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 )
 
 require (
-	github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913
+	github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/datawire/go-ftpserver v0.1.1 h1:73szT7FqirsyrofMNuq/tmYC+eRxhWtWswPd/
 github.com/datawire/go-ftpserver v0.1.1/go.mod h1:WXsutHvPI+JqjYEXD42U43++L5Samu9o+rMX7dY0Sc0=
 github.com/datawire/go-fuseftp/rpc v0.2.0 h1:KS7bmmHLqy3bpscwEhKolgTf+vykQlMbICamYkiEA/U=
 github.com/datawire/go-fuseftp/rpc v0.2.0/go.mod h1:Qk+XkTKLm/lSHkdziS/0a+4UYhtm2lUrDHNdfYUkXYY=
+github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913 h1:cDeePGUSRVyAk7d0vc+35xsOCb8FHBij9hvqgY33gw4=
+github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913/go.mod h1:ACfyPtU4avfGuHKBRFlLWBXxt9uwliIKgQfxnuOQpgo=
 github.com/datawire/metriton-go-client v0.1.1 h1:T+gFOmIWBg4Cc8B5OTst0lllflaT1Pdh/LaxA1YouTQ=
 github.com/datawire/metriton-go-client v0.1.1/go.mod h1:OVLUaTDnGNk58GluwoaFKaWTo0IYU03b9qiN14cdwkw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -673,8 +675,8 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.3
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.0/go.mod h1:h8TWwRAhQpOd0aM5nYsRD8+flnkj+526GEIVlarH7eY=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.0 h1:qZ3KzA4qPzLBDtQyPk4ydjlg8zvXbNysnFHaVMKJbVo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.0/go.mod h1:14Oo79mRwusSI02L0EfG3Gp1uF3+1wSL+D4zDysxyqs=
-go.opentelemetry.io/otel v1.10.0 h1:Y7DTJMR6zs1xkS/upamJYk0SxxN4C9AqRd77jmZnyY4=
-go.opentelemetry.io/otel v1.10.0/go.mod h1:NbvWjCthWHKBEUMpf0/v8ZRZlni86PpGFEMA9pnQSnQ=
+go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=
+go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 h1:TaB+1rQhddO1sF71MpZOZAuSPW1klK2M8XxfrBMfK7Y=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0/go.mod h1:78XhIg8Ht9vR4tbLNUhXsiOnE2HOuSeKAiAcoVQEpOY=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.10.0 h1:pDDYmo0QadUPal5fwXoY1pmMpFcdyhXOmL5drCrI3vU=
@@ -685,8 +687,8 @@ go.opentelemetry.io/otel/metric v0.32.1 h1:ftff5LSBCIDwL0UkhBuDg8j9NNxx2IusvJ18q
 go.opentelemetry.io/otel/metric v0.32.1/go.mod h1:iLPP7FaKMAD5BIxJ2VX7f2KTuz//0QK2hEUyti5psqQ=
 go.opentelemetry.io/otel/sdk v1.10.0 h1:jZ6K7sVn04kk/3DNUdJ4mqRlGDiXAVuIG+MMENpTNdY=
 go.opentelemetry.io/otel/sdk v1.10.0/go.mod h1:vO06iKzD5baltJz1zarxMCNHFpUlUiOy4s65ECtn6kE=
-go.opentelemetry.io/otel/trace v1.10.0 h1:npQMbR8o7mum8uF95yFbOEJffhs1sbCOfDh8zAJiH5E=
-go.opentelemetry.io/otel/trace v1.10.0/go.mod h1:Sij3YYczqAdz+EhmGhE6TpTxUO5/F/AzrK+kxfGqySM=
+go.opentelemetry.io/otel/trace v1.11.1 h1:ofxdnzsNrGBYXbP7t7zpUK281+go5rF7dvdIZXF8gdQ=
+go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4vbPHFGkTPtOk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/datawire/go-ftpserver v0.1.1 h1:73szT7FqirsyrofMNuq/tmYC+eRxhWtWswPd/
 github.com/datawire/go-ftpserver v0.1.1/go.mod h1:WXsutHvPI+JqjYEXD42U43++L5Samu9o+rMX7dY0Sc0=
 github.com/datawire/go-fuseftp/rpc v0.2.0 h1:KS7bmmHLqy3bpscwEhKolgTf+vykQlMbICamYkiEA/U=
 github.com/datawire/go-fuseftp/rpc v0.2.0/go.mod h1:Qk+XkTKLm/lSHkdziS/0a+4UYhtm2lUrDHNdfYUkXYY=
-github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be h1:q7GXkRb7nQviaHAdvF3Lp1u95I+s8gOjTRcbm9z+DtQ=
-github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
+github.com/datawire/k8sapi v0.1.1 h1:MHkhfh5ZfexyZDQY4NE68SZdq+CZyjMh667sKG1Unvg=
+github.com/datawire/k8sapi v0.1.1/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
 github.com/datawire/metriton-go-client v0.1.1 h1:T+gFOmIWBg4Cc8B5OTst0lllflaT1Pdh/LaxA1YouTQ=
 github.com/datawire/metriton-go-client v0.1.1/go.mod h1:OVLUaTDnGNk58GluwoaFKaWTo0IYU03b9qiN14cdwkw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,6 @@ github.com/datawire/go-ftpserver v0.1.1 h1:73szT7FqirsyrofMNuq/tmYC+eRxhWtWswPd/
 github.com/datawire/go-ftpserver v0.1.1/go.mod h1:WXsutHvPI+JqjYEXD42U43++L5Samu9o+rMX7dY0Sc0=
 github.com/datawire/go-fuseftp/rpc v0.2.0 h1:KS7bmmHLqy3bpscwEhKolgTf+vykQlMbICamYkiEA/U=
 github.com/datawire/go-fuseftp/rpc v0.2.0/go.mod h1:Qk+XkTKLm/lSHkdziS/0a+4UYhtm2lUrDHNdfYUkXYY=
-github.com/datawire/k8sapi v0.1.0 h1:loC+bjbxItkMBmnPXe7qRsldFoBkbc0Rk0vXzACn0lQ=
-github.com/datawire/k8sapi v0.1.0/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
-github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913 h1:cDeePGUSRVyAk7d0vc+35xsOCb8FHBij9hvqgY33gw4=
-github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913/go.mod h1:ACfyPtU4avfGuHKBRFlLWBXxt9uwliIKgQfxnuOQpgo=
 github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be h1:q7GXkRb7nQviaHAdvF3Lp1u95I+s8gOjTRcbm9z+DtQ=
 github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
 github.com/datawire/metriton-go-client v0.1.1 h1:T+gFOmIWBg4Cc8B5OTst0lllflaT1Pdh/LaxA1YouTQ=

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,12 @@ github.com/datawire/go-ftpserver v0.1.1 h1:73szT7FqirsyrofMNuq/tmYC+eRxhWtWswPd/
 github.com/datawire/go-ftpserver v0.1.1/go.mod h1:WXsutHvPI+JqjYEXD42U43++L5Samu9o+rMX7dY0Sc0=
 github.com/datawire/go-fuseftp/rpc v0.2.0 h1:KS7bmmHLqy3bpscwEhKolgTf+vykQlMbICamYkiEA/U=
 github.com/datawire/go-fuseftp/rpc v0.2.0/go.mod h1:Qk+XkTKLm/lSHkdziS/0a+4UYhtm2lUrDHNdfYUkXYY=
+github.com/datawire/k8sapi v0.1.0 h1:loC+bjbxItkMBmnPXe7qRsldFoBkbc0Rk0vXzACn0lQ=
+github.com/datawire/k8sapi v0.1.0/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
 github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913 h1:cDeePGUSRVyAk7d0vc+35xsOCb8FHBij9hvqgY33gw4=
 github.com/datawire/k8sapi v0.1.1-0.20221102000402-bab67787b913/go.mod h1:ACfyPtU4avfGuHKBRFlLWBXxt9uwliIKgQfxnuOQpgo=
+github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be h1:q7GXkRb7nQviaHAdvF3Lp1u95I+s8gOjTRcbm9z+DtQ=
+github.com/datawire/k8sapi v0.1.1-0.20221102212418-ff24519a45be/go.mod h1:JwHXYUKrMwYoAhl18CIf8XDqHduhKZPc/QZ75prLLQs=
 github.com/datawire/metriton-go-client v0.1.1 h1:T+gFOmIWBg4Cc8B5OTst0lllflaT1Pdh/LaxA1YouTQ=
 github.com/datawire/metriton-go-client v0.1.1/go.mod h1:OVLUaTDnGNk58GluwoaFKaWTo0IYU03b9qiN14cdwkw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
This PR addresses shared login. It adds a configmap to the helm chart. It watches for a configmap or secret with the correct data entry. If one does not exist, it patches that configmap with the apikey if the user connects while logged on or logs in while connected. Either way, once a apikey is in the cluster, the a-agent can login, so the watchers shut down. I also added the RBAC necessary for these changes.

I have to do a couple more things (like changelog) before merging, but it is ready for review

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
