### PR TITLE
Make file-sharing logic in traffic-agent reusable.

### DIFF
--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -28,24 +28,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
 
-func GetAmbassadorCloudConnectionInfo(ctx context.Context, address string) (*rpc.AmbassadorCloudConnection, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx, address, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	if err != nil {
-		return &rpc.AmbassadorCloudConnection{}, err
-	}
-	defer conn.Close()
-
-	manager := rpc.NewManagerClient(conn)
-	cloudConnectInfo, err := manager.CanConnectAmbassadorCloud(ctx, &empty.Empty{})
-	if err != nil {
-		return &rpc.AmbassadorCloudConnection{}, err
-	}
-	return cloudConnectInfo, nil
-}
-
 type interceptsStringer []*rpc.InterceptInfo
 
 func (is interceptsStringer) String() string {


### PR DESCRIPTION
## Description

Export a method that initializes the traffic-agent's file-sharing so that this code doesn't need to be duplicated in the enhanced traffic-agent.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
