### PR TITLE
add retry to dialRequestWatcher

### DIFF
--- a/cmd/traffic/cmd/manager/state/session.go
+++ b/cmd/traffic/cmd/manager/state/session.go
@@ -20,7 +20,7 @@ type SessionState interface {
 	Done() <-chan struct{}
 	LastMarked() time.Time
 	SetLastMarked(lastMarked time.Time)
-	Dials() <-chan *rpc.DialRequest
+	Dials() chan *rpc.DialRequest
 	EstablishBidiPipe(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
 	OnConnect(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
 }
@@ -118,7 +118,7 @@ func (ss *sessionState) Cancel() {
 	close(ss.dials)
 }
 
-func (ss *sessionState) Dials() <-chan *rpc.DialRequest {
+func (ss *sessionState) Dials() chan *rpc.DialRequest {
 	return ss.dials
 }
 

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -589,7 +589,7 @@ func (s *State) getRandomAgentSession(clientSessionID string) (agent SessionStat
 	return
 }
 
-func (s *State) WatchDial(sessionID string) <-chan *rpc.DialRequest {
+func (s *State) WatchDial(sessionID string) chan *rpc.DialRequest {
 	s.mu.RLock()
 	ss, ok := s.sessions[sessionID]
 	s.mu.RUnlock()

--- a/pkg/client/userd/trafficmgr/agents.go
+++ b/pkg/client/userd/trafficmgr/agents.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -14,7 +13,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/datawire/dlib/dlog"
-	"github.com/datawire/dlib/dtime"
 	"github.com/telepresenceio/telepresence/rpc/v2/common"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
@@ -182,18 +180,7 @@ func (s *session) watchAgents(ctx context.Context, opts []grpc.CallOption) error
 }
 
 func (s *session) agentInfoWatcher(ctx context.Context) error {
-	backoff := 100 * time.Millisecond
-	for ctx.Err() == nil {
-		if err := s.watchAgentsNS(ctx); err != nil {
-			dlog.Error(ctx, err)
-			dtime.SleepWithContext(ctx, backoff)
-			backoff *= 2
-			if backoff > 3*time.Second {
-				backoff = 3 * time.Second
-			}
-		}
-	}
-	return nil
+	return runWithRetry(ctx, s.watchAgentsNS)
 }
 
 // Deprecated.

--- a/pkg/client/userd/trafficmgr/dial_request.go
+++ b/pkg/client/userd/trafficmgr/dial_request.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (s *session) dialRequestWatcher(ctx context.Context) error {
+	return runWithRetry(ctx, s._dialRequestWatcher)
+}
+
+func (s *session) _dialRequestWatcher(ctx context.Context) error {
 	// Deal with dial requests from the manager
 	dialerStream, err := s.managerClient.WatchDial(ctx, s.sessionInfo)
 	if err != nil {

--- a/pkg/client/userd/trafficmgr/dial_request.go
+++ b/pkg/client/userd/trafficmgr/dial_request.go
@@ -12,8 +12,6 @@ func (s *session) dialRequestWatcher(ctx context.Context) error {
 
 func (s *session) _dialRequestWatcher(ctx context.Context) error {
 	// Deal with dial requests from the manager
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	dialerStream, err := s.managerClient.WatchDial(ctx, s.sessionInfo)
 	if err != nil {
 		return err

--- a/pkg/client/userd/trafficmgr/dial_request.go
+++ b/pkg/client/userd/trafficmgr/dial_request.go
@@ -12,6 +12,8 @@ func (s *session) dialRequestWatcher(ctx context.Context) error {
 
 func (s *session) _dialRequestWatcher(ctx context.Context) error {
 	// Deal with dial requests from the manager
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	dialerStream, err := s.managerClient.WatchDial(ctx, s.sessionInfo)
 	if err != nil {
 		return err

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -224,18 +224,7 @@ func (s *session) watchInterceptsHandler(ctx context.Context) error {
 	//     their exit statuses is just a memory leak
 	//  3. because we want a per-worker cancel, we'd have to implement our own Context
 	//     management on top anyway, so dgroup wouldn't actually save us any complexity.
-	backoff := 100 * time.Millisecond
-	for ctx.Err() == nil {
-		if err := s.watchInterceptsLoop(ctx); err != nil {
-			dlog.Error(ctx, err)
-			dtime.SleepWithContext(ctx, backoff)
-			backoff *= 2
-			if backoff > 3*time.Second {
-				backoff = 3 * time.Second
-			}
-		}
-	}
-	return nil
+	return runWithRetry(ctx, s.watchInterceptsLoop)
 }
 
 func (s *session) watchInterceptsLoop(ctx context.Context) error {

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -315,9 +315,6 @@ func readLoop(ctx context.Context, h streamReader) {
 // attaches a dialer Endpoint to that tunnel is spawned for each request that arrives. The method blocks until
 // the dialStream is closed.
 func DialWaitLoop(ctx context.Context, manager rpc.ManagerClient, dialStream rpc.Manager_WatchDialClient, sessionID string) error {
-	// create ctx to cleanup leftover dialRespond if waitloop dies
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	for ctx.Err() == nil {
 		dr, err := dialStream.Recv()
 		if err != nil {

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -315,6 +315,9 @@ func readLoop(ctx context.Context, h streamReader) {
 // attaches a dialer Endpoint to that tunnel is spawned for each request that arrives. The method blocks until
 // the dialStream is closed.
 func DialWaitLoop(ctx context.Context, manager rpc.ManagerClient, dialStream rpc.Manager_WatchDialClient, sessionID string) error {
+	// create ctx to cleanup leftover dialRespond if waitloop dies
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	for ctx.Err() == nil {
 		dr, err := dialStream.Recv()
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: njayp <nickjaypowell@gmail.com>

## Description
Telepresence would shut down if it lost connection for a few minutes. This was caused by the `dialRequestWatcher` go-routine, which would exit with error, cascading into the death of the session. Adding a retry to `dialRequestWatcher` fixed the problem.

There was a secondary problem where the first message after reconnecting failed. This was due to the traffic manager attempting to re-use the dead connection. Now, on failure, the listenrequest is put back in the channel to be used by the next connection