### PR TITLE
Reinstate kubernetes flags when running with daemon address.

### DIFF
--- a/build-aux/docker/images/Dockerfile.traffic
+++ b/build-aux/docker/images/Dockerfile.traffic
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine3.15 as tel2-build
+FROM golang:alpine as tel2-build
 
 RUN apk add --no-cache gcc musl-dev fuse-dev libcap
 
@@ -35,7 +35,7 @@ RUN \
 RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/traffic
 
 # The tel2 target is the one that gets published. It aims to be a small as possible.
-FROM alpine:3.15 as tel2
+FROM alpine as tel2
 
 RUN apk add --no-cache ca-certificates iptables
 

--- a/pkg/client/cli/cmds_misc.go
+++ b/pkg/client/cli/cmds_misc.go
@@ -113,16 +113,11 @@ func InitConnectRequest(ctx context.Context, cmd *cobra.Command) (*connector.Con
 		`Overrides any other manager namespace set in config`)
 	flags.AddFlagSet(nwFlags)
 
-	// Only include the kubernetes flags if the user daemon is started from the CLI. It's assumed that it is configured
-	// already using a default .kube/config if it is reachable using an address.
-	var kubeFlags *pflag.FlagSet
-	if client.GetEnv(ctx).UserDaemonAddress == "" {
-		kubeConfig := genericclioptions.NewConfigFlags(false)
-		kubeConfig.Namespace = nil // "connect", don't take --namespace
-		kubeFlags = pflag.NewFlagSet("Kubernetes flags", 0)
-		kubeConfig.AddFlags(kubeFlags)
-		flags.AddFlagSet(kubeFlags)
-	}
+	kubeConfig := genericclioptions.NewConfigFlags(false)
+	kubeConfig.Namespace = nil // "connect", don't take --namespace
+	kubeFlags := pflag.NewFlagSet("Kubernetes flags", 0)
+	kubeConfig.AddFlags(kubeFlags)
+	flags.AddFlagSet(kubeFlags)
 	return &cr, kubeFlags
 }
 


### PR DESCRIPTION
Removing those flags was a mistake. A connect must be able to propagate them to a running daemon.