### PR TITLE
Allow the intercept command to specify the target host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Feature: The Docker network used by a Kind or Minikube (using the "docker" driver) installation, is automatically
   detected and connected to a Docker container running the Telepresence daemon.
 
+- Feature: There's a new --address flag to the intercept command allowing users to set the target IP of the intercept.
+
 - Bugfix: The kubeconfig is made self-contained before running Telepresence daemon in a Docker container.
 
 - Bugfix: The client will no longer need cluster wide permissions when connected to a namespace scoped Traffic Manager.

--- a/integration_test/intercept_localhost_test.go
+++ b/integration_test/intercept_localhost_test.go
@@ -67,6 +67,7 @@ func (s *interceptLocalhostSuite) TestIntercept_WithCustomLocalhost() {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 		// If there was a response, make sure it's a 200
 		s.Require().Equal(http.StatusOK, resp.StatusCode)
 		return nil

--- a/integration_test/intercept_localhost_test.go
+++ b/integration_test/intercept_localhost_test.go
@@ -1,0 +1,82 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/vif/routing"
+)
+
+type interceptLocalhostSuite struct {
+	itest.Suite
+	itest.SingleService
+	cancelLocal  context.CancelFunc
+	defaultRoute *routing.Route
+	port         int
+}
+
+func (s *interceptLocalhostSuite) SuiteName() string {
+	return "InterceptLocalhost"
+}
+
+func init() {
+	itest.AddSingleServiceSuite("", "echo", func(h itest.SingleService) itest.TestingSuite {
+		return &interceptLocalhostSuite{Suite: itest.Suite{Harness: h}, SingleService: h}
+	})
+}
+
+func (s *interceptLocalhostSuite) SetupSuite() {
+	s.Suite.SetupSuite()
+	ctx := s.Context()
+	var err error
+	s.defaultRoute, err = routing.DefaultRoute(ctx)
+	s.Require().NoError(err)
+	dlog.Infof(ctx, "ip: %s: route: %s", s.defaultRoute.LocalIP, s.defaultRoute)
+	s.port, s.cancelLocal = itest.StartLocalHttpEchoServerWithHost(ctx, s.ServiceName(), s.defaultRoute.LocalIP.String())
+	s.CapturePodLogs(ctx, "app=echo", "traffic-agent", s.AppNamespace())
+}
+
+func (s *interceptLocalhostSuite) TearDownSuite() {
+	ctx := s.Context()
+	itest.TelepresenceOk(ctx, "leave", fmt.Sprintf("%s-%s", s.ServiceName(), s.AppNamespace()))
+	s.cancelLocal()
+	s.Eventually(func() bool {
+		stdout := itest.TelepresenceOk(ctx, "list", "--namespace", s.AppNamespace(), "--intercepts")
+		return !strings.Contains(stdout, s.ServiceName()+": intercepted")
+	}, 10*time.Second, time.Second)
+}
+
+func (s *interceptLocalhostSuite) TestIntercept_WithCustomLocalhost() {
+	ctx := s.Context()
+	doRequest := func(ctx context.Context, host, port string) error {
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s/", net.JoinHostPort(host, port)), nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		// If there was a response, make sure it's a 200
+		s.Require().Equal(http.StatusOK, resp.StatusCode)
+		return nil
+	}
+	// Make sure the IP address we think will respond is actually gonna respond, and that localhost won't
+	s.Require().NoError(doRequest(ctx, s.defaultRoute.LocalIP.String(), strconv.Itoa(s.port)))
+	s.Require().Error(doRequest(ctx, "127.0.0.1", strconv.Itoa(s.port)))
+
+	// Run the intercept
+	stdout := itest.TelepresenceOk(ctx, "intercept", "--namespace", s.AppNamespace(), s.ServiceName(), "--port", strconv.Itoa(s.port), "--address", s.defaultRoute.LocalIP.String())
+	s.Require().Contains(stdout, "Using Deployment "+s.ServiceName())
+	itest.PingInterceptedEchoServer(ctx, s.ServiceName(), "80")
+}

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -930,12 +930,11 @@ func DeleteNamespaces(ctx context.Context, namespaces ...string) {
 	wg.Wait()
 }
 
