### PR TITLE
More reliable telepresence connect --docker.

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: '~1.19.6'
       - name: Build dev image
         run: |
-          make save-image
+          make save-tel2-image
       - name: Upload image
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Build dev image
         run: |
-          make save-image
+          make save-tel2-image
       - name: Scan
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         name: Upload Docker image
         run: |
           docker login -u="${{ secrets.DOCKERHUB_USERNAME }}" -p="${{ secrets.DOCKERHUB_PASSWORD }}"
-          make push-image
+          make push-tel2-image
   release:
     runs-on: ubuntu-latest
     needs: build-release

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,8 +5,9 @@
 ### Development environment
 
  - `TELEPRESENCE_REGISTRY` (required) is the Docker registry that
-   `make push-image` pushes the `tel2` image to.  For most developers
-   the easiest thing is to set it to `docker.io/USERNAME`.
+   `make push-images` pushes the `tel2` and `telepresence` image to.
+   For most developers, the easiest thing is to set it to
+   `docker.io/USERNAME`.
 
  - `TELEPRESENCE_VERSION` (optional) is the "vSEMVER" string to
    compile-in to the binary and Docker image, if set.  Otherwise,
@@ -34,7 +35,7 @@
    `localhost:5000`, both from the cluster and from the local workstation.
 
  - `DEV_TELEPRESENCE_VERSION` (optional) if set to a version such as
-   `v2.6.7-alpha.0`, the integration tests will assume that this version
+   `v2.12.1-alpha.0`, the integration tests will assume that this version
    is pre-built and available, both as a CLI client (accessible from the
    current runtime path), and also pre-pushed into a pre-existing cluster
    accessible from `DTEST_KUBECONFIG`. In other words, if this is set, no
@@ -42,7 +43,7 @@
    can be quit rapid.
 
  - `DEV_AGENT_IMAGE` (optional) can be set to an alternative image to use
-   for the traffic agent, such as `ambassador-telepresence-agent:1.12.7-alpha.0`.
+   for the traffic agent, such as `ambassador-telepresence-agent:1.13.11-alpha.0`.
    This will make all tests use that traffic-agent instead of the default
    which uses the same image as the traffic-manager.
 
@@ -81,10 +82,10 @@ Example of running test with existing client and traffic-mananager:
 
 ```
 make private-registry
-export TELEPRESENCE_VERSION=v2.10.5-alpha.3
+export TELEPRESENCE_VERSION=v2.12.1-alpha.0
 export TELEPRESENCE_REGISTRY=localhost:5000
 make build
-make push-image
+make push-images
 export DTEST_KUBECONFIG=<your kubeconfig>
 export DTEST_REGISTRY=$TELEPRESENCE_REGISTRY
 export DEV_TELEPRESENCE_VERSION=$TELEPRESENCE_VERSION
@@ -136,27 +137,29 @@ Telemetry to Ambassador Labs can be disabled by having your os resolve the `metr
 The easiest thing to do to get going:
 
 ```console
-$ TELEPRESENCE_REGISTRY=docker.io/lukeshu make build push-images # use .\build-aux\winmake.bat build on windows
 $ TELEPRESENCE_REGISTRY=docker.io/thhal make build push-images # use .\build-aux\winmake.bat build on windows
-[make] TELEPRESENCE_VERSION=v2.6.7-19-g37085c2d7-1655891839
+[make] TELEPRESENCE_VERSION=v2.12.1-19-g37085c2d7-1655891839
 ... # Lots of output
-2.6.7-19-g37085c2d7-1655891839: digest: sha256:40fe852f8d8026a89f196293f37ae8c462c765c85572150d26263d78c43cdd4b size: 1157
+2.12.1-19-g37085c2d7-1655891839: digest: sha256:40fe852f8d8026a89f196293f37ae8c462c765c85572150d26263d78c43cdd4b size: 1157
 ```
 
-This has 2 primary outputs:
+This has 3 primary outputs:
  1. The `./build-output/bin/telepresence` executable binary
  2. The `${TELEPRESENCE_REGISTRY}/tel2` Docker image
+ 3. The `${TELEPRESENCE_REGISTRY}/telepresence` Docker image
 
-It essentially does 3 separate tasks:
+It essentially does 4 separate tasks:
  1. `make build` to build the `./build-output/bin/telepresence`
     executable binary
- 2. `make tel2` to build the `${TELEPRESENCE_REGISTRY}/tel2` Docker
+ 2. `make tel2-image` to build the `${TELEPRESENCE_REGISTRY}/tel2` Docker
     image.
