### PR TITLE
Revert "Add shorthand "-o" for the global "--output" flag."

### DIFF
--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -269,8 +269,8 @@ func GlobalFlags() *pflag.FlagSet {
 		"no-report", false,
 		"turn off anonymous crash reports and log submission on failure",
 	)
-	flags.StringP(
-		"output", "o", "default",
+	flags.String(
+		"output", "default",
 		"set the output format, supported values are 'json', 'yaml', and 'default'",
 	)
 	return flags


### PR DESCRIPTION
This reverts commit 6b4f89c7f63fbee5355fdf261bc7372d7cee926a.

-o conflicts with shorthand used in other commands.