### PR TITLE
Provide a way to override os.Stdxxx

### DIFF
--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/datawire/dtest"
 	telcharts "github.com/telepresenceio/telepresence/v2/charts"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
@@ -583,7 +584,7 @@ func Command(ctx context.Context, executable string, args ...string) *dexec.Cmd 
 	}
 	cmd.Env = maps.ToSortedSlice(env)
 	cmd.Dir = GetWorkingDir(ctx)
-	cmd.Stdin = getStdin(ctx)
+	cmd.Stdin = dos.Stdin(ctx)
 	return cmd
 }
 

--- a/integration_test/itest/context.go
+++ b/integration_test/itest/context.go
@@ -2,7 +2,6 @@ package itest
 
 import (
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -185,19 +184,6 @@ func getEnv(ctx context.Context) map[string]string {
 		return env
 	}
 	return nil
-}
-
-type stdinKey struct{}
-
-func WithStdin(ctx context.Context, rdr io.Reader) context.Context {
-	return context.WithValue(ctx, stdinKey{}, rdr)
-}
-
-func getStdin(ctx context.Context) io.Reader {
-	if rdr, ok := ctx.Value(stdinKey{}).(io.Reader); ok {
-		return rdr
-	}
-	return os.Stdin
 }
 
 type globalHarnessContextKey struct{}

--- a/pkg/client/cli/cmds_misc.go
+++ b/pkg/client/cli/cmds_misc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
 
@@ -81,7 +82,7 @@ func connectCommand(ctx context.Context) *cobra.Command {
 					_ = util.Disconnect(ctx, false)
 				}()
 			}
-			return proc.Run(ctx, nil, cmd, args[0], args[1:]...)
+			return proc.Run(dos.WithStdio(ctx, cmd), nil, args[0], args[1:]...)
 		},
 	}
 	request, kubeFlags = InitConnectRequest(ctx, cmd)

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -26,6 +26,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
@@ -215,6 +216,7 @@ func runCommand(sif State, ctx context.Context) error {
 	var s *state
 	sif.As(&s)
 
+	ctx = dos.WithStdio(ctx, s.cmd)
 	var cmd *dexec.Cmd
 	var err error
 	if s.DockerRun {
@@ -233,7 +235,7 @@ func runCommand(sif State, ctx context.Context) error {
 		}
 		cmd, err = s.startInDocker(ctx, envFile, s.Cmdline)
 	} else {
-		cmd, err = proc.Start(ctx, s.env, s.cmd, s.Cmdline[0], s.Cmdline[1:]...)
+		cmd, err = proc.Start(ctx, s.env, s.Cmdline[0], s.Cmdline[1:]...)
 	}
 	if err != nil {
 		dlog.Errorf(ctx, "error interceptor starting process: %v", err)

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 )
 
@@ -24,7 +24,7 @@ func Out(ctx context.Context) io.Writer {
 	if cmd, ok := ctx.Value(key{}).(*cobra.Command); ok {
 		return cmd.OutOrStdout()
 	}
-	return os.Stdout
+	return dos.Stdout(ctx)
 }
 
 // Err returns an io.Writer that writes to the ErrOrStderr of the current *cobra.Command, or
@@ -34,7 +34,7 @@ func Err(ctx context.Context) io.Writer {
 	if cmd, ok := ctx.Value(key{}).(*cobra.Command); ok {
 		return cmd.ErrOrStderr()
 	}
-	return os.Stderr
+	return dos.Stderr(ctx)
 }
 
 // Info is similar to Out, but if formatted output is requested, the output will be discarded.
@@ -48,7 +48,7 @@ func Info(ctx context.Context) io.Writer {
 		}
 		return cmd.OutOrStdout()
 	}
-	return os.Stdout
+	return dos.Stdout(ctx)
 }
 
 // Object sets the object to be marshalled and printed on stdout when formatted output

--- a/pkg/dos/stdio.go
+++ b/pkg/dos/stdio.go
@@ -1,0 +1,69 @@
+package dos
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+type Stdio interface {
+	InOrStdin() io.Reader
+	OutOrStdout() io.Writer
+	ErrOrStderr() io.Writer
+}
+
+// WithStdio returns a new context that is parented by the given context, that will return the values
+// from the given Stdio when used as an argument to in a call to Stdin, Stdout, or Stderr.
+func WithStdio(ctx context.Context, io Stdio) context.Context {
+	ctx = WithStdin(ctx, io.InOrStdin())
+	ctx = WithStdout(ctx, io.OutOrStdout())
+	return WithStderr(ctx, io.ErrOrStderr())
+}
+
+type outKey struct{}
+
+// Stdout returns the context's stdout io.Writer. If no such writer has been defined, it returns os.Stdout.
+func Stdout(ctx context.Context) io.Writer {
+	if w, ok := ctx.Value(outKey{}).(io.Writer); ok {
+		return w
+	}
+	return os.Stdout
+}
+
+// WithStdout returns a new context that is parented by the given context, that will return the given writer
+// when used as an argument to in a call to Stdout.
+func WithStdout(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, outKey{}, w)
+}
+
+type errKey struct{}
+
+// Stderr returns the context's stdout io.Writer. If no such writer has been defined, it returns os.Stderr.
+func Stderr(ctx context.Context) io.Writer {
+	if w, ok := ctx.Value(errKey{}).(io.Writer); ok {
+		return w
+	}
+	return os.Stderr
+}
+
+// WithStderr returns a new context that is parented by the given context, that will return the given writer
+// when used as an argument to in a call to Stderr.
+func WithStderr(ctx context.Context, w io.Writer) context.Context {
+	return context.WithValue(ctx, errKey{}, w)
+}
+
+type inKey struct{}
+
+// Stdin returns the context's stdin io.Reader. If no such reader has been defined, it returns os.Stdin.
+func Stdin(ctx context.Context) io.Reader {
+	if r, ok := ctx.Value(inKey{}).(io.Reader); ok {
+		return r
+	}
+	return os.Stdin
+}
+
+// WithStdin returns a new context that is parented by the given context, that will return the given reader
+// when used as an argument to in a call to Stdin.
+func WithStdin(ctx context.Context, w io.Reader) context.Context {
+	return context.WithValue(ctx, inKey{}, w)
+}


### PR DESCRIPTION
Adds ability to set `os.Stdout`, `os.Stderr`, and `os.Stdin` to the `dos` package.