### PR TITLE
Update repo address in Install section

### DIFF
--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -11,7 +11,7 @@ their services.
 ## Install
 
 ```sh
-helm repo add datawire https://getambassador.io
+helm repo add datawire https://app.getambassador.io
 helm install traffic-manager -n ambassador datawire/telepresence \
 --create-namespace \
 ```


### PR DESCRIPTION
## Description

Update repo address in Install section to https://app.getambassador.io
Te use of the previous one ( https://getambassador.io) is incorrect:

```bash
%> helm repo add datawire https://getambassador.io
Error: looks like "https://getambassador.io" is not a valid chart repository or cannot be reached: Get "https://www.getambassador.io/index.yaml": dial tcp [2a05:d014:275:cb01::c8]:443: connect: no route to host
```

## Checklist
Nop
