### PR TITLE
Fix "close of closed channel" panic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Bugfix: Ensure that `telepresence connect` succeeds even though DNS isn't configured correctly.
 
+- Bugfix: The traffic-manager would sometimes panic with a "close of closed channel" message and exit.
+
 - Bugfix: The traffic-manager would sometimes panic and exit after some time due to a type cast panic.
 
 ### 2.13.1 (April 20, 2023)


### PR DESCRIPTION
## Description

A guard for panic when writing on a possibly closed channel panicked because it closed another closed channel. This commit ensures that this other channel is closed only if it hasn't been closed already.

The panic would kill the traffic-manager and show a log similar to:
```
panic: send on closed channel [recovered]
	panic: close of closed channel

goroutine 61017761 [running]:
github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state.(*State).startLookup.func1.1()
	github.com/telepresenceio/telepresence/v2@v2.12.0/cmd/traffic/cmd/manager/state/dns.go:140 +0x36
panic({0x28ad5e0, 0x2e883e0})
	runtime/panic.go:884 +0x213
github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state.(*State).startLookup.func1(0xc0003b06d0?, 0xc00808f740?, 0xc0022f1810)
	github.com/telepresenceio/telepresence/v2@v2.12.0/cmd/traffic/cmd/manager/state/dns.go:143 +0x65
github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state.(*State).startLookup(0xc0003b06c0, {0xc005e37a40, 0x24}, {0xc0022e7630, 0x4c}, 0x2a83340?)
	github.com/telepresenceio/telepresence/v2@v2.12.0/cmd/traffic/cmd/manager/state/dns.go:144 +0x135
github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state.(*State).agentsLookup.func1({0xc005e37a40, 0x24})
	github.com/telepresenceio/telepresence/v2@v2.12.0/cmd/traffic/cmd/manager/state/dns.go:99 +0x1f3
created by github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state.(*State).agentsLookup
	github.com/telepresenceio/telepresence/v2@v2.12.0/cmd/traffic/cmd/manager/state/dns.go:92 +0x13a
```

Relates to datawire/telepresence2-proprietary#314

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
