### PR TITLE
Don't panic when --docker-run is combined with --name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   is not set to `team`.
 
 - Change: If the cluster is Kubernetes 1.21 or later, the mutating webhook will find the correct namespace
-  using the label `kubernetes.io/metadata.name` rather than `app.kuberenetes.io/name`.
+  using the label `kubernetes.io/metadata.name` rather than `app.kuberenetes.io/name`. Ticket [2913](https://github.com/telepresenceio/telepresence/issues/2913).
 
 - Change: The name of the mutating webhook now contains the namespace of the traffic-manager so
   that the webhook is easier to identify when there are multiple namespace scoped telepresence
@@ -29,13 +29,13 @@
 
 - Change: The OSS Helm chart is no longer pushed to the datawire Helm repository. It will
   instead be pushed from the telepresence proprietary repository. The OSS Helm chart is still
-  what's embedded in the OSS telepresence client.
+  what's embedded in the OSS telepresence client. PR [2943](https://github.com/telepresenceio/telepresence/pull/2943).
 
 - Bugfix: Telepresence no longer panics when `--docker-run` is combined with `--name <name>` instead of
   `--name=<name>`. Ticket [2953](https://github.com/telepresenceio/telepresence/issues/2953).
 
 - Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
-  hang when there is no running traffic-manager.
+  hang when there is no running traffic-manager. PR [2937](https://github.com/telepresenceio/telepresence/pull/2937).
 
 ### 2.9.5 (December 8, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
   instead be pushed from the telepresence proprietary repository. The OSS Helm chart is still
   what's embedded in the OSS telepresence client.
 
+- Bugfix: Telepresence no longer panics when `--docker-run` is combined with `--name <name>` instead of
+  `--name=<name>`. Ticket [2953](https://github.com/telepresenceio/telepresence/issues/2953).
+
 - Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
   hang when there is no running traffic-manager.
 

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -329,6 +329,31 @@ func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRe
 	return ir, nil
 }
 
+func getArg(args []string, flag string) (string, error) {
+	feq := flag + "="
+	for i, arg := range args {
+		var v string
+		switch {
+		case arg == flag:
+			i++
+			if i < len(args) {
+				if v = args[i]; strings.HasPrefix(v, "-") {
+					v = ""
+				}
+			}
+		case strings.HasPrefix(arg, feq):
+			v = arg[len(feq):]
+		default:
+			continue
+		}
+		if v == "" {
+			return "", errors.New("docker flag `--name` requires a value")
+		}
+		return v, nil
+	}
+	return "", nil
+}
+
 func (s *state) startInDocker(ctx context.Context, envFile string, args []string) (*dexec.Cmd, error) {
 	ourArgs := []string{
 		"run",
@@ -336,27 +361,11 @@ func (s *state) startInDocker(ctx context.Context, envFile string, args []string
 		"--dns-search", "tel2-search",
 	}
 
-	getArg := func(s string) (string, bool) {
-		for i, arg := range args {
-			if strings.Contains(arg, s) {
-				parts := strings.Split(arg, "=")
-				if len(parts) == 2 {
-					return parts[1], true
-				}
-				if i+1 < len(args) {
-					return parts[i+1], true
-				}
-				return "", true
-			}
-		}
-		return "", false
+	name, err := getArg(args, "--name")
+	if err != nil {
+		return nil, err
 	}
-
-	name, hasName := getArg("--name")
-	if hasName && name == "" {
-		return nil, errors.New("no value found for docker flag `--name`")
-	}
-	if !hasName {
+	if name == "" {
 		name = fmt.Sprintf("intercept-%s-%d", s.Name(), s.localPort)
 		ourArgs = append(ourArgs, "--name", name)
 	}
@@ -381,8 +390,7 @@ func (s *state) startInDocker(ctx context.Context, envFile string, args []string
 	cmd.Stderr = s.cmd.ErrOrStderr()
 	cmd.Stdin = s.cmd.InOrStdin()
 	dlog.Debugf(ctx, shellquote.ShellString("docker", args))
-	err := cmd.Start()
-	if err != nil {
+	if err = cmd.Start(); err != nil {
 		return nil, err
 	}
 	return cmd, err

--- a/pkg/client/cli/intercept/state_test.go
+++ b/pkg/client/cli/intercept/state_test.go
@@ -1,0 +1,70 @@
+package intercept
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_getArg(t *testing.T) {
+	tests := []struct {
+		args    []string
+		flag    string
+		wantV   string
+		wantErr bool
+	}{
+		{
+			[]string{"--name="},
+			"--name",
+			"",
+			true,
+		},
+		{
+			[]string{"--name"},
+			"--name",
+			"",
+			true,
+		},
+		{
+			[]string{"--name", "--other"},
+			"--name",
+			"",
+			true,
+		},
+		{
+			[]string{"--name", "-o"},
+			"--name",
+			"",
+			true,
+		},
+		{
+			[]string{"--name=value"},
+			"--name",
+			"value",
+			false,
+		},
+		{
+			[]string{"--name=-value-"},
+			"--name",
+			"-value-",
+			false,
+		},
+		{
+			[]string{"--name", "value"},
+			"--name",
+			"value",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
+			gotV, err := getArg(tt.args, tt.flag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getArg() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotV != tt.wantV {
+				t.Errorf("getArg() gotV = %v, want %v", gotV, tt.wantV)
+			}
+		})
+	}
+}

--- a/pkg/client/cli/intercept/state_test.go
+++ b/pkg/client/cli/intercept/state_test.go
@@ -57,13 +57,13 @@ func Test_getArg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
-			gotV, err := getArg(tt.args, tt.flag)
+			gotV, err := getUnparsedFlagValue(tt.args, tt.flag)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getArg() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getUnparsedFlagValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotV != tt.wantV {
-				t.Errorf("getArg() gotV = %v, want %v", gotV, tt.wantV)
+				t.Errorf("getUnparsedFlagValue() gotV = %v, want %v", gotV, tt.wantV)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

The code that parses arguments after `--` would panic on flags that
used `--flag value` instead of `--flag=value`. This commit ensures that
both variants work.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
