### PR TITLE
Fix make lint for m1 setups

### DIFF
--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -42,10 +42,13 @@ clobber-tools:
 PROTOC_VERSION=21.9
 ifeq ($(GOHOSTARCH),arm64)
   PROTOC_ARCH=aarch_64
+  PROTOLINT_ARCH=arm64
 else ifeq ($(GOHOSTARCH),amd64)
   PROTOC_ARCH=x86_64
+  PROTOLINT_ARCH=x86_64
 else
   PROTOC_ARCH=$(GOHOSTARCH)
+  PROTOLINT_ARCH=$(GOHOSTARCH)
 endif
 ifeq ($(GOHOSTOS),windows)
   PROTOC_OS_ARCH=win64
@@ -68,7 +71,7 @@ $(TOOLSDIR)/$(PROTOC_ZIP):
 #
 tools/protolint = $(TOOLSBINDIR)/protolint$(EXE)
 PROTOLINT_VERSION=0.42.0
-PROTOLINT_TGZ=protolint_$(PROTOLINT_VERSION)_$(GOHOSTOS)_$(PROTOC_ARCH).tar.gz
+PROTOLINT_TGZ=protolint_$(PROTOLINT_VERSION)_$(GOHOSTOS)_$(PROTOLINT_ARCH).tar.gz
 $(TOOLSDIR)/$(PROTOLINT_TGZ):
 	mkdir -p $(@D)
 	curl -sfL https://github.com/yoheimuta/protolint/releases/download/v$(PROTOLINT_VERSION)/$(PROTOLINT_TGZ) -o $@


### PR DESCRIPTION
## Description

I wasn't able to download protolint on m1 because the architecture nomenclature is different than the protoc repo.

Here: https://github.com/yoheimuta/protolint/releases

I've just duplicated the variable to fix the issue.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
