### PR TITLE
Ensure that CLI and user-daemon binaries are the same version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.10.2 (TBD)
+
+- Bugfix: Ensure that CLI and user-daemon binaries are the same version when running `telepresence helm install`
+  or `telepresence helm upgrade`.
+
 ### 2.10.1 (January 11, 2023)
 
 - Bugfix: Fixed a regex in our release process.

--- a/pkg/client/cli/cmd_helm.go
+++ b/pkg/client/cli/cmd_helm.go
@@ -57,7 +57,8 @@ func helmInstallCommand() *cobra.Command {
 			return ha.run(cmd, args)
 		},
 		Annotations: map[string]string{
-			ann.UserDaemon: ann.Required,
+			ann.UserDaemon:   ann.Required,
+			ann.VersionCheck: ann.Required,
 		},
 	}
 
@@ -81,7 +82,8 @@ func helmUpgradeCommand() *cobra.Command {
 		Short: "Upgrade telepresence traffic manager",
 		RunE:  ha.run,
 		Annotations: map[string]string{
-			ann.UserDaemon: ann.Required,
+			ann.UserDaemon:   ann.Required,
+			ann.VersionCheck: ann.Required,
 		},
 	}
 


### PR DESCRIPTION
## Description

The `telepresence helm install` and `telepresence helm upgrade` commands did not check that the version of the currently running user daemon was the same as the version of the CLI binary, which led to some weird errors.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
