### PR TITLE
Fix error context being thrown with version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Bugfix: The client will no longer need cluster wide permissions when connected to a namespace scoped Traffic Manager.
 
-- BugFix: The version command won't throw an error anymore if there are no kubeconfig file defined.
+- BugFix: The version command won't throw an error anymore if there is no kubeconfig file defined.
 
 ### 2.12.1 (March 22, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bugfix: The client will no longer need cluster wide permissions when connected to a namespace scoped Traffic Manager.
 
+- BugFix: The version command won't throw an error anymore if there are no kubeconfig file defined.
+
 ### 2.12.1 (March 22, 2023)
 
 - Bugfix: Illegal characters are now replaced when a docker container name is generated from a kubernetes context name. 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -75,6 +75,23 @@ export DTEST_KUBECONFIG=<your kubeconfig>
 export DTEST_REGISTRY=localhost:5000
 go test ./integration_test/... -v -testify.m=Test_InterceptDetailedOutput
 ```
+
+If you run these tests on a Mac, localhost won't work. Please use the docker hub, or this value for the registry:
+
+```cli
+export DTEST_REGISTRY=host.docker.internal:5000
+```
+
+You must also set this in your docker engine settings: 
+
+```json
+{
+   "insecure-registries": [
+     "host.docker.internal:5000"
+   ]
+}
+```
+
 The test takes about a minute to complete when using an existing cluster
 and a private registry created by `make private-registry`. During that time
 it:

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -31,7 +31,7 @@ func (s *cliSuite) Test_Version() {
 	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
 }
 
-func (s *cliSuite) Test_VersionWithoutKubeContext() {
+func (s *cliSuite) Test_VersionWithInvalidKubeContext() {
 	stdout, _, err := itest.Telepresence(itest.WithEnv(s.Context(), map[string]string{
 		"KUBECONFIG": "file-that-does-not-exist",
 	}), "version")

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -31,6 +31,17 @@ func (s *cliSuite) Test_Version() {
 	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
 }
 
+func (s *cliSuite) Test_VersionWithoutKubeContext() {
+	stdout, _, err := itest.Telepresence(itest.WithEnv(s.Context(), map[string]string{
+		"KUBECONFIG": "file-that-does-not-exist",
+	}), "version")
+	if err != nil {
+		s.Require().NoError(err)
+	}
+
+	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
+}
+
 func (s *cliSuite) Test_Help() {
 	// TODO: Fix these tests
 	s.T().Skip("these tests don't work")

--- a/pkg/client/cli/connect/init_command.go
+++ b/pkg/client/cli/connect/init_command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 )
 
 type cmdInitKey struct{}
@@ -37,7 +38,7 @@ func CommandInitializer(cmd *cobra.Command) (err error) {
 			ctx = daemon.WithDefaultRequest(ctx, cmd)
 		}
 		if ctx, err = ensureUserDaemon(ctx, v == ann.Required); err != nil {
-			if v == ann.Optional && err == ErrNoUserDaemon {
+			if v == ann.Optional && (err == ErrNoUserDaemon || errcat.GetCategory(err) == errcat.Config) {
 				// This is OK, but further initialization is not possible
 				err = nil
 			}


### PR DESCRIPTION
## Description

When using the version command, and that the kubeconfig is wrong, we can have an error preventing the user from seing the correct output.

This PR changes the code to also ignore KubeConfig errors when the user daemon isn't required.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
