### PR TITLE
Make --docker a global flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.x.x (TBD)
 
-- Feature: Telepresence can now start or connect to a daemon in a docker container.
+- Feature: Telepresence can now start or connect to a daemon in a docker container by use of the global `--docker` flag.
 
 - Feature: Adds an authenticator package to support integration with the [client-go credential](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) plugins when the
   daemon runs in a docker container.

--- a/pkg/client/cli/cmd.go
+++ b/pkg/client/cli/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/intercept"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
@@ -112,8 +113,8 @@ func hasKubeFlags(cmd *cobra.Command) bool {
 }
 
 func addUsageTemplate(cmd *cobra.Command) {
-	cobra.AddTemplateFunc("globalFlags", func(cmd *cobra.Command) *pflag.FlagSet { return GlobalFlags(hasKubeFlags(cmd)) })
-	cobra.AddTemplateFunc("flags", func(cmd *cobra.Command) *pflag.FlagSet { return localFlags(cmd, kubeFlags(), GlobalFlags(false)) })
+	cobra.AddTemplateFunc("globalFlags", func(cmd *cobra.Command) *pflag.FlagSet { return global.Flags(hasKubeFlags(cmd)) })
+	cobra.AddTemplateFunc("flags", func(cmd *cobra.Command) *pflag.FlagSet { return localFlags(cmd, kubeFlags(), global.Flags(false)) })
 	cobra.AddTemplateFunc("hasKubeFlags", hasKubeFlags)
 	cobra.AddTemplateFunc("kubeFlags", kubeFlags)
 	cobra.AddTemplateFunc("wrappedFlagUsages", func(flags *pflag.FlagSet) string {
@@ -195,7 +196,7 @@ func AddSubCommands(cmd *cobra.Command) {
 		command.SetContext(ctx)
 	}
 	cmd.AddCommand(commands...)
-	cmd.PersistentFlags().AddFlagSet(GlobalFlags(false))
+	cmd.PersistentFlags().AddFlagSet(global.Flags(false))
 	addCompletionCommand(cmd)
 	cmd.InitDefaultHelpCmd()
 	addUsageTemplate(cmd)
@@ -267,23 +268,4 @@ func argsCheck(f cobra.PositionalArgs) cobra.PositionalArgs {
 		}
 		return nil
 	}
-}
-
-func GlobalFlags(hasKubeFlags bool) *pflag.FlagSet {
-	flags := pflag.NewFlagSet("", 0)
-	if !hasKubeFlags {
-		flags.String(
-			"context", "",
-			"The name of the kubeconfig context to use",
-		)
-	}
-	flags.Bool(
-		"no-report", false,
-		"turn off anonymous crash reports and log submission on failure",
-	)
-	flags.String(
-		"output", "default",
-		"set the output format, supported values are 'json', 'yaml', and 'default'",
-	)
-	return flags
 }

--- a/pkg/client/cli/cmd_status.go
+++ b/pkg/client/cli/cmd_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/util"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
@@ -85,7 +86,7 @@ func fixFlag(cmd *cobra.Command, _ []string) error {
 	}
 	rootCmd := cmd.Parent()
 	if json {
-		if err = rootCmd.PersistentFlags().Set("output", "json"); err != nil {
+		if err = rootCmd.PersistentFlags().Set(global.FlagOutput, "json"); err != nil {
 			return err
 		}
 	}

--- a/pkg/client/cli/connect/request.go
+++ b/pkg/client/cli/connect/request.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
-	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 )
 

--- a/pkg/client/cli/global/flags.go
+++ b/pkg/client/cli/global/flags.go
@@ -5,6 +5,7 @@ import (
 )
 
 const (
+	FlagDocker   = "docker"
 	FlagContext  = "context"
 	FlagOutput   = "output"
 	FlagNoReport = "no-report"
@@ -15,6 +16,7 @@ func Flags(hasKubeFlags bool) *pflag.FlagSet {
 	if !hasKubeFlags {
 		flags.String(FlagContext, "", "The name of the kubeconfig context to use")
 	}
+	flags.Bool(FlagDocker, false, "Start, or connect to, daemon in a docker container")
 	flags.Bool(FlagNoReport, false, "Turn off anonymous crash reports and log submission on failure")
 	flags.String(FlagOutput, "default", "Set the output format, supported values are 'json', 'yaml', and 'default'")
 	return flags

--- a/pkg/client/cli/global/flags.go
+++ b/pkg/client/cli/global/flags.go
@@ -1,0 +1,21 @@
+package global
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	FlagContext  = "context"
+	FlagOutput   = "output"
+	FlagNoReport = "no-report"
+)
+
+func Flags(hasKubeFlags bool) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", 0)
+	if !hasKubeFlags {
+		flags.String(FlagContext, "", "The name of the kubeconfig context to use")
+	}
+	flags.Bool(FlagNoReport, false, "Turn off anonymous crash reports and log submission on failure")
+	flags.String(FlagOutput, "default", "Set the output format, supported values are 'json', 'yaml', and 'default'")
+	return flags
+}

--- a/pkg/client/cli/output/output.go
+++ b/pkg/client/cli/output/output.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 )
@@ -98,7 +99,7 @@ func DefaultYAML(cmd *cobra.Command, _ []string) error {
 		rootCmd = p
 	}
 	if fmt == formatDefault {
-		if err = rootCmd.PersistentFlags().Set("output", "yaml"); err != nil {
+		if err = rootCmd.PersistentFlags().Set(global.FlagOutput, "yaml"); err != nil {
 			return err
 		}
 	}
@@ -198,7 +199,7 @@ func WantsStream(cmd *cobra.Command) bool {
 }
 
 func validateFlag(cmd *cobra.Command) (format, error) {
-	if of := cmd.Flags().Lookup("output"); of != nil && of.DefValue == "default" {
+	if of := cmd.Flags().Lookup(global.FlagOutput); of != nil && of.DefValue == "default" {
 		fmt := strings.ToLower(of.Value.String())
 		switch fmt {
 		case "yaml":

--- a/pkg/client/cli/output/output_test.go
+++ b/pkg/client/cli/output/output_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 )
 
 func TestWithOutput(t *testing.T) {
@@ -37,7 +39,7 @@ func TestWithOutput(t *testing.T) {
 		cmd.SetContext(context.Background())
 		cmd.RunE = re
 
-		cmd.PersistentFlags().String("output", "default", "")
+		cmd.PersistentFlags().String(global.FlagOutput, "default", "")
 
 		return &cmd, &stdoutBuf, &stderrBuf
 	}


### PR DESCRIPTION
## Description

Adds `--docker` as a global flag so that it can be passed to all
commands to avoid conflicts between a host based daemon and a docker
daemon in cases where one is preferred but the current connect state is
unknown.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
