### PR TITLE
Restore the ability to set loglevel in the root daemon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### 2.9.3 (TBD)
 
 - Feature: The helm chart now supports `livenessProbe` and `readinessProbe` for the traffic-manager
-  deployment so that the pod automatically restarts if it doesnt respond.
+  deployment, so that the pod automatically restarts if it doesn't respond.
+
+- Bugfix: Using `telepresence loglevel LEVEL` now also sets the log level in the root daemon.
 
 ### 2.9.2 (November 16, 2022)
 

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -392,6 +392,10 @@ func (s *Service) SetLogLevel(ctx context.Context, request *manager.LogLevelRequ
 		} else {
 			result = &empty.Empty{}
 		}
+		_ = s.withRootDaemon(ctx, func(ctx context.Context, rd daemon.DaemonClient) error {
+			_, _ = rd.SetLogLevel(ctx, request)
+			return nil
+		})
 	})
 	return
 }


### PR DESCRIPTION
## Description

The ability set the loglevel in the root daemon using the command `telepresence loglevel <level>` got lost 2.8.0 rewrite, where the CLI no longer communicates directly with the root daemon. The call was removed from the CLI but never added to the user daemon.

This PR adds the missing `SetLogLevel` call from the user daemon to the root daemon.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
