### PR TITLE
Add build-deps to dependency snapshot workflow

### DIFF
--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -19,6 +19,10 @@ jobs:
         with:
           go-version: '~1.19.6'
 
+      # we need fuseftp.bits
+      - name: "Build dependencies"
+        run: make build-deps
+
       - name: Run snapshot action
         uses: actions/go-dependency-submission@v1
         with:


### PR DESCRIPTION
## Description

The dependency submission workflow is [failing](https://github.com/telepresenceio/telepresence/actions/runs/4266377829/jobs/7426823380) because it didn't include the fuseftp.bits as a prerequisite.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
