### PR TITLE
Don't attempt to summarize non-existent logs.

### DIFF
--- a/pkg/client/logging/initcontext.go
+++ b/pkg/client/logging/initcontext.go
@@ -91,6 +91,9 @@ func SummarizeLog(ctx context.Context, name string) (string, error) {
 	filename := filepath.Join(dir, name+".log")
 	file, err := os.Open(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
 		return "", err
 	}
 	defer file.Close()


### PR DESCRIPTION
Changes the `SummarizeLog` so that it returns an empty string and no error when the requested log doesn't exist.