### PR TITLE
Make telepresence helm xxx work with docker based daemon.

### DIFF
--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -51,10 +51,11 @@ func (s *helmSuite) Test_HelmCanInterceptInManagedNamespace() {
 
 func (s *helmSuite) Test_HelmCannotInterceptInUnmanagedNamespace() {
 	ctx := s.Context()
-	ctx = itest.WithUser(ctx, "default")
 	_, stderr, err := itest.Telepresence(ctx, "intercept", "--namespace", s.appSpace2, "--mount", "false", s.ServiceName(), "--port", "9090")
 	s.Error(err)
-	s.Contains(stderr, `No interceptable deployment, replicaset, or statefulset matching echo found`)
+	s.True(
+		strings.Contains(stderr, `No interceptable deployment, replicaset, or statefulset matching echo found`) ||
+			strings.Contains(stderr, `cannot get resource "deployments" in API group "apps" in the namespace`))
 }
 
 func (s *helmSuite) Test_HelmWebhookInjectsInManagedNamespace() {

--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -113,10 +113,12 @@ func (s *helmSuite) Test_HelmMultipleInstalls() {
 	})
 
 	s.Run("Uninstalls Successfully", func() {
+		defer itest.TelepresenceQuitOk(s.Context())
 		s.UninstallTrafficManager(s.Context(), s.mgrSpace2)
 	})
 }
 
 func (s *helmSuite) Test_CollidingInstalls() {
+	defer itest.TelepresenceQuitOk(s.Context())
 	s.Error(s.InstallTrafficManager(s.Context(), nil, s.mgrSpace2, s.AppNamespace(), s.appSpace2))
 }

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -33,6 +33,7 @@ func (s *helmSuite) assertInjected(ctx context.Context, name, namespace string, 
 }
 
 func (s *helmSuite) injectPolicyTest(ctx context.Context, policy agentconfig.InjectPolicy) {
+	itest.TelepresenceOk(ctx, "quit", "-s")
 	namespace := fmt.Sprintf("%s-%s", strings.ToLower(policy.String()), s.Suffix())
 	ctx = itest.WithEnv(ctx, map[string]string{"TELEPRESENCE_MANAGER_NAMESPACE": namespace})
 	itest.CreateNamespaces(ctx, namespace)
@@ -86,7 +87,6 @@ func (s *helmSuite) injectPolicyTest(ctx context.Context, policy agentconfig.Inj
 
 func (s *helmSuite) TestInjectPolicy() {
 	ctx := s.Context()
-	itest.TelepresenceOk(ctx, "quit", "-s")
 	defer func() {
 		itest.TelepresenceOk(ctx, "connect")
 	}()

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -86,11 +86,6 @@ func (s *helmSuite) injectPolicyTest(ctx context.Context, policy agentconfig.Inj
 }
 
 func (s *helmSuite) TestInjectPolicy() {
-	ctx := s.Context()
-	defer func() {
-		itest.TelepresenceOk(ctx, "connect")
-	}()
-
 	for _, policy := range []agentconfig.InjectPolicy{agentconfig.OnDemand, agentconfig.WhenEnabled} {
 		s.Run(policy.String(), func() {
 			s.injectPolicyTest(s.Context(), policy)

--- a/integration_test/itest/helm.go
+++ b/integration_test/itest/helm.go
@@ -42,7 +42,7 @@ func (h *helmAndService) setup(ctx context.Context) bool {
 }
 
 func (h *helmAndService) tearDown(ctx context.Context) {
-	TelepresenceOk(ctx, "quit")
+	TelepresenceQuitOk(ctx)
 	h.UninstallTrafficManager(ctx, h.ManagerNamespace())
 
 	// Helm uninstall does deletions asynchronously, which means the rbac might not be cleaned

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -40,7 +40,7 @@ func (s *notConnectedSuite) Test_Uninstall() {
 	// The telepresence-test-developer will not be able to uninstall everything
 	stdout = itest.TelepresenceOk(ctx, "helm", "uninstall")
 	defer s.installTelepresence(ctx)
-	s.Equal("Traffic Manager uninstalled successfully", stdout)
+	s.Contains(stdout, "Traffic Manager uninstalled successfully")
 
 	// Double check webhook agent is uninstalled
 	require.NoError(s.RolloutStatusWait(ctx, deployname))

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -40,7 +40,7 @@ func (s *notConnectedSuite) Test_Uninstall() {
 	// The telepresence-test-developer will not be able to uninstall everything
 	stdout = itest.TelepresenceOk(ctx, "helm", "uninstall")
 	defer s.installTelepresence(ctx)
-	itest.AssertQuitOutput(ctx, stdout)
+	s.Equal("Traffic Manager uninstalled successfully", stdout)
 
 	// Double check webhook agent is uninstalled
 	require.NoError(s.RolloutStatusWait(ctx, deployname))

--- a/integration_test/webhook_test.go
+++ b/integration_test/webhook_test.go
@@ -64,7 +64,8 @@ func (s *notConnectedSuite) Test_AgentImageFromConfig() {
 	// creating the traffic-manager
 	uninstallEverything := func() {
 		stdout := itest.TelepresenceOk(ctx, "helm", "uninstall")
-		itest.AssertQuitOutput(ctx, stdout)
+		s.Contains(stdout, "Traffic Manager uninstalled successfully")
+		itest.TelepresenceQuitOk(ctx)
 		s.Require().Eventually(
 			func() bool {
 				stdout, _ := itest.KubectlOut(ctx, s.ManagerNamespace(),

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -454,11 +454,10 @@ func (s *Service) Quit(ctx context.Context, ex *empty.Empty) (*empty.Empty, erro
 func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Result, error) {
 	result := &common.Result{}
 	s.logCall(ctx, "Helm", func(c context.Context) {
+		s.quitDisable = true
 		if s.rootSessionInProc {
 			// Temporarily disable quit so that session cancel doesn't cancel everything
-			s.quitDisable = true
 			defer func() {
-				s.quitDisable = false
 				go func() {
 					// Give this call time to return its result before the gRPC server shuts down.
 					time.Sleep(10 * time.Millisecond)
@@ -467,16 +466,34 @@ func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Resul
 			}()
 		}
 
+		var sessionDone <-chan struct{}
+		s.sessionLock.Lock()
+		if s.session != nil {
+			sessionDone = s.session.Done()
+		}
+		s.sessionLock.Unlock()
+
 		// Traffic manager will vanish, so we can't have an alive session.
 		s.cancelSession()
 		_ = s.withRootDaemon(ctx, func(ctx context.Context, rd daemon.DaemonClient) error {
 			_, _ = rd.Disconnect(ctx, &empty.Empty{})
+			s.quitDisable = false
 			return nil
 		})
+		if sessionDone != nil {
+			<-sessionDone
+		}
+		s.quitDisable = false
+
+		config, err := client.DaemonKubeconfig(ctx, req.ConnectRequest)
+		if err != nil {
+			result = errcat.ToResult(err)
+			return
+		}
 
 		sr := s.scout
 		if req.Type == rpc.HelmRequest_UNINSTALL {
-			err := trafficmgr.DeleteManager(c, req)
+			err := trafficmgr.DeleteManager(c, req, config)
 			if err != nil {
 				sr.Report(ctx, "helm_uninstall_failure", scout.Entry{Key: "error", Value: err.Error()})
 				result = errcat.ToResult(err)
@@ -484,7 +501,7 @@ func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Resul
 				sr.Report(ctx, "helm_uninstall_success")
 			}
 		} else {
-			err := trafficmgr.EnsureManager(c, req)
+			err := trafficmgr.EnsureManager(c, req, config)
 			if err != nil {
 				sr.Report(ctx, "helm_install_failure", scout.Entry{Key: "error", Value: err.Error()}, scout.Entry{Key: "upgrade", Value: req.Type == rpc.HelmRequest_UPGRADE})
 				result = errcat.ToResult(err)

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -454,6 +454,26 @@ func (s *Service) Quit(ctx context.Context, ex *empty.Empty) (*empty.Empty, erro
 func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Result, error) {
 	result := &common.Result{}
 	s.logCall(ctx, "Helm", func(c context.Context) {
+		if s.rootSessionInProc {
+			// Temporarily disable quit so that session cancel doesn't cancel everything
+			s.quitDisable = true
+			defer func() {
+				s.quitDisable = false
+				go func() {
+					// Give this call time to return its result before the gRPC server shuts down.
+					time.Sleep(10 * time.Millisecond)
+					s.quit()
+				}()
+			}()
+		}
+
+		// Traffic manager will vanish, so we can't have an alive session.
+		s.cancelSession()
+		_ = s.withRootDaemon(ctx, func(ctx context.Context, rd daemon.DaemonClient) error {
+			_, _ = rd.Disconnect(ctx, &empty.Empty{})
+			return nil
+		})
+
 		sr := s.scout
 		if req.Type == rpc.HelmRequest_UNINSTALL {
 			err := trafficmgr.DeleteManager(c, req)
@@ -477,6 +497,10 @@ func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Resul
 }
 
 func (s *Service) RemoteMountAvailability(ctx context.Context, _ *empty.Empty) (*common.Result, error) {
+	if proc.RunningInContainer() {
+		// We mount using docker volumes and the telemount driver plugin.
+		return errcat.ToResult(nil), nil
+	}
 	if client.GetConfig(ctx).Intercept.UseFtp {
 		return errcat.ToResult(s.FuseFTPError()), nil
 	}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -281,17 +281,13 @@ func connectCluster(c context.Context, cr *rpc.ConnectRequest, config *client.Ku
 	return cluster, nil
 }
 
-func DeleteManager(ctx context.Context, req *rpc.HelmRequest) error {
+func DeleteManager(ctx context.Context, req *rpc.HelmRequest, config *client.Kubeconfig) error {
 	cr := req.GetConnectRequest()
 	if cr == nil {
 		dlog.Info(ctx, "Connect_request in Helm_request was nil, using defaults")
 		cr = &rpc.ConnectRequest{}
 	}
 
-	config, err := client.DaemonKubeconfig(ctx, cr)
-	if err != nil {
-		return err
-	}
 	cluster, err := connectCluster(ctx, cr, config)
 	if err != nil {
 		return err
@@ -301,7 +297,7 @@ func DeleteManager(ctx context.Context, req *rpc.HelmRequest) error {
 		ctx, cluster.ConfigFlags, cluster.GetManagerNamespace(), false, req.Crds)
 }
 
-func EnsureManager(ctx context.Context, req *rpc.HelmRequest) error {
+func EnsureManager(ctx context.Context, req *rpc.HelmRequest, config *client.Kubeconfig) error {
 	// seg guard
 	cr := req.GetConnectRequest()
 	if cr == nil {
@@ -309,10 +305,6 @@ func EnsureManager(ctx context.Context, req *rpc.HelmRequest) error {
 		cr = &rpc.ConnectRequest{}
 	}
 
-	config, err := client.DaemonKubeconfig(ctx, cr)
-	if err != nil {
-		return err
-	}
 	cluster, err := connectCluster(ctx, cr, config)
 	if err != nil {
 		return err

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -1156,7 +1156,7 @@ func (s *session) connectRootDaemon(ctx context.Context, oi *rootdRpc.OutboundIn
 		if err != nil {
 			return nil, err
 		}
-		if err = rootSession.Start(ctx, dgroup.ParentGroup(ctx)); err != nil {
+		if err = rootSession.Start(ctx, dgroup.NewGroup(ctx, dgroup.GroupConfig{})); err != nil {
 			return nil, err
 		}
 		rd = rootSession


### PR DESCRIPTION
This commit ensures that the `telepresence helm xxx` commands work seamlessly with a container based daemon. The user can do:

    $ telepresence connect --docker
    $ telepresence helm xxx

or:

    $ telepresence helm --docker xxx
