### PR TITLE
authenticator: fix a bug in how env variables are propagated

### DIFF
--- a/pkg/authenticator/exec.go
+++ b/pkg/authenticator/exec.go
@@ -23,6 +23,7 @@ func (e execCredentialBinary) Resolve(
 	cmd.Stdout = &buf
 	cmd.Stderr = dos.Stderr(ctx)
 	cmd.DisableLogging = true
+	cmd.Env = dos.Environ(ctx)
 
 	for i := range execConfig.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", execConfig.Env[i].Name, execConfig.Env[i].Value))

--- a/pkg/authenticator/exec_test.go
+++ b/pkg/authenticator/exec_test.go
@@ -1,0 +1,35 @@
+package authenticator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd/api"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestExecCredentialsNoLocalEnv(t *testing.T) {
+	t.Setenv("GLOBAL_ENV", "global-val")
+
+	config := &clientcmdapi.ExecConfig{
+		Command: "sh",
+		Args:    []string{"-c", "echo $GLOBAL_ENV/$LOCAL_ENV"},
+	}
+	result, err := execCredentialBinary{}.Resolve(context.Background(), config)
+	assert.NoError(t, err)
+	assert.Equal(t, string(result), "global-val/\n")
+}
+
+func TestExecCredentialsYesLocalEnv(t *testing.T) {
+	t.Setenv("GLOBAL_ENV", "global-val")
+
+	config := &clientcmdapi.ExecConfig{
+		Command: "sh",
+		Args:    []string{"-c", "echo $GLOBAL_ENV/$LOCAL_ENV"},
+		Env:     []api.ExecEnvVar{{"LOCAL_ENV", "local-val"}},
+	}
+	result, err := execCredentialBinary{}.Resolve(context.Background(), config)
+	assert.NoError(t, err)
+	assert.Equal(t, string(result), "global-val/local-val\n")
+}

--- a/pkg/authenticator/exec_test.go
+++ b/pkg/authenticator/exec_test.go
@@ -27,7 +27,7 @@ func TestExecCredentialsYesLocalEnv(t *testing.T) {
 	config := &clientcmdapi.ExecConfig{
 		Command: "sh",
 		Args:    []string{"-c", "echo $GLOBAL_ENV/$LOCAL_ENV"},
-		Env:     []api.ExecEnvVar{{"LOCAL_ENV", "local-val"}},
+		Env:     []api.ExecEnvVar{{Name: "LOCAL_ENV", Value: "local-val"}},
 	}
 	result, err := execCredentialBinary{}.Resolve(context.Background(), config)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

fix a bug in how env variables are propagated in kubeauth-foreground

related to https://github.com/datawire/telepresence-docker-extension-issues/issues/12

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
