### PR TITLE
Use "kubernetes.default" service when extracting cluster domain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
   instead be pushed from the telepresence proprietary repository. The OSS Helm chart is still
   what's embedded in the OSS telepresence client.
 
+- Bugfix: Telepresence traffic-manager extracts the cluster domain (e.g. "cluster.local") using a CNAME lookup for "kubernetes.default"
+  instead of "kubernetes.default.svc".
+
 - Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
   hang when there is no running traffic-manager.
 

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -91,13 +91,13 @@ func NewInfo(ctx context.Context) Info {
 			oi.clusterID, err)
 	}
 
-	apiSvc := "kubernetes.default.svc"
+	apiSvc := "kubernetes.default"
 	var clusterDomain string
 	if cn, err := net.LookupCNAME(apiSvc); err != nil {
 		dlog.Infof(ctx, `Unable to determine cluster domain from CNAME of %s: %v"`, err, apiSvc)
 		clusterDomain = "cluster.local."
 	} else {
-		clusterDomain = cn[len(apiSvc)+1:]
+		clusterDomain = cn[len(apiSvc)+5:]
 	}
 	dlog.Infof(ctx, "Using cluster domain %q", clusterDomain)
 


### PR DESCRIPTION
## Description

The traffic-manager would use "kubernetes.default.svc" prior to this commit, and that often failed.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
