### PR TITLE
Make version output nicer, and add DisplayName extension point.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ fuseftp.bits
 # Don't accidentally add binaries built byintegration tests
 /integration_test/testdata/echo-server/echo-server
 /build-aux/genversion/genversion
+
+# Vagrant
+.vagrant/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Change: The root daemon now communicates directly with the traffic-manager instead of routing all
   outbound traffic through the user daemon.
 
+- Change: The output of `telepresence version` is now aligned and no longer contains "(api v3)"
+
 - Bugfix: Using `telepresence loglevel LEVEL` now also sets the log level in the root daemon.
 
 - Bugfix: Multi valued kubernetes flags such as `--as-group` are now propagated correctly.

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/stretchr/testify/suite"
 
@@ -27,12 +28,12 @@ func (s *cliSuite) Test_Version() {
 		s.Require().NoError(err)
 	}
 	s.Empty(stderr)
-	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
+	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
 }
 
 func (s *cliSuite) Test_Help() {
 	// TODO: Fix these tests
-	s.T().Skip("these test doesn't work")
+	s.T().Skip("these tests don't work")
 	const (
 		helpHead  = `Telepresence can connect to a cluster and route all outbound traffic`
 		usageHead = `Usage:`

--- a/integration_test/cloud_config_test.go
+++ b/integration_test/cloud_config_test.go
@@ -138,11 +138,12 @@ func (s *notConnectedSuite) Test_RootdCloudLogLevel() {
 	ctx = filelocation.WithAppUserConfigDir(ctx, configDir)
 	ctx, err = client.SetConfig(ctx, configDir, configYamlStr)
 	require.NoError(err)
+	itest.TelepresenceQuitOk(ctx) // Because context changed
 
 	var currentLine int64
 	s.Eventually(func() bool {
 		itest.TelepresenceOk(ctx, "connect")
-		defer itest.TelepresenceQuitOk(ctx)
+		itest.TelepresenceDisconnectOk(ctx)
 
 		rootLog, err := os.Open(rootLogName)
 		require.NoError(err)
@@ -186,7 +187,9 @@ func (s *notConnectedSuite) Test_RootdCloudLogLevel() {
 			RootDaemon: logrus.DebugLevel,
 		},
 	})
+	itest.TelepresenceQuitOk(ctx) // Because context changed
 	itest.TelepresenceOk(ctx, "connect")
+	itest.TelepresenceDisconnectOk(ctx)
 	defer itest.TelepresenceQuitOk(ctx)
 	levelSet = false
 	for scn.Scan() && !levelSet {
@@ -236,11 +239,12 @@ func (s *notConnectedSuite) Test_UserdCloudLogLevel() {
 	ctx = filelocation.WithAppUserConfigDir(ctx, configDir)
 	ctx, err = client.SetConfig(ctx, configDir, configYamlStr)
 	require.NoError(err)
+	itest.TelepresenceQuitOk(ctx) // Because context changed
 
 	var currentLine int64
 	s.Eventually(func() bool {
 		itest.TelepresenceOk(ctx, "connect")
-		defer itest.TelepresenceQuitOk(ctx)
+		itest.TelepresenceDisconnectOk(ctx)
 
 		logF, err := os.Open(logName)
 		require.NoError(err)
@@ -284,7 +288,11 @@ func (s *notConnectedSuite) Test_UserdCloudLogLevel() {
 			UserDaemon: logrus.DebugLevel,
 		},
 	})
+	itest.TelepresenceQuitOk(ctx) // Because context changed
+
 	itest.TelepresenceOk(ctx, "connect")
+	itest.TelepresenceDisconnectOk(ctx)
+
 	defer itest.TelepresenceQuitOk(ctx)
 	levelSet = false
 	for scn.Scan() && !levelSet {

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/stretchr/testify/suite"
 
@@ -27,10 +28,11 @@ func (s *connectedSuite) Test_ListExcludesTM() {
 
 func (s *connectedSuite) Test_ReportsAllVersions() {
 	stdout := itest.TelepresenceOk(s.Context(), "version")
-	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("Root Daemon: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("User Daemon: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("Traffic Manager: %s", s.TelepresenceVersion()))
+	rxVer := regexp.QuoteMeta(s.TelepresenceVersion())
+	s.Regexp(fmt.Sprintf(`Client\s*: %s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`Root Daemon\s*: %s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`User Daemon\s*: %s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`Traffic Manager\s*: %s`, rxVer), stdout)
 }
 
 func (s *connectedSuite) Test_ReportsNotConnected() {
@@ -38,10 +40,11 @@ func (s *connectedSuite) Test_ReportsNotConnected() {
 	itest.TelepresenceDisconnectOk(ctx)
 	defer itest.TelepresenceOk(itest.WithUser(ctx, "default"), "connect")
 	stdout := itest.TelepresenceOk(ctx, "version")
-	s.Contains(stdout, fmt.Sprintf("Client: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("Root Daemon: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, fmt.Sprintf("User Daemon: %s", s.TelepresenceVersion()))
-	s.Contains(stdout, "Traffic Manager: not connected")
+	rxVer := regexp.QuoteMeta(s.TelepresenceVersion())
+	s.Regexp(fmt.Sprintf(`Client\s*: %s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`Root Daemon\s*: %s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`User Daemon\s*: %s`, rxVer), stdout)
+	s.Regexp(`Traffic Manager\s*: not connected`, stdout)
 }
 
 func (s *connectedSuite) Test_Status() {

--- a/pkg/client/cli/cmd_version.go
+++ b/pkg/client/cli/cmd_version.go
@@ -15,6 +15,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 func versionCommand() *cobra.Command {
@@ -24,7 +25,7 @@ func versionCommand() *cobra.Command {
 
 		Short:   "Show version",
 		PreRunE: util.ForcedUpdateCheck,
-		RunE:    PrintVersion,
+		RunE:    printVersion,
 		Annotations: map[string]string{
 			ann.RootDaemon:        ann.Optional,
 			ann.UserDaemon:        ann.Optional,
@@ -33,44 +34,46 @@ func versionCommand() *cobra.Command {
 	}
 }
 
-// PrintVersion requests version info from the daemon and prints both client and daemon version.
-func PrintVersion(cmd *cobra.Command, _ []string) error {
+func printVersion(cmd *cobra.Command, _ []string) error {
 	if err := util.InitCommand(cmd); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Client: %s\n",
-		client.DisplayVersion())
+	kvf := ioutil.DefaultKeyValueFormatter()
+	kvf.Add(client.DisplayName, client.Version())
 
 	ctx := cmd.Context()
 	version, err := daemonVersion(ctx)
 	switch {
 	case err == nil:
-		fmt.Fprintf(cmd.OutOrStdout(), "Root Daemon: %s (api v%d)\n", version.Version, version.ApiVersion)
+		kvf.Add("Root Daemon", version.Version)
 	case err == util.ErrNoRootDaemon:
-		fmt.Fprintln(cmd.OutOrStdout(), "Root Daemon: not running")
+		kvf.Add("Root Daemon", "not running")
 	default:
-		fmt.Fprintf(cmd.OutOrStdout(), "Root Daemon: error: %v\n", err)
+		kvf.Add("Root Daemon", fmt.Sprintf("error: %v", err))
 	}
 
 	version, err = connectorVersion(ctx)
 	switch {
 	case err == nil:
-		fmt.Fprintf(cmd.OutOrStdout(), "User Daemon: %s (api v%d)\n", version.Version, version.ApiVersion)
+		kvf.Add("User Daemon", version.Version)
 		var mgrVer *manager.VersionInfo2
 		mgrVer, err = managerVersion(ctx)
 		switch {
 		case err == nil:
-			fmt.Fprintf(cmd.OutOrStdout(), "Traffic Manager: %s\n", mgrVer.Version)
+			kvf.Add("Traffic Manager", mgrVer.Version)
 		case status.Code(err) == codes.Unavailable:
-			fmt.Fprintln(cmd.OutOrStdout(), "Traffic Manager: not connected")
+			kvf.Add("Traffic Manager", "not connected")
 		default:
-			fmt.Fprintf(cmd.OutOrStdout(), "Traffic Manager: error: %v\n", err)
+			kvf.Add("Traffic Manager", fmt.Sprintf("error: %v", err))
 		}
 	case err == util.ErrNoUserDaemon:
-		fmt.Fprintln(cmd.OutOrStdout(), "User Daemon: not running")
+		kvf.Add("User Daemon", "not running")
 	default:
-		fmt.Fprintf(cmd.OutOrStdout(), "User Daemon: error: %v\n", err)
+		kvf.Add("User Daemon", fmt.Sprintf("error: %v", err))
 	}
+	out := cmd.OutOrStdout()
+	_, _ = kvf.WriteTo(out)
+	ioutil.WriteString(out, "\n")
 	return nil
 }
 

--- a/pkg/client/cli/main.go
+++ b/pkg/client/cli/main.go
@@ -28,6 +28,7 @@ func InitContext(ctx context.Context) context.Context {
 		ctx = rootd.WithNewServiceFunc(ctx, rootd.NewService)
 		ctx = rootd.WithNewSessionFunc(ctx, rootd.NewSession)
 	default:
+		client.DisplayName = "Client"
 		ctx = util.WithCommandInitializer(ctx, util.CommandInitializer)
 		ctx = WithSubCommands(ctx)
 	}

--- a/pkg/client/cli/util/describe_intercepts.go
+++ b/pkg/client/cli/util/describe_intercepts.go
@@ -6,30 +6,24 @@ import (
 	"strings"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 func DescribeIntercepts(iis []*manager.InterceptInfo, volumeMountsPrevented error, debug bool) string {
 	sb := strings.Builder{}
 	sb.WriteString("intercepted")
-	for i, ii := range iis {
-		if i > 0 {
-			sb.WriteByte('\n')
-		}
+	for _, ii := range iis {
+		sb.WriteByte('\n')
 		describeIntercept(ii, volumeMountsPrevented, debug, &sb)
 	}
 	return sb.String()
 }
 
 func describeIntercept(ii *manager.InterceptInfo, volumeMountsPrevented error, debug bool, sb *strings.Builder) {
-	type kv struct {
-		Key   string
-		Value string
-	}
-
-	var fields []kv
-
-	fields = append(fields, kv{"Intercept name", ii.Spec.Name})
-	fields = append(fields, kv{"State", func() string {
+	kvf := ioutil.DefaultKeyValueFormatter()
+	kvf.Prefix = "   "
+	kvf.Add("Intercept name", ii.Spec.Name)
+	kvf.Add("State", func() string {
 		msg := ""
 		if ii.Disposition > manager.InterceptDispositionType_WAITING {
 			msg += "error: "
@@ -39,34 +33,34 @@ func describeIntercept(ii *manager.InterceptInfo, volumeMountsPrevented error, d
 			msg += ": " + ii.Message
 		}
 		return msg
-	}()})
-	fields = append(fields, kv{"Workload kind", ii.Spec.WorkloadKind})
+	}())
+	kvf.Add("Workload kind", ii.Spec.WorkloadKind)
 
 	if debug {
-		fields = append(fields, kv{"ID", ii.Id})
+		kvf.Add("ID", ii.Id)
 	}
 
-	fields = append(fields, kv{
+	kvf.Add(
 		"Destination",
 		net.JoinHostPort(ii.Spec.TargetHost, fmt.Sprintf("%d", ii.Spec.TargetPort)),
-	})
+	)
 
 	if ii.Spec.ServicePortIdentifier != "" {
-		fields = append(fields, kv{"Service Port Identifier", ii.Spec.ServicePortIdentifier})
+		kvf.Add("Service Port Identifier", ii.Spec.ServicePortIdentifier)
 	}
 	if debug {
-		fields = append(fields, kv{"Mechanism", ii.Spec.Mechanism})
-		fields = append(fields, kv{"Mechanism Args", fmt.Sprintf("%q", ii.Spec.MechanismArgs)})
-		fields = append(fields, kv{"Metadata", fmt.Sprintf("%q", ii.Metadata)})
+		kvf.Add("Mechanism", ii.Spec.Mechanism)
+		kvf.Add("Mechanism Args", fmt.Sprintf("%q", ii.Spec.MechanismArgs))
+		kvf.Add("Metadata", fmt.Sprintf("%q", ii.Metadata))
 	}
 
 	if ii.ClientMountPoint != "" {
-		fields = append(fields, kv{"Volume Mount Point", ii.ClientMountPoint})
+		kvf.Add("Volume Mount Point", ii.ClientMountPoint)
 	} else if volumeMountsPrevented != nil {
-		fields = append(fields, kv{"Volume Mount Error", volumeMountsPrevented.Error()})
+		kvf.Add("Volume Mount Error", volumeMountsPrevented.Error())
 	}
 
-	fields = append(fields, kv{"Intercepting", func() string {
+	kvf.Add("Intercepting", func() string {
 		if ii.MechanismArgsDesc == "" {
 			if len(ii.Spec.MechanismArgs) > 0 {
 				return fmt.Sprintf("using mechanism=%q with args=%q", ii.Spec.Mechanism, ii.Spec.MechanismArgs)
@@ -74,7 +68,7 @@ func describeIntercept(ii *manager.InterceptInfo, volumeMountsPrevented error, d
 			return fmt.Sprintf("using mechanism=%q", ii.Spec.Mechanism)
 		}
 		return ii.MechanismArgsDesc
-	}()})
+	}())
 
 	if ii.PreviewDomain != "" {
 		previewURL := ii.PreviewDomain
@@ -83,24 +77,10 @@ func describeIntercept(ii *manager.InterceptInfo, volumeMountsPrevented error, d
 		if !strings.HasPrefix(previewURL, "https://") && !strings.HasPrefix(previewURL, "http://") {
 			previewURL = "https://" + previewURL
 		}
-		fields = append(fields, kv{"Preview URL", previewURL})
+		kvf.Add("Preview URL", previewURL)
 	}
 	if l5Hostname := ii.GetPreviewSpec().GetIngress().GetL5Host(); l5Hostname != "" {
-		fields = append(fields, kv{"Layer 5 Hostname", l5Hostname})
+		kvf.Add("Layer 5 Hostname", l5Hostname)
 	}
-
-	klen := 0
-	for _, kv := range fields {
-		if len(kv.Key) > klen {
-			klen = len(kv.Key)
-		}
-	}
-	for _, kv := range fields {
-		vlines := strings.Split(strings.TrimSpace(kv.Value), "\n")
-		fmt.Fprintf(sb, "\n    %-*s: %s", klen, kv.Key, vlines[0])
-		for _, vline := range vlines[1:] {
-			sb.WriteString("\n      ")
-			sb.WriteString(vline)
-		}
-	}
+	_, _ = kvf.WriteTo(sb)
 }

--- a/pkg/client/version.go
+++ b/pkg/client/version.go
@@ -12,6 +12,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
+var DisplayName = "Telepresence" //nolint:gochecknoglobals // extension point
+
 // Version returns the version of this executable.
 func Version() string {
 	return version.Version
@@ -30,7 +32,7 @@ func GetInstallMechanism() (string, error) {
 	execPath, err := os.Executable()
 	mechanism := "undetermined"
 	if err != nil {
-		wrapErr := fmt.Errorf("Unable to get exec path: %w", err)
+		wrapErr := fmt.Errorf("unable to get exec path: %w", err)
 		return mechanism, wrapErr
 	}
 

--- a/pkg/ioutil/keyvalueformatter.go
+++ b/pkg/ioutil/keyvalueformatter.go
@@ -1,0 +1,63 @@
+package ioutil
+
+import (
+	"io"
+	"strings"
+)
+
+// KeyValueFormatter will format each key/value pair added by Add so that they
+// are prefixed with Prefix and have a vertically aligned ':' between the key and
+// the value. Each pair is separated by a newline, and if a value contains newlines,
+// then each line in that value, except the first one will be prefixed with `Prefix`,
+// and Indent.
+type KeyValueFormatter struct {
+	kvs       []string
+	Prefix    string
+	Indent    string
+	Separator string
+}
+
+func DefaultKeyValueFormatter() *KeyValueFormatter {
+	return &KeyValueFormatter{
+		Indent:    "    ",
+		Separator: ": ",
+	}
+}
+
+// Add adds a key value pair that will be included in the formatted output.
+func (f *KeyValueFormatter) Add(k, v string) {
+	f.kvs = append(f.kvs, k, v)
+}
+
+// WriteTo writes the formatted output to the given io.Writer.
+func (f *KeyValueFormatter) WriteTo(out io.Writer) (int64, error) {
+	kLen := 0
+	kvs := f.kvs
+	t := len(kvs)
+
+	// Figure out length of the longest key
+	for i := 0; i < t; i += 2 {
+		if l := len(kvs[i]); l > kLen {
+			kLen = l
+		}
+	}
+	n := 0
+	for i := 0; i < t; i += 2 {
+		if i > 0 {
+			n += WriteString(out, "\n")
+		}
+		lines := strings.Split(strings.TrimSpace(kvs[i+1]), "\n")
+		n += Printf(out, "%s%-*s%s%s", f.Prefix, kLen, kvs[i], f.Separator, lines[0])
+		for _, line := range lines[1:] {
+			n += Printf(out, "\n%s%s%s", f.Prefix, f.Indent, line)
+		}
+	}
+	return int64(n), nil
+}
+
+// String returns the formatted output string.
+func (f *KeyValueFormatter) String() string {
+	sb := &strings.Builder{}
+	_, _ = f.WriteTo(sb)
+	return sb.String()
+}

--- a/pkg/ioutil/print.go
+++ b/pkg/ioutil/print.go
@@ -22,3 +22,12 @@ func Printf(out io.Writer, format string, args ...any) int {
 	}
 	return n
 }
+
+// WriteString is like io.WriteString but panics on error.
+func WriteString(out io.Writer, s string) int {
+	n, err := io.WriteString(out, s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}


### PR DESCRIPTION
## Description

Replaces the key/value formatting of `describeIntercept` with a generic `ioutil.KeyValueFormatter`, and also uses that formatte to format the output of `telepresence version`.

The `cmd_version` command now also uses a global variable `DisplayName`, which is intended to be an extension point so that `Client` can be replaced with `Enhanced Client` or similar.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