-// StartLocalHttpEchoServer starts a local http server that echoes a line with the given name and
-// the current URL path. The port is returned together with function that cancels the server.
-func StartLocalHttpEchoServer(ctx context.Context, name string) (int, context.CancelFunc) {
+// StartLocalHttpEchoServerWithAddress is like StartLocalHttpEchoServer but binds to a specific host instead of localhost.
+func StartLocalHttpEchoServerWithHost(ctx context.Context, name string, host string) (int, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(ctx)
 	lc := net.ListenConfig{}
-	l, err := lc.Listen(ctx, "tcp", "localhost:0")
+	l, err := lc.Listen(ctx, "tcp", net.JoinHostPort(host, "0"))
 	require.NoError(getT(ctx), err, "failed to listen on localhost")
 	go func() {
 		sc := &dhttp.ServerConfig{
@@ -946,6 +945,13 @@ func StartLocalHttpEchoServer(ctx context.Context, name string) (int, context.Ca
 		_ = sc.Serve(ctx, l)
 	}()
 	return l.Addr().(*net.TCPAddr).Port, cancel
+
+}
+
+// StartLocalHttpEchoServer starts a local http server that echoes a line with the given name and
+// the current URL path. The port is returned together with function that cancels the server.
+func StartLocalHttpEchoServer(ctx context.Context, name string) (int, context.CancelFunc) {
+	return StartLocalHttpEchoServerWithHost(ctx, name, "localhost")
 }
 
 // PingInterceptedEchoServer assumes that a server has been created using StartLocalHttpEchoServer and

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -945,7 +945,6 @@ func StartLocalHttpEchoServerWithHost(ctx context.Context, name string, host str
 		_ = sc.Serve(ctx, l)
 	}()
 	return l.Addr().(*net.TCPAddr).Port, cancel
-
 }
 
 // StartLocalHttpEchoServer starts a local http server that echoes a line with the given name and

--- a/pkg/client/cli/intercept/command.go
+++ b/pkg/client/cli/intercept/command.go
@@ -23,6 +23,7 @@ type Command struct {
 	Namespace      string // --namespace
 	Port           string // --port // only valid if !localOnly
 	ServiceName    string // --service // only valid if !localOnly
+	Address        string // --address // only valid if !localOnly
 	LocalOnly      bool   // --local-only
 	LocalMountPort uint16 // --local-mount-port
 
@@ -48,6 +49,11 @@ func (a *Command) AddFlags(flags *pflag.FlagSet) {
 		`Local port to forward to. If intercepting a service with multiple ports, `+
 		`use <local port>:<svcPortIdentifier>, where the identifier is the port name or port number. `+
 		`With --docker-run, use <local port>:<container port> or <local port>:<container port>:<svcPortIdentifier>.`,
+	)
+
+	flags.StringVar(&a.Address, "address", "127.0.0.1", ``+
+		`Local address to forward to, Only accepts IP address as a value. `+
+		`e.g. '--address 10.0.0.2'`,
 	)
 
 	flags.StringVar(&a.ServiceName, "service", "", "Name of service to intercept. If not provided, we will try to auto-detect one")

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/scout"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
 )
@@ -313,6 +314,10 @@ func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRe
 		return nil, err
 	}
 	spec.TargetPort = int32(s.localPort)
+	if iputil.Parse(s.Address) == nil {
+		return nil, fmt.Errorf("--address %s is not a valid IP address", s.Address)
+	}
+	spec.TargetHost = s.Address
 
 	doMount := false
 	ir.LocalMountPort = int32(s.LocalMountPort)


### PR DESCRIPTION
## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
