### PR TITLE
Add ability to pass annotations to the metriton reporter.

### DIFF
--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -25,12 +25,15 @@ type bufEntry struct {
 	entries []Entry
 }
 
+type ReportAnnotator func(map[string]any)
+
 // Reporter is a Metriton reported.
 type Reporter struct {
-	index    int
-	buffer   chan bufEntry
-	done     chan struct{}
-	reporter *metriton.Reporter
+	index            int
+	buffer           chan bufEntry
+	done             chan struct{}
+	reportAnnotators []ReportAnnotator
+	reporter         *metriton.Reporter
 }
 
 // Entry is a key/value association used when reporting.
@@ -166,7 +169,7 @@ func getInstallIDFromFilesystem(ctx context.Context, reporter *metriton.Reporter
 // before entries are discarded.
 const bufferSize = 40
 
-func NewReporterForInstallType(ctx context.Context, mode string, installType InstallType) *Reporter {
+func NewReporterForInstallType(ctx context.Context, mode string, installType InstallType, reportAnnotators []ReportAnnotator) *Reporter {
 	r := &Reporter{
 		reporter: &metriton.Reporter{
 			Application: "telepresence2",
@@ -181,15 +184,19 @@ func NewReporterForInstallType(ctx context.Context, mode string, installType Ins
 				return id, nil
 			},
 		},
+		reportAnnotators: reportAnnotators,
 	}
 	r.initialize(ctx, mode, runtime.GOOS, runtime.GOARCH)
 	return r
 }
 
+// ReportAnnotators are the default annotator functions that the NewReporter function will pass to NewReporterForInstallType.
+var ReportAnnotators []ReportAnnotator //nolint:gochecknoglobals // extension point
+
 // NewReporter creates a new initialized Reporter instance that can be used to
 // send telepresence reports to Metriton.
 func NewReporter(ctx context.Context, mode string) *Reporter {
-	return NewReporterForInstallType(ctx, mode, CLI)
+	return NewReporterForInstallType(ctx, mode, CLI, ReportAnnotators)
 }
 
 // initialization broken out or constructor for the benefit of testing.
@@ -200,7 +207,7 @@ func (r *Reporter) initialize(ctx context.Context, mode, goos, goarch string) {
 	// Fixed (growing) metadata passed with every report
 	baseMeta := getOsMetadata(ctx)
 	baseMeta["mode"] = mode
-	baseMeta["trace_id"] = uuid.New()
+	baseMeta["trace_id"] = uuid.New().String() //  It's sent as JSON so might as well convert it to a string once here.
 	baseMeta["goos"] = goos
 	baseMeta["goarch"] = goarch
 
@@ -307,6 +314,9 @@ func (r *Reporter) doReport(ctx context.Context, be *bufEntry) {
 	metadata := make(map[string]any, 4+len(be.entries))
 	metadata["action"] = be.action
 	metadata["index"] = r.index
+	for _, ra := range r.reportAnnotators {
+		ra(metadata)
+	}
 	for _, metaItem := range be.entries {
 		metadata[metaItem.Key] = metaItem.Value
 	}

--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -190,13 +190,13 @@ func NewReporterForInstallType(ctx context.Context, mode string, installType Ins
 	return r
 }
 
-// ReportAnnotators are the default annotator functions that the NewReporter function will pass to NewReporterForInstallType.
-var ReportAnnotators []ReportAnnotator //nolint:gochecknoglobals // extension point
+// DefaultReportAnnotators are the default annotator functions that the NewReporter function will pass to NewReporterForInstallType.
+var DefaultReportAnnotators []ReportAnnotator //nolint:gochecknoglobals // extension point
 
 // NewReporter creates a new initialized Reporter instance that can be used to
 // send telepresence reports to Metriton.
 func NewReporter(ctx context.Context, mode string) *Reporter {
-	return NewReporterForInstallType(ctx, mode, CLI, ReportAnnotators)
+	return NewReporterForInstallType(ctx, mode, CLI, DefaultReportAnnotators)
 }
 
 // initialization broken out or constructor for the benefit of testing.
@@ -207,7 +207,7 @@ func (r *Reporter) initialize(ctx context.Context, mode, goos, goarch string) {
 	// Fixed (growing) metadata passed with every report
 	baseMeta := getOsMetadata(ctx)
 	baseMeta["mode"] = mode
-	baseMeta["trace_id"] = uuid.New().String() //  It's sent as JSON so might as well convert it to a string once here.
+	baseMeta["trace_id"] = uuid.NewString() //  It's sent as JSON so might as well convert it to a string once here.
 	baseMeta["goos"] = goos
 	baseMeta["goarch"] = goarch
 


### PR DESCRIPTION
## Description

Adds the `ReportAnnotations` extension point so that other modules can add dynamic data to the metriton reports.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
