### PR TITLE
Ensure correct connect response even when context is cancelled.

### DIFF
--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -200,8 +200,6 @@ func ManageSessions(c context.Context, si userd.Service) error {
 		case cr := <-s.connectRequest:
 			rsp := startSession(c, si, cr, &wg)
 			select {
-			case <-c.Done():
-				return nil
 			case s.connectResponse <- rsp:
 			default:
 				// Nobody left to read the response? That's fine really. Just means that


### PR DESCRIPTION
This commit fixes an intermittent problem where a context cancellation would cause a response to never be posted on the `connectResponse` channel, and hence cause a bad reply to the client in the form of an EOF when the process instead died.

A command that often reproduced the problem was

    telepresence connect --docker

on a cluster where no traffic-manager was installed.