### PR TITLE
Export the InitConnectRequest and FlagMap (former kubeFlagMap)

### DIFF
--- a/pkg/client/cli/cmd_config.go
+++ b/pkg/client/cli/cmd_config.go
@@ -34,14 +34,14 @@ func configViewCommand() *cobra.Command {
 		PersistentPreRunE: output.DefaultYAML,
 		Short:             "View current Telepresence configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			request.KubeFlags = kubeFlagMap(kubeFlags)
+			request.KubeFlags = FlagMap(kubeFlags)
 			util.AddKubeconfigEnv(request)
 			cmd.SetContext(util.WithConnectionRequest(cmd.Context(), request))
 			return configView(cmd, args)
 		},
 	}
 	cmd.Flags().BoolP("client-only", "c", false, "Only view config from client file.")
-	request, kubeFlags = initConnectRequest(cmd)
+	request, kubeFlags = InitConnectRequest(cmd)
 	return cmd
 }
 

--- a/pkg/client/cli/cmd_helm.go
+++ b/pkg/client/cli/cmd_helm.go
@@ -68,7 +68,7 @@ func helmInstallCommand() *cobra.Command {
 	uf := flags.Lookup("upgrade")
 	uf.Hidden = true
 	uf.Deprecated = `Use "telepresence helm upgrade" instead of "telepresence helm install --upgrade"`
-	ha.Request, ha.kubeFlags = initConnectRequest(cmd)
+	ha.Request, ha.kubeFlags = InitConnectRequest(cmd)
 	return cmd
 }
 
@@ -93,7 +93,7 @@ func helmUpgradeCommand() *cobra.Command {
 		"when upgrading, reset the values to the ones built into the chart")
 	flags.BoolVarP(&ha.ReuseValues, "reuse-values", "", false,
 		"when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f")
-	ha.Request, ha.kubeFlags = initConnectRequest(cmd)
+	ha.Request, ha.kubeFlags = InitConnectRequest(cmd)
 	return cmd
 }
 
@@ -127,7 +127,7 @@ func helmUninstallCommand() *cobra.Command {
 			ann.VersionCheck: ann.Required,
 		},
 	}
-	ha.Request, ha.kubeFlags = initConnectRequest(cmd)
+	ha.Request, ha.kubeFlags = InitConnectRequest(cmd)
 	return cmd
 }
 
@@ -147,7 +147,7 @@ func (ha *HelmOpts) run(cmd *cobra.Command, _ []string) error {
 	if err = util.InitCommand(cmd); err != nil {
 		return err
 	}
-	ha.Request.KubeFlags = kubeFlagMap(ha.kubeFlags)
+	ha.Request.KubeFlags = FlagMap(ha.kubeFlags)
 
 	util.AddKubeconfigEnv(ha.Request)
 

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -252,7 +252,7 @@ func genConfigMapSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the agent's entry in the telepresence-agents configmap.",
 		Long:  "Generate YAML for the agent's entry in the telepresence-agents configmap. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, kubeFlagMap(kubeFlags))
+			return info.run(cmd, FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()
@@ -314,7 +314,7 @@ func genContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the traffic-agent container.",
 		Long:  "Generate YAML for the traffic-agent container. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, kubeFlagMap(kubeFlags))
+			return info.run(cmd, FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()
@@ -383,7 +383,7 @@ func genInitContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the traffic-agent init container.",
 		Long:  "Generate YAML for the traffic-agent init container. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, kubeFlagMap(kubeFlags))
+			return info.run(cmd, FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()

--- a/pkg/client/cli/cmds_misc.go
+++ b/pkg/client/cli/cmds_misc.go
@@ -66,7 +66,7 @@ func connectCommand() *cobra.Command {
 			ann.Session:    ann.Required,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			request.KubeFlags = kubeFlagMap(kubeFlags)
+			request.KubeFlags = FlagMap(kubeFlags)
 			cmd.SetContext(util.WithConnectionRequest(cmd.Context(), request))
 			if err := util.InitCommand(cmd); err != nil {
 				return err
@@ -83,11 +83,15 @@ func connectCommand() *cobra.Command {
 			return proc.Run(ctx, nil, cmd, args[0], args[1:]...)
 		},
 	}
-	request, kubeFlags = initConnectRequest(cmd)
+	request, kubeFlags = InitConnectRequest(cmd)
 	return cmd
 }
 
-func initConnectRequest(cmd *cobra.Command) (*connector.ConnectRequest, *pflag.FlagSet) {
+// InitConnectRequest adds the networking flags and Kubernetes flags to the given command and
+// returns a ConnectRequest and a FlagSet with the Kubernetes flags. The FlagSet is returned
+// here so that a map of flags that gets modified can be extracted using FlagMap once the flag
+// parsing has completed.
+func InitConnectRequest(cmd *cobra.Command) (*connector.ConnectRequest, *pflag.FlagSet) {
 	cr := connector.ConnectRequest{}
 	flags := cmd.Flags()
 

--- a/pkg/client/cli/util.go
+++ b/pkg/client/cli/util.go
@@ -20,9 +20,10 @@ func AsCSV(vs []string) string {
 	return strings.TrimSuffix(b.String(), "\n")
 }
 
-func kubeFlagMap(kubeFlags *pflag.FlagSet) map[string]string {
-	kubeFlagMap := make(map[string]string, kubeFlags.NFlag())
-	kubeFlags.VisitAll(func(flag *pflag.Flag) {
+// FlagMap returns a map of the flags that has been modified in the given FlagSet.
+func FlagMap(flags *pflag.FlagSet) map[string]string {
+	flagMap := make(map[string]string, flags.NFlag())
+	flags.VisitAll(func(flag *pflag.Flag) {
 		if flag.Changed {
 			var v string
 			if sv, ok := flag.Value.(pflag.SliceValue); ok {
@@ -30,8 +31,8 @@ func kubeFlagMap(kubeFlags *pflag.FlagSet) map[string]string {
 			} else {
 				v = flag.Value.String()
 			}
-			kubeFlagMap[flag.Name] = v
+			flagMap[flag.Name] = v
 		}
 	})
-	return kubeFlagMap
+	return flagMap
 }


### PR DESCRIPTION
Those functions are needed in the pro client.

The `kubeFlagMap` was renamed to `FlagMap` because it's actually generic.
