### PR TITLE
Add timeouts to the uninstall-agents pre-delete hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.9.6 (TBD)
 
+- Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
+  hang when there is no running traffic-manager.
+
 - Change: If the cluster is Kubernetes 1.21 or later, the mutating webhook will find the correct namespace
   using the label `kubernetes.io/metadata.name` rather than `app.kuberenetes.io/name`.
 

--- a/charts/telepresence/templates/pre-delete-hook.yaml
+++ b/charts/telepresence/templates/pre-delete-hook.yaml
@@ -49,7 +49,7 @@ spec:
             - sh
             - -c
           args:
-            - 'curl --fail --request DELETE https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/uninstall || exit 0'
+            - 'curl --fail --connect-timeout 5 --max-time 60 --request DELETE https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/uninstall || exit 0'
       volumes:
         - name: secret-volume
           secret:


### PR DESCRIPTION
## Description

Helm uninstall of a failed installation took a vary long time because the `uninstall-agents` job got stuck when it didn't get any responses from the agent-injector.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
