### PR TITLE
fix url in test-vpn test-results message

### DIFF
--- a/pkg/client/cli/cmd_diag_vpn.go
+++ b/pkg/client/cli/cmd_diag_vpn.go
@@ -219,7 +219,8 @@ func (di *vpnDiagInfo) run(cmd *cobra.Command, _ []string) (err error) {
 		fmt.Fprintln(cmd.OutOrStdout(), instruction)
 	}
 	if configIssues {
-		fmt.Fprintln(cmd.OutOrStdout(), "\nPlease see https://www.telepresence.io/docs/latest/reference/vpn for more info on these corrective actions, as well as examples")
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"\nPlease see https://www.getambassador.io/docs/telepresence/latest/reference/vpn/ for more info on these corrective actions, as well as examples")
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "\nStill having issues? Please create a new github issue at https://github.com/telepresenceio/telepresence/issues/new?template=Bug_report.md\n",
 		"Please make sure to add the following to your issue:\n",


### PR DESCRIPTION
## Description

The URL provided by the test-vpn command is broken. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
