### PR TITLE
Ensure that the docker container name is valid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.12.1 (TBD)
+
+- Bugfix: Illegal characters are now replaced when a docker container name is generated from a kubernetes context name. 
+
 ### 2.12.0 (March 20, 2023)
 
 - Feature: Telepresence can now start or connect to a daemon in a docker container by use of the global `--docker` flag.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -47,6 +47,17 @@
    This will make all tests use that traffic-agent instead of the default
    which uses the same image as the traffic-manager.
 
+The above environment can optionally be provided in a `itest.yml` file
+that is placed adjacent to the normal `config.yml` file used to configure
+Telepresence. The `itest.yml` currently has only one single entry, the
+`Env` which is a map. It can look something like this:
+
+```yaml
+Env:
+  DEV_TELEPRESENCE_VERSION: v2.12.1-alpha.0
+  DTEST_KUBECONFIG: /home/thhal/.kube/testconfig
+```
+
 The output of `make help` has a bit more information.
 
 ### Running integration tests

--- a/integration_test/itest/context.go
+++ b/integration_test/itest/context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
@@ -24,7 +25,7 @@ const (
 )
 
 func withProfile(ctx context.Context) context.Context {
-	profile, ok := os.LookupEnv("TELEPRESENCE_TEST_PROFILE")
+	profile, ok := dos.LookupEnv(ctx, "TELEPRESENCE_TEST_PROFILE")
 	if !ok {
 		return context.WithValue(ctx, profileKey{}, DefaultProfile)
 	}

--- a/integration_test/itest/env.go
+++ b/integration_test/itest/env.go
@@ -1,0 +1,52 @@
+package itest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
+)
+
+type itestConfig struct {
+	Env map[string]string `json:"env,omitempty"`
+}
+
+func LoadEnv(ctx context.Context) context.Context {
+	dir, err := filelocation.AppUserConfigDir(ctx)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			getT(ctx).Fatal(err)
+		}
+		return ctx
+	}
+	cf := filepath.Join(dir, "itest.yml")
+	data, err := os.ReadFile(cf)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			getT(ctx).Fatal(cf, err)
+		}
+		return ctx
+	}
+
+	var ic itestConfig
+	if err := yaml.Unmarshal(data, &ic); err != nil {
+		getT(ctx).Fatal(cf, err)
+		return ctx
+	}
+
+	env := os.Environ()
+	dosEnv := make(dos.MapEnv, len(env))
+	for _, ep := range env {
+		if ix := strings.IndexByte(ep, '='); ix > 0 {
+			dosEnv[ep[:ix]] = ep[ix+1:]
+		}
+	}
+	maps.Merge(dosEnv, ic.Env)
+	return dos.WithEnv(ctx, dosEnv)
+}

--- a/integration_test/itest/runner.go
+++ b/integration_test/itest/runner.go
@@ -136,6 +136,7 @@ func RunTests(c context.Context) {
 
 // RunTests creates all suites using the added constructors and runs them.
 func (r *runner) RunTests(c context.Context) { //nolint:gocognit
+	c = LoadEnv(c)
 	dtest.WithMachineLock(c, func(c context.Context) {
 		WithCluster(c, func(c context.Context) {
 			for _, f := range r.withCluster {

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -99,7 +99,7 @@ func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required
 	}
 
 	// Check if a running daemon can be discovered.
-	name, err := daemonName(ctx)
+	name, err := contextName(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,16 +142,16 @@ func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required
 	return newUserDaemon(conn, false), nil
 }
 
-func daemonName(ctx context.Context) (string, error) {
+func contextName(ctx context.Context) (string, error) {
 	var flags map[string]string
 	if cr := daemon.GetRequest(ctx); cr != nil {
 		flags = cr.KubeFlags
 	}
-	contextName, _, err := client.CurrentContext(flags)
+	name, _, err := client.CurrentContext(flags)
 	if err != nil {
 		return "", err
 	}
-	return contextName, nil
+	return name, nil
 }
 
 func newUserDaemon(conn *grpc.ClientConn, remote bool) *daemon.UserClient {

--- a/pkg/client/docker/daemon_test.go
+++ b/pkg/client/docker/daemon_test.go
@@ -1,0 +1,51 @@
+package docker
+
+import "testing"
+
+func TestSafeContainerName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			"@",
+			"a",
+		},
+		{
+			"@x",
+			"ax",
+		},
+		{
+			"x@",
+			"x_",
+		},
+		{
+			"x@y",
+			"x_y",
+		},
+		{
+			"x™y", // multibyte char
+			"x_y",
+		},
+		{
+			"x™", // multibyte char
+			"x_",
+		},
+		{
+			"_y",
+			"ay",
+		},
+		{
+			"_y_",
+			"ay_",
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SafeContainerName(tt.name); got != tt.want {
+				t.Errorf("SafeContainerName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The name used for `docker run --name <name>` must comply with the
regular expression `[a-zA-Z0-9][a-zA-Z0-9_.-]`. This is however not true
for the name of a Kubernetes context. So when using a context name as
the argument to `--name`, it must be mangled so that any illegal
characters are replaced.

This commit adds the `SafeContainerName` function which replaces all
illegal characters with an underscore unless it's the very first
character, in which case it is replaced with an 'a'.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
