### PR TITLE
use `IsValidPortName` instead of `IsDNS1035Label`

### DIFF
--- a/pkg/agentconfig/portidentifier.go
+++ b/pkg/agentconfig/portidentifier.go
@@ -20,7 +20,7 @@ func ValidatePort(s string) error {
 	_, err := ParseNumericPort(s)
 	if err == ErrNotInteger {
 		err = nil
-		if errs := validation.IsDNS1035Label(s); len(errs) > 0 {
+		if errs := validation.IsValidPortName(s); len(errs) > 0 {
 			err = fmt.Errorf(strings.Join(errs, " and "))
 		}
 	}


### PR DESCRIPTION
## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
