### PR TITLE
Add a Mount struct to the detailed intercept output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Feature: The Telepresence daemon can now run as a long-lived process in a docker container so that CLI commands that
   run in other containers can use a common daemon for network access and intercepts.
 
+- Feature: A new boolean flag `--detailed-output` was added to the `telepresence intercept` command. It will output very
+  detailed information about an intercept when used together with `--output=[json|yaml]`.
+  Pull Request [3013](https://github.com/telepresenceio/telepresence/pull/3013).
+
 - Feature: IPv6 support.
   Ticket [2978](https://github.com/telepresenceio/telepresence/issues/2978).
 

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -124,14 +124,14 @@ endif
 
 FUSEFTP_VERSION=$(shell go list -m -f {{.Version}} github.com/datawire/go-fuseftp/rpc)
 
-pkg/client/userd/daemon/fuseftp.bits: $(BUILDDIR)/fuseftp-$(GOOS)-$(GOARCH)$(BEXE) FORCE
+pkg/client/remotefs/fuseftp.bits: $(BUILDDIR)/fuseftp-$(GOOS)-$(GOARCH)$(BEXE) FORCE
 	cp $< $@
 
 $(BUILDDIR)/fuseftp-$(GOOS)-$(GOARCH)$(BEXE): go.mod
 	mkdir -p $(BUILDDIR)
 	curl --fail -L https://github.com/datawire/go-fuseftp/releases/download/$(FUSEFTP_VERSION)/fuseftp-$(GOOS)-$(GOARCH)$(BEXE) -o $@
 
-build-deps: pkg/client/userd/daemon/fuseftp.bits
+build-deps: pkg/client/remotefs/fuseftp.bits
 
 ifeq ($(GOHOSTOS),windows)
 WINTUN_VERSION=0.14.1

--- a/integration_test/intercept_mount_test.go
+++ b/integration_test/intercept_mount_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/intercept"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
 type interceptMountSuite struct {
@@ -141,12 +143,20 @@ func (s *singleServiceSuite) Test_InterceptDetailedOutput() {
 		itest.TelepresenceOk(ctx, "leave", fmt.Sprintf("%s-%s", s.ServiceName(), s.AppNamespace()))
 	}()
 	var iInfo intercept.Info
-	s.Require().NoError(json.Unmarshal([]byte(stdout), &iInfo))
+	require := s.Require()
+	require.NoError(json.Unmarshal([]byte(stdout), &iInfo))
 	s.Equal(iInfo.Name, fmt.Sprintf("%s-%s", s.ServiceName(), s.AppNamespace()))
 	s.Equal(iInfo.Disposition, "ACTIVE")
 	s.Equal(iInfo.WorkloadKind, "Deployment")
 	s.Equal(iInfo.TargetPort, int32(port))
 	s.Equal(iInfo.Environment["TELEPRESENCE_CONTAINER"], "echo-server")
+	m := iInfo.Mount
+	require.NotNil(m)
+	s.NotNil(iputil.Parse(m.PodIP))
+	s.NotZero(m.Port)
+	s.Equal(agentconfig.ExportsMountPoint+"/echo-server", m.RemoteDir)
+	require.Len(m.Mounts, 1)
+	s.Equal(m.Mounts[0], "/var/run/secrets/kubernetes.io")
 }
 
 func (s *singleServiceSuite) Test_NoInterceptorResponse() {

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -102,8 +102,11 @@ func WithCluster(ctx context.Context, f func(ctx context.Context)) {
 		s.suffix = strconv.Itoa(os.Getpid())
 	}
 	s.testVersion, s.prePushed = os.LookupEnv("DEV_TELEPRESENCE_VERSION")
-	if !s.prePushed {
+	if s.prePushed {
+		dlog.Infof(ctx, "Using pre-pushed binary %s", s.testVersion)
+	} else {
 		s.testVersion = "v2.9.0-gotest.z" + s.suffix
+		dlog.Infof(ctx, "Building temp binary %s", s.testVersion)
 	}
 	version.Version, version.Structured = version.Init(s.testVersion, "TELEPRESENCE_VERSION")
 	s.compatVersion = os.Getenv("DEV_COMPAT_VERSION")

--- a/pkg/client/cli/intercept/info.go
+++ b/pkg/client/cli/intercept/info.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
-	client2 "github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 )
 
 type Ingress struct {
@@ -71,7 +71,7 @@ func NewMount(ctx context.Context, ii *manager.InterceptInfo, mountError string)
 	}
 	if ii.MountPoint != "" {
 		var port int32
-		if client2.GetConfig(ctx).Intercept.UseFtp {
+		if client.GetConfig(ctx).Intercept.UseFtp {
 			port = ii.FtpPort
 		} else {
 			port = ii.SftpPort

--- a/pkg/client/cli/intercept/info.go
+++ b/pkg/client/cli/intercept/info.go
@@ -1,9 +1,12 @@
 package intercept
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	client2 "github.com/telepresenceio/telepresence/v2/pkg/client"
 )
 
 type Ingress struct {
@@ -11,6 +14,15 @@ type Ingress struct {
 	Port   int32  `json:"port,omitempty"    yaml:"port,omitempty"`
 	UseTLS bool   `json:"use_tls,omitempty" yaml:"use_tls,omitempty"`
 	L5Host string `json:"l5host,omitempty"  yaml:"l5host,omitempty"`
+}
+
+type Mount struct {
+	LocalDir  string   `json:"local_dir,omitempty"     yaml:"local_dir,omitempty"`
+	RemoteDir string   `json:"remote_dir,omitempty"    yaml:"remote_dir,omitempty"`
+	Error     string   `json:"error,omitempty"         yaml:"error,omitempty"`
+	PodIP     string   `json:"pod_ip,omitempty"        yaml:"pod_ip,omitempty"`
+	Port      int32    `json:"port,omitempty"          yaml:"port,omitempty"`
+	Mounts    []string `json:"mounts,omitempty"        yaml:"mounts,omitempty"`
 }
 
 type Info struct {
@@ -23,8 +35,7 @@ type Info struct {
 	TargetPort    int32             `json:"target_port,omitempty"     yaml:"target_port,omitempty"`
 	ServicePortID string            `json:"service_port_id,omitempty" yaml:"service_port_id,omitempty"`
 	Environment   map[string]string `json:"environment,omitempty"     yaml:"environment,omitempty"`
-	MountPoint    string            `json:"mount_point,omitempty"     yaml:"mount_point,omitempty"`
-	MountError    string            `json:"mount_error,omitempty"     yaml:"mount_error,omitempty"`
+	Mount         *Mount            `json:"mount,omitempty"           yaml:"mount,omitempty"`
 	HttpFilter    []string          `json:"http_filter,omitempty"     yaml:"http_filter,omitempty"`
 	Global        bool              `json:"global,omitempty"          yaml:"global,omitempty"`
 	PreviewURL    string            `json:"preview_url,omitempty"     yaml:"preview_url,omitempty"`
@@ -54,7 +65,29 @@ func PreviewURL(pu string) string {
 	return pu
 }
 
-func NewInfo(ii *manager.InterceptInfo, mountError string) *Info {
+func NewMount(ctx context.Context, ii *manager.InterceptInfo, mountError string) *Mount {
+	if mountError != "" {
+		return &Mount{Error: mountError}
+	}
+	if ii.MountPoint != "" {
+		var port int32
+		if client2.GetConfig(ctx).Intercept.UseFtp {
+			port = ii.FtpPort
+		} else {
+			port = ii.SftpPort
+		}
+		return &Mount{
+			LocalDir:  ii.ClientMountPoint,
+			RemoteDir: ii.MountPoint,
+			PodIP:     ii.PodIp,
+			Port:      port,
+			Mounts:    filepath.SplitList(ii.Environment["TELEPRESENCE_MOUNTS"]),
+		}
+	}
+	return nil
+}
+
+func NewInfo(ctx context.Context, ii *manager.InterceptInfo, mountError string) *Info {
 	spec := ii.Spec
 	return &Info{
 		ID:            ii.Id,
@@ -64,10 +97,9 @@ func NewInfo(ii *manager.InterceptInfo, mountError string) *Info {
 		WorkloadKind:  spec.WorkloadKind,
 		TargetHost:    spec.TargetHost,
 		TargetPort:    spec.TargetPort,
+		Mount:         NewMount(ctx, ii, mountError),
 		ServicePortID: spec.ServicePortName,
 		Environment:   ii.Environment,
-		MountPoint:    ii.MountPoint,
-		MountError:    mountError,
 		HttpFilter:    spec.MechanismArgs,
 		Global:        spec.Mechanism == "tcp",
 		PreviewURL:    PreviewURL(ii.PreviewDomain),

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -195,7 +195,7 @@ func create(sif State, ctx context.Context) (acquired bool, err error) {
 		if volumeMountProblem != nil {
 			mountError = volumeMountProblem.Error()
 		}
-		output.Object(ctx, NewInfo(intercept, mountError), true)
+		output.Object(ctx, NewInfo(ctx, intercept, mountError), true)
 	} else {
 		fmt.Fprintln(s.cmd.OutOrStdout(), util.DescribeIntercepts([]*manager.InterceptInfo{intercept}, volumeMountProblem, false))
 	}

--- a/pkg/client/remotefs/ftp.go
+++ b/pkg/client/remotefs/ftp.go
@@ -1,0 +1,77 @@
+package remotefs
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/datawire/dlib/dcontext"
+	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/go-fuseftp/rpc"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+)
+
+type ftpMounter struct {
+	client rpc.FuseFTPClient
+	id     *rpc.MountIdentifier
+}
+
+func NewFTPMounter(client rpc.FuseFTPClient) Mounter {
+	return &ftpMounter{client: client}
+}
+
+func (m *ftpMounter) Start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
+	// The FTPClient and the NewHost must be controlled by the intercept context and not by the pod context that
+	// is passed as a parameter, because those services will survive pod changes.
+	var addr netip.AddrPort
+	if iputil.IsIpV6Addr(podIP) {
+		addr = netip.MustParseAddrPort(fmt.Sprintf("[%s]:%d", podIP, port))
+	} else {
+		addr = netip.MustParseAddrPort(fmt.Sprintf("%s:%d", podIP, port))
+	}
+	if m.id == nil {
+		dlog.Infof(ctx, "Mounting FTP file system for intercept %q (address %s) at %q", id, addr, clientMountPoint)
+		// FTPs remote mount is already relative to the agentconfig.ExportsMountPoint
+		rmp := strings.TrimPrefix(mountPoint, agentconfig.ExportsMountPoint)
+		id, err := m.client.Mount(ctx, &rpc.MountRequest{
+			MountPoint: clientMountPoint,
+			FtpServer: &rpc.AddressAndPort{
+				Ip:   iputil.Parse(podIP),
+				Port: port,
+			},
+			ReadTimeout: durationpb.New(5 * time.Second),
+			Directory:   rmp,
+		})
+		if err != nil {
+			return err
+		}
+		m.id = id
+
+		// Ensure unmount when intercept context is cancelled
+		go func() {
+			<-ctx.Done()
+			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
+			defer cancel()
+			if _, err = m.client.Unmount(ctx, m.id); err != nil {
+				dlog.Error(ctx, err)
+			}
+		}()
+		return nil
+	}
+
+	// Assign a new address to the FTP client. This kills any open connections but leaves the FUSE driver intact
+	dlog.Infof(ctx, "Switching remote address to %s for FTP file system for intercept %q at %q", addr, id, clientMountPoint)
+	_, err := m.client.SetFtpServer(ctx, &rpc.SetFtpServerRequest{
+		FtpServer: &rpc.AddressAndPort{
+			Ip:   iputil.Parse(podIP),
+			Port: port,
+		},
+		Id: m.id,
+	})
+	return err
+}

--- a/pkg/client/remotefs/mounter.go
+++ b/pkg/client/remotefs/mounter.go
@@ -1,0 +1,11 @@
+package remotefs
+
+import "context"
+
+// A Mounter is responsible for mounting a remote filesystem in a local directory or drive letter.
+type Mounter interface {
+	// Start mounts the remote directory given by mountPoint on the local directory or drive letter
+	// given ty clientMountPoint. The podIP and port is the address to the remote FTP or SFTP server.
+	// The id is just used for logging purposes.
+	Start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error
+}

--- a/pkg/client/remotefs/sftp.go
+++ b/pkg/client/remotefs/sftp.go
@@ -1,0 +1,101 @@
+package remotefs
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/datawire/dlib/dcontext"
+	"github.com/datawire/dlib/dgroup"
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/dpipe"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+)
+
+type sftpMounter struct {
+	sync.Mutex
+	podWG *sync.WaitGroup
+}
+
+func NewSFTPMounter(wg *sync.WaitGroup) Mounter {
+	return &sftpMounter{podWG: wg}
+}
+
+func (m *sftpMounter) Start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
+	if iputil.IsIpV6Addr(podIP) {
+		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("[/%s]:%d", podIP, port))
+	} else {
+		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/%s:%d", podIP, port))
+	}
+
+	// The mount is terminated and restarted when the intercept pod changes, so we
+	// must set up a wait/done pair here to ensure that this happens synchronously
+	m.podWG.Add(1)
+	go func() {
+		defer m.podWG.Done()
+
+		// Be really sure that the following doesn't happen in parallel using multiple
+		// pods for the same intercept. One must die before the next is created.
+		m.Lock()
+		defer m.Unlock()
+
+		dlog.Infof(ctx, "Mounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
+		defer dlog.Infof(ctx, "Unmounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
+
+		// Retry mount in case it gets disconnected
+		err := client.Retry(ctx, "sshfs", func(ctx context.Context) error {
+			dl := &net.Dialer{Timeout: 3 * time.Second}
+			var conn net.Conn
+			var err error
+			if iputil.IsIpV6Addr(podIP) {
+				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("[%s]:%d", podIP, port))
+			} else {
+				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", podIP, port))
+			}
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+			sshfsArgs := []string{
+				"-F", "none", // don't load the user's config file
+				"-f", // foreground operation
+
+				// connection settings
+				"-C", // compression
+				"-oConnectTimeout=10",
+				"-oStrictHostKeyChecking=no",     // don't bother checking the host key...
+				"-oUserKnownHostsFile=/dev/null", // and since we're not checking it, don't bother remembering it either
+				"-o", "slave",                    // Unencrypted via stdin/stdout
+
+				// mount directives
+				"-o", "follow_symlinks",
+				"-o", "allow_root", // needed to make --docker-run work as docker runs as root
+				"localhost:" + mountPoint, // what to mount
+				clientMountPoint,          // where to mount it
+			}
+			exe := "sshfs"
+			if runtime.GOOS == "windows" {
+				// Use sshfs-win to launch the sshfs
+				sshfsArgs = append([]string{"cmd", "-ouid=-1", "-ogid=-1"}, sshfsArgs...)
+				exe = "sshfs-win"
+			}
+			err = dpipe.DPipe(ctx, conn, exe, sshfsArgs...)
+			time.Sleep(time.Second)
+
+			// sshfs sometimes leave the mount point in a bad state. This will clean it up
+			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
+			defer cancel()
+			_ = proc.CommandContext(ctx, "fusermount", "-uz", clientMountPoint).Run()
+			return err
+		}, 3*time.Second, 6*time.Second)
+		if err != nil {
+			dlog.Error(ctx, err)
+		}
+	}()
+	return nil
+}

--- a/pkg/client/userd/service.go
+++ b/pkg/client/userd/service.go
@@ -6,9 +6,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/datawire/dlib/dgroup"
-	"github.com/datawire/go-fuseftp/rpc"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/remotefs"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 )
 
@@ -32,7 +32,8 @@ type Service interface {
 	// GetAPIKey returns the current API key
 	GetAPIKey(context.Context) (string, error)
 
-	GetFuseFTPClient(ctx context.Context) rpc.FuseFTPClient
+	// FuseFTPMgr returns the manager responsible for creating a client that can connect to the FuseFTP service.
+	FuseFTPMgr() remotefs.FuseFTPManager
 
 	RootSessionInProcess() bool
 }

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -42,7 +42,7 @@ import (
 )
 
 type mounter interface {
-	start(ctx context.Context, ic *intercept) error
+	start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error
 }
 
 // intercept tracks the life-cycle of an intercept, dictated by the intercepts

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -29,6 +29,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/remotefs"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
@@ -40,10 +41,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/restapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 )
-
-type mounter interface {
-	start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error
-}
 
 // intercept tracks the life-cycle of an intercept, dictated by the intercepts
 // arrival and departure in the watchInterceptsLoop.
@@ -64,7 +61,7 @@ type intercept struct {
 	pid int
 
 	// The mounter of the remote file system.
-	mounter
+	remotefs.Mounter
 }
 
 // interceptResult is what gets written to the awaitIntercept's waitCh channel when the

--- a/pkg/client/userd/trafficmgr/mount.go
+++ b/pkg/client/userd/trafficmgr/mount.go
@@ -47,16 +47,23 @@ func (ic *intercept) startMount(ctx context.Context, podWG *sync.WaitGroup) {
 		return
 	}
 
+	var port int32
 	m := ic.mounter
+	mountCtx := ctx
 	if m == nil {
 		if useFtp {
 			m = &ftpMounter{client: fuseftp}
+			port = ic.FtpPort
+
+			// The FTP mounter survives multiple starts for the same intercept. It just resets the port
+			mountCtx = ic.ctx
 		} else {
 			m = &sftpMounter{podWG: podWG}
+			port = ic.SftpPort
 		}
 		ic.mounter = m
 	}
-	err := m.start(ctx, ic)
+	err := m.start(mountCtx, ic.Id, ic.ClientMountPoint, ic.MountPoint, ic.PodIp, port)
 	if err != nil && ctx.Err() == nil {
 		dlog.Error(ctx, err)
 	}
@@ -67,25 +74,24 @@ type ftpMounter struct {
 	id     *rpc.MountIdentifier
 }
 
-func (m *ftpMounter) start(_ context.Context, ic *intercept) error {
+func (m *ftpMounter) start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
 	// The FTPClient and the NewHost must be controlled by the intercept context and not by the pod context that
 	// is passed as a parameter, because those services will survive pod changes.
-	ctx := ic.ctx
 	var addr netip.AddrPort
-	if iputil.IsIpV6Addr(ic.PodIp) {
-		addr = netip.MustParseAddrPort(fmt.Sprintf("[%s]:%d", ic.PodIp, ic.FtpPort))
+	if iputil.IsIpV6Addr(podIP) {
+		addr = netip.MustParseAddrPort(fmt.Sprintf("[%s]:%d", podIP, port))
 	} else {
-		addr = netip.MustParseAddrPort(fmt.Sprintf("%s:%d", ic.PodIp, ic.FtpPort))
+		addr = netip.MustParseAddrPort(fmt.Sprintf("%s:%d", podIP, port))
 	}
 	if m.id == nil {
-		dlog.Infof(ctx, "Mounting FTP file system for intercept %q (address %s) at %q", ic.Id, addr, ic.ClientMountPoint)
+		dlog.Infof(ctx, "Mounting FTP file system for intercept %q (address %s) at %q", id, addr, clientMountPoint)
 		// FTPs remote mount is already relative to the agentconfig.ExportsMountPoint
-		rmp := strings.TrimPrefix(ic.MountPoint, agentconfig.ExportsMountPoint)
+		rmp := strings.TrimPrefix(mountPoint, agentconfig.ExportsMountPoint)
 		id, err := m.client.Mount(ctx, &rpc.MountRequest{
-			MountPoint: ic.ClientMountPoint,
+			MountPoint: clientMountPoint,
 			FtpServer: &rpc.AddressAndPort{
-				Ip:   iputil.Parse(ic.PodIp),
-				Port: ic.FtpPort,
+				Ip:   iputil.Parse(podIP),
+				Port: port,
 			},
 			ReadTimeout: durationpb.New(5 * time.Second),
 			Directory:   rmp,
@@ -97,7 +103,7 @@ func (m *ftpMounter) start(_ context.Context, ic *intercept) error {
 
 		// Ensure unmount when intercept context is cancelled
 		go func() {
-			<-ic.ctx.Done()
+			<-ctx.Done()
 			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
 			defer cancel()
 			if _, err = m.client.Unmount(ctx, m.id); err != nil {
@@ -108,11 +114,11 @@ func (m *ftpMounter) start(_ context.Context, ic *intercept) error {
 	}
 
 	// Assign a new address to the FTP client. This kills any open connections but leaves the FUSE driver intact
-	dlog.Infof(ctx, "Switching remote address to %s for FTP file system for intercept %q at %q", addr, ic.Id, ic.ClientMountPoint)
+	dlog.Infof(ctx, "Switching remote address to %s for FTP file system for intercept %q at %q", addr, id, clientMountPoint)
 	_, err := m.client.SetFtpServer(ctx, &rpc.SetFtpServerRequest{
 		FtpServer: &rpc.AddressAndPort{
-			Ip:   iputil.Parse(ic.PodIp),
-			Port: ic.FtpPort,
+			Ip:   iputil.Parse(podIP),
+			Port: port,
 		},
 		Id: m.id,
 	})
@@ -124,11 +130,11 @@ type sftpMounter struct {
 	podWG *sync.WaitGroup
 }
 
-func (m *sftpMounter) start(ctx context.Context, ic *intercept) error {
-	if iputil.IsIpV6Addr(ic.PodIp) {
-		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("[/%s]:%d", ic.PodIp, ic.SftpPort))
+func (m *sftpMounter) start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
+	if iputil.IsIpV6Addr(podIP) {
+		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("[/%s]:%d", podIP, port))
 	} else {
-		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/%s:%d", ic.PodIp, ic.SftpPort))
+		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/%s:%d", podIP, port))
 	}
 
 	// The mount is terminated and restarted when the intercept pod changes, so we
@@ -142,18 +148,18 @@ func (m *sftpMounter) start(ctx context.Context, ic *intercept) error {
 		m.Lock()
 		defer m.Unlock()
 
-		dlog.Infof(ctx, "Mounting SFTP file system for intercept %q (pod %s) at %q", ic.Id, ic.PodIp, ic.ClientMountPoint)
-		defer dlog.Infof(ctx, "Unmounting SFTP file system for intercept %q (pod %s) at %q", ic.Id, ic.PodIp, ic.ClientMountPoint)
+		dlog.Infof(ctx, "Mounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
+		defer dlog.Infof(ctx, "Unmounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
 
 		// Retry mount in case it gets disconnected
 		err := client.Retry(ctx, "sshfs", func(ctx context.Context) error {
 			dl := &net.Dialer{Timeout: 3 * time.Second}
 			var conn net.Conn
 			var err error
-			if iputil.IsIpV6Addr(ic.PodIp) {
-				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("[%s]:%d", ic.PodIp, ic.SftpPort))
+			if iputil.IsIpV6Addr(podIP) {
+				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("[%s]:%d", podIP, port))
 			} else {
-				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", ic.PodIp, ic.SftpPort))
+				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", podIP, port))
 			}
 			if err != nil {
 				return err
@@ -173,8 +179,8 @@ func (m *sftpMounter) start(ctx context.Context, ic *intercept) error {
 				// mount directives
 				"-o", "follow_symlinks",
 				"-o", "allow_root", // needed to make --docker-run work as docker runs as root
-				"localhost:" + ic.MountPoint, // what to mount
-				ic.ClientMountPoint,          // where to mount it
+				"localhost:" + mountPoint, // what to mount
+				clientMountPoint,          // where to mount it
 			}
 			exe := "sshfs"
 			if runtime.GOOS == "windows" {
@@ -188,7 +194,7 @@ func (m *sftpMounter) start(ctx context.Context, ic *intercept) error {
 			// sshfs sometimes leave the mount point in a bad state. This will clean it up
 			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
 			defer cancel()
-			_ = proc.CommandContext(ctx, "fusermount", "-uz", ic.ClientMountPoint).Run()
+			_ = proc.CommandContext(ctx, "fusermount", "-uz", clientMountPoint).Run()
 			return err
 		}, 3*time.Second, 6*time.Second)
 		if err != nil {

--- a/pkg/client/userd/trafficmgr/mount.go
+++ b/pkg/client/userd/trafficmgr/mount.go
@@ -2,26 +2,13 @@ package trafficmgr
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"net/netip"
-	"runtime"
-	"strings"
 	"sync"
-	"time"
 
-	"google.golang.org/protobuf/types/known/durationpb"
-
-	"github.com/datawire/dlib/dcontext"
-	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/go-fuseftp/rpc"
-	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/remotefs"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd"
-	"github.com/telepresenceio/telepresence/v2/pkg/dpipe"
-	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
 
 func (ic *intercept) shouldMount() bool {
@@ -33,173 +20,40 @@ func (ic *intercept) shouldMount() bool {
 func (ic *intercept) startMount(ctx context.Context, podWG *sync.WaitGroup) {
 	var fuseftp rpc.FuseFTPClient
 	useFtp := client.GetConfig(ctx).Intercept.UseFtp
+	var port int32
+	mountCtx := ctx
 	if useFtp {
 		if ic.FtpPort == 0 {
 			dlog.Errorf(ctx, "Client is configured to perform remote mounts using FTP, but only SFTP is provided by the traffic-agent")
 			return
 		}
-		if fuseftp = userd.GetService(ctx).GetFuseFTPClient(ctx); fuseftp == nil {
+		if fuseftp = userd.GetService(ctx).FuseFTPMgr().GetFuseFTPClient(ctx); fuseftp == nil {
 			dlog.Errorf(ctx, "Client is configured to perform remote mounts using FTP, but the fuseftp server was unable to start")
 			return
 		}
-	} else if ic.SftpPort == 0 {
-		dlog.Errorf(ctx, "Client is configured to perform remote mounts using SFTP, but only FTP is provided by the traffic-agent")
-		return
+		port = ic.FtpPort
+
+		// The FTP mounter survives multiple starts for the same intercept. It just resets the port
+		mountCtx = ic.ctx
+	} else {
+		if ic.SftpPort == 0 {
+			dlog.Errorf(ctx, "Client is configured to perform remote mounts using SFTP, but only FTP is provided by the traffic-agent")
+			return
+		}
+		port = ic.SftpPort
 	}
 
-	var port int32
-	m := ic.mounter
-	mountCtx := ctx
+	m := ic.Mounter
 	if m == nil {
 		if useFtp {
-			m = &ftpMounter{client: fuseftp}
-			port = ic.FtpPort
-
-			// The FTP mounter survives multiple starts for the same intercept. It just resets the port
-			mountCtx = ic.ctx
+			m = remotefs.NewFTPMounter(fuseftp)
 		} else {
-			m = &sftpMounter{podWG: podWG}
-			port = ic.SftpPort
+			m = remotefs.NewSFTPMounter(podWG)
 		}
-		ic.mounter = m
+		ic.Mounter = m
 	}
-	err := m.start(mountCtx, ic.Id, ic.ClientMountPoint, ic.MountPoint, ic.PodIp, port)
+	err := m.Start(mountCtx, ic.Id, ic.ClientMountPoint, ic.MountPoint, ic.PodIp, port)
 	if err != nil && ctx.Err() == nil {
 		dlog.Error(ctx, err)
 	}
-}
-
-type ftpMounter struct {
-	client rpc.FuseFTPClient
-	id     *rpc.MountIdentifier
-}
-
-func (m *ftpMounter) start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
-	// The FTPClient and the NewHost must be controlled by the intercept context and not by the pod context that
-	// is passed as a parameter, because those services will survive pod changes.
-	var addr netip.AddrPort
-	if iputil.IsIpV6Addr(podIP) {
-		addr = netip.MustParseAddrPort(fmt.Sprintf("[%s]:%d", podIP, port))
-	} else {
-		addr = netip.MustParseAddrPort(fmt.Sprintf("%s:%d", podIP, port))
-	}
-	if m.id == nil {
-		dlog.Infof(ctx, "Mounting FTP file system for intercept %q (address %s) at %q", id, addr, clientMountPoint)
-		// FTPs remote mount is already relative to the agentconfig.ExportsMountPoint
-		rmp := strings.TrimPrefix(mountPoint, agentconfig.ExportsMountPoint)
-		id, err := m.client.Mount(ctx, &rpc.MountRequest{
-			MountPoint: clientMountPoint,
-			FtpServer: &rpc.AddressAndPort{
-				Ip:   iputil.Parse(podIP),
-				Port: port,
-			},
-			ReadTimeout: durationpb.New(5 * time.Second),
-			Directory:   rmp,
-		})
-		if err != nil {
-			return err
-		}
-		m.id = id
-
-		// Ensure unmount when intercept context is cancelled
-		go func() {
-			<-ctx.Done()
-			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
-			defer cancel()
-			if _, err = m.client.Unmount(ctx, m.id); err != nil {
-				dlog.Error(ctx, err)
-			}
-		}()
-		return nil
-	}
-
-	// Assign a new address to the FTP client. This kills any open connections but leaves the FUSE driver intact
-	dlog.Infof(ctx, "Switching remote address to %s for FTP file system for intercept %q at %q", addr, id, clientMountPoint)
-	_, err := m.client.SetFtpServer(ctx, &rpc.SetFtpServerRequest{
-		FtpServer: &rpc.AddressAndPort{
-			Ip:   iputil.Parse(podIP),
-			Port: port,
-		},
-		Id: m.id,
-	})
-	return err
-}
-
-type sftpMounter struct {
-	sync.Mutex
-	podWG *sync.WaitGroup
-}
-
-func (m *sftpMounter) start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error {
-	if iputil.IsIpV6Addr(podIP) {
-		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("[/%s]:%d", podIP, port))
-	} else {
-		ctx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/%s:%d", podIP, port))
-	}
-
-	// The mount is terminated and restarted when the intercept pod changes, so we
-	// must set up a wait/done pair here to ensure that this happens synchronously
-	m.podWG.Add(1)
-	go func() {
-		defer m.podWG.Done()
-
-		// Be really sure that the following doesn't happen in parallel using multiple
-		// pods for the same intercept. One must die before the next is created.
-		m.Lock()
-		defer m.Unlock()
-
-		dlog.Infof(ctx, "Mounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
-		defer dlog.Infof(ctx, "Unmounting SFTP file system for intercept %q (pod %s) at %q", id, podIP, clientMountPoint)
-
-		// Retry mount in case it gets disconnected
-		err := client.Retry(ctx, "sshfs", func(ctx context.Context) error {
-			dl := &net.Dialer{Timeout: 3 * time.Second}
-			var conn net.Conn
-			var err error
-			if iputil.IsIpV6Addr(podIP) {
-				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("[%s]:%d", podIP, port))
-			} else {
-				conn, err = dl.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", podIP, port))
-			}
-			if err != nil {
-				return err
-			}
-			defer conn.Close()
-			sshfsArgs := []string{
-				"-F", "none", // don't load the user's config file
-				"-f", // foreground operation
-
-				// connection settings
-				"-C", // compression
-				"-oConnectTimeout=10",
-				"-oStrictHostKeyChecking=no",     // don't bother checking the host key...
-				"-oUserKnownHostsFile=/dev/null", // and since we're not checking it, don't bother remembering it either
-				"-o", "slave",                    // Unencrypted via stdin/stdout
-
-				// mount directives
-				"-o", "follow_symlinks",
-				"-o", "allow_root", // needed to make --docker-run work as docker runs as root
-				"localhost:" + mountPoint, // what to mount
-				clientMountPoint,          // where to mount it
-			}
-			exe := "sshfs"
-			if runtime.GOOS == "windows" {
-				// Use sshfs-win to launch the sshfs
-				sshfsArgs = append([]string{"cmd", "-ouid=-1", "-ogid=-1"}, sshfsArgs...)
-				exe = "sshfs-win"
-			}
-			err = dpipe.DPipe(ctx, conn, exe, sshfsArgs...)
-			time.Sleep(time.Second)
-
-			// sshfs sometimes leave the mount point in a bad state. This will clean it up
-			ctx, cancel := context.WithTimeout(dcontext.WithoutCancel(ctx), time.Second)
-			defer cancel()
-			_ = proc.CommandContext(ctx, "fusermount", "-uz", clientMountPoint).Run()
-			return err
-		}, 3*time.Second, 6*time.Second)
-		if err != nil {
-			dlog.Error(ctx, err)
-		}
-	}()
-	return nil
 }


### PR DESCRIPTION
## Description

When running the Telepresence daemon inside a container, it's desirable to prevent it from mounting remote directories because such mounts will not be visible to other containers unless the bind-mounted volume where the mount is made uses `bind-propagation=shared`. The bind propagation is not supported when using Docker Desktop (so in essence, it only works on Linux). In essence, this means that the mounts must be made by the host, based on information from the intercept, before the container that handles the intercepted traffic is started.

This PR adds a `mount` structure to the output from `telepresence intercept --detailed-output --output json xxx`. The struct will be filled in with mount details from the intercepted container even if the intercept was made using `--mount=false`. This enables an orchestrator to run the daemon and the intercept command in containers, capture this output, and then mount directories directory from the host before starting the intercept handlers.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
