### PR TITLE
Close all spdy streams when session ends.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Bugfix: Initialization of FTP type file sharing is delayed, so that setting it using the Helm chart
   value `intercept.useFtp=true` works as expected.
 
+- Bugfix: The port-forward that is created when Telepresence connects to a cluster is now properly
+  closed when `telepresence quit` is called.
+
 ### 2.9.3 (November 23, 2022)
 
 - Feature: The helm chart now supports `livenessProbe` and `readinessProbe` for the traffic-manager

--- a/pkg/dnet/kpfconn_test.go
+++ b/pkg/dnet/kpfconn_test.go
@@ -155,12 +155,12 @@ func TestKubectlPortForward(t *testing.T) {
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		dial, err := dnet.NewK8sPortForwardDialer(ctx, kubeConfig, ki)
+		dialer, err := dnet.NewK8sPortForwardDialer(ctx, kubeConfig, ki)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 
-		cliConn, err = dial(ctx, fmt.Sprintf("pods/SOMEPODNAME.SOMENAMESPACE:%d", podListener.Addr().(*net.TCPAddr).Port))
+		cliConn, err = dialer.Dial(ctx, fmt.Sprintf("pods/SOMEPODNAME.SOMENAMESPACE:%d", podListener.Addr().(*net.TCPAddr).Port))
 		t.Log("dialed")
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
## Description

Prior to this change, all spdy streams (used for port forwards to the traffic-manager) were left open after a `telepresence quit`. This meant that both the client and the traffic-manager retained connections that were no longer used, resulting in ever-increasing resource consumption until the client was killed with an explicit `telepresence quit -s`.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
