### PR TITLE
Add the kubeauth.log to the set of logs collected by gather-logs

### DIFF
--- a/pkg/client/cli/cmd/gather_logs.go
+++ b/pkg/client/cli/cmd/gather_logs.go
@@ -70,7 +70,7 @@ telepresence gather-logs --daemons=None
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&gl.outputFile, "output-file", "o", "", "The file you want to output the logs to.")
-	flags.StringVar(&gl.daemons, "daemons", "all", "The daemons you want logs from: all, root, user, None")
+	flags.StringVar(&gl.daemons, "daemons", "all", "The daemons you want logs from: all, root, user, kubeauth, None")
 	flags.BoolVar(&gl.trafficManager, "traffic-manager", true, "If you want to collect logs from the traffic-manager")
 	flags.StringVar(&gl.trafficAgents, "traffic-agents", "all", "Traffic-agents to collect logs from: all, name substring, None")
 	flags.BoolVarP(&gl.anon, "anonymize", "a", false, "To anonymize pod names + namespaces from the logs")
@@ -130,11 +130,13 @@ func (gl *gatherLogsCommand) gatherLogs(cmd *cobra.Command, _ []string) error {
 	var daemonLogs []string
 	switch gl.daemons {
 	case "all":
-		daemonLogs = append(daemonLogs, "cli", "connector", "daemon")
+		daemonLogs = append(daemonLogs, "cli", "connector", "daemon", "kubeauth")
 	case "root":
 		daemonLogs = append(daemonLogs, "daemon")
 	case "user":
 		daemonLogs = append(daemonLogs, "connector")
+	case "kubeauth":
+		daemonLogs = append(daemonLogs, "kubeauth")
 	case "None":
 	default:
 		return errcat.User.New("Options for --daemons are: all, root, user, or None")

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -32,6 +32,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
@@ -380,6 +381,7 @@ func LaunchDaemon(ctx context.Context, name string) (conn *grpc.ClientConn, err 
 func tryLaunch(ctx context.Context, port int, name string, args []string) error {
 	stdErr := bytes.Buffer{}
 	stdOut := bytes.Buffer{}
+	dlog.Debug(ctx, shellquote.ShellString("docker", args))
 	cmd := proc.CommandContext(ctx, "docker", args...)
 	cmd.DisableLogging = true
 	cmd.Stderr = &stdErr


### PR DESCRIPTION
Adds the new `kubeauth.log` that the kubernetes authenticator creates to
the set of log files gathered by the `telepresence gather-logs` command.
