### PR TITLE
Add ability to set pull secrets in intercepted pods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.9.6 (TBD)
 
+- Feature: Image pull secrets for the traffic-agent can now be added using the Helm chart setting
+  `agent.image.pullSecrets`.
+
 - Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
   hang when there is no running traffic-manager.
 

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -147,6 +147,10 @@ spec:
             value: {{ .agent.image.registry }}
           {{- end }}
           {{- end }}
+          {{- with .agent.image.pullSecrets }}
+          - name: AGENT_IMAGE_PULL_SECRETS
+            value: '{{ toJson . }}'
+          {{- end }}
           {{- with .agent.envoy }}
           {{- if .logLevel }}
           - name: AGENT_ENVOY_LOG_LEVEL

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -205,6 +205,7 @@ agent:
     registry: docker.io/datawire
     name:
     tag:
+    pullSecrets: []
   envoy:
     logLevel: warning
     serverPort: 18000

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -106,6 +106,9 @@ type Sidecar struct {
 	// The fully qualified name of the traffic-agent image, i.e. "docker.io/tel2:2.5.4"
 	AgentImage string `json:"agentImage,omitempty"`
 
+	// Secrets used when pulling the agent image from a private registry
+	PullSecrets []core.LocalObjectReference `json:"pullSecrets,omitempty"`
+
 	// The name of the traffic-agent instance. Typically, the same as the name of the workload owner
 	AgentName string `json:"agentName,omitempty"`
 

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -30,6 +30,7 @@ type GeneratorConfig struct {
 	LogLevel            string
 	InitResources       *core.ResourceRequirements
 	Resources           *core.ResourceRequirements
+	PullSecrets         []core.LocalObjectReference
 	EnvoyLogLevel       string
 	EnvoyServerPort     uint16
 	EnvoyAdminPort      uint16
@@ -101,6 +102,7 @@ func Generate(ctx context.Context, wl k8sapi.Workload, cfg *GeneratorConfig) (sc
 		Containers:      ccs,
 		InitResources:   cfg.InitResources,
 		Resources:       cfg.Resources,
+		PullSecrets:     cfg.PullSecrets,
 	}
 	ag.RecordInSpan(span)
 	return ag, nil


### PR DESCRIPTION
## Description

Adds the Helm chart element `agent.image.pullSecrets` to the Helm chart.
When set, the pull secretes will end up in the same pod as an injected
traffic-agent, so that the traffic-agent image can be pulled from a
private repository.## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
