### PR TITLE
Make the client environment OS-specific.

### DIFF
--- a/pkg/client/envconfig.go
+++ b/pkg/client/envconfig.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Env struct {
+	OSSpecificEnv
 	// I'd like to set TELEPRESENCE_LOGIN_DOMAIN,default=auth.datawire.io, but
 	// sethvargo/go-envconfig doesn't support filling in the default for our later references to
 	// it in following settings, so we have to do the hack with maybeSetDefault below.  *sigh* I
@@ -26,8 +27,6 @@ type Env struct {
 
 	// This environment variable becomes the default for the images.agentImage and images.webhookAgentImage
 	AgentImage string `env:"TELEPRESENCE_AGENT_IMAGE,                   parser=possibly-empty-string,default="`
-
-	Shell string `env:"SHELL, parser=nonempty-string,default=/bin/bash"`
 
 	TelepresenceUID int `env:"TELEPRESENCE_UID, parser=strconv.ParseInt, default=0"`
 	TelepresenceGID int `env:"TELEPRESENCE_GID, parser=strconv.ParseInt, default=0"`

--- a/pkg/client/envconfig_unix.go
+++ b/pkg/client/envconfig_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package client
+
+type OSSpecificEnv struct {
+	Shell string `env:"SHELL, parser=nonempty-string,default=/bin/bash"`
+}

--- a/pkg/client/envconfig_windows.go
+++ b/pkg/client/envconfig_windows.go
@@ -1,0 +1,5 @@
+package client
+
+type OSSpecificEnv struct {
+	Shell string `env:"ComSpec, parser=nonempty-string,default=C:\\WINDOWS\\system32\\cmd.exe"`
+}


### PR DESCRIPTION
The `Env.Shell` is `SHELL` on Unix and the default is `/bin/bash`. On Windows `Env.Shell` it is `ComSpec` with a default of `C:\WINDOWS\system32\cmd.exe`.
