### PR TITLE
Make the intergration_tests pull-secret aware.

### DIFF
--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -10,7 +10,8 @@ runs:
     - name: Run tests
       env:
         DTEST_KUBECONFIG: "${{ inputs.kubeconfig }}"
-        DTEST_REGISTRY: "docker.io/datawire"
+        DTEST_REGISTRY: ghcr.io/${{ github.repository_owner }}
+        DTEST_PULL_SECRET: ghcr-pull-secret
       uses: nick-invision/retry@v2.8.2
       with:
         max_attempts: 3

--- a/.github/actions/prepare-cluster/action.yaml
+++ b/.github/actions/prepare-cluster/action.yaml
@@ -7,9 +7,6 @@ inputs:
   gke-credentials:
     description: "Service account credentials in JSON format. Account needs permissions to create/destroy clusters"
     required: true
-  tel-image:
-    description: "Path to the image to load onto the cluster"
-    required: true
   cluster-distribution:
     description: "Cluster distribution"
     required: true
@@ -43,13 +40,9 @@ runs:
         kubeconfig: "${{ steps.kubeconfig.outputs.KUBECONFIG }}"
         kubeceptionToken: ${{ inputs.kubeception-token }}
         gkeCredentials: ${{ inputs.gke-credentials }}
-    - name: Load image
+    - name: Create ghcr pull secret
       shell: bash
       env:
         KUBECONFIG: "${{ steps.kubeconfig.outputs.KUBECONFIG }}"
       run: |
-        kubectl apply -f build-aux/image-importer.yaml
-        kubectl rollout status -w deployment/image-importer
-        POD_NAME=$(kubectl get pod -ojsonpath='{.items[0].metadata.name}' -l app=image-importer)
-        kubectl cp "${{ inputs.tel-image }}" "$POD_NAME:/tmp/image.tar"
-        kubectl exec $POD_NAME -- //hostbin/ctr images import //tmp/image.tar
+        kubectl create secret docker-registry ghcr-pull-secret --docker-server=ghcr.io --docker-username=${{ github.repository_owner }} --docker-password=${{ github.token }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -19,14 +19,17 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.19'
-      - name: Build dev image
-        run: |
-          make tel2-image
-      - name: Upload image
-        uses: actions/upload-artifact@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          name: image
-          path: build-output/tel2-image.tar
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build and push dev image
+        env:
+          TELEPRESENCE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+        run: |
+          make push-image
   run_tests:
     strategy:
       fail-fast: false
@@ -48,15 +51,11 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: ./.github/actions/install-dependencies
         name: install dependencies
-      - uses: actions/download-artifact@v3
-        with:
-          name: image
       - run: make build
       - uses: ./.github/actions/prepare-cluster
         with:
           kubeception-token: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           gke-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          tel-image: tel2-image.tar
           cluster-distribution: ${{ matrix.clusters.distribution }}
           cluster-version: ${{ matrix.clusters.version }}
         id: kluster

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,6 +1,6 @@
 name: "Integration Tests"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,4 +43,4 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "binaries/*"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}

