### PR TITLE
Ensure that google credentials are picked up correctly by root daemon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.9.5 (TBD)
+
+- Bugfix: A regression that was introduced in 2.9.3, preventing use of gce authentication without also 
+  having a config element present in the gce configuration in the kubeconfig, has been fixed.
+
 ### 2.9.4 (December 5, 2022)
 
 - Feature: The traffic-manager can automatically detect that the node subnets are different from the

--- a/pkg/client/cli/util/connector.go
+++ b/pkg/client/cli/util/connector.go
@@ -83,12 +83,16 @@ func AddKubeconfigEnv(cr *connector.ConnectRequest) {
 	// and since those files can be specified, both as a --kubeconfig flag and in the KUBECONFIG setting, and since the flag won't
 	// accept multiple path entries, we need to pass the environment setting to the connector daemon so that it can set it every
 	// time it receives a new config.
-	if cfg, ok := os.LookupEnv("KUBECONFIG"); ok {
-		if cr.KubeFlags == nil {
-			cr.KubeFlags = make(map[string]string)
+	addEnv := func(key string) {
+		if cfg, ok := os.LookupEnv(key); ok {
+			if cr.KubeFlags == nil {
+				cr.KubeFlags = make(map[string]string)
+			}
+			cr.KubeFlags[key] = cfg
 		}
-		cr.KubeFlags["KUBECONFIG"] = cfg
 	}
+	addEnv("KUBECONFIG")
+	addEnv("GOOGLE_APPLICATION_CREDENTIALS")
 }
 
 func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required bool) (conn *grpc.ClientConn, err error) {


### PR DESCRIPTION
## Description

A user using `gcloud auth` to authenticate to a GKE cluster would not be able to login unless the kubeconfig also contained a gce config element. This was becaue the root daemon was looking in the wrong place for the generated credentials file.

This commit ensures that setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable has the desired effect, and also that the default credentials are found when it is not set.

Signed-off-by: Thomas Hallgren <thomas@datawire.io>

A few sentences describing the overall goals of the pull request's commits.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
