### PR TITLE
Fix agent.image / agentInjector.agentImage confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Feature: The traffic-manager can automatically detect that the node subnets are different from the
   pod subnets, and switch detection strategy to instead use subnets that cover the pod IPs.
 
+- Bugfix: Telepresence now uses the correct `agent.image` properties in the Helm chart when copying
+  agent image settings from the `config.yml` file.
+
 - Bugfix: Initialization of FTP type file sharing is delayed, so that setting it using the Helm chart
   value `intercept.useFtp=true` works as expected.
 

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -315,5 +315,6 @@ install: build ## (Install) Installs the telepresence binary to $(bindir)
 .PHONY: all test images push-images
 all:         build image     ## (ZAlias) Alias for 'build image'
 test:        check-all       ## (ZAlias) Alias for 'check-all'
-images:      image           ## (ZAlias) Alias for 'image'
+images:      tel2            ## (ZAlias) Alias for 'tel2'
+image:       tel2            ## (ZAlias) Alias for 'tel2'
 push-images: push-image      ## (ZAlias) Alias for 'push-image'

--- a/pkg/install/helm/install.go
+++ b/pkg/install/helm/install.go
@@ -56,28 +56,27 @@ func getValues(ctx context.Context) map[string]any {
 			"maxReceiveSize": clientConfig.Grpc.MaxReceiveSize.String(),
 		}
 	}
-	apc := clientConfig.Intercept.AppProtocolStrategy
-	if wai, wr := imgConfig.AgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" || apc != k8sapi.Http2Probe {
-		agentImage := make(map[string]any)
+	if wai, wr := imgConfig.AgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" {
+		image := make(map[string]any)
 		if wai != "" {
 			parts := strings.Split(wai, ":")
-			image := wai
+			name := wai
 			tag := ""
 			if len(parts) > 1 {
-				image = parts[0]
+				name = parts[0]
 				tag = parts[1]
 			}
-			agentImage["name"] = image
-			agentImage["tag"] = tag
+			image["name"] = name
+			image["tag"] = tag
 		}
 		if wr != "" {
-			agentImage["registry"] = wr
+			image["registry"] = wr
 		}
-		agentInjector := map[string]any{"agentImage": agentImage}
-		values["agentInjector"] = agentInjector
-		if apc != k8sapi.Http2Probe {
-			agentInjector["appProtocolStrategy"] = apc.String()
-		}
+		values["agent"] = map[string]any{"image": image}
+	}
+
+	if apc := clientConfig.Intercept.AppProtocolStrategy; apc != k8sapi.Http2Probe {
+		values["agentInjector"] = map[string]any{"appProtocolStrategy": apc.String()}
 	}
 	if clientConfig.TelepresenceAPI.Port != 0 {
 		values["telepresenceAPI"] = map[string]any{


### PR DESCRIPTION
## Description

The code picking the agent name, image, and registry, from `config.yml`
was using the old deprecated `agentInjector.agentImage` instead of
`agent.image` and also didn't consider the proper defaults.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
