### PR TITLE
Let the Helm chart hooks include the helm revision as a query parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,13 @@
   what's embedded in the OSS telepresence client.
 
 - Bugfix: Telepresence traffic-manager extracts the cluster domain (e.g. "cluster.local") using a CNAME lookup for "kubernetes.default"
-  instead of "kubernetes.default.svc".
+  instead of "kubernetes.default.svc". [PR 2959](https://github.com/telepresenceio/telepresence/pull/2959).
 
 - Bugfix: A timeout was added to the pre-delete hook `uninstall-agents`, so that a helm uninstall doesn't
   hang when there is no running traffic-manager.
+
+- Bugfix: The `Helm.Revision` is now used to prevent that Helm hook calls are served by the wrong revision of
+  the traffic-manager. [Issue 2954](https://github.com/telepresenceio/telepresence/issues/2954).
 
 ### 2.9.5 (December 8, 2022)
 

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -224,6 +224,8 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          - name: HELM_REVISION
+            value: {{ $.Release.Revision | quote }}
           ports:
           - name: api
             containerPort: {{ .apiPort }}

--- a/charts/telepresence/templates/post-upgrade-hook.yaml
+++ b/charts/telepresence/templates/post-upgrade-hook.yaml
@@ -61,7 +61,7 @@ spec:
             - '--fail'
             - '--request'
             - POST
-            - 'https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/upgrade-legacy'
+            - 'https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/upgrade-legacy?revision={{ .Release.Revision }}'
       volumes:
         - name: secret-volume
           secret:

--- a/charts/telepresence/templates/pre-delete-hook.yaml
+++ b/charts/telepresence/templates/pre-delete-hook.yaml
@@ -49,7 +49,7 @@ spec:
             - sh
             - -c
           args:
-            - 'curl --fail --connect-timeout 5 --max-time 60 --request DELETE https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/uninstall || exit 0'
+            - 'curl --fail --connect-timeout 5 --max-time 60 --request DELETE https://{{ .Values.agentInjector.name }}.{{ include "traffic-manager.namespace" . }}/uninstall?revision={{ .Release.Revision }} || exit 0'
       volumes:
         - name: secret-volume
           secret:

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -49,6 +49,8 @@ type Env struct {
 	PodCIDRs        []*net.IPNet `env:"POD_CIDRS,         parser=split-ipnet, default="`
 	PodIP           net.IP       `env:"POD_IP,            parser=ip"`
 
+	HelmRevision int `env:"HELM_REVISION, parser=strconv.ParseInt, default=0"`
+
 	AgentRegistry            string                      `env:"AGENT_REGISTRY,           parser=nonempty-string"`
 	AgentImage               string                      `env:"AGENT_IMAGE,              parser=string,         default="`
 	AgentImagePullSecrets    []core.LocalObjectReference `env:"AGENT_IMAGE_PULL_SECRETS, parser=json-local-refs,default="`


### PR DESCRIPTION
## Description

A race condition may occur during upgrade where the http call issued from a job started by a Helm pre-delete hook, is served by the upgraded traffic-manager rather than the deleted one.

This commit adds the `Helm.Revision` as a `HELM_REVISION` environment variable to the traffic-manager, and as a query parameter to the URL calls that the Helm hooks perform. The service then compares those revisions and discards the call when they don't match.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
