### PR TITLE
wip: RunAsUser / RunAsGroup / RunAsNonRoot

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -1,5 +1,3 @@
-# syntax = docker/dockerfile:1.3
-
 # Copyright 2020-2022 Datawire. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +17,7 @@ FROM golang:alpine3.15 as tel2-build
 RUN apk add --no-cache gcc musl-dev fuse-dev libcap
 
 WORKDIR telepresence
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY rpc/ rpc/

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -2,6 +2,7 @@ package managerutil_test
 
 import (
 	"context"
+	core "k8s.io/api/core/v1"
 	"net"
 	"testing"
 	"time"
@@ -103,6 +104,21 @@ func TestEnvconfig(t *testing.T) {
 				e.AgentRunAsUser = &userValue
 				e.AgentRunAsGroup = &groupValue
 				e.AgentRunAsNonRoot = &falseVal
+			},
+		},
+		"capabilities": {
+			Input: map[string]string{
+				"AGENT_CAPABILITIES_ADD":  "SYS_TIME, NET_ADMIN",
+				"AGENT_CAPABILITIES_DROP": "ALL",
+			},
+			Output: func(e *managerutil.Env) {
+				e.AgentCapabilitiesAdd = []core.Capability{
+					"SYS_TIME",
+					"NET_ADMIN",
+				}
+				e.AgentCapabilitiesDrop = []core.Capability{
+					"ALL",
+				}
 			},
 		},
 	}

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -91,14 +91,14 @@ func TestEnvconfig(t *testing.T) {
 		},
 		"references-2": {
 			Input: map[string]string{
-				"AGENT_RUN_AS_USER":     "1000",
-				"AGENT_RUN_AS_GROUP":    "",
-				"AGENT_RUN_AS_NON_ROOT": "false",
+				"AGENT_RUN_AS_USER":     "1001",
+				"AGENT_RUN_AS_GROUP":    "2002",
+				"AGENT_RUN_AS_NON_ROOT": "true",
 			},
 			Output: func(e *managerutil.Env) {
-				var user1000 = int64(1000)
-				var group1000 = int64(1000)
-				var falseVal = false
+				var user1000 = int64(1001)
+				var group1000 = int64(2002)
+				var falseVal = true
 
 				e.AgentRunAsUser = &user1000
 				e.AgentRunAsGroup = &group1000

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -96,12 +96,12 @@ func TestEnvconfig(t *testing.T) {
 				"AGENT_RUN_AS_NON_ROOT": "true",
 			},
 			Output: func(e *managerutil.Env) {
-				var user1000 = int64(1001)
-				var group1000 = int64(2002)
+				var userValue = int64(1001)
+				var groupValue = int64(2002)
 				var falseVal = true
 
-				e.AgentRunAsUser = &user1000
-				e.AgentRunAsGroup = &group1000
+				e.AgentRunAsUser = &userValue
+				e.AgentRunAsGroup = &groupValue
 				e.AgentRunAsNonRoot = &falseVal
 			},
 		},

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -77,6 +77,34 @@ func TestEnvconfig(t *testing.T) {
 				e.ClientRoutingNeverProxySubnets = []*net.IPNet{a, b}
 			},
 		},
