### PR TITLE
intercept: fix 'creting' typo

### DIFF
--- a/pkg/client/cli/intercept/result.go
+++ b/pkg/client/cli/intercept/result.go
@@ -35,8 +35,8 @@ func Result(r *connector.InterceptResult, err error) error {
 	case common.InterceptError_NAMESPACE_AMBIGUITY:
 		nss := strings.Split(r.ErrorText, ",")
 		msg = fmt.Sprintf(
-			"A workstation cannot have simultaneous intercepts in different namespaces. Leave all intercepts in %q before creting new ones in %q",
-			nss[0], nss[1])
+			"Cannot create an intercept in namespace %q. A workstation cannot have simultaneous intercepts in different namespaces. Leave all intercepts in namespace %q first.",
+			nss[1], nss[0])
 	case common.InterceptError_LOCAL_TARGET_IN_USE:
 		spec := r.InterceptInfo.Spec
 		msg = fmt.Sprintf("Port %s:%d is already in use by intercept %s",


### PR DESCRIPTION
## Description

fix 'creting' typo

while here, adjust the error message to be a bit more clear about what failed and what you should try instead.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
