### PR TITLE
Better parsing of the telepresence helm install --set x=y values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Feature: The traffic-manager can automatically detect that the node subnets are different from the
   pod subnets, and switch detection strategy to instead use subnets that cover the pod IPs.
 
+- Bugfix: The `telepresence helm` command `--set x=y` flag didn't correctly set values of other types
+  than `string`. The code now uses standard Helm semantics for this flag.
+
 - Bugfix: Telepresence now uses the correct `agent.image` properties in the Helm chart when copying
   agent image settings from the `config.yml` file.
 


### PR DESCRIPTION
## Description

Removes the home-brewed value parser in favor of the parser used by the Helm install command.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