+		"references": {
+			Input: map[string]string{
+				"AGENT_RUN_AS_USER":     "",
+				"AGENT_RUN_AS_GROUP":    "",
+				"AGENT_RUN_AS_NON_ROOT": "",
+			},
+			Output: func(e *managerutil.Env) {
+				e.AgentRunAsUser = nil
+				e.AgentRunAsGroup = nil
+				e.AgentRunAsNonRoot = nil
+			},
+		},
+		"references-2": {
+			Input: map[string]string{
+				"AGENT_RUN_AS_USER":     "1000",
+				"AGENT_RUN_AS_GROUP":    "",
+				"AGENT_RUN_AS_NON_ROOT": "false",
+			},
+			Output: func(e *managerutil.Env) {
+				var user1000 = int64(1000)
+				var group1000 = int64(1000)
+				var falseVal = false
+
+				e.AgentRunAsUser = &user1000
+				e.AgentRunAsGroup = &group1000
+				e.AgentRunAsNonRoot = &falseVal
+			},
+		},
 	}
 
 	for tcName, tc := range testcases {
@@ -97,7 +125,7 @@ func TestEnvconfig(t *testing.T) {
 			ctx, err := managerutil.LoadEnv(context.Background(), lookup)
 			require.NoError(t, err)
 			actual := managerutil.GetEnv(ctx)
-			assert.Equal(t, &expected, actual)
+			assert.EqualValues(t, &expected, actual) // Pointers are different here
 			assert.Equal(t, "", actual.QualifiedAgentImage())
 		})
 	}

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -101,6 +101,11 @@ func AgentContainer(
 		Env:          evs,
 		EnvFrom:      efs,
 		VolumeMounts: mounts,
+		SecurityContext: &core.SecurityContext{
+			RunAsNonRoot: config.RunAsNonRoot,
+			RunAsUser:    config.RunAsUser,
+			RunAsGroup:   config.RunAsGroup,
+		},
 		ReadinessProbe: &core.Probe{
 			ProbeHandler: core.ProbeHandler{
 				Exec: &core.ExecAction{

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -105,7 +105,12 @@ func AgentContainer(
 			RunAsNonRoot: config.RunAsNonRoot,
 			RunAsUser:    config.RunAsUser,
 			RunAsGroup:   config.RunAsGroup,
+			Capabilities: &core.Capabilities{
+				Add:  config.CapabilitiesAdd,
+				Drop: config.CapabilitiesDrop,
+			},
 		},
+
 		ReadinessProbe: &core.Probe{
 			ProbeHandler: core.ProbeHandler{
 				Exec: &core.ExecAction{

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -155,6 +155,9 @@ type Sidecar struct {
 	RunAsNonRoot *bool  `json:"runAsNonRoot,omitempty"`
 	RunAsUser    *int64 `json:"runAsUser,omitempty"`
 	RunAsGroup   *int64 `json:"runAsGroup,omitempty"`
+
+	CapabilitiesAdd  []core.Capability `json:"capabilitiesAdd"`
+	CapabilitiesDrop []core.Capability `json:"capabilitiesDrop"`
 }
 
 func (s *Sidecar) RecordInSpan(span trace.Span) {

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -150,6 +150,11 @@ type Sidecar struct {
 
 	// The intercepts managed by the agent
 	Containers []*Container `json:"containers,omitempty"`
+
+	// Security Context to apply to the container
+	RunAsNonRoot *bool  `json:"runAsNonRoot,omitempty"`
+	RunAsUser    *int64 `json:"runAsUser,omitempty"`
+	RunAsGroup   *int64 `json:"runAsGroup,omitempty"`
 }
 
 func (s *Sidecar) RecordInSpan(span trace.Span) {

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -36,6 +36,8 @@ type GeneratorConfig struct {
 	RunAsUser           *int64
 	RunAsGroup          *int64
 	RunAsNonRoot        *bool
+	CapabilitiesAdd     []core.Capability
+	CapabilitiesDrop    []core.Capability
 }
 
 func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (sc *agentconfig.Sidecar, err error) {
@@ -88,25 +90,27 @@ func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (sc
 	}
 
 	ag := &agentconfig.Sidecar{
-		AgentImage:      cfg.QualifiedAgentImage,
-		AgentName:       wl.GetName(),
-		LogLevel:        cfg.LogLevel,
-		Namespace:       wl.GetNamespace(),
-		WorkloadName:    wl.GetName(),
-		WorkloadKind:    wl.GetKind(),
-		ManagerHost:     ManagerAppName + "." + cfg.ManagerNamespace,
-		ManagerPort:     cfg.ManagerPort,
-		APIPort:         cfg.APIPort,
-		TracingPort:     cfg.TracingPort,
-		EnvoyLogLevel:   cfg.EnvoyLogLevel,
-		EnvoyServerPort: cfg.EnvoyServerPort,
-		EnvoyAdminPort:  cfg.EnvoyAdminPort,
-		Containers:      ccs,
-		InitResources:   cfg.InitResources,
-		Resources:       cfg.Resources,
-		RunAsUser:       cfg.RunAsUser,
-		RunAsGroup:      cfg.RunAsGroup,
-		RunAsNonRoot:    cfg.RunAsNonRoot,
+		AgentImage:       cfg.QualifiedAgentImage,
+		AgentName:        wl.GetName(),
+		LogLevel:         cfg.LogLevel,
+		Namespace:        wl.GetNamespace(),
+		WorkloadName:     wl.GetName(),
+		WorkloadKind:     wl.GetKind(),
+		ManagerHost:      ManagerAppName + "." + cfg.ManagerNamespace,
+		ManagerPort:      cfg.ManagerPort,
+		APIPort:          cfg.APIPort,
+		TracingPort:      cfg.TracingPort,
+		EnvoyLogLevel:    cfg.EnvoyLogLevel,
+		EnvoyServerPort:  cfg.EnvoyServerPort,
+		EnvoyAdminPort:   cfg.EnvoyAdminPort,
+		Containers:       ccs,
+		InitResources:    cfg.InitResources,
+		Resources:        cfg.Resources,
+		RunAsUser:        cfg.RunAsUser,
+		RunAsGroup:       cfg.RunAsGroup,
+		RunAsNonRoot:     cfg.RunAsNonRoot,
+		CapabilitiesAdd:  cfg.CapabilitiesAdd,
+		CapabilitiesDrop: cfg.CapabilitiesDrop,
 	}
 	ag.RecordInSpan(span)
 	return ag, nil

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -33,6 +33,9 @@ type GeneratorConfig struct {
 	EnvoyLogLevel       string
 	EnvoyServerPort     uint16
 	EnvoyAdminPort      uint16
+	RunAsUser           *int64
+	RunAsGroup          *int64
+	RunAsNonRoot        *bool
 }
 
 func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (sc *agentconfig.Sidecar, err error) {
@@ -101,6 +104,9 @@ func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (sc
 		Containers:      ccs,
 		InitResources:   cfg.InitResources,
 		Resources:       cfg.Resources,
+		RunAsUser:       cfg.RunAsUser,
+		RunAsGroup:      cfg.RunAsGroup,
+		RunAsNonRoot:    cfg.RunAsNonRoot,
 	}
 	ag.RecordInSpan(span)
 	return ag, nil


### PR DESCRIPTION
## Description

This PR (still WIP, review is appreciated) is going to fix #2730 and finally allow running telepresence in environments where it's not possible to run privileged containers / some restrictions are in place.

This effectively adds the following options:

- `AGENT_RUN_AS_USER`
- `AGENT_RUN_AS_GROUP`
- `AGENT_RUN_AS_NON_ROOT`
- `AGENT_CAPABILITIES_ADD`
- `AGENT_CAPABILITIES_DROP`

### Helm Chart

This change will require a slight modification of the Helm chart too, here is my proposal:

`deployment.yaml`
```diff
*** 181,186 ****
--- 181,206 ----
              value: "{{ join " " . }}"
            {{- end }}
            {{- end }}
+           {{- if .agent.securityContext.runAsUser }}
+           - name: AGENT_RUN_AS_USER
+             value: {{ .agent.securityContext.runAsUser | quote }}
+           {{- end }}
+           {{- if .agent.securityContext.runAsGroup }}
+           - name: AGENT_RUN_AS_GROUP
+             value: {{ .agent.securityContext.runAsGroup | quote }}
+           {{- end }}
+           {{- if .agent.securityContext.runAsNonRoot }}
+           - name: AGENT_RUN_AS_NON_ROOT
+             value: {{ .agent.securityContext.runAsNonRoot | quote }}
+           {{- end }}
+           {{- if gt (len .agent.securityContext.capAdd) 0 }}
+           - name: AGENT_CAPABILITIES_ADD
+             value: {{ join ", " .agent.securityContext.capAdd }}
+           {{- end }}
+           {{- if gt (len .agent.securityContext.capDrop) 0 }}
+           - name: AGENT_CAPABILITIES_DROP
+             value: {{ join ", " .agent.securityContext.capDrop }}
+           {{- end }}
          {{- /*
          Client configuration
          */}}
```

and the related `values.yaml`:

```diff
*** 209,214 ****
--- 209,220 ----
      logLevel: warning
      serverPort: 18000
      adminPort: 19000
+   securityContext:
+     runAsGroup: {}
+     runAsUser: {}
+     runAsNonRoot: {}
+     capAdd: []
+     capDrop: []
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
