### PR TITLE
Automatically detect and add "minikube" and "kind" Docker networks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.12.2 (TBD)
 
+- Feature: The Docker network used by a Kind or Minikube (using the "docker" driver) installation, is automatically
+  detected and connected to a Docker container running the Telepresence daemon.
+
 - Bugfix: The kubeconfig is made self-contained before running Telepresence daemon in a Docker container.
 
 - Bugfix: The client will no longer need cluster wide permissions when connected to a namespace scoped Traffic Manager.


### PR DESCRIPTION
## Description

Makes the "minikube" and "kind" Docker networks available to a Telepresence daemon that runs in a Docker container when they exist and have a container connected to them.

This makes it possible for a container based daemon to connect to a Minikube (using the docker driver) or Kind cluster.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
