### PR TITLE
Longer grace-period when expiring daemon caches

### DIFF
--- a/pkg/client/cache/daemons.go
+++ b/pkg/client/cache/daemons.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
@@ -80,7 +81,8 @@ func daemonInfoFiles(ctx context.Context) ([]fs.DirEntry, error) {
 		if err != nil {
 			return nil, err
 		}
-		if fi.ModTime().Add(keepAliveInterval + 200*time.Millisecond).Before(time.Now()) {
+		if fi.ModTime().Add(keepAliveInterval + 600*time.Millisecond).Before(time.Now()) {
+			dlog.Debugf(ctx, "Daemon cache %s has expired.", file.Name())
 			// File has gone stale
 			if err = DeleteFromUserCache(ctx, filepath.Join(daemonsDirName, file.Name())); err != nil {
 				return nil, err


### PR DESCRIPTION
## Description

This helps prevent issues with cache files being deleted prematurely when there's clock skew between the CLI and the docker container running the daemons

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
