### PR TITLE
Build fuseftp conditionally. Don't include it client image.

### DIFF
--- a/pkg/client/remotefs/fuseftp.go
+++ b/pkg/client/remotefs/fuseftp.go
@@ -1,3 +1,6 @@
+//go:build !docker
+// +build !docker
+
 package remotefs
 
 import (

--- a/pkg/client/remotefs/fuseftp_docker.go
+++ b/pkg/client/remotefs/fuseftp_docker.go
@@ -1,0 +1,30 @@
+//go:build docker
+// +build docker
+
+package remotefs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/datawire/go-fuseftp/rpc"
+)
+
+type fuseFtpMgr struct{}
+
+type FuseFTPManager interface {
+	DeferInit(ctx context.Context) error
+	GetFuseFTPClient(ctx context.Context) rpc.FuseFTPClient
+}
+
+func NewFuseFTPManager() FuseFTPManager {
+	return &fuseFtpMgr{}
+}
+
+func (s *fuseFtpMgr) DeferInit(ctx context.Context) error {
+	return errors.New("fuseftp client is not available")
+}
+
+func (s *fuseFtpMgr) GetFuseFTPClient(ctx context.Context) rpc.FuseFTPClient {
+	return nil
+}


### PR DESCRIPTION
If the build is made with `DOCKER_BUILD=1`, then the fuseftp.bits will not be downloaded and embedded into the binary. It is replaced by a dummy that reports that fuseftp isn't available.