### PR TITLE
Raphaelreyna/helm install mode

### DIFF
--- a/charts/telepresence/templates/trafficManager-configmap.yaml
+++ b/charts/telepresence/templates/trafficManager-configmap.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.trafficManager }}
   {{- if ne .Values.trafficManager.mode "team" }}
     {{- if .Values.intercept.disableGlobal }}
-      {{- fail "intercept.disableGlobal=true requires that traffic-manager.mode be set to 'team'" }}
+      {{- fail "intercept.disableGlobal=true requires that trafficManager.mode be set to 'team'" }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/cmd/traffic/cmd/manager/internal/config/trafficManager.go
+++ b/cmd/traffic/cmd/manager/internal/config/trafficManager.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"gopkg.in/yaml.v3"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 )
 
 type Mode manager.Mode

--- a/pkg/client/cli/cmd_helm.go
+++ b/pkg/client/cli/cmd_helm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/errcat"
@@ -27,10 +28,15 @@ type helmArgs struct {
 	valuePairs []string
 	request    *connector.ConnectRequest
 	kubeFlags  *pflag.FlagSet
+	mode       manager.Mode
 }
 
 func helmInstallCommand() *cobra.Command {
-	var upgrade bool
+	var (
+		upgrade              bool
+		teamMode, singleMode bool
+	)
+
 	ha := &helmArgs{
 		cmdType: connector.HelmRequest_INSTALL,
 	}
@@ -41,6 +47,14 @@ func helmInstallCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if upgrade {
 				ha.cmdType = connector.HelmRequest_UPGRADE
+			}
+			switch {
+			case teamMode && singleMode:
+				return fmt.Errorf("flags `--team-mode` and `--single-mode` are mutually exclusive")
+			case teamMode:
+				ha.mode = manager.Mode_MODE_TEAM
+			case singleMode:
+				ha.mode = manager.Mode_MODE_SINGLE
 			}
 			return ha.run(cmd, args)
 		},
@@ -53,6 +67,8 @@ func helmInstallCommand() *cobra.Command {
 	flags.BoolVarP(&upgrade, "upgrade", "u", false, "replace the traffic manager if it already exists")
 	flags.StringSliceVarP(&ha.values, "values", "f", []string{}, "specify values in a YAML file or a URL (can specify multiple)")
 	flags.StringSliceVarP(&ha.valuePairs, "set", "", []string{}, "specify a value as a.b=v (can specify multiple or separate values with commas: a.b=v1,a.c=v2)")
+	flags.BoolVarP(&teamMode, "team-mode", "", false, "set the traffic-manager to team mode")
+	flags.BoolVarP(&singleMode, "single-mode", "", false, "set the traffic-manager to single user mode")
 
 	ha.request, ha.kubeFlags = initConnectRequest(cmd)
 	return cmd
@@ -101,6 +117,14 @@ func (ha *helmArgs) run(cmd *cobra.Command, _ []string) error {
 		ValuePairs:     ha.valuePairs,
 		ConnectRequest: ha.request,
 	}
+
+	switch ha.mode {
+	case manager.Mode_MODE_SINGLE:
+		request.ValuePairs = append(request.ValuePairs, "trafficManager.mode=single")
+	case manager.Mode_MODE_TEAM:
+		request.ValuePairs = append(request.ValuePairs, "trafficManager.mode=team")
+	}
+
 	util.AddKubeconfigEnv(request.ConnectRequest)
 	resp, err := userD.Helm(ctx, request)
 	if err != nil {


### PR DESCRIPTION
## Description
Adds the flags `--team-mode` and `--single-mode` to the command telepresence helm install. These are equivalent to setting `--set trafficManager.mode=team` and `--set trafficManager.mode=single` respectively.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
