### PR TITLE
Add login domain env to integration tests

### DIFF
--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -88,6 +88,7 @@ type cluster struct {
 	logCapturingPods sync.Map
 	agentImageName   string
 	agentImageTag    string
+	loginDomain      string
 }
 
 func WithCluster(ctx context.Context, f func(ctx context.Context)) {
@@ -132,6 +133,10 @@ func WithCluster(ctx context.Context, f func(ctx context.Context)) {
 	}
 	if s.agentRegistry == "" {
 		s.agentRegistry = s.registry
+	}
+	s.loginDomain = os.Getenv("DEV_LOGIN_DOMAIN")
+	if s.loginDomain == "" {
+		s.loginDomain = "localhost"
 	}
 	require.NoError(t, s.generalError)
 
@@ -315,7 +320,7 @@ func (s *cluster) GlobalEnv() map[string]string {
 		"TELEPRESENCE_VERSION":      s.testVersion,
 		"TELEPRESENCE_AGENT_IMAGE":  s.agentImageName + ":" + s.agentImageTag, // Prevent attempts to retrieve image from SystemA
 		"TELEPRESENCE_REGISTRY":     s.registry,
-		"TELEPRESENCE_LOGIN_DOMAIN": "localhost",
+		"TELEPRESENCE_LOGIN_DOMAIN": s.loginDomain,
 		"KUBECONFIG":                s.kubeConfig,
 	}
 	yes := struct{}{}


### PR DESCRIPTION
## Description

Add `DEV_LOGIN_DOMAIN` environment variable to be able to login during integration tests with the propriety version

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
