### PR TITLE
Use kubernetes.io/metadata.name when mutating webhook matches namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 2.9.6 (TBD)
+
+- Change: If the cluster is Kubernetes 1.21 or later, the mutating webhook will find the correct namespace
+  using the label `kubernetes.io/metadata.name` rather than `app.kuberenetes.io/name`.
+
+- Change: The name of the mutating webhook now contains the namespace of the traffic-manager so that
+  the webhook is easier to identify when there are multiple namespace scoped telepresence installations
+  in the cluster.
+
 ### 2.9.5 (December 8, 2022)
 
 - Security: Update golang to 1.19.4 to address [CVE-2022-41720 and CVE-2022-41717](https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU).

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -44,7 +44,11 @@ webhooks:
 {{- if .Values.managerRbac.namespaced }}
   namespaceSelector:
     matchExpressions:
+{{- if and (eq (int .Capabilities.KubeVersion.Major)  1) (lt (int .Capabilities.KubeVersion.Minor) 21) }}
       - key: app.kubernetes.io/name
+{{- else }}
+      - key: kubernetes.io/metadata.name
+{{- end }}
         operator: In
         values:
 {{- range .Values.managerRbac.namespaces }}

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -38,7 +38,7 @@ webhooks:
     scope: '*'
   failurePolicy: {{ .Values.agentInjector.webhook.failurePolicy }}
   reinvocationPolicy: {{ .Values.agentInjector.webhook.reinvocationPolicy }}
-  name: agent-injector.getambassador.io
+  name: agent-injector-{{ include "traffic-manager.namespace" . }}.getambassador.io
   sideEffects: {{ .Values.agentInjector.webhook.sideEffects }}
   timeoutSeconds: {{ .Values.agentInjector.webhook.timeoutSeconds }}
 {{- if .Values.managerRbac.namespaced }}


### PR DESCRIPTION
## Description

The `kubernetes.io/metadata.name` is always set in Kubernetes versions
1.21 and higher. This commit ensures that it is used in favor of
`app.kubernetes.io/name` on such versions.

Closes #2913

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
