### PR TITLE
Add ability to install a released traffic-manager to the integration_tests.

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: '1.19'
       - name: Build dev image
         run: |
-          make tel2-image
+          make save-image
       - name: Upload image
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build dev image
         run: |
-          make tel2-image
+          make save-image
       - name: Scan
         uses: aquasecurity/trivy-action@master
         with:

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -157,17 +157,18 @@ release-binary: $(TELEPRESENCE)
 	mkdir -p $(RELEASEDIR)
 	cp $(TELEPRESENCE) $(RELEASEDIR)/telepresence-$(GOOS)-$(GOARCH)$(BEXE)
 
-.PHONY: tel2
-tel2: build-deps
+.PHONY: image
+image: build-deps
 	mkdir -p $(BUILDDIR)
 	printf $(TELEPRESENCE_VERSION) > $(BUILDDIR)/version.txt ## Pass version in a file instead of a --build-arg to maximize cache usage
-	docker build --target $@ --tag $@ --tag $(TELEPRESENCE_REGISTRY)/$@:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f base-image/Dockerfile .
+	docker build --target tel2 --tag tel2 --tag $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f base-image/Dockerfile .
 
 .PHONY: push-image
-push-image: tel2 ## (Build) Push the manager/agent container image to $(TELEPRESENCE_REGISTRY)
+push-image: image ## (Build) Push the manager/agent container image to $(TELEPRESENCE_REGISTRY)
 	docker push $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION))
 
-tel2-image: tel2
+.PHONY: save-image
+save-image: image
 	docker save $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) > $(BUILDDIR)/tel2-image.tar
 
 .PHONY: clobber
@@ -307,6 +308,7 @@ install: build ## (Install) Installs the telepresence binary to $(bindir)
 .PHONY: all test images push-images
 all:         build image     ## (ZAlias) Alias for 'build image'
 test:        check-all       ## (ZAlias) Alias for 'check-all'
-images:      tel2            ## (ZAlias) Alias for 'tel2'
-image:       tel2            ## (ZAlias) Alias for 'tel2'
+images:      image           ## (ZAlias) Alias for 'tel2'
+tel2:        image           ## (ZAlias) Alias for 'tel2'
+tel2-image:  save-image      ## (ZAlias) Alias for 'tel2'
 push-images: push-image      ## (ZAlias) Alias for 'push-image'

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -57,7 +57,7 @@ func (is *installSuite) Test_NonHelmInstall() {
 
 	chart, err := is.PackageHelmChart(ctx)
 	require.NoError(err)
-	values := is.GetValuesForHelm(map[string]string{}, is.ManagerNamespace(), is.AppNamespace())
+	values := is.GetValuesForHelm(map[string]string{}, false, is.ManagerNamespace(), is.AppNamespace())
 	values = append([]string{"template", "traffic-manager", chart, "-n", is.ManagerNamespace()}, values...)
 	manifest, err := itest.Output(ctx, "helm", values...)
 	require.NoError(err)

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -219,7 +219,7 @@ func (s *cluster) ensureDockerImage(ctx context.Context, errs chan<- error, wg *
 	}
 
 	runMake := func(target string) {
-		out, err := Command(WithOSSRoot(ctx), makeExe, target).CombinedOutput()
+		out, err := Command(WithModuleRoot(ctx), makeExe, target).CombinedOutput()
 		if err != nil {
 			errs <- RunError(err, out)
 		}
@@ -228,7 +228,7 @@ func (s *cluster) ensureDockerImage(ctx context.Context, errs chan<- error, wg *
 	wgs.Add(1)
 	go func() {
 		defer wgs.Done()
-		runMake("tel2")
+		runMake("image")
 	}()
 	wgs.Wait()
 


### PR DESCRIPTION
Adds the method `InstallTrafficManagerVersion` to the integration_test framework so that tests can be written that exercises the current client against older traffic-managers.
