### PR TITLE
Use a better strategy for determining the cluster domain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Feature: There's a new --address flag to the intercept command allowing users to set the target IP of the intercept.
 
+- Bugfix: The Traffic Manager uses a fail-proof way to determine the cluster domain.
+
 - Bugfix: DNS on windows is more reliable and performant.
 
 - Bugfix: The kubeconfig is made self-contained before running Telepresence daemon in a Docker container.


### PR DESCRIPTION
## Description

This PR replaces the strategy for determining the cluster domain with one that uses a reverse lookup of the IP for the agent-injector service. This should work in all clusters. The former strategy didn't.

Closes #3114

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
