### PR TITLE
Add support for profiling using pprof to the daemons.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -280,6 +280,25 @@ command to `cat` to trigger the usual logfile setup:
 $ telepresence connector-foreground | cat
 ```
 
+### Profiling the daemons
+
+The daemons can be profiled using [pprof](https://pkg.go.dev/net/http/pprof).
+The profiling is initialized using the following flags:
+
+```console
+$ telepresence quit -s
+$ telepresence connect --userd-profiling-port 6060 --rootd-profiling-port 6061
+```
+
+If a daemon is started with pprof, then the goroutine stacks and much other
+info can be found by connecting your browser to http://localhost:6060/debug/pprof/
+(swap 6060 for whatever port you used with the flags)
+
+#### Dumping the goroutine stacks
+
+A dump will be produced in the respective logs for the daemon simply by killing it
+with a SIGQUIT signal. On Windows however, using profiling is the only option.
+
 ### RBAC issues
 
 If you are debugging or working on RBAC-related feature work with

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -129,7 +130,11 @@ func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required
 	if _, err = ensureAppUserConfigDir(ctx); err != nil {
 		return nil, errcat.NoDaemonLogs.New(err)
 	}
-	if err = proc.StartInBackground(false, connectorDaemon, "connector-foreground"); err != nil {
+	args := []string{connectorDaemon, "connector-foreground"}
+	if cr.UserDaemonProfilingPort > 0 {
+		args = append(args, "--pprof", strconv.Itoa(int(cr.UserDaemonProfilingPort)))
+	}
+	if err = proc.StartInBackground(false, args...); err != nil {
 		return nil, errcat.NoDaemonLogs.Newf("failed to launch the connector service: %w", err)
 	}
 	if err = socket.WaitUntilAppears("connector", socket.ConnectorName, 10*time.Second); err != nil {

--- a/pkg/client/cli/daemon/request.go
+++ b/pkg/client/cli/daemon/request.go
@@ -19,8 +19,10 @@ type Request struct {
 	Docker bool
 
 	// Request is created on-demand, not by InitRequest
-	Implicit    bool
-	kubeFlagSet *pflag.FlagSet
+	Implicit                bool
+	kubeFlagSet             *pflag.FlagSet
+	UserDaemonProfilingPort uint16
+	RootDaemonProfilingPort uint16
 }
 
 // InitRequest adds the networking flags and Kubernetes flags to the given command and
@@ -46,6 +48,15 @@ func InitRequest(cmd *cobra.Command) *Request {
 	nwFlags.StringVar(&cr.ManagerNamespace, "manager-namespace", "", `The namespace where the traffic manager is to be found. `+
 		`Overrides any other manager namespace set in config`)
 	flags.AddFlagSet(nwFlags)
+
+	dbgFlags := pflag.NewFlagSet("Debug and Profiling flags", 0)
+	dbgFlags.Uint16Var(&cr.UserDaemonProfilingPort,
+		"userd-profiling-port", 0, "Start a pprof server in the user daemon on this port")
+	_ = dbgFlags.MarkHidden("userd-profiling-port")
+	dbgFlags.Uint16Var(&cr.RootDaemonProfilingPort,
+		"rootd-profiling-port", 0, "Start a pprof server in the root daemon on this port")
+	_ = dbgFlags.MarkHidden("rootd-profiling-port")
+	flags.AddFlagSet(dbgFlags)
 
 	kubeConfig := genericclioptions.NewConfigFlags(false)
 	kubeConfig.Namespace = nil // "connect", don't take --namespace

--- a/pkg/client/rootd/service.go
+++ b/pkg/client/rootd/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/socket"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
+	"github.com/telepresenceio/telepresence/v2/pkg/pprof"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
@@ -54,6 +55,7 @@ func GetNewServiceFunc(ctx context.Context) NewServiceFunc {
 const (
 	ProcessName = "daemon"
 	titleName   = "Daemon"
+	pprofFlag   = "pprof"
 )
 
 func help() string {
@@ -109,16 +111,17 @@ func (s *Service) As(ptr any) {
 
 // Command returns the telepresence sub-command "daemon-foreground".
 func Command() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:    ProcessName + "-foreground <logging dir> <config dir>",
 		Short:  "Launch Telepresence " + titleName + " in the foreground (debug)",
 		Args:   cobra.ExactArgs(2),
 		Hidden: true,
 		Long:   help(),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), args[0], args[1])
-		},
+		RunE:   run,
 	}
+	flags := cmd.Flags()
+	flags.Uint16(pprofFlag, 0, "start pprof server on the given port")
+	return cmd
 }
 
 func (s *Service) Version(_ context.Context, _ *empty.Empty) (*common.VersionInfo, error) {
@@ -376,13 +379,17 @@ func (s *Service) serveGrpc(c context.Context, l net.Listener, tracer common.Tra
 }
 
 // run is the main function when executing as the daemon.
-func run(c context.Context, loggingDir, configDir string) error {
+func run(cmd *cobra.Command, args []string) error {
 	if !proc.IsAdmin() {
 		return fmt.Errorf("telepresence %s must run with elevated privileges", ProcessName)
 	}
 
 	// seed random generator (used when shuffling IPs)
 	rand.Seed(time.Now().UnixNano())
+
+	loggingDir := args[0]
+	configDir := args[1]
+	c := cmd.Context()
 
 	// Spoof the AppUserLogDir and AppUserConfigDir so that they return the original user's
 	// directories rather than directories for the root user.
@@ -394,6 +401,14 @@ func run(c context.Context, loggingDir, configDir string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 	c = client.WithConfig(c, cfg)
+	flags := cmd.Flags()
+	if pprofPort, _ := flags.GetUint16(pprofFlag); pprofPort > 0 {
+		go func() {
+			if err := pprof.PprofServer(c, pprofPort); err != nil {
+				dlog.Error(c, err)
+			}
+		}()
+	}
 
 	c = dgroup.WithGoroutineName(c, "/"+ProcessName)
 	c, err = logging.InitContext(c, ProcessName, logging.RotateDaily, true)

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1,0 +1,15 @@
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/datawire/dlib/dhttp"
+)
+
+func PprofServer(ctx context.Context, port uint16) error {
+	sc := dhttp.ServerConfig{Handler: http.DefaultServeMux}
+	return sc.ListenAndServe(ctx, fmt.Sprintf("localhost:%d", port))
+}


### PR DESCRIPTION
## Description

Adds the hidden flags `--userd-profiling-port` and `--rootd-profiling-port` to the `telepresence connect` command. When set to a port number, the respective daemon will start a `pprof` listener on that port.

See https://pkg.go.dev/net/http/pprof for more info.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
