### PR TITLE
Fix panic while using telepresence uninstall --everything

### DIFF
--- a/pkg/client/cli/cmd/uninstall.go
+++ b/pkg/client/cli/cmd/uninstall.go
@@ -48,7 +48,7 @@ func (u *uninstallCommand) args(cmd *cobra.Command, args []string) error {
 	if u.everything {
 		ha := &HelmCommand{
 			RequestType: connector.HelmRequest_UNINSTALL,
-			Request:     &daemon.Request{},
+			Request:     daemon.InitRequest(cmd),
 		}
 		fmt.Fprintln(cmd.OutOrStderr(), "--everything is deprecated. Please use telepresence helm uninstall")
 		return ha.run(cmd, args)
@@ -81,6 +81,8 @@ func (u *uninstallCommand) run(cmd *cobra.Command, args []string) error {
 	case u.agent:
 		ur.UninstallType = connector.UninstallRequest_NAMED_AGENTS
 		ur.Agents = args
+	case u.everything:
+		return nil
 	default:
 		ur.UninstallType = connector.UninstallRequest_ALL_AGENTS
 	}


### PR DESCRIPTION
## Description

`telepresence uninstall --everything` raises a panic error because it tries to validate the kubeFlags at some point. By using `InitRequest` it initializes everything we need.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
