### PR TITLE
switch to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Telepresence 2 is based on learnings from the original Telepresence architecture
 Start with an empty cluster:
 
 ```console
-$ kubectl create deploy hello --image=k8s.gcr.io/echoserver:1.4
+$ kubectl create deploy hello --image=registry.k8s.io/echoserver:1.4
 deployment.apps/hello created
 $ kubectl expose deploy hello --port 80 --target-port 8080
 service/hello exposed
@@ -252,7 +252,7 @@ Init Containers:
 Containers:
   echoserver:
     Container ID:   containerd://80d4645769a06b8671b5a4ce29d28abfa72ce5659ba96916c231bb9629593a29
-    Image:          k8s.gcr.io/echoserver:1.4
+    Image:          reistry.k8s.io/echoserver:1.4
     Image ID:       sha256:523cad1a4df732d41406c9de49f932cd60d56ffd50619158a2977fd1066028f9
     Port:           <none>
     Host Port:      <none>
@@ -321,7 +321,7 @@ Events:
   Normal  Pulled     13m   kubelet            Successfully pulled image "docker.io/datawire/ambassador-telepresence-agent:1.12.6" in 17.043659509s
   Normal  Created    13m   kubelet            Created container tel-agent-init
   Normal  Started    13m   kubelet            Started container tel-agent-init
-  Normal  Pulled     13m   kubelet            Container image "k8s.gcr.io/echoserver:1.4" already present on machine
+  Normal  Pulled     13m   kubelet            Container image "registry.k8s.io/echoserver:1.4" already present on machine
   Normal  Created    13m   kubelet            Created container echoserver
   Normal  Started    13m   kubelet            Started container echoserver
   Normal  Pulled     13m   kubelet            Container image "docker.io/datawire/ambassador-telepresence-agent:1.12.6" already present on machine


### PR DESCRIPTION
## Description

A few sentences describing the overall goals of the pull request's commits.
The main Kubernetes container registry is now defaulted to registry.k8s.io. See: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/.
Switching to the new registry in the readme docs.
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
