### PR TITLE
Don't use `systemd.resolved` based DNS resolver unless cluster is proxied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 
 - Bugfix: Multi valued kubernetes flags such as `--as-group` are now propagated correctly.
 
-- Bugfix: The root daemon would sometimes hang indefinetily when quit and connect were called
+- Bugfix: The root daemon would sometimes hang indefinitely when quit and connect were called
   in rapid succession.
+
+- Bugfix: Don't use `systemd.resolved` base DNS resolver unless cluster is proxied.
 
 ### 2.9.2 (November 16, 2022)
 

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -70,7 +70,7 @@ func (s *Server) tryResolveD(c context.Context, dev vif.Device, configureDNS fun
 			initDone <- struct{}{}
 			return errResolveDNotConfigured
 		}
-		return s.Run(c, initDone, listeners, nil, s.resolveInCluster)
+		return s.Run(c, initDone, listeners, nil, s.resolveInCluster, true)
 	})
 
 	g.Go("SanityCheck", func(c context.Context) error {

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -83,6 +83,9 @@ type Server struct {
 
 	// ready is closed when the DNS server is fully configured
 	ready chan error
+
+	// Whether the TUN-device is proxying cluster CIDRs
+	proxyCluster bool
 }
 
 type cacheEntry struct {
@@ -633,10 +636,11 @@ func (s *Server) resolveQuery(q *dns.Question, dv *cacheEntry) (dnsproxy.RRs, in
 }
 
 // Run starts the DNS server(s) and waits for them to end.
-func (s *Server) Run(c context.Context, initDone chan<- struct{}, listeners []net.PacketConn, fallbackPool FallbackPool, resolve Resolver) error {
+func (s *Server) Run(c context.Context, initDone chan<- struct{}, listeners []net.PacketConn, fallbackPool FallbackPool, resolve Resolver, proxyCluster bool) error {
 	s.ctx = c
 	s.fallbackPool = fallbackPool
 	s.resolve = resolve
+	s.proxyCluster = proxyCluster
 
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 	for _, listener := range listeners {

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -130,7 +130,7 @@ func (r *resolveFile) setSearchPaths(paths ...string) {
 //	man 5 resolver
 //
 // or, if not on a Mac, follow this link: https://www.manpagez.com/man/5/resolver/
-func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net.IP, *net.UDPAddr)) error {
+func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, configureDNS func(net.IP, *net.UDPAddr)) error {
 	resolverDirName := filepath.Join("/etc", "resolver")
 	resolverFileName := filepath.Join(resolverDirName, "telepresence.local")
 
@@ -185,7 +185,7 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 			return s.updateResolverFiles(c, resolverDirName, resolverFileName, dnsAddr, paths)
 		}, dev)
 		// Server will close the listener, so no need to close it here.
-		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
+		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster, proxyCluster)
 	})
 	return g.Wait()
 }

--- a/pkg/client/rootd/dns/server_windows.go
+++ b/pkg/client/rootd/dns/server_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
 )
 
-func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net.IP, *net.UDPAddr)) error {
+func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, configureDNS func(net.IP, *net.UDPAddr)) error {
 	listener, err := newLocalUDPListener(c)
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 	g.Go("Server", func(c context.Context) error {
 		// No need to close listener. It's closed by the dns server.
 		s.processSearchPaths(g, s.updateRouterDNS, dev)
-		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
+		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster, proxyCluster)
 	})
 	return g.Wait()
 }

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -699,7 +699,7 @@ func (s *Session) run(c context.Context) error {
 		cancelDNSLock.Lock()
 		ctx, cancelDNS = context.WithCancel(ctx)
 		cancelDNSLock.Unlock()
-		return s.dnsServer.Worker(ctx, s.dev, s.configureDNS)
+		return s.dnsServer.Worker(ctx, s.dev, s.proxyCluster, s.configureDNS)
 	})
 
 	g.Go("stack", func(_ context.Context) error {


### PR DESCRIPTION
## Description

There is no CIDR to place the DNS in when the cluster isn't proxied by the TUN-device and as a result, the `systemd.resolved` DNS resolver's call to `SetLinkDNS` is pointless.

This commit changes the Linux DNS behavior so that it always falls back to the overriding resolver when the cluster CIDR's are already available on the host.

Closes #2811

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
