### PR TITLE
Better status and version output when running one daemon.

### DIFF
--- a/pkg/client/cli/main.go
+++ b/pkg/client/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd/trafficmgr"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
 
 func InitContext(ctx context.Context) context.Context {
@@ -28,7 +29,11 @@ func InitContext(ctx context.Context) context.Context {
 	ctx = client.WithEnv(ctx, env)
 	switch client.ProcessName() {
 	case userd.ProcessName:
-		client.DisplayName = "OSS User Daemon"
+		if proc.RunningInContainer() {
+			client.DisplayName = "OSS Daemon in container"
+		} else {
+			client.DisplayName = "OSS User Daemon"
+		}
 		ctx = userd.WithNewServiceFunc(ctx, userDaemon.NewService)
 		ctx = userd.WithNewSessionFunc(ctx, trafficmgr.NewSession)
 	case rootd.ProcessName:

--- a/pkg/client/cli/util/connector.go
+++ b/pkg/client/cli/util/connector.go
@@ -218,6 +218,11 @@ func ensureSession(ctx context.Context, required bool) (context.Context, error) 
 func connectSession(ctx context.Context, userD *UserDaemon, request *connect.Request, required bool) (*Session, error) {
 	var ci *connector.ConnectInfo
 	var err error
+	if userD.Remote {
+		// We never pass on KUBECONFIG or --kubeconfig to a remote daemon.
+		delete(request.KubeFlags, "KUBECONFIG")
+		delete(request.KubeFlags, "kubeconfig")
+	}
 	cat := errcat.Unknown
 	if request.Implicit {
 		// implicit calls use the current Status instead of passing flags and mapped namespaces.

--- a/pkg/ioutil/keyvalueformatter.go
+++ b/pkg/ioutil/keyvalueformatter.go
@@ -46,13 +46,18 @@ func (f *KeyValueFormatter) WriteTo(out io.Writer) (int64, error) {
 		if i > 0 {
 			n += WriteString(out, "\n")
 		}
-		lines := strings.Split(strings.TrimSpace(kvs[i+1]), "\n")
+		lines := strings.Split(strings.TrimRight(kvs[i+1], " \t\r\n"), "\n")
 		n += Printf(out, "%s%-*s%s%s", f.Prefix, kLen, kvs[i], f.Separator, lines[0])
 		for _, line := range lines[1:] {
 			n += Printf(out, "\n%s%s%s", f.Prefix, f.Indent, line)
 		}
 	}
 	return int64(n), nil
+}
+
+func (f *KeyValueFormatter) Println(out io.Writer) int {
+	n, _ := f.WriteTo(out)
+	return int(n) + Println(out, "")
 }
 
 // String returns the formatted output string.


### PR DESCRIPTION
This PR fixes the output from the status and version commands when running a single daemon, and also ensures that `--kubeconfig` and `KUBECONFIG` aren't passed on to a remote daemon.