- 3. `make push-image` to push the `${TELEPRESENCE_REGISTRY}/tel2`
-    Docker image.
+ 3. `make client-image` to build the `${TELEPRESENCE_REGISTRY}/telepresence` Docker
+   image.
+ 4. `make push-images` to push the `${TELEPRESENCE_REGISTRY}/tel2` and `${TELEPRESENCE_REGISTRY}/telepresence`
+    Docker images.
 
 You can run any of those tasks separately, but be warned: The
-`TELEPRESENCE_VERSION` for all 3 needs to agree, and `make` includes a
+`TELEPRESENCE_VERSION` for all 4 needs to agree, and `make` includes a
 timestamp in the default `TELEPRESENCE_VERSION`; if you run the tasks
 separately you will need to explicitly set the `TELEPRESENCE_VERSION`
 environment variable so that they all agree.
@@ -170,7 +173,7 @@ will want to set it to the version of a previously-pushed Docker
 image.
 
 You may think that the initial suggestion of running `make build
-push-image` all the time (so that every build gets new matching
+push-images` all the time (so that every build gets new matching
 version numbers) would be terribly slow.  However, This is not as slow
 as you might think; both `go` and `docker` are very good about reusing
 existing builds and avoiding unnecessary work.

--- a/integration_test/install_test.go
+++ b/integration_test/install_test.go
@@ -132,9 +132,9 @@ func (is *installSuite) Test_EnsureManager_toleratesFailedInstall() {
 	defer restoreVersion()
 	defer is.UninstallTrafficManager(ctx, is.ManagerNamespace())
 
-	cfg := client.GetDefaultConfig()
-	cfg.Timeouts.PrivateHelm = 30 * time.Second
-	ctx = itest.WithConfig(ctx, &cfg)
+	ctx = itest.WithConfig(ctx, func(cfg *client.Config) {
+		cfg.Timeouts.PrivateHelm = 30 * time.Second
+	})
 	ctx, kc := is.cluster(ctx, "default", is.ManagerNamespace())
 	require.Error(ensureTrafficManager(ctx, kc))
 	restoreVersion()

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -896,21 +896,17 @@ func PingInterceptedEchoServer(ctx context.Context, svc, svcPort string) {
 	)
 }
 
-func WithConfig(c context.Context, addConfig *client.Config) context.Context {
-	if addConfig != nil {
-		t := getT(c)
-		origConfig := client.GetConfig(c)
-		config := *origConfig // copy
-		config.Merge(addConfig)
-		configYaml, err := yaml.Marshal(&config)
-		require.NoError(t, err)
-		configYamlStr := string(configYaml)
-
-		configDir := t.TempDir()
-		c = filelocation.WithAppUserConfigDir(c, configDir)
-		c, err = client.SetConfig(c, configDir, configYamlStr)
-		require.NoError(t, err)
-	}
+func WithConfig(c context.Context, modifierFunc func(config *client.Config)) context.Context {
+	t := getT(c)
+	configCopy := *client.GetConfig(c)
+	modifierFunc(&configCopy)
+	configYaml, err := yaml.Marshal(&configCopy)
+	require.NoError(t, err)
+	configYamlStr := string(configYaml)
+	configDir := t.TempDir()
+	c = filelocation.WithAppUserConfigDir(c, configDir)
+	c, err = client.SetConfig(c, configDir, configYamlStr)
+	require.NoError(t, err)
 	return c
 }
 

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -149,7 +149,7 @@ func WithCluster(ctx context.Context, f func(ctx context.Context)) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 	go s.ensureExecutable(ctx, errs, wg)
-	go s.ensureDockerImage(ctx, errs, wg)
+	go s.ensureDockerImages(ctx, errs, wg)
 	go s.ensureCluster(ctx, wg)
 	wg.Wait()
 	close(errs)
@@ -211,7 +211,7 @@ func (s *cluster) ensureDocker(ctx context.Context, wg *sync.WaitGroup) {
 	dtest.DockerRegistry(log.WithDiscardingLogger(ctx))
 }
 
-func (s *cluster) ensureDockerImage(ctx context.Context, errs chan<- error, wg *sync.WaitGroup) {
+func (s *cluster) ensureDockerImages(ctx context.Context, errs chan<- error, wg *sync.WaitGroup) {
 	defer wg.Done()
 	if s.prePushed || s.isCI {
 		return
@@ -235,15 +235,19 @@ func (s *cluster) ensureDockerImage(ctx context.Context, errs chan<- error, wg *
 		}
 	}
 
-	wgs.Add(1)
+	wgs.Add(2)
 	go func() {
 		defer wgs.Done()
-		runMake("image")
+		runMake("tel2-image")
+	}()
+	go func() {
+		defer wgs.Done()
+		runMake("client-image")
 	}()
 	wgs.Wait()
 
 	//  Image built and a registry exists. Push the image
-	runMake("push-image")
+	runMake("push-images")
 }
 
 func (s *cluster) ensureCluster(ctx context.Context, wg *sync.WaitGroup) {

--- a/integration_test/not_connected_test.go
+++ b/integration_test/not_connected_test.go
@@ -89,9 +89,9 @@ func (s *notConnectedSuite) Test_ConnectingToOtherNamespace() {
 		ctx := itest.WithEnv(ctx, map[string]string{"TELEPRESENCE_MANAGER_NAMESPACE": ""})
 
 		// Set the config to some nonsense to verify that the flag wins
-		cfg := client.GetDefaultConfig()
-		cfg.Cluster.DefaultManagerNamespace = "daffy-duck"
-		ctx = itest.WithConfig(ctx, &cfg)
+		ctx = itest.WithConfig(ctx, func(cfg *client.Config) {
+			cfg.Cluster.DefaultManagerNamespace = "daffy-duck"
+		})
 		stdout := itest.TelepresenceOk(ctx, "connect", "--manager-namespace="+mgrSpace2)
 		s.Contains(stdout, "Connected to context")
 		stdout = itest.TelepresenceOk(ctx, "status")
@@ -102,9 +102,9 @@ func (s *notConnectedSuite) Test_ConnectingToOtherNamespace() {
 		itest.TelepresenceQuitOk(ctx)
 		ctx := itest.WithEnv(ctx, map[string]string{"TELEPRESENCE_MANAGER_NAMESPACE": ""})
 
-		cfg := client.GetDefaultConfig()
-		cfg.Cluster.DefaultManagerNamespace = mgrSpace2
-		ctx = itest.WithConfig(ctx, &cfg)
+		ctx = itest.WithConfig(ctx, func(cfg *client.Config) {
+			cfg.Cluster.DefaultManagerNamespace = mgrSpace2
+		})
 		stdout := itest.TelepresenceOk(ctx, "connect")
 		s.Contains(stdout, "Connected to context")
 		stdout = itest.TelepresenceOk(ctx, "status")

--- a/integration_test/webhook_test.go
+++ b/integration_test/webhook_test.go
@@ -56,9 +56,9 @@ func (s *notConnectedSuite) Test_AgentImageFromConfig() {
 
 	// Use a config with agentImage to validate that it's the
 	// latter that is used in the traffic-manager
-	cfg := client.GetDefaultConfig()
-	cfg.Images.PrivateAgentImage = "imageFromConfig:0.0.1"
-	ctxAI := itest.WithConfig(ctx, &cfg)
+	ctxAI := itest.WithConfig(ctx, func(cfg *client.Config) {
+		cfg.Images.PrivateAgentImage = "imageFromConfig:0.0.1"
+	})
 
 	// Remove the traffic-manager since we are altering config that applies to
 	// creating the traffic-manager

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -339,6 +339,7 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	allArgs = append(allArgs,
 		"run",
 		"--rm",
+		"-d",
 		"--cidfile", cidFileName,
 	)
 	allArgs = append(allArgs, opts...)

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -2,6 +2,7 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -29,6 +30,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/docker/kubeauth"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnet"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
@@ -131,11 +133,22 @@ func DiscoverDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, er
 // ConnectDaemon connects to a daemon at the given address.
 func ConnectDaemon(ctx context.Context, address string) (conn *grpc.ClientConn, err error) {
 	// Assume that the user daemon is running and connect to it using the given address instead of using a socket.
-	return grpc.DialContext(ctx, address,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithNoProxy(),
-		grpc.WithBlock(),
-		grpc.FailOnNonTempDialError(true))
+	for i := 0; ; i++ {
+		conn, err := grpc.DialContext(ctx, address,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithNoProxy(),
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true))
+		if err != nil {
+			if i < 5 && strings.Contains(err.Error(), "connection refused") {
+				// It's likely that we were too quick. Let's take a nap and try again
+				time.Sleep(time.Duration(i*50) * time.Millisecond)
+				continue
+			}
+			return nil, err
+		}
+		return conn, err
+	}
 }
 
 // PullImage checks if the given image exists locally by doing docker image inspect. A docker pull is
@@ -345,10 +358,27 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	allArgs = append(allArgs, opts...)
 	allArgs = append(allArgs, image)
 	allArgs = append(allArgs, args...)
+	for i := 0; ; i++ {
+		err = tryLaunch(ctx, addr.Port, name, cidFileName, allArgs)
+		if err != nil {
+			if i < 3 && strings.Contains(err.Error(), "already in use by container") {
+				// This may happen if the daemon has died (and hence, we never discovered it), but
+				// the container still hasn't died. Let's sleep for a short while and retry.
+				dtime.SleepWithContext(ctx, 500*time.Millisecond)
+				continue
+			}
+			return nil, errcat.NoDaemonLogs.New(err)
+		}
+		break
+	}
+	return ConnectDaemon(ctx, addr.String())
+}
 
-	cmd := proc.StdCommand(ctx, "docker", allArgs...)
+func tryLaunch(ctx context.Context, port int, name, cidFileName string, args []string) error {
+	stdErr := &bytes.Buffer{}
+	cmd := proc.StdCommand(dos.WithStderr(ctx, stdErr), "docker", args...)
 	if err := cmd.Start(); err != nil {
-		return nil, errcat.NoDaemonLogs.New(err)
+		return err
 	}
 
 	cidFound := make(chan string, 1)
@@ -356,9 +386,9 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	go func() {
 		defer close(cidFound)
 		for ctx.Err() == nil {
-			dtime.SleepWithContext(ctx, 50*time.Millisecond)
+			dtime.SleepWithContext(ctx, 10*time.Millisecond)
 			if _, err := os.Stat(cidFileName); err == nil {
-				dtime.SleepWithContext(ctx, 200*time.Millisecond)
+				dtime.SleepWithContext(ctx, 10*time.Millisecond)
 				cid, err := os.ReadFile(cidFileName)
 				if err == nil {
 					cidFound <- string(cid)
@@ -370,33 +400,23 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	go func() {
 		defer close(errStart)
 		if err := cmd.Wait(); err != nil {
-			err = fmt.Errorf("daemon container exited with %v", err)
-			dlog.Error(ctx, err)
-			errStart <- err
+			errStart <- fmt.Errorf("daemon container exited: %s: %v", stdErr.String(), err)
 		} else {
 			dlog.Debug(ctx, "daemon container exited normally")
 		}
 	}()
-	if err != nil {
-		return nil, err
-	}
 	select {
 	case <-ctx.Done(): // Everything is cancelled
+		return nil
 	case cid := <-cidFound: // Success, the daemon info file exists
-		err := cache.SaveDaemonInfo(ctx,
+		return cache.SaveDaemonInfo(ctx,
 			&cache.DaemonInfo{
 				Options:     map[string]string{"cid": cid},
 				InDocker:    true,
-				DaemonPort:  addr.Port,
+				DaemonPort:  port,
 				KubeContext: name,
-			}, cache.DaemonInfoFile(name, addr.Port))
-		if err != nil {
-			return nil, err
-		}
-		// Give the listener time to start
-		dtime.SleepWithContext(ctx, 500*time.Millisecond)
+			}, cache.DaemonInfoFile(name, port))
 	case err := <-errStart: // Daemon exited before the daemon info came into existence
-		return nil, errcat.NoDaemonLogs.New(err)
+		return err
 	}
-	return ConnectDaemon(ctx, addr.String())
 }

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -454,16 +454,10 @@ func (s *Service) Quit(ctx context.Context, ex *empty.Empty) (*empty.Empty, erro
 func (s *Service) Helm(ctx context.Context, req *rpc.HelmRequest) (*common.Result, error) {
 	result := &common.Result{}
 	s.logCall(ctx, "Helm", func(c context.Context) {
+		// Temporarily disable quit so that session cancel doesn't cancel everything
 		s.quitDisable = true
 		if s.rootSessionInProc {
-			// Temporarily disable quit so that session cancel doesn't cancel everything
-			defer func() {
-				go func() {
-					// Give this call time to return its result before the gRPC server shuts down.
-					time.Sleep(10 * time.Millisecond)
-					s.quit()
-				}()
-			}()
+			defer s.quit()
 		}
 
 		var sessionDone <-chan struct{}


### PR DESCRIPTION
Adds two retries.
1. When a docker daemon isn't found to be running (it's DaemonInfo file
   is missing), there's still a chance that the container hasn't stopped
   yet. This commit therefore adds a retry when encountering the error
   "already in use by container" why trying to launch the client image.
2. Once the client image is launched, it might take some time before it
   accepts gRPC connections. A retry is therefore added for the dial
   attempt.
