### PR TITLE
Add a method to build a docker image

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -314,7 +314,11 @@ check-unit: build-deps ## (QA) Run the test suite
 	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 CGO_ENABLED=$(CGO_ENABLED) go test -timeout=20m ./cmd/... ./pkg/...
 
 .PHONY: check-integration
+ifeq ($(GOHOSTOS), linux)
+check-integration: client-image $(tools/helm) ## (QA) Run the test suite
+else
 check-integration: build-deps $(tools/helm) ## (QA) Run the test suite
+endif
 	# We run the test suite with TELEPRESENCE_LOGIN_DOMAIN set to localhost since that value
 	# is only used for extensions. Therefore, we want to validate that our tests, and
 	# telepresence, run without requiring any outside dependencies.

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -31,7 +31,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/dnet"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
-	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
@@ -317,7 +316,6 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	if proc.RunningInContainer() {
 		return nil, errors.New("unable to start a docker container from within a container")
 	}
-	cidFileName, err := ioutil.CreateTempName("", "cid*.txt")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cidfile: %v", err)
 	}
@@ -338,13 +336,12 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 		"run",
 		"--rm",
 		"-d",
-		"--cidfile", cidFileName,
 	)
 	allArgs = append(allArgs, opts...)
 	allArgs = append(allArgs, image)
 	allArgs = append(allArgs, args...)
 	for i := 1; ; i++ {
-		err = tryLaunch(ctx, addr.Port, name, cidFileName, allArgs)
+		err = tryLaunch(ctx, addr.Port, name, allArgs)
 		if err != nil {
 			if i < 6 && strings.Contains(err.Error(), "already in use by container") {
 				// This may happen if the daemon has died (and hence, we never discovered it), but
@@ -359,52 +356,25 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 	return ConnectDaemon(ctx, addr.String())
 }
 
-func tryLaunch(ctx context.Context, port int, name, cidFileName string, args []string) error {
-	stdErr := &bytes.Buffer{}
+func tryLaunch(ctx context.Context, port int, name string, args []string) error {
+	stdErr := bytes.Buffer{}
+	stdOut := bytes.Buffer{}
 	cmd := proc.CommandContext(ctx, "docker", args...)
 	cmd.DisableLogging = true
-	cmd.Stderr = stdErr
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	cidFound := make(chan string, 1)
-	defer close(cidFound)
-
-	errStart := make(chan error, 1)
-	go func() {
-		for ctx.Err() == nil {
-			dtime.SleepWithContext(ctx, 10*time.Millisecond)
-			if _, err := os.Stat(cidFileName); err == nil {
-				dtime.SleepWithContext(ctx, 10*time.Millisecond)
-				cid, err := os.ReadFile(cidFileName)
-				if err == nil {
-					cidFound <- string(cid)
-					return
-				}
-			}
+	cmd.Stderr = &stdErr
+	cmd.Stdout = &stdOut
+	if err := cmd.Run(); err != nil {
+		errStr := strings.TrimSpace(stdErr.String())
+		if errStr == "" {
+			errStr = err.Error()
 		}
-	}()
-	go func() {
-		defer close(errStart)
-		if err := cmd.Wait(); err != nil {
-			errStart <- fmt.Errorf("daemon container exited: %s: %v", stdErr.String(), err)
-		} else {
-			dlog.Debug(ctx, "daemon container exited normally")
-		}
-	}()
-	select {
-	case <-ctx.Done(): // Everything is cancelled
-		return ctx.Err()
-	case cid := <-cidFound: // Success, the daemon info file exists
-		return cache.SaveDaemonInfo(ctx,
-			&cache.DaemonInfo{
-				Options:     map[string]string{"cid": cid},
-				InDocker:    true,
-				DaemonPort:  port,
-				KubeContext: name,
-			}, cache.DaemonInfoFile(name, port))
-	case err := <-errStart: // Daemon exited before the daemon info came into existence
-		return err
+		return fmt.Errorf("launch of daemon container failed: %s", errStr)
 	}
+	return cache.SaveDaemonInfo(ctx,
+		&cache.DaemonInfo{
+			Options:     map[string]string{"cid": strings.TrimSpace(stdOut.String())},
+			InDocker:    true,
+			DaemonPort:  port,
+			KubeContext: name,
+		}, cache.DaemonInfoFile(name, port))
 }

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -152,23 +151,6 @@ func ConnectDaemon(ctx context.Context, address string) (conn *grpc.ClientConn, 
 		}
 		return conn, nil
 	}
-}
-
-// PullImage checks if the given image exists locally by doing docker image inspect. A docker pull is
-// performed if no local image is found. Stdout is silenced during those operations.
-func PullImage(ctx context.Context, image string) error {
-	cmd := proc.StdCommand(ctx, "docker", "image", "inspect", image)
-	cmd.Stderr = io.Discard
-	cmd.Stdout = io.Discard
-	if cmd.Run() == nil {
-		// Image exists in the local cache, so don't bother pulling it.
-		return nil
-	}
-	cmd = proc.StdCommand(ctx, "docker", "pull", image)
-	// Docker run will put the pull logs in stderr, but docker pull will put them in stdout.
-	// We discard them here, so they don't spam the user. They'll get errors through stderr if it comes to it.
-	cmd.Stdout = io.Discard
-	return cmd.Run()
 }
 
 const kubeAuthPortFile = kubeauth.CommandName + ".port"

--- a/pkg/client/docker/image.go
+++ b/pkg/client/docker/image.go
@@ -1,0 +1,40 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+)
+
+// BuildImage builds an image from source. Stdout is silenced during those operations. The
+// image ID is returned.
+func BuildImage(ctx context.Context, context string, buildArgs []string) (string, error) {
+	args := append([]string{"build", "--quiet"}, buildArgs...)
+	cmd := proc.StdCommand(ctx, "docker", append(args, context)...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// PullImage checks if the given image exists locally by doing docker image inspect. A docker pull is
+// performed if no local image is found. Stdout is silenced during those operations.
+func PullImage(ctx context.Context, image string) error {
+	cmd := proc.StdCommand(ctx, "docker", "image", "inspect", image)
+	cmd.Stderr = io.Discard
+	cmd.Stdout = io.Discard
+	if cmd.Run() == nil {
+		// Image exists in the local cache, so don't bother pulling it.
+		return nil
+	}
+	cmd = proc.StdCommand(ctx, "docker", "pull", image)
+	// Docker run will put the pull logs in stderr, but docker pull will put them in stdout.
+	// We discard them here, so they don't spam the user. They'll get errors through stderr if it comes to it.
+	cmd.Stdout = io.Discard
+	return cmd.Run()
+}


### PR DESCRIPTION
Sometimes it is desirable to build an image from source instead of
pulling it. This commit adds the necessary function to do that.