### PR TITLE
Lock podIP/port for FTP and SFTP for the duration of an intercept.

### DIFF
--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -93,11 +93,15 @@ func NewInfo(ctx context.Context) Info {
 
 	apiSvc := "kubernetes.default"
 	var clusterDomain string
-	if cn, err := net.LookupCNAME(apiSvc); err != nil {
+	if cn, err := net.LookupCNAME(apiSvc); err == nil {
+		apiSvcX := apiSvc + ".svc."
+		if strings.HasPrefix(cn, apiSvcX) {
+			clusterDomain = cn[len(apiSvcX):]
+		}
+	}
+	if clusterDomain == "" {
 		dlog.Infof(ctx, `Unable to determine cluster domain from CNAME of %s: %v"`, err, apiSvc)
 		clusterDomain = "cluster.local."
-	} else {
-		clusterDomain = cn[len(apiSvc)+5:]
 	}
 	dlog.Infof(ctx, "Using cluster domain %q", clusterDomain)
 

--- a/cmd/traffic/cmd/manager/state/l4mapping.go
+++ b/cmd/traffic/cmd/manager/state/l4mapping.go
@@ -1,0 +1,76 @@
+package state
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/ipproto"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+)
+
+type l3Mapping struct {
+	tunnel.ConnID
+	active bool
+}
+
+// newMapping creates a mapping from an srcIP to a destIP. The mapping will map all ports transparently
+// except the one port that it is created with. That port is explicitly mapped to another port.
+//
+// Example:
+//
+//	Let's say a map is created with 10.20.30.40:54387 => 10.20.30.62:21. An access to 10.20.30.40:54387
+//	will then get redirected to 10.20.30.62:21, i.e. both the IP and the port will change. An access to
+//	10.20.30.40:1234 however, will only change the IP and redirect to 10.20.30.62:1234.
+//
+// The reason for this behavior is that FTP, when using PASV and EPSV, will requuest new ports from the
+// server. The server replies with a port number, and the client then connects to that port. So while
+// mapping the original IP and port used by FTP is fine, all subsequent calls must map the IP only.
+//
+// Isn't there a risk that the explicit port collides with other ports then? Well, yes, there is, so
+// this type of mapping must be used with caution. The client session will only use this mechanism
+// to map the initial ftp or sftp address, and will always use the default ports (21 and 22) as the
+// source in the mapping. The traffic-agents ftp and sftp servers will never use ports < 1000 so
+// it should be quite safe.
+func newMapping(proto int, srcIP, destIP net.IP, srcPort, destPort uint16) *l3Mapping {
+	return &l3Mapping{
+		ConnID: tunnel.NewConnID(proto, srcIP, destIP, srcPort, destPort),
+		active: true,
+	}
+}
+
+// mappedID returns its argument if the destination of the given id doesn't match the source of this
+// mapping. When there's a mach, the mapped ConnID is return, or an empty ConnID if is inactive.
+func (m *l3Mapping) mappedID(id tunnel.ConnID) (tunnel.ConnID, bool) {
+	if !(m.Protocol() == id.Protocol() && id.Destination().Equal(m.Source())) {
+		return id, false
+	}
+	if !m.active {
+		return "", true
+	}
+	var targetPort uint16
+	if id.DestinationPort() == m.SourcePort() {
+		// Use explicit port mapping
+		targetPort = m.DestinationPort()
+	} else {
+		// Map IP but let port remain as is. This ensures that FTP PASV works OK.
+		targetPort = id.DestinationPort()
+	}
+	return tunnel.NewConnID(m.Protocol(), id.Source(), m.Destination(), id.SourcePort(), targetPort), true
+}
+
+func (m *l3Mapping) setActive(active bool) {
+	m.active = active
+}
+
+func (m *l3Mapping) setDestination(destIP net.IP, destPort uint16) {
+	m.ConnID = tunnel.NewConnID(m.Protocol(), m.Source(), destIP, m.SourcePort(), destPort)
+	m.active = true
+}
+
+func (m *l3Mapping) String() string {
+	return fmt.Sprintf("%s mapping %s -> %s",
+		ipproto.String(m.Protocol()),
+		iputil.JoinIpPort(m.Source(), m.SourcePort()),
+		iputil.JoinIpPort(m.Destination(), m.DestinationPort()))
+}

--- a/cmd/traffic/cmd/manager/state/session.go
+++ b/cmd/traffic/cmd/manager/state/session.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/ipproto"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
 
@@ -21,7 +23,7 @@ type SessionState interface {
 	LastMarked() time.Time
 	SetLastMarked(lastMarked time.Time)
 	Dials() chan *rpc.DialRequest
-	EstablishBidiPipe(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
+	EstablishBidiPipe(context.Context, tunnel.Stream, tunnel.ConnID) (tunnel.Endpoint, error)
 	OnConnect(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
 }
 
@@ -42,10 +44,9 @@ type sessionState struct {
 // EstablishBidiPipe registers the given stream as waiting for a matching stream to arrive in a call
 // to Tunnel, sends a DialRequest to the owner of this sessionState, and then waits. When the call
 // arrives, a BidiPipe connecting the two streams is returned.
-func (ss *sessionState) EstablishBidiPipe(ctx context.Context, stream tunnel.Stream) (tunnel.Endpoint, error) {
+func (ss *sessionState) EstablishBidiPipe(ctx context.Context, stream tunnel.Stream, id tunnel.ConnID) (tunnel.Endpoint, error) {
 	// Dispatch directly to agent and let the dial happen there
 	bidiPipeCh := make(chan tunnel.Endpoint)
-	id := stream.ID()
 	abp := &awaitingBidiPipe{stream: stream, bidiPipeCh: bidiPipeCh}
 
 	ss.Lock()
@@ -144,9 +145,39 @@ func newSessionState(ctx context.Context, now time.Time) sessionState {
 	}
 }
 
+type remoteFsMapping struct {
+	ftp    *l3Mapping
+	sftp   *l3Mapping
+	gcMark bool
+}
+
+func (rm *remoteFsMapping) mappedID(id tunnel.ConnID) (tunnel.ConnID, bool) {
+	if rm.ftp != nil {
+		if mid, ok := rm.ftp.mappedID(id); ok {
+			return mid, true
+		}
+	}
+	if rm.sftp != nil {
+		if mid, ok := rm.sftp.mappedID(id); ok {
+			return mid, true
+		}
+	}
+	return "", false
+}
+
+func (rm *remoteFsMapping) setActive(active bool) {
+	if rm.ftp != nil {
+		rm.ftp.setActive(active)
+	}
+	if rm.sftp != nil {
+		rm.sftp.setActive(active)
+	}
+}
+
 type clientSessionState struct {
 	sessionState
-	pool *tunnel.Pool
+	pool     *tunnel.Pool
+	mappings map[string]*remoteFsMapping
 }
 
 func newClientSessionState(ctx context.Context, ts time.Time) *clientSessionState {
@@ -154,6 +185,101 @@ func newClientSessionState(ctx context.Context, ts time.Time) *clientSessionStat
 		sessionState: newSessionState(ctx, ts),
 		pool:         tunnel.NewPool(),
 	}
+}
+
+// lockFileServerIP calls lockFileServerIP for each of given the intercepts snapshot and then
+// removes mappings that are no longer in use.
+func (ss *clientSessionState) lockFileServerIPs(cepts []*rpc.InterceptInfo) {
+	ss.Lock()
+	defer ss.Unlock()
+	if len(cepts) == 0 {
+		ss.mappings = nil
+		return
+	}
+	if len(ss.mappings) == 0 {
+		ss.mappings = make(map[string]*remoteFsMapping)
+	} else {
+		// Make all mappings candidates for GC
+		for _, m := range ss.mappings {
+			m.gcMark = true
+		}
+	}
+	for _, cept := range cepts {
+		ss.lockFileServerIPLocked(cept)
+	}
+	for k, m := range ss.mappings {
+		if m.gcMark {
+			delete(ss.mappings, k)
+		}
+	}
+}
+
+// lockFileServerIP ensures that the IP:port that an intercept use for ftp or sftp stays
+// stable for the duration of the intercept. It does this by adding l4mappings for the initial
+// IP and port 21 to the initial IP and the real port.
+// Subsequent IP/port changes caused by stopping/starting intercepted pods will then just change
+// the target of this mapping, and thereby hiding the changes from the client.
+func (ss *clientSessionState) lockFileServerIP(cept *rpc.InterceptInfo) {
+	ss.Lock()
+	defer ss.Unlock()
+	ss.lockFileServerIPLocked(cept)
+}
+
+func (ss *clientSessionState) lockFileServerIPLocked(cept *rpc.InterceptInfo) {
+	rm := ss.mappings[cept.Id]
+	if rm != nil {
+		// Intercept still exists in some form, so don't gc this one.
+		rm.gcMark = false
+	}
+
+	if cept.Disposition != rpc.InterceptDispositionType_ACTIVE {
+		// Intercept is not active and its remote FS cannot be accessed at this point
+		if rm != nil {
+			rm.setActive(false)
+		}
+		return
+	}
+
+	podIP := iputil.Parse(cept.PodIp)
+	if podIP == nil || cept.FtpPort == 0 && cept.SftpPort == 0 {
+		return
+	}
+
+	if rm == nil {
+		rm = &remoteFsMapping{}
+		ss.mappings[cept.Id] = rm
+	}
+	mapPort := func(port, dfltPort int32, mp **l3Mapping) int32 {
+		if port == 0 {
+			// Agent no longer provides ftp/sftp. Odd, but OK.
+			*mp = nil
+			return 0
+		}
+		if m := *mp; m == nil {
+			// Lock the FTP for this intercept to podIP:21. This is what the
+			// client will see henceforth.
+			*mp = newMapping(ipproto.TCP, podIP, podIP, uint16(dfltPort), uint16(port))
+		} else {
+			m.setDestination(podIP, uint16(port))
+			podIP = m.Source() // ftp and sftp will always have the same source
+		}
+		return dfltPort
+	}
+	cept.FtpPort = mapPort(cept.FtpPort, 21, &rm.ftp)
+	cept.SftpPort = mapPort(cept.SftpPort, 22, &rm.sftp)
+	cept.PodIp = podIP.String()
+}
+
+func (ss *clientSessionState) mappedID(id tunnel.ConnID) tunnel.ConnID {
+	ss.Lock()
+	for _, rm := range ss.mappings {
+		if mid, ok := rm.mappedID(id); ok {
+			id = mid
+			break
+		}
+	}
+	ss.Unlock()
+	return id
 }
 
 type agentSessionState struct {

--- a/pkg/client/remotefs/mounter.go
+++ b/pkg/client/remotefs/mounter.go
@@ -1,11 +1,14 @@
 package remotefs
 
-import "context"
+import (
+	"context"
+	"net"
+)
 
 // A Mounter is responsible for mounting a remote filesystem in a local directory or drive letter.
 type Mounter interface {
 	// Start mounts the remote directory given by mountPoint on the local directory or drive letter
 	// given ty clientMountPoint. The podIP and port is the address to the remote FTP or SFTP server.
 	// The id is just used for logging purposes.
-	Start(ctx context.Context, id, clientMountPoint, mountPoint, podIP string, port int32) error
+	Start(ctx context.Context, id, clientMountPoint, mountPoint string, podIP net.IP, port uint16) error
 }

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -133,7 +133,7 @@ func (ic *intercept) startForwards(ctx context.Context, wg *sync.WaitGroup) {
 	for _, port := range ic.localPorts() {
 		var pfCtx context.Context
 		if iputil.IsIpV6Addr(ic.PodIp) {
-			pfCtx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("[/%s]:%s", ic.PodIp, port))
+			pfCtx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/[%s]:%s", ic.PodIp, port))
 		} else {
 			pfCtx = dgroup.WithGoroutineName(ctx, fmt.Sprintf("/%s:%s", ic.PodIp, port))
 		}

--- a/pkg/client/userd/trafficmgr/mount.go
+++ b/pkg/client/userd/trafficmgr/mount.go
@@ -9,6 +9,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/remotefs"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
 func (ic *intercept) shouldMount() bool {
@@ -52,7 +53,7 @@ func (ic *intercept) startMount(ctx context.Context, podWG *sync.WaitGroup) {
 		}
 		ic.Mounter = m
 	}
-	err := m.Start(mountCtx, ic.Id, ic.ClientMountPoint, ic.MountPoint, ic.PodIp, port)
+	err := m.Start(mountCtx, ic.Id, ic.ClientMountPoint, ic.MountPoint, iputil.Parse(ic.PodIp), uint16(port))
 	if err != nil && ctx.Err() == nil {
 		dlog.Error(ctx, err)
 	}

--- a/pkg/forwarder/tcp.go
+++ b/pkg/forwarder/tcp.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/ipproto"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -169,7 +170,7 @@ func (f *interceptor) interceptConn(ctx context.Context, conn net.Conn, iCept *m
 
 	spec := iCept.Spec
 	destIp := iputil.Parse(spec.TargetHost)
-	id := tunnel.NewConnID(tunnel.IPProto(addr.Network()), srcIp, destIp, srcPort, uint16(spec.TargetPort))
+	id := tunnel.NewConnID(ipproto.Parse(addr.Network()), srcIp, destIp, srcPort, uint16(spec.TargetPort))
 	id.SpanRecord(span)
 
 	ms, err := f.manager.Tunnel(ctx)

--- a/pkg/ipproto/ipproto.go
+++ b/pkg/ipproto/ipproto.go
@@ -2,9 +2,43 @@
 // https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 package ipproto
 
+import "fmt"
+
 const (
 	TCP    = 6
 	UDP    = 17
 	ICMP   = 1
 	ICMPV6 = 58
 )
+
+// Parse returns the IP protocol for the given network. Currently only supports
+// TCP, UDP, and ICMP.
+func Parse(network string) int {
+	switch network {
+	case "tcp", "tcp4":
+		return TCP
+	case "udp", "udp4", "udp6":
+		return UDP
+	case "icmp":
+		return ICMP
+	case "icmpv6":
+		return ICMPV6
+	default:
+		return -1
+	}
+}
+
+func String(proto int) string {
+	switch proto {
+	case ICMP:
+		return "icmp"
+	case TCP:
+		return "tcp"
+	case UDP:
+		return "udp"
+	case ICMPV6:
+		return "icmpv6"
+	default:
+		return fmt.Sprintf("IP-protocol %d", proto)
+	}
+}

--- a/pkg/iputil/join.go
+++ b/pkg/iputil/join.go
@@ -1,0 +1,17 @@
+package iputil
+
+import (
+	"net"
+	"strconv"
+)
+
+func JoinIpPort(ip net.IP, port uint16) string {
+	ps := strconv.Itoa(int(port))
+	if ip4 := ip.To4(); ip4 != nil {
+		return ip4.String() + ":" + ps
+	}
+	if ip6 := ip.To4(); ip6 != nil {
+		return "[" + ip6.String() + "]:" + ps
+	}
+	return ":" + ps
+}

--- a/pkg/tunnel/connid.go
+++ b/pkg/tunnel/connid.go
@@ -158,38 +158,6 @@ func (id ConnID) SpanRecord(span trace.Span) {
 	)
 }
 
-// IPProto returns the IP protocol for the given network. Currently only supports
-// TCP, UDP, and ICMP.
-func IPProto(network string) int {
-	switch network {
-	case "tcp", "tcp4":
-		return ipproto.TCP
-	case "udp", "udp4", "udp6":
-		return ipproto.UDP
-	case "icmp":
-		return ipproto.ICMP
-	case "icmpv6":
-		return ipproto.ICMPV6
-	default:
-		return -1
-	}
-}
-
-func protoString(proto int) string {
-	switch proto {
-	case ipproto.ICMP:
-		return "icmp"
-	case ipproto.TCP:
-		return "tcp"
-	case ipproto.UDP:
-		return "udp"
-	case ipproto.ICMPV6:
-		return "icmpv6"
-	default:
-		return fmt.Sprintf("IP-protocol %d", proto)
-	}
-}
-
 // Reply returns a copy of this ConnID with swapped source and destination properties.
 func (id ConnID) Reply() ConnID {
 	return NewConnID(id.Protocol(), id.Destination(), id.Source(), id.DestinationPort(), id.SourcePort())
@@ -197,7 +165,7 @@ func (id ConnID) Reply() ConnID {
 
 // ReplyString returns a formatted string suitable for logging showing the destination:destinationPort -> source:sourcePort.
 func (id ConnID) ReplyString() string {
-	return fmt.Sprintf("%s %s:%d -> %s:%d", protoString(id.Protocol()), id.Destination(), id.DestinationPort(), id.Source(), id.SourcePort())
+	return fmt.Sprintf("%s %s:%d -> %s:%d", ipproto.String(id.Protocol()), id.Destination(), id.DestinationPort(), id.Source(), id.SourcePort())
 }
 
 // String returns a formatted string suitable for logging showing the source:sourcePort -> destination:destinationPort.
@@ -205,5 +173,5 @@ func (id ConnID) String() string {
 	if len(id) < 13 {
 		return "bogus ConnID"
 	}
-	return fmt.Sprintf("%s %s:%d -> %s:%d", protoString(id.Protocol()), id.Source(), id.SourcePort(), id.Destination(), id.DestinationPort())
+	return fmt.Sprintf("%s %s:%d -> %s:%d", ipproto.String(id.Protocol()), id.Source(), id.SourcePort(), id.Destination(), id.DestinationPort())
 }


### PR DESCRIPTION
## Description

The telepresence client mounts remote directories based on a podIP and
port that are passed on in the `InterceptInfo`. An intercept will
survive a pod restart that will yield new podIP/port combinations and
the daemon will deal with this correctly. The mount code that now
executes outside the daemon doesn't, because it doesn't watch the
intercepts.

Rather that reimplementing that logic and force the client to watch
intercepts, this commit moves the concern of keeping the podIP and port
stable for the duration of an intercept by introducing an IP map
mechanism that hides the fact that pod IP is restarted.

Similar functionality could have been obtained by using a service and
well-known ports in the traffic-agent, but that will require new RBAC
privileges. The approach used here is completely hidden from the user.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
