### PR TITLE
Fix missing env vars for integration tests

### DIFF
--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -196,8 +196,10 @@ func (s *cluster) ensureExecutable(ctx context.Context, errs chan<- error, wg *s
 
 	ctx = WithModuleRoot(ctx)
 	exe := "telepresence"
-	env := make(map[string]string)
-	env["TELEPRESENCE_VERSION"] = s.testVersion
+	env := map[string]string{
+		"TELEPRESENCE_VERSION":  s.testVersion,
+		"TELEPRESENCE_REGISTRY": s.registry,
+	}
 	if runtime.GOOS == "windows" {
 		env["CGO_ENABLED"] = "0"
 		exe += ".exe"
@@ -233,7 +235,10 @@ func (s *cluster) ensureDockerImages(ctx context.Context, errs chan<- error, wg 
 	}
 
 	runMake := func(target string) {
-		out, err := Command(WithModuleRoot(ctx), makeExe, target).CombinedOutput()
+		out, err := Command(WithEnv(WithModuleRoot(ctx), map[string]string{
+			"TELEPRESENCE_VERSION":  s.testVersion,
+			"TELEPRESENCE_REGISTRY": s.registry,
+		}), makeExe, target).CombinedOutput()
 		if err != nil {
 			errs <- RunError(err, out)
 		}


### PR DESCRIPTION
## Description

Some variables were missing when you build / push / test with a docker hub repo.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
