### PR TITLE
Update readme to document installing and removing traffic manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Root Daemon: v2.6.7 (api v3)
 User Daemon: v2.6.7 (api v3)
 ```
 
+### Setup Traffic Manager in the cluster
+
+Install Traffic Manager in your cluster. By default, it will reside in the `ambassador` namespace:
+```console
+$ telepresence helm install
+
+Traffic Manager installed successfully
+```
+
 ### Establish a connection to  the cluster (outbound traffic)
 
 Let telepresence connect:
@@ -335,7 +344,7 @@ You can uninstall the traffic-agent from specific deployments or from all deploy
 case the traffic-manager and all traffic-agents will be uninstalled.
 
 ```
-telepresence uninstall --everything
+$ telepresence helm uninstall
 ```
 will remove everything that was automatically installed by telepresence from the cluster.
 


### PR DESCRIPTION
## Description

Just adding a bit of documentation on how to install and remove traffic manager on the cluster.

Using `telepresence connect` before installing traffic manager yield this error 
```
Launching Telepresence Root Daemon
telepresence connect: error: connector.Connect: traffic manager not found, if it is not installed, please run 'telepresence helm install'. If it is installed, try connecting with a --manager-namespace to point telepresence to the namespace it's installed in.
```

And `telepresence uninstall --everything` is deprecated, so I changed it to `telepresence helm uninstall`

## Checklist

This only a change in the `Readme.md` file, so the checklist is not applicable, since there are no new features

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
