### PR TITLE
add the ability to stream formatted objects

### DIFF
--- a/pkg/client/cli/cmd_list.go
+++ b/pkg/client/cli/cmd_list.go
@@ -126,10 +126,10 @@ func (s *listInfo) list(cmd *cobra.Command, _ []string) error {
 looper:
 	for {
 		select {
-		case r := <-ch:
-			s.printList(ctx, r.Workloads, stdout, formattedOutput)
 		case <-ctx.Done():
 			break looper
+		case r := <-ch:
+			s.printList(ctx, r.Workloads, stdout, formattedOutput)
 		}
 	}
 	return nil
@@ -138,7 +138,7 @@ looper:
 func (s *listInfo) printList(ctx context.Context, workloads []*connector.WorkloadInfo, stdout io.Writer, formattedOut bool) {
 	if len(workloads) == 0 {
 		if formattedOut {
-			output.Object(ctx, []struct{}{}, false)
+			output.StreamObject(ctx, []struct{}{}, false)
 		} else {
 			fmt.Fprintln(stdout, "No Workloads (Deployments, StatefulSets, or ReplicaSets)")
 		}
@@ -161,7 +161,7 @@ func (s *listInfo) printList(ctx context.Context, workloads []*connector.Workloa
 	}
 
 	if formattedOut {
-		output.Object(ctx, workloads, false)
+		output.StreamObject(ctx, workloads, false)
 	} else {
 		includeNs := false
 		ns := s.namespace

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -124,7 +124,14 @@ func Execute(cmd *cobra.Command) (*cobra.Command, bool, error) {
 	if err == nil && o.override {
 		obj = o.obj
 	} else {
-		response := o.shapeObjInfo(cmd, o.obj)
+		var stdoutobj any
+		if buf := o.Buffer; buf.Len() > 0 {
+			stdoutobj = buf.String()
+		} else if obj != nil {
+			stdoutobj = o.obj
+		}
+
+		response := o.shapeObjInfo(cmd, stdoutobj)
 		if err != nil {
 			response.Err = err.Error()
 		}
@@ -143,11 +150,9 @@ func (o *output) shapeObjInfo(cmd *cobra.Command, obj any) *object {
 	response := &object{
 		Cmd: cmd.Name(),
 	}
-	if buf := o.Buffer; buf.Len() > 0 {
-		response.Stdout = buf.String()
-	} else if obj != nil {
-		response.Stdout = obj
-	}
+
+	response.Stdout = obj
+
 	if buf, ok := cmd.ErrOrStderr().(*bytes.Buffer); ok && buf.Len() > 0 {
 		response.Stderr = buf.String()
 	}

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -79,7 +79,7 @@ func StreamObject(ctx context.Context, obj any, override bool) {
 	if cmd, ok := ctx.Value(key{}).(*cobra.Command); ok {
 		if o, ok := cmd.OutOrStdout().(*output); ok {
 			if !o.override {
-				obj = o.shapeObjInfo(cmd, obj)
+				obj = shapeObjInfo(cmd, obj)
 			}
 			o.write(obj)
 		}
@@ -131,7 +131,7 @@ func Execute(cmd *cobra.Command) (*cobra.Command, bool, error) {
 			stdoutobj = o.obj
 		}
 
-		response := o.shapeObjInfo(cmd, stdoutobj)
+		response := shapeObjInfo(cmd, stdoutobj)
 		if err != nil {
 			response.Err = err.Error()
 		}
@@ -146,7 +146,7 @@ func Execute(cmd *cobra.Command) (*cobra.Command, bool, error) {
 	return cmd, true, err
 }
 
-func (o *output) shapeObjInfo(cmd *cobra.Command, obj any) *object {
+func shapeObjInfo(cmd *cobra.Command, obj any) *object {
 	response := &object{
 		Cmd: cmd.Name(),
 	}
@@ -156,6 +156,7 @@ func (o *output) shapeObjInfo(cmd *cobra.Command, obj any) *object {
 	if buf, ok := cmd.ErrOrStderr().(*bytes.Buffer); ok && buf.Len() > 0 {
 		response.Stderr = buf.String()
 	}
+
 	return response
 }
 

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -78,7 +78,7 @@ func Object(ctx context.Context, obj any, override bool) {
 func StreamObject(ctx context.Context, obj any, override bool) {
 	if cmd, ok := ctx.Value(key{}).(*cobra.Command); ok {
 		if o, ok := cmd.OutOrStdout().(*output); ok {
-			if !o.override {
+			if !override {
 				obj = shapeObjInfo(cmd, obj)
 			}
 			o.write(obj)

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -154,8 +154,8 @@ func (o *output) shapeObjInfo(cmd *cobra.Command, obj any) *object {
 	return response
 }
 
-// makeWriterForFmt creates an appropriate writer for the given fmt
-func makeWriterForFmt(format format, originalStdout io.Writer) func(obj any) {
+// makeWriterForFormat creates an appropriate writer for the given format.
+func makeWriterForFormat(format format, originalStdout io.Writer) func(obj any) {
 	switch format {
 	case formatJSON:
 		// create the encoder once
@@ -193,7 +193,7 @@ func setFormat(cmd *cobra.Command) {
 		}
 		if fmt != formatDefault {
 			o := output{
-				write: makeWriterForFmt(fmt, cmd.OutOrStdout()),
+				write: makeWriterForFormat(fmt, cmd.OutOrStdout()),
 			}
 			cmd.SetOut(&o)
 			cmd.SetErr(&bytes.Buffer{})


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
Fixes panic caused by in `telepresence list --output json --watch`. Adds a function that will immediately print an object. **This PR is not well tested.**

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
