### PR TITLE
Ensure that TELEPRESENCE_MOUNT env is split using a ':' separator.

### DIFF
--- a/pkg/client/cli/intercept/info.go
+++ b/pkg/client/cli/intercept/info.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"path/filepath"
 	"strings"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
@@ -83,12 +82,17 @@ func NewMount(ctx context.Context, ii *manager.InterceptInfo, mountError string)
 		} else {
 			port = ii.SftpPort
 		}
+		var mounts []string
+		if tpMounts := ii.Environment["TELEPRESENCE_MOUNTS"]; tpMounts != "" {
+			// This is a Unix path, so we cannot use filepath.SplitList
+			mounts = strings.Split(tpMounts, ":")
+		}
 		return &Mount{
 			LocalDir:  ii.ClientMountPoint,
 			RemoteDir: ii.MountPoint,
 			PodIP:     ii.PodIp,
 			Port:      port,
-			Mounts:    filepath.SplitList(ii.Environment["TELEPRESENCE_MOUNTS"]),
+			Mounts:    mounts,
 		}
 	}
 	return nil


### PR DESCRIPTION
The environment was incorrectly split using `filepath.SplitList`. On windows that didn't work because it tries to split on ';'.