### PR TITLE
Add a make private-registry target and instructions on how to run tests.

### DIFF
--- a/k8s/private-reg-proxy.yaml
+++ b/k8s/private-reg-proxy.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: private-registry-proxy
+  labels:
+   app: private-registry-proxy
+spec:
+  selector:
+    matchLabels:
+      app: private-registry-proxy
+  template:
+    metadata:
+      labels:
+        app: private-registry-proxy
+    spec:
+      containers:
+        - name: tcp-proxy
+          image: quay.io/bentoml/proxy-to-service:v2
+          args:
+            - tcp
+            - "5000"
+            - docker-registry.default.svc.cluster.local
+          ports:
+            - containerPort: 5000
+              hostPort: 5000
+              name: tcp
+              protocol: TCP


### PR DESCRIPTION
The DEVELOPMENT.md didn't cover the topic of running individual integration tests, and how to make such tests run fairly quickly. This commit adds some helpful information.