### PR TITLE
change upgrade message to output.Info writer

### DIFF
--- a/pkg/client/cli/util/update_check.go
+++ b/pkg/client/cli/util/update_check.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
 )
 
 const (
@@ -75,7 +76,7 @@ func updateCheck(cmd *cobra.Command, forceCheck bool) error {
 		return uc.StoreNextCheck(cmd.Context(), time.Hour)
 	}
 	if update != nil {
-		fmt.Fprintf(cmd.OutOrStdout(),
+		fmt.Fprintf(output.Info(cmd.Context()),
 			"An update of %s from version %s to %s is available. Please visit https://www.getambassador.io/docs/telepresence/latest/install/upgrade/ for more info.\n",
 			binaryName, &ourVersion, update)
 	}


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
change upgrade message writer to ouput.Info writer. This will prevent this message from appearing in `--ouput=json` objects