### PR TITLE
Ensure proper DNS function when no cluster CIDR is routed by the VIF.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Feature: There's a new --address flag to the intercept command allowing users to set the target IP of the intercept.
 
+- Bugfix: DNS works properly even when no cluster subnet is routed by the Telepresence VIF.
+
 - Bugfix: The Traffic Manager uses a fail-proof way to determine the cluster domain.
 
 - Bugfix: DNS on windows is more reliable and performant.

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -70,7 +70,7 @@ func (s *Server) tryResolveD(c context.Context, dev vif.Device, configureDNS fun
 			initDone <- struct{}{}
 			return errResolveDNotConfigured
 		}
-		return s.Run(c, initDone, listeners, nil, s.resolveInCluster, true)
+		return s.Run(c, initDone, listeners, nil, s.resolveInCluster)
 	})
 
 	g.Go("SanityCheck", func(c context.Context) error {

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -83,9 +83,6 @@ type Server struct {
 
 	// ready is closed when the DNS server is fully configured
 	ready chan error
-
-	// Whether the TUN-device is proxying cluster CIDRs
-	proxyCluster bool
 }
 
 type cacheEntry struct {
@@ -638,11 +635,10 @@ func (s *Server) resolveQuery(q *dns.Question, dv *cacheEntry) (dnsproxy.RRs, in
 }
 
 // Run starts the DNS server(s) and waits for them to end.
-func (s *Server) Run(c context.Context, initDone chan<- struct{}, listeners []net.PacketConn, fallbackPool FallbackPool, resolve Resolver, proxyCluster bool) error {
+func (s *Server) Run(c context.Context, initDone chan<- struct{}, listeners []net.PacketConn, fallbackPool FallbackPool, resolve Resolver) error {
 	s.ctx = c
 	s.fallbackPool = fallbackPool
 	s.resolve = resolve
-	s.proxyCluster = proxyCluster
 
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 	for _, listener := range listeners {

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -130,7 +130,7 @@ func (r *resolveFile) setSearchPaths(paths ...string) {
 //	man 5 resolver
 //
 // or, if not on a Mac, follow this link: https://www.manpagez.com/man/5/resolver/
-func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, configureDNS func(net.IP, *net.UDPAddr)) error {
+func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net.IP, *net.UDPAddr)) error {
 	resolverDirName := filepath.Join("/etc", "resolver")
 	resolverFileName := filepath.Join(resolverDirName, "telepresence.local")
 
@@ -188,7 +188,7 @@ func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, co
 			return s.updateResolverFiles(c, resolverDirName, resolverFileName, dnsAddr, paths)
 		}, dev)
 		// Server will close the listener, so no need to close it here.
-		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster, proxyCluster)
+		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
 	})
 	return g.Wait()
 }

--- a/pkg/client/rootd/dns/server_windows.go
+++ b/pkg/client/rootd/dns/server_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
 )
 
-func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, configureDNS func(net.IP, *net.UDPAddr)) error {
+func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net.IP, *net.UDPAddr)) error {
 	listener, err := newLocalUDPListener(c)
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func (s *Server) Worker(c context.Context, dev vif.Device, proxyCluster bool, co
 	g.Go("Server", func(c context.Context) error {
 		// No need to close listener. It's closed by the dns server.
 		s.processSearchPaths(g, s.updateRouterDNS, dev)
-		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster, proxyCluster)
+		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
 	})
 	return g.Wait()
 }

--- a/pkg/client/rootd/in_process.go
+++ b/pkg/client/rootd/in_process.go
@@ -103,12 +103,7 @@ func NewInProcSession(
 	mi *rpc.OutboundInfo,
 	mc manager.ManagerClient,
 	ver semver.Version,
-) (*InProcSession, error) {
+) *InProcSession {
 	ctx, cancel := context.WithCancel(ctx)
-	s, err := newSession(ctx, scout, mi, &userdToManagerShortcut{mc}, ver)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-	return &InProcSession{Session: s, cancel: cancel}, nil
+	return &InProcSession{Session: newSession(ctx, scout, mi, &userdToManagerShortcut{mc}, ver), cancel: cancel}
 }

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -1176,10 +1176,7 @@ func (s *session) connectRootDaemon(ctx context.Context, oi *rootdRpc.OutboundIn
 	svc := userd.GetService(ctx)
 	if svc.RootSessionInProcess() {
 		// Just run the root session in-process.
-		rootSession, err := rootd.NewInProcSession(ctx, svc.Reporter(), oi, s.managerClient, s.managerVersion)
-		if err != nil {
-			return nil, err
-		}
+		rootSession := rootd.NewInProcSession(ctx, svc.Reporter(), oi, s.managerClient, s.managerVersion)
 		if err = rootSession.Start(ctx, dgroup.NewGroup(ctx, dgroup.GroupConfig{})); err != nil {
 			return nil, err
 		}

--- a/pkg/vif/routing/routing_linux.go
+++ b/pkg/vif/routing/routing_linux.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-
-	//nolint:depguard // sys/unix does not have NetlinkRIB
-	"syscall"
+	"syscall" //nolint:depguard // sys/unix does not have NetlinkRIB
 	"unsafe"
 
 	"github.com/datawire/dlib/dexec"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
-const findInterfaceRegex = `^(local\s)?[0-9.]+(\s+via\s+(?P<gw>[0-9.]+))?\s+dev\s+(?P<dev>[a-z0-9-]+)\s+src\s+(?P<src>[0-9.]+)`
+const findInterfaceRegex = `^(local\s)?[0-9.]+(\s+via\s+(?P<gw>[0-9.]+))?\s+dev\s+(?P<dev>[a-z0-9-]+)\s+(table\s+[a-z0-9]+\s+)?src\s+(?P<src>[0-9.]+)`
 
 var (
 	findInterfaceRe = regexp.MustCompile(findInterfaceRegex) //nolint:gochecknoglobals // constant


### PR DESCRIPTION
## Description

Telepresence does not route cluster subnets that are already available on the workstation, which is good, but the DNS malfunctions on Linux and Windows unless there is a subnet covering the IP of the Telepresence DNS server, which is bad.

This PR ensures that a subnet is routed by the VIF even when none of the cluster's subnets are routed. In such situations, a tiny subnet is created with a 30-bit mask. It is guaranteed not to collide with any of the subnets used by existing network interfaces. The DNS server will then use an IP in that subnet.

On darwin (macOS), no special DNS subnet is needed because the DNS is managed by adding and removing entries under /etc/resolver that points directly to a port on localhost. So when no subnets are routed, there's actually no need for a VIF. This commit takes this into account, so that no VIF is started unless there's a need for it.

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
