### PR TITLE
Fix a couple of issues with Helm flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 - Feature: Adds an authenticator package to support integration with the [client-go credential](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) plugins when the
   daemon runs in a docker container.
 
+- Feature: The `telepresence helm` command now accepts a `--namespace` flag.
+
 - Bugfix: The traffic-manager will no longer panic when the CNAME of kubernetes.default doesn't contain .svc.
+
+- Bugfix: The `telepresence helm install/upgrade --set` family of flags now work correctly with comma separated values.
 
 ### 2.11.1 (February 27, 2023)
 

--- a/integration_test/docker_daemon_test.go
+++ b/integration_test/docker_daemon_test.go
@@ -1,0 +1,84 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	goRuntime "runtime"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+)
+
+type dockerDaemonSuite struct {
+	itest.Suite
+	itest.NamespacePair
+}
+
+func init() {
+	itest.AddNamespacePairSuite("", func(h itest.NamespacePair) suite.TestingSuite {
+		return &dockerDaemonSuite{Suite: itest.Suite{Harness: h}, NamespacePair: h}
+	})
+}
+
+func (s *dockerDaemonSuite) Context() context.Context {
+	return itest.WithConfig(s.Suite.Context(), func(cfg *client.Config) {
+		cfg.Intercept.UseFtp = false
+	})
+}
+
+func (s *dockerDaemonSuite) SetupSuite() {
+	if s.IsCI() && goRuntime.GOOS != "linux" {
+		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
+		return
+	}
+	s.Suite.SetupSuite()
+	args := append([]string{"helm", "install", "--docker", "-n", s.ManagerNamespace()}, s.GetValuesForHelm(nil, false, s.ManagerNamespace(), s.AppNamespace())...)
+	args = append(args, "-f", filepath.Join("testdata", "namespaced-values.yaml"))
+
+	ctx := s.Context()
+	ctx = itest.WithWorkingDir(itest.WithUser(ctx, "default"), filepath.Join(itest.GetOSSRoot(ctx), "integration_test"))
+	itest.TelepresenceOk(ctx, args...)
+}
+
+func (s *dockerDaemonSuite) TearDownSuite() {
+	itest.TelepresenceOk(itest.WithUser(s.Context(), "default"), "helm", "uninstall", "-n", s.ManagerNamespace(), "--docker")
+}
+
+func (s *dockerDaemonSuite) Test_DockerDaemon_status() {
+	ctx := s.Context()
+	itest.TelepresenceOk(ctx, "connect", "--manager-namespace", s.ManagerNamespace(), "--docker")
+	defer itest.TelepresenceQuitOk(ctx)
+
+	jsOut := itest.TelepresenceOk(ctx, "status", "--output", "json")
+
+	require := s.Require()
+	var statusMap map[string]any
+	require.NoError(json.Unmarshal([]byte(jsOut), &statusMap))
+	ud, ok := statusMap["user_daemon"]
+	s.True(ok)
+	udm, ok := ud.(map[string]any)
+	s.True(ok)
+	s.Equal(udm["running"], true)
+	s.Equal(udm["name"], "OSS Daemon in container")
+	s.Equal(udm["status"], "Connected")
+}
+
+func (s *dockerDaemonSuite) Test_DockerDaemon_hostDaemonConflict() {
+	ctx := s.Context()
+	defer itest.TelepresenceQuitOk(ctx)
+	itest.TelepresenceOk(ctx, "connect", "--manager-namespace", s.ManagerNamespace())
+
+	_, stdErr, err := itest.Telepresence(ctx, "connect", "--manager-namespace", s.ManagerNamespace(), "--docker")
+	s.Error(err)
+	s.Contains(stdErr, "option --docker cannot be used as long as a daemon is running on the host")
+}
+
+func (s *dockerDaemonSuite) Test_DockerDaemon_daemonHostNotConflict() {
+	ctx := s.Context()
+	defer itest.TelepresenceQuitOk(ctx)
+	itest.TelepresenceOk(ctx, "connect", "--manager-namespace", s.ManagerNamespace(), "--docker")
+	itest.TelepresenceOk(ctx, "connect", "--manager-namespace", s.ManagerNamespace())
+}

--- a/pkg/client/cli/cmd/helm.go
+++ b/pkg/client/cli/cmd/helm.go
@@ -73,6 +73,7 @@ func helmInstall() *cobra.Command {
 	uf.Hidden = true
 	uf.Deprecated = `Use "telepresence helm upgrade" instead of "telepresence helm install --upgrade"`
 	ha.Request = daemon.InitRequest(cmd)
+	flags.StringVarP(&ha.Request.ManagerNamespace, "namespace", "n", "", "namespace scope for this request")
 	return cmd
 }
 
@@ -99,6 +100,7 @@ func helmUpgrade() *cobra.Command {
 	flags.BoolVarP(&ha.ReuseValues, "reuse-values", "", false,
 		"when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f")
 	ha.Request = daemon.InitRequest(cmd)
+	flags.StringVarP(&ha.Request.ManagerNamespace, "namespace", "n", "", "namespace scope for this request")
 	return cmd
 }
 
@@ -138,8 +140,10 @@ func helmUninstall() *cobra.Command {
 			ann.VersionCheck: ann.Required,
 		},
 	}
-	ha.addCRDsFlags(cmd.Flags())
+	flags := cmd.Flags()
+	ha.addCRDsFlags(flags)
 	ha.Request = daemon.InitRequest(cmd)
+	flags.StringVarP(&ha.Request.ManagerNamespace, "namespace", "n", "", "namespace scope for this request")
 	return cmd
 }
 

--- a/pkg/client/cli/cmd/helm.go
+++ b/pkg/client/cli/cmd/helm.go
@@ -103,15 +103,15 @@ func helmUpgrade() *cobra.Command {
 }
 
 func (ha *HelmCommand) addValueSettingFlags(flags *pflag.FlagSet) {
-	flags.StringSliceVarP(&ha.ValueFiles, "values", "f", []string{},
+	flags.StringArrayVarP(&ha.ValueFiles, "values", "f", []string{},
 		"specify values in a YAML file or a URL (can specify multiple)")
-	flags.StringSliceVarP(&ha.Values, "set", "", []string{},
+	flags.StringArrayVarP(&ha.Values, "set", "", []string{},
 		"specify a value as a.b=v (can specify multiple or separate values with commas: a.b=v1,a.c=v2)")
-	flags.StringSliceVarP(&ha.FileValues, "set-file", "", []string{},
+	flags.StringArrayVarP(&ha.FileValues, "set-file", "", []string{},
 		"set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
-	flags.StringSliceVarP(&ha.JSONValues, "set-json", "", []string{},
+	flags.StringArrayVarP(&ha.JSONValues, "set-json", "", []string{},
 		"set JSON values on the command line (can specify multiple or separate values with commas: a.b=jsonval1,a.c=jsonval2)")
-	flags.StringSliceVarP(&ha.StringValues, "set-string", "", []string{},
+	flags.StringArrayVarP(&ha.StringValues, "set-string", "", []string{},
 		"set STRING values on the command line (can specify multiple or separate values with commas: a.b=val1,a.c=val2)")
 	if HelmInstallExtendFlagsFunc != nil {
 		HelmInstallExtendFlagsFunc(flags)


### PR DESCRIPTION
## Description

Fixes a problem with comma separated values in `telepresence helm install/update --set` flag family, and adds the `-n`/`--namespace` flag to all `telepresence helm` commands.

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
