### PR TITLE
Fix unchecked cast panic in traffic-manager pod watcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 2.13.2 (TBD)
+
+- Bugfix: The traffic-manager would sometimes panic and exit after some time due to a type cast panic.
+
+### 2.13.1 (April 20, 2023)
+
+- Change: Update ambassador-agent to version 1.13.13
+
 ### 2.13.0 (April 18, 2023)
 
 - Feature: The Docker network used by a Kind or Minikube (using the "docker" driver) installation, is automatically


### PR DESCRIPTION
## Description

A watcher isn't guaranteed to always receive an object of the watched type. The `DeleteFunc` in particular, can receive an instance of `cache.DeleteFinalStateUnknown`. This commit ensures that the traffic-manager's node and pod watcher uses checked casts only and that the `cache.DeleteFinalStateUnknown` is handled properly.

Closes #3149

## Checklist


 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
