### PR TITLE
Defer initialization of fuseftp until it is really needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.9.4 (TBD)
+
+- Bugfix: Initialization of FTP type file sharing is delayed, so that setting it using the Helm chart
+  value `intercept.useFtp=true` works as expected.
+
 ### 2.9.3 (November 23, 2022)
 
 - Feature: The helm chart now supports `livenessProbe` and `readinessProbe` for the traffic-manager

--- a/cmd/traffic/cmd/poddaemon/main.go
+++ b/cmd/traffic/cmd/poddaemon/main.go
@@ -154,7 +154,7 @@ func main(ctx context.Context, args *Args) error {
 		// TODO: perhaps provide the real thing if we decide to embed the fuseftp binary
 		fuseftpCh := make(chan rpc.FuseFTPClient)
 		close(fuseftpCh)
-		return user_daemon.ManageSessions(ctx, userdService, <-fuseftpCh)
+		return user_daemon.ManageSessions(ctx, userdService)
 	})
 	grp.Go("main", func(ctx context.Context) error {
 		dlog.Infof(ctx, "Connecting to traffic manager...")

--- a/pkg/client/userd/service.go
+++ b/pkg/client/userd/service.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/datawire/dlib/dgroup"
+	"github.com/datawire/go-fuseftp/rpc"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 )
@@ -25,6 +26,8 @@ type Service interface {
 
 	// GetAPIKey returns the current API key
 	GetAPIKey(context.Context) (string, error)
+
+	GetFuseFTPClient(ctx context.Context) rpc.FuseFTPClient
 }
 
 type NewServiceFunc func(context.Context, *dgroup.Group, *scout.Reporter, *client.Config, *grpc.Server) (Service, error)
@@ -40,4 +43,17 @@ func GetNewServiceFunc(ctx context.Context) NewServiceFunc {
 		return f
 	}
 	panic("No User daemon Service creator has been registered")
+}
+
+type serviceKey struct{}
+
+func WithService(ctx context.Context, s Service) context.Context {
+	return context.WithValue(ctx, serviceKey{}, s)
+}
+
+func GetService(ctx context.Context) Service {
+	if f, ok := ctx.Value(serviceKey{}).(Service); ok {
+		return f
+	}
+	panic("No User daemon Service has been registered")
 }

--- a/pkg/client/userd/session.go
+++ b/pkg/client/userd/session.go
@@ -11,7 +11,6 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/datawire/dlib/dgroup"
-	rpc2 "github.com/datawire/go-fuseftp/rpc"
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
@@ -91,7 +90,7 @@ type Session interface {
 	Done() <-chan struct{}
 }
 
-type NewSessionFunc func(context.Context, *scout.Reporter, *rpc.ConnectRequest, Service, rpc2.FuseFTPClient) (context.Context, Session, *connector.ConnectInfo)
+type NewSessionFunc func(context.Context, *scout.Reporter, *rpc.ConnectRequest) (context.Context, Session, *connector.ConnectInfo)
 
 type newSessionKey struct{}
 

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -23,7 +23,6 @@ import (
 	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
-	rpc2 "github.com/datawire/go-fuseftp/rpc"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/rpc/v2/common"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/connector"
@@ -164,7 +163,7 @@ func newPodIntercepts() *podIntercepts {
 }
 
 // start a port forward for the given intercept and remembers that it's alive.
-func (lpf *podIntercepts) start(ctx context.Context, ic *intercept, fuseftp rpc2.FuseFTPClient) {
+func (lpf *podIntercepts) start(ctx context.Context, ic *intercept) {
 	if !ic.shouldForward() && !ic.shouldMount() {
 		return
 	}
@@ -191,7 +190,7 @@ func (lpf *podIntercepts) start(ctx context.Context, ic *intercept, fuseftp rpc2
 	ctx, cancel := context.WithCancel(ctx)
 	lp := &podIntercept{cancelPod: cancel}
 	if ic.shouldMount() {
-		ic.startMount(ctx, fuseftp, &lp.wg)
+		ic.startMount(ctx, &lp.wg)
 	}
 	if ic.shouldForward() {
 		ic.startForwards(ctx, &lp.wg)
@@ -316,7 +315,7 @@ func (s *session) handleInterceptSnapshot(ctx context.Context, podIcepts *podInt
 			ic.FtpPort = 0
 			ic.SftpPort = 0
 		}
-		podIcepts.start(ctx, ic, s.fuseFtp)
+		podIcepts.start(ctx, ic)
 	}
 	if active == 0 {
 		ins = ""


### PR DESCRIPTION
## Description

Setting `intercept.fuseFtp=true` in the Helm chart didn't work, because the fuseftp server was initialized when the session booted up. This commit ensures that the initialization is deferred until the first intercept is made.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