--- a/integration_test/cloud_config_test.go
+++ b/integration_test/cloud_config_test.go
@@ -70,7 +70,7 @@ func (s *notConnectedSuite) Test_CloudNeverProxy() {
 	_, err = f.Write(b)
 	require.NoError(err)
 
-	itest.TelepresenceOk(ctx, "helm", "install", "--upgrade", "--set", "logLevel=debug,agent.logLevel=debug", "-f", values)
+	s.TelepresenceHelmInstall(ctx, true, values, map[string]string{"logLevel": "debug", "agent.logLevel": "debug"})
 	defer s.rollbackTM()
 
 	s.Eventually(func() bool {
@@ -122,7 +122,11 @@ func (s *notConnectedSuite) Test_RootdCloudLogLevel() {
 	}
 	rootLog.Close()
 
-	itest.TelepresenceOk(ctx, "helm", "install", "--upgrade", "--set", "logLevel=debug,agent.logLevel=debug,client.logLevels.rootDaemon=trace")
+	s.TelepresenceHelmInstall(ctx, true, "", map[string]string{
+		"logLevel":                    "debug",
+		"agent.logLevel":              "debug",
+		"client.logLevels.rootDaemon": "trace",
+	})
 	defer s.rollbackTM()
 
 	// logrus.InfoLevel is the 0 value, so it's considered as unset if that's what's used,
@@ -223,7 +227,11 @@ func (s *notConnectedSuite) Test_UserdCloudLogLevel() {
 	}
 	logF.Close()
 
-	itest.TelepresenceOk(ctx, "helm", "install", "--upgrade", "--set", "logLevel=debug,agent.logLevel=debug,client.logLevels.userDaemon=trace")
+	s.TelepresenceHelmInstall(ctx, true, "", map[string]string{
+		"logLevel":                    "debug",
+		"agent.logLevel":              "debug",
+		"client.logLevels.userDaemon": "trace",
+	})
 	defer s.rollbackTM()
 
 	// logrus.InfoLevel is the 0 value, so it's considered as unset if that's what's used,

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -101,7 +101,7 @@ func (s *singleServiceSuite) TestGatherLogs_OnlyMappedLogs() {
 	require := s.Require()
 	ctx := s.Context()
 	otherNS := fmt.Sprintf("other-ns-%s", s.Suffix())
-	itest.CreateNamespaces(ctx, otherNS)
+	s.CreateNamespaces(ctx, otherNS)
 	defer itest.DeleteNamespaces(ctx, otherNS)
 	itest.ApplyEchoService(ctx, s.ServiceName(), otherNS, 8083)
 	itest.TelepresenceOk(ctx, "intercept", "--namespace", otherNS, "--mount", "false", s.ServiceName())

--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -30,7 +30,7 @@ func (s *helmSuite) SetupSuite() {
 	s.Suite.SetupSuite()
 	ctx := s.Context()
 	itest.TelepresenceQuitOk(ctx)
-	itest.CreateNamespaces(ctx, s.appSpace2, s.mgrSpace2)
+	s.CreateNamespaces(ctx, s.appSpace2, s.mgrSpace2)
 	itest.ApplyEchoService(ctx, s.ServiceName(), s.appSpace2, 80)
 	itest.TelepresenceOk(ctx, "connect")
 }

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -35,7 +35,7 @@ func (s *helmSuite) assertInjected(ctx context.Context, name, namespace string, 
 func (s *helmSuite) injectPolicyTest(ctx context.Context, policy agentconfig.InjectPolicy) {
 	namespace := fmt.Sprintf("%s-%s", strings.ToLower(policy.String()), s.Suffix())
 	ctx = itest.WithEnv(ctx, map[string]string{"TELEPRESENCE_MANAGER_NAMESPACE": namespace})
-	itest.CreateNamespaces(ctx, namespace)
+	s.CreateNamespaces(ctx, namespace)
 	defer itest.DeleteNamespaces(ctx, namespace)
 
 	s.NoError(s.InstallTrafficManager(ctx, map[string]string{"agentInjector.injectPolicy": policy.String()}, namespace))

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -325,7 +325,7 @@ func (is *installSuite) Test_No_Upgrade() {
 func (is *installSuite) Test_findTrafficManager_differentNamespace_present() {
 	ctx := is.Context()
 	customNamespace := fmt.Sprintf("custom-%d", os.Getpid())
-	itest.CreateNamespaces(ctx, customNamespace)
+	is.CreateNamespaces(ctx, customNamespace)
 	defer itest.DeleteNamespaces(ctx, customNamespace)
 	defer is.UninstallTrafficManager(ctx, customNamespace)
 	ctx = itest.WithEnv(ctx, map[string]string{"TELEPRESENCE_MANAGER_NAMESPACE": customNamespace})

--- a/integration_test/itest/connected.go
+++ b/integration_test/itest/connected.go
@@ -26,7 +26,11 @@ func (ch *connected) setup(ctx context.Context) bool {
 	t := getT(ctx)
 	_, _, _ = Telepresence(ctx, "quit", "-s") //nolint:dogsled // don't care about any of the returns
 	// Start once with default user to ensure that the auto-installer can run OK.
-	TelepresenceOk(WithUser(ctx, "default"), "helm", "install", "--set", "logLevel=debug", "--set", "agent.logLevel=debug")
+	ch.TelepresenceHelmInstall(WithUser(ctx, "default"), false, "", map[string]string{
+		"logLevel":       "debug",
+		"agent.logLevel": "debug",
+	})
+
 	stdout := TelepresenceOk(WithUser(ctx, "default"), "connect")
 	require.Contains(t, stdout, "Connected to context default")
 	TelepresenceQuitOk(ctx)

--- a/integration_test/itest/namespace.go
+++ b/integration_test/itest/namespace.go
@@ -48,7 +48,7 @@ func WithNamespacePair(ctx context.Context, suffix string, f func(NamespacePair)
 const purposeLabel = "tp-cli-testing"
 
 func (s *nsPair) setup(ctx context.Context) bool {
-	CreateNamespaces(ctx, s.namespace, s.managerNamespace)
+	s.CreateNamespaces(ctx, s.namespace, s.managerNamespace)
 	ctx = WithWorkingDir(ctx, filepath.Join(GetOSSRoot(ctx), "integration_test"))
 	err := Run(ctx, "kubectl", "apply", "-n", s.managerNamespace, "-f", filepath.Join("testdata", "k8s", "client_connect_rbac.yaml"))
 	require.NoError(getT(ctx), err, "failed to create connect Role/RoleBinding", TestUser)

--- a/integration_test/limitrange_test.go
+++ b/integration_test/limitrange_test.go
@@ -77,7 +77,7 @@ func (s *helmSuite) TestLimitRange() {
 	}()
 
 	limitedNS := fmt.Sprintf("limited-ns-%s", s.Suffix())
-	itest.CreateNamespaces(ctx, limitedNS)
+	s.CreateNamespaces(ctx, limitedNS)
 	defer itest.DeleteNamespaces(ctx, limitedNS)
 
 	s.Run("Never", func() {

--- a/integration_test/not_connected_test.go
+++ b/integration_test/not_connected_test.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func (s *notConnectedSuite) installTelepresence(ctx context.Context) {
-	itest.TelepresenceOk(ctx, "helm", "install", "--set", "logLevel=debug,agent.logLevel=debug")
+	s.TelepresenceHelmInstall(ctx, false, "", map[string]string{"logLevel": "debug", "agent.logLevel": "debug"})
 }
 
 func (s *notConnectedSuite) SetupSuite() {

--- a/integration_test/webhook_test.go
+++ b/integration_test/webhook_test.go
@@ -49,7 +49,7 @@ func (s *notConnectedSuite) Test_AgentImageFromConfig() {
 	// Restore the traffic-manager at the end of this function
 	ctx := itest.WithUser(s.Context(), "default")
 	defer func() {
-		itest.TelepresenceOk(ctx, "helm", "install")
+		s.TelepresenceHelmInstall(ctx, false, "", nil)
 		itest.TelepresenceOk(ctx, "connect")
 		itest.TelepresenceDisconnectOk(ctx)
 	}()
@@ -78,7 +78,7 @@ func (s *notConnectedSuite) Test_AgentImageFromConfig() {
 	uninstallEverything()
 
 	// And reinstall it
-	itest.TelepresenceOk(ctxAI, "helm", "install")
+	s.TelepresenceHelmInstall(ctxAI, false, "", nil)
 	itest.TelepresenceOk(ctxAI, "connect")
 
 	// When this function ends we uninstall the manager


### PR DESCRIPTION
## Description

Ensures that a secret that has been added to the default namespace of
the cluster prior running the tests is copied to all namespaces that
are created in the tests, and that all helm installs propagates the
secret to both the traffic-manager deployment and to the agent-injector.

This PR also contains a commit that changes the container registry used
during the build to GitHub Container Repository (GHCR).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
