### PR TITLE
add support for ipv6 clusters (fixes #2978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### 2.X.X (TBD)
 
+- Bugfix: Fixes IPv6 support.
+  Ticket [2978](https://github.com/telepresenceio/telepresence/issues/2978).
+
+### 2.X.X (TBD)
+
 - Feature: Adds two parameters `--also-proxy` and `--never-proxy` to the `telepresence connect` command.
   Ticket [2950](https://github.com/telepresenceio/telepresence/issues/2950).
 

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	k8s.io/client-go v0.26.0
 	k8s.io/kubectl v0.26.0
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
+	sigs.k8s.io/kustomize/kyaml v0.13.9
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -179,7 +180,6 @@ require (
 	oras.land/oras-go v1.2.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 

--- a/pkg/iputil/ipnet.go
+++ b/pkg/iputil/ipnet.go
@@ -24,20 +24,6 @@ func IPNetFromRPC(r *manager.IPNet) *net.IPNet {
 	}
 }
 
-//func IPNetFromRPC(r *manager.IPNet) *net.IPNet {
-//	var mask net.IPMask
-//	if len(r.Ip) > 4 {
-//		mask = net.CIDRMask(int(r.Mask), 128)
-//	} else {
-//		mask = net.CIDRMask(int(r.Mask), len(r.Ip)*8)
-//	}
-//
-//	return &net.IPNet{
-//		IP:   r.Ip,
-//		Mask: mask,
-//	}
-//}
-
 func IsIpV6Addr(ipAddStr string) bool {
 	return strings.Count(ipAddStr, ":") >= 2
 }

--- a/pkg/iputil/ipnet.go
+++ b/pkg/iputil/ipnet.go
@@ -3,8 +3,8 @@ package iputil
 import (
 	"encoding/json"
 	"net"
-
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"strings"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 )
@@ -22,6 +22,24 @@ func IPNetFromRPC(r *manager.IPNet) *net.IPNet {
 		IP:   r.Ip,
 		Mask: net.CIDRMask(int(r.Mask), len(r.Ip)*8),
 	}
+}
+
+//func IPNetFromRPC(r *manager.IPNet) *net.IPNet {
+//	var mask net.IPMask
+//	if len(r.Ip) > 4 {
+//		mask = net.CIDRMask(int(r.Mask), 128)
+//	} else {
+//		mask = net.CIDRMask(int(r.Mask), len(r.Ip)*8)
+//	}
+//
+//	return &net.IPNet{
+//		IP:   r.Ip,
+//		Mask: mask,
+//	}
+//}
+
+func IsIpV6Addr(ipAddStr string) bool {
+	return strings.Count(ipAddStr, ":") >= 2
 }
 
 // Subnet is a net.IPNet that can be marshalled/unmarshalled as yaml or json.

--- a/pkg/iputil/ipnet.go
+++ b/pkg/iputil/ipnet.go
@@ -3,8 +3,9 @@ package iputil
 import (
 	"encoding/json"
 	"net"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 )

--- a/pkg/vif/device_darwin.go
+++ b/pkg/vif/device_darwin.go
@@ -155,8 +155,8 @@ type addrIfReq struct {
 // See https://www.unix.com/man-page/osx/4/netintro/
 
 type addrLifetime struct {
-	expire         float64 // nolint:unused
-	preferred      float64 // nolint:unused
+	expire         float64 //nolint:unused //not used
+	preferred      float64 //nolint:unused // not used
 	validLifeTime  uint32
 	prefixLifeTime uint32
 }
@@ -171,10 +171,12 @@ type addrIfReq6 struct {
 }
 
 // SIOCAIFADDR_IN6 is the same ioctlHandle identifier as unix.SIOCAIFADDR adjusted with size of addrIfReq6.
-const SIOCAIFADDR_IN6 = (unix.SIOCAIFADDR & 0xe000ffff) | (uint(unsafe.Sizeof(addrIfReq6{})) << 16)
-const ND6_INFINITE_LIFETIME = 0xffffffff
-const IN6_IFF_NODAD = 0x0020
-const IN6_IFF_SECURED = 0x0400
+const (
+	SIOCAIFADDR_IN6       = (unix.SIOCAIFADDR & 0xe000ffff) | (uint(unsafe.Sizeof(addrIfReq6{})) << 16)
+	ND6_INFINITE_LIFETIME = 0xffffffff
+	IN6_IFF_NODAD         = 0x0020
+	IN6_IFF_SECURED       = 0x0400
+)
 
 // SIOCDIFADDR_IN6 is the same ioctlHandle identifier as unix.SIOCDIFADDR adjusted with size of addrIfReq6.
 const SIOCDIFADDR_IN6 = (unix.SIOCDIFADDR & 0xe000ffff) | (uint(unsafe.Sizeof(addrIfReq6{})) << 16)

--- a/pkg/vif/device_darwin.go
+++ b/pkg/vif/device_darwin.go
@@ -154,20 +154,20 @@ type addrIfReq struct {
 //
 // See https://www.unix.com/man-page/osx/4/netintro/
 
-type in6_addrlifetime struct {
-	ia6t_expire    float64 // nolint:unused
-	ia6t_preferred float64 // nolint:unused
-	ia6t_vltime    uint32
-	ia6t_pltime    uint32
+type addrLifetime struct {
+	expire         float64 // nolint:unused
+	preferred      float64 // nolint:unused
+	validLifeTime  uint32
+	prefixLifeTime uint32
 }
 
 type addrIfReq6 struct {
-	name          [unix.IFNAMSIZ]byte
-	addr          unix.RawSockaddrInet6
-	dest          unix.RawSockaddrInet6
-	mask          unix.RawSockaddrInet6
-	flags         int32 //nolint:structcheck // this is the type returned by the kernel, not our own type
-	ifra_lifetime in6_addrlifetime
+	name         [unix.IFNAMSIZ]byte
+	addr         unix.RawSockaddrInet6
+	dest         unix.RawSockaddrInet6
+	mask         unix.RawSockaddrInet6
+	flags        int32 //nolint:structcheck // this is the type returned by the kernel, not our own type
+	addrLifetime addrLifetime
 }
 
 // SIOCAIFADDR_IN6 is the same ioctlHandle identifier as unix.SIOCAIFADDR adjusted with size of addrIfReq6.
@@ -213,8 +213,8 @@ func (t *nativeDevice) setAddr(subnet *net.IPNet, to net.IP) error {
 				mask:  unix.RawSockaddrInet6{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET6},
 				flags: IN6_IFF_NODAD | IN6_IFF_SECURED,
 			}
-			ifreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME
-			ifreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME
+			ifreq.addrLifetime.validLifeTime = ND6_INFINITE_LIFETIME
+			ifreq.addrLifetime.prefixLifeTime = ND6_INFINITE_LIFETIME
 
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], subnet.IP.To16())
@@ -249,8 +249,8 @@ func (t *nativeDevice) removeAddr(subnet *net.IPNet, to net.IP) error {
 				dest: unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
 				mask: unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
 			}
-			ifreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME
-			ifreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME
+			ifreq.addrLifetime.validLifeTime = ND6_INFINITE_LIFETIME
+			ifreq.addrLifetime.prefixLifeTime = ND6_INFINITE_LIFETIME
 
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], subnet.IP.To16())

--- a/pkg/vif/device_darwin.go
+++ b/pkg/vif/device_darwin.go
@@ -153,21 +153,28 @@ type addrIfReq struct {
 // Address structure for the SIOCAIFADDR_IN6 ioctlHandle request
 //
 // See https://www.unix.com/man-page/osx/4/netintro/
+
+type in6_addrlifetime struct {
+	ia6t_expire    float64 // nolint:unused
+	ia6t_preferred float64 // nolint:unused
+	ia6t_vltime    uint32
+	ia6t_pltime    uint32
+}
+
 type addrIfReq6 struct {
-	name           [unix.IFNAMSIZ]byte
-	addr           unix.RawSockaddrInet6
-	dest           unix.RawSockaddrInet6
-	mask           unix.RawSockaddrInet6
-	flags          int32 //nolint:structcheck // this is the type returned by the kernel, not our own type
-	expire         int64 //nolint:structcheck // likewise
-	preferred      int64 //nolint:structcheck // likewise
-	validLifeTime  uint32
-	prefixLifeTime uint32
+	name          [unix.IFNAMSIZ]byte
+	addr          unix.RawSockaddrInet6
+	dest          unix.RawSockaddrInet6
+	mask          unix.RawSockaddrInet6
+	flags         int32 //nolint:structcheck // this is the type returned by the kernel, not our own type
+	ifra_lifetime in6_addrlifetime
 }
 
 // SIOCAIFADDR_IN6 is the same ioctlHandle identifier as unix.SIOCAIFADDR adjusted with size of addrIfReq6.
 const SIOCAIFADDR_IN6 = (unix.SIOCAIFADDR & 0xe000ffff) | (uint(unsafe.Sizeof(addrIfReq6{})) << 16)
 const ND6_INFINITE_LIFETIME = 0xffffffff
+const IN6_IFF_NODAD = 0x0020
+const IN6_IFF_SECURED = 0x0400
 
 // SIOCDIFADDR_IN6 is the same ioctlHandle identifier as unix.SIOCDIFADDR adjusted with size of addrIfReq6.
 const SIOCDIFADDR_IN6 = (unix.SIOCDIFADDR & 0xe000ffff) | (uint(unsafe.Sizeof(addrIfReq6{})) << 16)
@@ -187,9 +194,9 @@ func (t *nativeDevice) setAddr(subnet *net.IPNet, to net.IP) error {
 	if sub4, to4, ok := addrToIp4(subnet, to); ok {
 		return withSocket(unix.AF_INET, func(fd int) error {
 			ifreq := &addrIfReq{
-				addr: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
-				dest: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
-				mask: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
+				addr: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet4, Family: unix.AF_INET},
+				dest: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet4, Family: unix.AF_INET},
+				mask: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet4, Family: unix.AF_INET},
 			}
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], sub4.IP)
@@ -202,16 +209,16 @@ func (t *nativeDevice) setAddr(subnet *net.IPNet, to net.IP) error {
 	} else {
 		return withSocket(unix.AF_INET6, func(fd int) error {
 			ifreq := &addrIfReq6{
-				addr:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				dest:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				mask:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				validLifeTime:  ND6_INFINITE_LIFETIME,
-				prefixLifeTime: ND6_INFINITE_LIFETIME,
+				addr:  unix.RawSockaddrInet6{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET6},
+				mask:  unix.RawSockaddrInet6{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET6},
+				flags: IN6_IFF_NODAD | IN6_IFF_SECURED,
 			}
+			ifreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME
+			ifreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME
+
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], subnet.IP.To16())
 			copy(ifreq.mask.Addr[:], subnet.Mask)
-			copy(ifreq.dest.Addr[:], to.To16())
 			err := ioctl(fd, SIOCAIFADDR_IN6, unsafe.Pointer(ifreq))
 			runtime.KeepAlive(ifreq)
 			return err
@@ -223,9 +230,9 @@ func (t *nativeDevice) removeAddr(subnet *net.IPNet, to net.IP) error {
 	if sub4, to4, ok := addrToIp4(subnet, to); ok {
 		return withSocket(unix.AF_INET, func(fd int) error {
 			ifreq := &addrIfReq{
-				addr: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
-				dest: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
-				mask: unix.RawSockaddrInet4{Len: 16, Family: unix.AF_INET},
+				addr: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET},
+				dest: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET},
+				mask: unix.RawSockaddrInet4{Len: unix.SizeofSockaddrInet6, Family: unix.AF_INET},
 			}
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], sub4.IP)
@@ -238,16 +245,16 @@ func (t *nativeDevice) removeAddr(subnet *net.IPNet, to net.IP) error {
 	} else {
 		return withSocket(unix.AF_INET6, func(fd int) error {
 			ifreq := &addrIfReq6{
-				addr:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				dest:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				mask:           unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
-				validLifeTime:  ND6_INFINITE_LIFETIME,
-				prefixLifeTime: ND6_INFINITE_LIFETIME,
+				addr: unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
+				dest: unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
+				mask: unix.RawSockaddrInet6{Len: 28, Family: unix.AF_INET6},
 			}
+			ifreq.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME
+			ifreq.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME
+
 			copy(ifreq.name[:], t.name)
 			copy(ifreq.addr.Addr[:], subnet.IP.To16())
 			copy(ifreq.mask.Addr[:], subnet.Mask)
-			copy(ifreq.dest.Addr[:], to.To16())
 			err := ioctl(fd, SIOCDIFADDR_IN6, unsafe.Pointer(ifreq))
 			runtime.KeepAlive(ifreq)
 			return err


### PR DESCRIPTION
## Description

This PR fixes networking for IPv6 clusters

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
