### PR TITLE
Fix panic when using --local-only with --docker-run in intercept.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,45 @@
 # Changelog
 
+### 2.13.3 (TBD)
+- Bugfix: Running `telepresence intercept --local-only --docker-run` no longer results in a panic.
+  Ticket [3171](https://github.com/telepresenceio/telepresence/issues/3171).
+
+- Bugfix: Running `telepresence intercept --local-only --mount false` no longer results in an incorrect error message
+  saying "a local-only intercept cannot have mounts".
+  Ticket [3171](https://github.com/telepresenceio/telepresence/issues/3171).
+
 ### 2.13.2 (May 12, 2023)
 - Bugfix: Replaced `/` characters with a `-` when the authenticator service creates the kubeconfig in the Telepresence cache.
+  PR [3167](https://github.com/telepresenceio/telepresence/issues/3167).
 
 - Feature: Configurable strategy (`auto`, `powershell`. or `registry`) to set the global DNS search path on Windows. Default
   is `auto` which means try `powershell` first, and if it fails, fall back to `registry`.
+  Ticket [3152](https://github.com/telepresenceio/telepresence/issues/3152).
 
 - Feature: The timeout for the traffic manager to wait for traffic agent to arrive can
   now be configured in the `values.yaml` file using `timeouts.agentArrival`. The default
   timeout is still 30 seconds.
+  PR [3148](https://github.com/telepresenceio/telepresence/issues/3148).
 
 - Bugfix: The automatic discovery of a local container based cluster (minikube or kind) used when the
   Telepresence daemon runs in a container, now works on macOS and Windows, and with different profiles,
   ports, and cluster names
+  PR [3165](https://github.com/telepresenceio/telepresence/issues/3165).
 
 - Bugfix: FTP Stability improvements. Multiple simultaneous intercepts can transfer large files in bidirectionally and in parallel.
+  PR [3157](https://github.com/telepresenceio/telepresence/issues/3157).
 
 - Bugfix: Pods using persistent volumes no longer causes timeouts when intercepted.
 
 - Bugfix: Ensure that `telepresence connect` succeeds even though DNS isn't configured correctly.
+  Ticket [3143](https://github.com/telepresenceio/telepresence/issues/3143).
+  PR [3154](https://github.com/telepresenceio/telepresence/issues/3154).
 
 - Bugfix: The traffic-manager would sometimes panic with a "close of closed channel" message and exit.
+  PR [3160](https://github.com/telepresenceio/telepresence/issues/3160).
 
 - Bugfix: The traffic-manager would sometimes panic and exit after some time due to a type cast panic.
+  Ticket [3149](https://github.com/telepresenceio/telepresence/issues/3149).
 
 ### 2.13.1 (April 20, 2023)
 

--- a/pkg/client/cli/intercept/command.go
+++ b/pkg/client/cli/intercept/command.go
@@ -120,7 +120,9 @@ func (a *Command) Validate(cmd *cobra.Command, positional []string) error {
 			return errcat.User.New("a local-only intercept cannot have a port")
 		}
 		if cmd.Flag("mount").Changed {
-			return errcat.User.New("a local-only intercept cannot have mounts")
+			if doMount, _ := a.GetMountPoint(); doMount {
+				return errcat.User.New("a local-only intercept cannot have mounts")
+			}
 		}
 		return nil
 	}

--- a/pkg/client/cli/intercept/docker_run.go
+++ b/pkg/client/cli/intercept/docker_run.go
@@ -196,7 +196,7 @@ func (s *state) startInDocker(ctx context.Context, daemonName, envFile string, a
 		if !set {
 			ourArgs = append(ourArgs, "--rm")
 		}
-		if !s.mountDisabled {
+		if !(s.mountDisabled || s.info == nil) {
 			m := s.info.Mount
 			if m != nil {
 				if err := docker.EnsureVolumePlugin(ctx); err != nil {

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -94,6 +94,7 @@ func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRe
 
 	if s.AgentName == "" {
 		// local-only
+		s.mountDisabled = true
 		return ir, nil
 	}
 


### PR DESCRIPTION
## Description

Also fixes an incorrect message when using `--local-only` with `--mount false`.

Closes #3171

## Checklist

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
