### PR TITLE
Use external kubernetes authenticator in container based daemon.

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -160,6 +160,11 @@ else
 	CGO_ENABLED=$(CGO_ENABLED) $(sdkroot) go build -trimpath -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $@ ./cmd/telepresence
 endif
 
+# Make local authenticator. This is for test only as it's really only intended to run from within a container
+.PHONY: authenticator
+authenticator:
+	CGO_ENABLED=$(CGO_ENABLED) $(sdkroot) go build -trimpath -o $(BINDIR)/$@ ./cmd/$@
+
 .PHONY: release-binary
 release-binary: $(TELEPRESENCE)
 	mkdir -p $(RELEASEDIR)

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -16,18 +15,10 @@ import (
 
 func main() {
 	cmd := &cobra.Command{
-		Use:  "authenticator [contextName]",
-		Args: cobra.ExactArgs(1),
+		Use:  "authenticator <contextName> <address>",
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			address := os.Getenv("AUTHENTICATOR_ADDR")
-			portEnv := os.Getenv("AUTHENTICATOR_PORT")
-
-			port, err := strconv.Atoi(portEnv)
-			if err != nil {
-				return fmt.Errorf("failed to convert port value: %s", portEnv)
-			}
-
-			if err := authenticateContext(cmd.Context(), args[0], address, port); err != nil {
+			if err := authenticateContext(cmd.Context(), args[0], args[1]); err != nil {
 				return fmt.Errorf("failed to authenticate context %s: %w", args[0], err)
 			}
 			return nil
@@ -38,8 +29,8 @@ func main() {
 	}
 }
 
-func authenticateContext(ctx context.Context, contextName, serverAddr string, port int) error {
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", serverAddr, port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+func authenticateContext(ctx context.Context, contextName, serverAddr string) error {
+	conn, err := grpc.Dial(serverAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("failed to dial GRPC server: %w", err)
 	}

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -23,6 +23,7 @@ func main() {
 			}
 			return nil
 		},
+		SilenceUsage: true,
 	}
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/pkg/authenticator/grpc/authenticator.go
+++ b/pkg/authenticator/grpc/authenticator.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/authenticator"
 	"github.com/telepresenceio/telepresence/v2/pkg/authenticator"
 )
@@ -29,6 +30,7 @@ type AuthenticatorServer struct {
 
 // GetContextExecCredentials returns credentials for a particular Kubernetes context on the host machine.
 func (h *AuthenticatorServer) GetContextExecCredentials(ctx context.Context, request *rpc.GetContextExecCredentialsRequest) (*rpc.GetContextExecCredentialsResponse, error) {
+	dlog.Debugf(ctx, "GetContextExecCredentials(%s)", request.ContextName)
 	rawExecCredentials, err := h.authenticator.GetExecCredentials(ctx, request.ContextName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve exec credentils: %w", err)

--- a/pkg/authenticator/patcher/patcher.go
+++ b/pkg/authenticator/patcher/patcher.go
@@ -2,27 +2,20 @@ package patcher
 
 import (
 	"fmt"
-	"os"
 
-	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const KubeConfigStubBinaryName = "authenticator"
 
-// GenerateTempKubeConfigStubFile go through the kubeconfig file and replace all users using the Exec auth method by
-// an invocation of the stub binary. It returns the temp kubeconfig file to mount, and the client config.
-func GenerateTempKubeConfigStubFile(originalKubeConfig clientcmd.ClientConfig) (string, error) {
-	rawConfig, err := originalKubeConfig.RawConfig()
-	if err != nil {
-		return "", err
-	}
-
+// ReplaceAuthExecWithStub goes through the kubeconfig and replaces all uses of the Exec auth method by
+// an invocation of the stub binary.
+func ReplaceAuthExecWithStub(rawConfig *clientcmdapi.Config, address string) error {
 	for contextName, kubeContext := range rawConfig.Contexts {
 		// Find related Auth.
 		authInfo, ok := rawConfig.AuthInfos[kubeContext.AuthInfo]
 		if !ok {
-			return "", fmt.Errorf("auth info %s not found for context %s", kubeContext.AuthInfo, contextName)
+			return fmt.Errorf("auth info %s not found for context %s", kubeContext.AuthInfo, contextName)
 		}
 
 		// If it isn't an exec mode context, just return the default host kubeconfig.
@@ -34,21 +27,18 @@ func GenerateTempKubeConfigStubFile(originalKubeConfig clientcmd.ClientConfig) (
 		authInfo.Exec = &clientcmdapi.ExecConfig{
 			APIVersion: authInfo.Exec.APIVersion,
 			Command:    KubeConfigStubBinaryName,
-			Args:       []string{contextName},
+			Args:       []string{contextName, address},
 		}
-		authInfo.Exec.Args = []string{contextName}
 	}
+	return nil
+}
 
-	tmpConfFile, err := os.CreateTemp(os.TempDir(), "kubeconfig")
-	if err != nil {
-		return "", err
+// NeedsStubbedExec returns true if the config contains at least one user with an Exec type AuthInfo.
+func NeedsStubbedExec(rawConfig *clientcmdapi.Config) bool {
+	for _, kubeContext := range rawConfig.Contexts {
+		if authInfo, ok := rawConfig.AuthInfos[kubeContext.AuthInfo]; ok && authInfo.Exec != nil {
+			return true
+		}
 	}
-	_ = tmpConfFile.Close()
-
-	err = clientcmd.WriteToFile(rawConfig, tmpConfFile.Name())
-	if err != nil {
-		return "", err
-	}
-
-	return tmpConfFile.Name(), nil
+	return false
 }

--- a/pkg/authenticator/patcher/patcher.go
+++ b/pkg/authenticator/patcher/patcher.go
@@ -25,9 +25,10 @@ func ReplaceAuthExecWithStub(rawConfig *clientcmdapi.Config, address string) err
 
 		// Patch exec.
 		authInfo.Exec = &clientcmdapi.ExecConfig{
-			APIVersion: authInfo.Exec.APIVersion,
-			Command:    KubeConfigStubBinaryName,
-			Args:       []string{contextName, address},
+			InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+			APIVersion:      authInfo.Exec.APIVersion,
+			Command:         KubeConfigStubBinaryName,
+			Args:            []string{contextName, address},
 		}
 	}
 	return nil

--- a/pkg/client/cli/main.go
+++ b/pkg/client/cli/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/docker/kubeauth"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/rootd"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd"
@@ -69,6 +70,7 @@ func Main(ctx context.Context) {
 			SilenceErrors: true, // main() will handle it after .ExecuteContext() returns
 			SilenceUsage:  true, // our FlagErrorFunc will handle it
 		}
+		cmd.AddCommand(kubeauth.Command())
 		cmd.AddCommand(userDaemon.Command())
 		cmd.AddCommand(rootd.Command())
 		if err := cmd.ExecuteContext(ctx); err != nil {

--- a/pkg/client/cli/util/connector.go
+++ b/pkg/client/cli/util/connector.go
@@ -219,9 +219,8 @@ func connectSession(ctx context.Context, userD *UserDaemon, request *connect.Req
 	var ci *connector.ConnectInfo
 	var err error
 	if userD.Remote {
-		// We never pass on KUBECONFIG or --kubeconfig to a remote daemon.
+		// We never pass on KUBECONFIG to a remote daemon.
 		delete(request.KubeFlags, "KUBECONFIG")
-		delete(request.KubeFlags, "kubeconfig")
 	}
 	cat := errcat.Unknown
 	if request.Implicit {
@@ -252,6 +251,11 @@ func connectSession(ctx context.Context, userD *UserDaemon, request *connect.Req
 
 	if !required {
 		return nil, nil
+	}
+	if userD.Remote {
+		if err = docker.EnableK8SAuthenticator(ctx); err != nil {
+			return nil, err
+		}
 	}
 	if ci, err = userD.Connect(ctx, &request.ConnectRequest); err != nil {
 		return nil, err

--- a/pkg/client/cli/util/connector.go
+++ b/pkg/client/cli/util/connector.go
@@ -129,7 +129,7 @@ func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required
 	if _, err = ensureAppUserConfigDir(ctx); err != nil {
 		return nil, errcat.NoDaemonLogs.New(err)
 	}
-	if err = proc.StartInBackground(connectorDaemon, "connector-foreground"); err != nil {
+	if err = proc.StartInBackground(false, connectorDaemon, "connector-foreground"); err != nil {
 		return nil, errcat.NoDaemonLogs.Newf("failed to launch the connector service: %w", err)
 	}
 	if err = socket.WaitUntilAppears("connector", socket.ConnectorName, 10*time.Second); err != nil {

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -88,6 +89,9 @@ func DaemonOptions(ctx context.Context, name string) ([]string, *net.TCPAddr, er
 		"-v", fmt.Sprintf("%s:%s:ro", tpConfig, dockerTpConfig),
 		"-v", fmt.Sprintf("%s:%s", tpCache, dockerTpCache),
 		"-v", fmt.Sprintf("%s:%s", tpLog, dockerTpLog),
+	}
+	if runtime.GOOS == "linux" {
+		opts = append(opts, "--add-host", "host.docker.internal:host-gateway")
 	}
 	env := client.GetEnv(ctx)
 	if env.ScoutDisable {

--- a/pkg/client/docker/kubeauth/cmd.go
+++ b/pkg/client/docker/kubeauth/cmd.go
@@ -1,0 +1,114 @@
+package kubeauth
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/datawire/dlib/dhttp"
+	"github.com/datawire/dlib/dlog"
+	authGrpc "github.com/telepresenceio/telepresence/v2/pkg/authenticator/grpc"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+)
+
+const (
+	CommandName       = "kubeauth-foreground"
+	PortFileStaleTime = 3 * time.Second
+)
+
+type authService struct {
+	portFile  string
+	kubeFlags *genericclioptions.ConfigFlags
+}
+
+func Command() *cobra.Command {
+	as := authService{kubeFlags: genericclioptions.NewConfigFlags(false)}
+	c := &cobra.Command{
+		Use:    CommandName,
+		Short:  "Launch Telepresence Kubernetes authenticator",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		RunE:   as.run,
+	}
+	flags := c.Flags()
+	flags.StringVar(&as.portFile, "portfile", "", "File where server existence is announced.")
+	as.kubeFlags.AddFlags(flags)
+	return c
+}
+
+func (as *authService) run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	cfg, err := client.LoadConfig(ctx)
+	if err != nil {
+		return err
+	}
+	ctx = client.WithConfig(ctx, cfg)
+
+	if as.portFile == "" {
+		return errcat.User.New("missing required flag --portfile")
+	}
+	grpcListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return errcat.NoDaemonLogs.Newf("unable to open a port on localhost: %w", err)
+	}
+
+	ctx, err = logging.InitContext(ctx, "kubeauth", logging.RotateNever, false)
+	if err != nil {
+		return err
+	}
+	addr := grpcListener.Addr().(*net.TCPAddr)
+	dlog.Infof(ctx, "kubeauth listening on address %s", addr)
+
+	ctx, cancel := context.WithCancel(ctx)
+	if err := as.keepPortFileAlive(ctx, cancel, addr.Port); err != nil {
+		return err
+	}
+
+	grpcHandler := grpc.NewServer()
+	authGrpc.RegisterAuthenticatorServer(grpcHandler, as.kubeFlags.ToRawKubeConfigLoader())
+
+	sc := &dhttp.ServerConfig{Handler: grpcHandler}
+	return sc.Serve(ctx, grpcListener)
+}
+
+func (as *authService) keepPortFileAlive(ctx context.Context, cancel context.CancelFunc, port int) error {
+	pb := binary.BigEndian.AppendUint16(nil, uint16(port))
+	if err := os.WriteFile(as.portFile, pb, 0o644); err != nil {
+		return err
+	}
+	dlog.Infof(ctx, "kubeauth created %s with %d", as.portFile, port)
+	go func() {
+		ticker := time.NewTicker(PortFileStaleTime)
+		defer func() {
+			ticker.Stop()
+			_ = os.Remove(as.portFile)
+			dlog.Debugf(ctx, "kubeauth removed %s", as.portFile)
+		}()
+		now := time.Now()
+		for {
+			if err := os.Chtimes(as.portFile, now, now); err != nil {
+				if !os.IsNotExist(err) {
+					// File is removed, so stop trying to update its timestamps and die
+					dlog.Errorf(ctx, "failed to update timestamp on %s: %v", as.portFile, err)
+				}
+				dlog.Info(ctx, "kubeauth exiting")
+				cancel()
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case now = <-ticker.C:
+			}
+		}
+	}()
+	return nil
+}

--- a/pkg/client/docker/kubeauth/cmd.go
+++ b/pkg/client/docker/kubeauth/cmd.go
@@ -2,15 +2,20 @@ package kubeauth
 
 import (
 	"context"
-	"encoding/binary"
+	"encoding/json"
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
 	authGrpc "github.com/telepresenceio/telepresence/v2/pkg/authenticator/grpc"
@@ -21,12 +26,20 @@ import (
 
 const (
 	CommandName       = "kubeauth-foreground"
+	PortFileDir       = "kubeauth"
 	PortFileStaleTime = 3 * time.Second
 )
 
 type authService struct {
-	portFile  string
-	kubeFlags *genericclioptions.ConfigFlags
+	portFile    string
+	kubeFlags   *genericclioptions.ConfigFlags
+	cancel      context.CancelFunc
+	configFiles []string
+}
+
+type PortFile struct {
+	Port       int    `json:"port"`
+	Kubeconfig string `json:"kubeconfig"`
 }
 
 func Command() *cobra.Command {
@@ -67,48 +80,106 @@ func (as *authService) run(cmd *cobra.Command, _ []string) error {
 	addr := grpcListener.Addr().(*net.TCPAddr)
 	dlog.Infof(ctx, "kubeauth listening on address %s", addr)
 
-	ctx, cancel := context.WithCancel(ctx)
-	if err := as.keepPortFileAlive(ctx, cancel, addr.Port); err != nil {
+	config := as.kubeFlags.ToRawKubeConfigLoader()
+	as.configFiles = config.ConfigAccess().GetLoadingPrecedence()
+	p := PortFile{
+		Port:       addr.Port,
+		Kubeconfig: strings.Join(as.configFiles, string(filepath.ListSeparator)),
+	}
+	pb, err := json.Marshal(&p)
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(as.portFile, pb, 0o644); err != nil {
 		return err
 	}
 
-	grpcHandler := grpc.NewServer()
-	authGrpc.RegisterAuthenticatorServer(grpcHandler, as.kubeFlags.ToRawKubeConfigLoader())
-
-	sc := &dhttp.ServerConfig{Handler: grpcHandler}
-	return sc.Serve(ctx, grpcListener)
+	ctx, as.cancel = context.WithCancel(ctx)
+	g := dgroup.NewGroup(ctx, dgroup.GroupConfig{})
+	g.Go("portfile-alive", as.keepPortFileAlive)
+	g.Go("portfile-watcher", as.watchFiles)
+	g.Go("grpc-server", func(ctx context.Context) error {
+		grpcHandler := grpc.NewServer()
+		authGrpc.RegisterAuthenticatorServer(grpcHandler, config)
+		sc := &dhttp.ServerConfig{Handler: grpcHandler}
+		return sc.Serve(ctx, grpcListener)
+	})
+	return g.Wait()
 }
 
-func (as *authService) keepPortFileAlive(ctx context.Context, cancel context.CancelFunc, port int) error {
-	pb := binary.BigEndian.AppendUint16(nil, uint16(port))
-	if err := os.WriteFile(as.portFile, pb, 0o644); err != nil {
+func (as *authService) keepPortFileAlive(ctx context.Context) error {
+	ticker := time.NewTicker(PortFileStaleTime)
+	defer func() {
+		ticker.Stop()
+		_ = os.Remove(as.portFile)
+		dlog.Debugf(ctx, "kubeauth removed %s", as.portFile)
+	}()
+	now := time.Now()
+	for {
+		if err := os.Chtimes(as.portFile, now, now); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to update timestamp on %s: %v", as.portFile, err)
+			}
+			// File is removed, so stop trying to update its timestamps and die
+			dlog.Info(ctx, "kubeauth exiting")
+			as.cancel()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case now = <-ticker.C:
+		}
+	}
+}
+
+func (as *authService) watchFiles(ctx context.Context) error {
+	// If any of the files that the current kubeconfig uses changes, then we die
+	files := as.configFiles
+
+	// If the portFile changes, then we die
+	files = append(files, as.portFile)
+
+	dirs := make(map[string]struct{})
+	for _, file := range files {
+		dir := filepath.Dir(file)
+		dirs[dir] = struct{}{}
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
 		return err
 	}
-	dlog.Infof(ctx, "kubeauth created %s with %d", as.portFile, port)
-	go func() {
-		ticker := time.NewTicker(PortFileStaleTime)
-		defer func() {
-			ticker.Stop()
-			_ = os.Remove(as.portFile)
-			dlog.Debugf(ctx, "kubeauth removed %s", as.portFile)
-		}()
-		now := time.Now()
-		for {
-			if err := os.Chtimes(as.portFile, now, now); err != nil {
-				if !os.IsNotExist(err) {
-					// File is removed, so stop trying to update its timestamps and die
-					dlog.Errorf(ctx, "failed to update timestamp on %s: %v", as.portFile, err)
-				}
-				dlog.Info(ctx, "kubeauth exiting")
-				cancel()
-				return
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case now = <-ticker.C:
+	defer watcher.Close()
+
+	isOfInterest := func(s string, files []string) bool {
+		for _, file := range files {
+			if s == file {
+				return true
 			}
 		}
-	}()
-	return nil
+		return false
+	}
+	for dir := range dirs {
+		// Can't watch things that doesn't exist. We want to know if files in there change though.
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		if err = watcher.Add(dir); err != nil {
+			return err
+		}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err = <-watcher.Errors:
+			dlog.Error(ctx, err)
+		case event := <-watcher.Events:
+			if event.Op&(fsnotify.Remove|fsnotify.Write|fsnotify.Create) != 0 && isOfInterest(event.Name, files) {
+				dlog.Infof(ctx, "Terminated due to %s in %s", event.Op, event.Name)
+				as.cancel()
+			}
+		}
+	}
 }

--- a/pkg/client/docker/kubeauth/cmd.go
+++ b/pkg/client/docker/kubeauth/cmd.go
@@ -134,7 +134,7 @@ func (as *authService) keepPortFileAlive(ctx context.Context) error {
 }
 
 func (as *authService) watchFiles(ctx context.Context) error {
-	// If any of the files that the current kubeconfig uses changes, then we die
+	// If any of the files that the current kubeconfig uses change, then we die
 	files := as.configFiles
 
 	// If the portFile changes, then we die
@@ -161,7 +161,7 @@ func (as *authService) watchFiles(ctx context.Context) error {
 		return false
 	}
 	for dir := range dirs {
-		// Can't watch things that doesn't exist. We want to know if files in there change though.
+		// Can't watch things that don't exist. We want to know if files in there change though.
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -220,6 +220,12 @@ func startSession(ctx context.Context, si userd.Service, cr *rpc.ConnectRequest,
 	ctx, session, rsp := userd.GetNewSessionFunc(ctx)(ctx, s.scout, cr)
 	if ctx.Err() != nil || rsp.Error != rpc.ConnectInfo_UNSPECIFIED {
 		cancel()
+		if s.rootSessionInProc {
+			// Simplified session management. The daemon handles one session, then exits.
+			s.sessionLock.Unlock()
+			_, _ = s.Quit(ctx, nil)
+			s.sessionLock.Lock()
+		}
 		return rsp
 	}
 

--- a/pkg/proc/exec.go
+++ b/pkg/proc/exec.go
@@ -87,8 +87,8 @@ func Run(ctx context.Context, env map[string]string, exe string, args ...string)
 	return Wait(ctx, cancel, cmd)
 }
 
-func StartInBackground(args ...string) error {
-	return startInBackground(args...)
+func StartInBackground(includeEnv bool, args ...string) error {
+	return startInBackground(includeEnv, args...)
 }
 
 func StartInBackgroundAsRoot(ctx context.Context, args ...string) error {

--- a/pkg/proc/exec_unix.go
+++ b/pkg/proc/exec_unix.go
@@ -26,8 +26,11 @@ func isAdmin() bool {
 	return os.Geteuid() == 0
 }
 
-func startInBackground(args ...string) error {
+func startInBackground(includeEnv bool, args ...string) error {
 	cmd := exec.Command(args[0], args[1:]...)
+	if includeEnv {
+		cmd.Env = os.Environ()
+	}
 
 	// Ensure that the processes uses a process group of its own to prevent
 	// it getting affected by <ctrl-c> in the terminal
@@ -76,7 +79,7 @@ func startInBackgroundAsRoot(ctx context.Context, args ...string) error {
 		args = append([]string{"sudo", "--non-interactive"}, args...)
 	}
 
-	return startInBackground(args...)
+	return startInBackground(false, args...)
 }
 
 func terminate(p *os.Process) error {

--- a/pkg/proc/exec_windows.go
+++ b/pkg/proc/exec_windows.go
@@ -18,7 +18,7 @@ func CommandContext(ctx context.Context, name string, args ...string) *dexec.Cmd
 	return cmd
 }
 
-func startInBackground(args ...string) error {
+func startInBackground(_ bool, args ...string) error {
 	return shellExec("open", args[0], args[1:]...)
 }
 


### PR DESCRIPTION
## Description

This PR incorporates the authentication method introduced in PR #3052 into the flow when connecting to a container based daemon using `telepresence connect --docker`.

New `telepresence kubeauth-foreground --portfile <path>` subcommand.
This command starts the gRPC service that performs the host-based authentication. The server is started on demand the first time a `telepresence connect --docker` uses a kubernetes context with a user configured with an `exec` type authentication. When started, it allocates a port and announces that port as  a two byte binary integer in the given port file. The server will keep on running until it is killed or until the portfile is removed, and while running, it will touch the port file every three seconds so that stale port files can be detected and removed.

The port is picked up by the CLI binary and the address `docker.host.internal:<port>` is injected into a stubbed kubeconfig, which is then mounted into the docker container that runs the daemon. This approach makes it unnecessary to use environment variables to pass and address and a port.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
