### PR TITLE
Make scout env var prefix public

### DIFF
--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -17,8 +17,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
-// Environment variable prefix for additional metadata to be reported.
-const environmentMetadataPrefix = "TELEPRESENCE_REPORT_"
+// EnvironmentMetadataPrefix is the Environment variable prefix for additional metadata to be reported.
+const EnvironmentMetadataPrefix = "TELEPRESENCE_REPORT_"
 
 type bufEntry struct {
 	action  string
@@ -332,8 +332,8 @@ func getDefaultEnvironmentMetadata() map[string]string {
 	metadata := map[string]string{}
 	for _, e := range os.Environ() {
 		pair := strings.SplitN(e, "=", 2)
-		if strings.HasPrefix(pair[0], environmentMetadataPrefix) {
-			key := strings.ToLower(strings.TrimPrefix(pair[0], environmentMetadataPrefix))
+		if strings.HasPrefix(pair[0], EnvironmentMetadataPrefix) {
+			key := strings.ToLower(strings.TrimPrefix(pair[0], EnvironmentMetadataPrefix))
 			metadata[key] = pair[1]
 		}
 	}


### PR DESCRIPTION
## Description

This variable should be public to make it importable from code base depending on this repo.

In this particular case, telepresence-pro needs it to know what env var to set.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
