### PR TITLE
Collect flag utility functions into one place.

### DIFF
--- a/pkg/client/cli/cmd_config.go
+++ b/pkg/client/cli/cmd_config.go
@@ -34,7 +34,7 @@ func configViewCommand() *cobra.Command {
 		PersistentPreRunE: output.DefaultYAML,
 		Short:             "View current Telepresence configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			request.KubeFlags = FlagMap(kubeFlags)
+			request.KubeFlags = util.FlagMap(kubeFlags)
 			util.AddKubeconfigEnv(request)
 			cmd.SetContext(util.WithConnectionRequest(cmd.Context(), request))
 			return configView(cmd, args)

--- a/pkg/client/cli/cmd_helm.go
+++ b/pkg/client/cli/cmd_helm.go
@@ -147,7 +147,7 @@ func (ha *HelmOpts) run(cmd *cobra.Command, _ []string) error {
 	if err = util.InitCommand(cmd); err != nil {
 		return err
 	}
-	ha.Request.KubeFlags = FlagMap(ha.kubeFlags)
+	ha.Request.KubeFlags = util.FlagMap(ha.kubeFlags)
 
 	util.AddKubeconfigEnv(ha.Request)
 

--- a/pkg/client/cli/cmds_genyaml.go
+++ b/pkg/client/cli/cmds_genyaml.go
@@ -22,6 +22,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 )
@@ -252,7 +253,7 @@ func genConfigMapSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the agent's entry in the telepresence-agents configmap.",
 		Long:  "Generate YAML for the agent's entry in the telepresence-agents configmap. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, FlagMap(kubeFlags))
+			return info.run(cmd, util.FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()
@@ -314,7 +315,7 @@ func genContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the traffic-agent container.",
 		Long:  "Generate YAML for the traffic-agent container. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, FlagMap(kubeFlags))
+			return info.run(cmd, util.FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()
@@ -383,7 +384,7 @@ func genInitContainerSubCommand(yamlInfo *genYAMLInfo) *cobra.Command {
 		Short: "Generate YAML for the traffic-agent init container.",
 		Long:  "Generate YAML for the traffic-agent init container. See genyaml for more info on what this means",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.run(cmd, FlagMap(kubeFlags))
+			return info.run(cmd, util.FlagMap(kubeFlags))
 		},
 	}
 	flags := cmd.Flags()

--- a/pkg/client/cli/cmds_misc.go
+++ b/pkg/client/cli/cmds_misc.go
@@ -66,7 +66,7 @@ func connectCommand() *cobra.Command {
 			ann.Session:    ann.Required,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			request.KubeFlags = FlagMap(kubeFlags)
+			request.KubeFlags = util.FlagMap(kubeFlags)
 			cmd.SetContext(util.WithConnectionRequest(cmd.Context(), request))
 			if err := util.InitCommand(cmd); err != nil {
 				return err

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -328,35 +328,6 @@ func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRe
 	return ir, nil
 }
 
-// getUnparsedFlagValue returns the value of a flag that has been provided after a "--" on the command
-// line, and hence hasn't been parsed as a normal flag. Typical use case is:
-//
-//	telepresence intercept --docker-run ... -- --name <name>
-func getUnparsedFlagValue(args []string, flag string) (string, error) {
-	feq := flag + "="
-	for i, arg := range args {
-		var v string
-		switch {
-		case arg == flag:
-			i++
-			if i < len(args) {
-				if v = args[i]; strings.HasPrefix(v, "-") {
-					v = ""
-				}
-			}
-		case strings.HasPrefix(arg, feq):
-			v = arg[len(feq):]
-		default:
-			continue
-		}
-		if v == "" {
-			return "", fmt.Errorf("flag %q requires a value", flag)
-		}
-		return v, nil
-	}
-	return "", nil
-}
-
 func (s *state) startInDocker(ctx context.Context, envFile string, args []string) (*dexec.Cmd, error) {
 	ourArgs := []string{
 		"run",
@@ -364,7 +335,7 @@ func (s *state) startInDocker(ctx context.Context, envFile string, args []string
 		"--dns-search", "tel2-search",
 	}
 
-	name, err := getUnparsedFlagValue(args, "--name")
+	name, err := util.GetUnparsedFlagValue(args, "--name")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/cli/util/flags.go
+++ b/pkg/client/cli/util/flags.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -35,4 +36,33 @@ func FlagMap(flags *pflag.FlagSet) map[string]string {
 		}
 	})
 	return flagMap
+}
+
+// GetUnparsedFlagValue returns the value of a flag that has been provided after a "--" on the command
+// line, and hence hasn't been parsed as a normal flag. Typical use case is:
+//
+//	telepresence intercept --docker-run ... -- --name <name>
+func GetUnparsedFlagValue(args []string, flag string) (string, error) {
+	feq := flag + "="
+	for i, arg := range args {
+		var v string
+		switch {
+		case arg == flag:
+			i++
+			if i < len(args) {
+				if v = args[i]; strings.HasPrefix(v, "-") {
+					v = ""
+				}
+			}
+		case strings.HasPrefix(arg, feq):
+			v = arg[len(feq):]
+		default:
+			continue
+		}
+		if v == "" {
+			return "", fmt.Errorf("flag %q requires a value", flag)
+		}
+		return v, nil
+	}
+	return "", nil
 }

--- a/pkg/client/cli/util/flags.go
+++ b/pkg/client/cli/util/flags.go
@@ -1,4 +1,4 @@
-package cli
+package util
 
 import (
 	"bytes"

--- a/pkg/client/cli/util/flags_test.go
+++ b/pkg/client/cli/util/flags_test.go
@@ -1,11 +1,11 @@
-package intercept
+package util
 
 import (
 	"strings"
 	"testing"
 )
 
-func Test_getArg(t *testing.T) {
+func TestGetUnparsedFlagValue(t *testing.T) {
 	tests := []struct {
 		args    []string
 		flag    string
@@ -57,7 +57,7 @@ func Test_getArg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(strings.Join(tt.args, "_"), func(t *testing.T) {
-			gotV, err := getUnparsedFlagValue(tt.args, tt.flag)
+			gotV, err := GetUnparsedFlagValue(tt.args, tt.flag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getUnparsedFlagValue() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This PR moves flag utility functions from cli/util.go and cli/intercept/state.go into util/flag.go and exports the `util.GetUnparsedFlagValue()` function so that it can be used from other modules.