### PR TITLE
Node CIDRs are not pod CIDRs unless they cover the traffic-manager's IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.9.4 (TBD)
 
+- Feature: The traffic-manager can automatically detect that the node subnets are different from the
+  pod subnets, and switch detection strategy to instead use subnets that cover the pod IPs.
+
 - Bugfix: Initialization of FTP type file sharing is delayed, so that setting it using the Helm chart
   value `intercept.useFtp=true` works as expected.
 


### PR DESCRIPTION
## Description

When using cluster's like Minikube with a Docker driver, the node CIDRs are not used as pod CIDRs.

This PR checks if the IP of the traffic-manager is covered by a node CIDR, and if not, the node strategy is abandoned. If the default "auto" `PodCIDRStrategy` is used, that means that the discovery fall back to "coverPodIPs".

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
