### PR TITLE
Add the kube context and daemon address to the cache

### DIFF
--- a/pkg/client/cache/daemons.go
+++ b/pkg/client/cache/daemons.go
@@ -14,10 +14,10 @@ import (
 )
 
 type DaemonInfo struct {
-	Options       map[string]string
-	InDocker      bool
-	KubeContext   string
-	DaemonAddress string
+	Options     map[string]string
+	InDocker    bool
+	KubeContext string
+	DaemonPort  int
 }
 
 const (

--- a/pkg/client/cache/daemons.go
+++ b/pkg/client/cache/daemons.go
@@ -14,8 +14,10 @@ import (
 )
 
 type DaemonInfo struct {
-	Options  map[string]string
-	InDocker bool
+	Options       map[string]string
+	InDocker      bool
+	KubeContext   string
+	DaemonAddress string
 }
 
 const (

--- a/pkg/client/cache/daemons.go
+++ b/pkg/client/cache/daemons.go
@@ -14,10 +14,10 @@ import (
 )
 
 type DaemonInfo struct {
-	Options     map[string]string
-	InDocker    bool
-	KubeContext string
-	DaemonPort  int
+	Options     map[string]string `json:"options,omitempty"`
+	InDocker    bool              `json:"in_docker,omitempty"`
+	KubeContext string            `json:"kube_context,omitempty"`
+	DaemonPort  int               `json:"daemon_port,omitempty"`
 }
 
 const (

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -378,8 +378,10 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	case cid := <-cidFound: // Success, the daemon info file exists
 		err := cache.SaveDaemonInfo(ctx,
 			&cache.DaemonInfo{
-				Options:  map[string]string{"cid": cid},
-				InDocker: true,
+				Options:       map[string]string{"cid": cid},
+				InDocker:      true,
+				DaemonAddress: addr.String(),
+				KubeContext:   name,
 			}, cache.DaemonInfoFile(name, addr.Port))
 		if err != nil {
 			return nil, err

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -378,10 +378,10 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	case cid := <-cidFound: // Success, the daemon info file exists
 		err := cache.SaveDaemonInfo(ctx,
 			&cache.DaemonInfo{
-				Options:       map[string]string{"cid": cid},
-				InDocker:      true,
-				DaemonAddress: addr.String(),
-				KubeContext:   name,
+				Options:     map[string]string{"cid": cid},
+				InDocker:    true,
+				DaemonPort:  addr.Port,
+				KubeContext: name,
 			}, cache.DaemonInfoFile(name, addr.Port))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

Add the kube context and daemon address to the cache

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
