### PR TITLE
Fix panic when CNAME of kubernetes.default doesn't contain .svc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Feature: Adds an authenticator package to support integration with the [client-go credential](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) plugins when the
   daemon runs in a docker container.
 
+- Bugfix: The traffic-manager will no longer panic when the CNAME of kubernetes.default doesn't contain .svc.
+
 ### 2.11.1 (February 27, 2023)
 
 - Bugfix: The multi-arch build now for the proprietary traffic-manager and traffic-agent now works for both amd64 and arm64.

--- a/cmd/traffic/cmd/manager/internal/cluster/info.go
+++ b/cmd/traffic/cmd/manager/internal/cluster/info.go
@@ -93,11 +93,12 @@ func NewInfo(ctx context.Context) Info {
 
 	apiSvc := "kubernetes.default"
 	var clusterDomain string
-	if cn, err := net.LookupCNAME(apiSvc); err != nil {
+	if cn, err := net.LookupCNAME(apiSvc); err == nil && strings.HasSuffix(cn, apiSvc+".svc.") {
+		clusterDomain = cn[len(apiSvc)+5:]
+	}
+	if clusterDomain == "" {
 		dlog.Infof(ctx, `Unable to determine cluster domain from CNAME of %s: %v"`, err, apiSvc)
 		clusterDomain = "cluster.local."
-	} else {
-		clusterDomain = cn[len(apiSvc)+5:]
 	}
 	dlog.Infof(ctx, "Using cluster domain %q", clusterDomain)
 

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -570,6 +570,7 @@ func (s *cluster) UninstallTrafficManager(ctx context.Context, managerNamespace 
 	// Helm uninstall does deletions asynchronously, so let's wait until the deployment is gone
 	assert.Eventually(t, func() bool { return len(RunningPods(ctx, "traffic-manager", managerNamespace)) == 0 },
 		20*time.Second, 2*time.Second, "traffic-manager deployment was not removed")
+	TelepresenceQuitOk(ctx)
 }
 
 func KubeConfig(ctx context.Context) string {

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -155,6 +155,9 @@ func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, co
 	}
 
 	kubernetesZone := s.clusterDomain
+	if kubernetesZone == "" {
+		kubernetesZone = "cluster.local."
+	}
 	kubernetesZone = kubernetesZone[:len(kubernetesZone)-1] // strip trailing dot
 	rf := resolveFile{
 		port:        dnsAddr.Port,


### PR DESCRIPTION
Closes #3015

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
