### PR TITLE
Correct namespace selector for cluster versions with non-numeric characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - Bugfix: The helm chart now correctly handles custom `agentInjector.webhook.port` that was not being set in hook URLs.
 
+- Bugfix: The mutating webhook now correctly applies the namespace selector even if the cluster version contains non-numeric characters. For example, it can now handle versions such as Major:"1", Minor:"22+".
+
 ### 2.13.2 (May 12, 2023)
 - Bugfix: Replaced `/` characters with a `-` when the authenticator service creates the kubeconfig in the Telepresence cache.
   PR [3167](https://github.com/telepresenceio/telepresence/issues/3167).

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -89,3 +89,16 @@ RBAC rules required to create an intercept in a namespace; excludes any rules th
   resources: ["deployments", "replicasets", "statefulsets"]
   verbs: ["get", "watch", "list"]
 {{- end }}
+
+{{/*
+Kubernetes version
+*/}}
+{{- define "kube.version.major" }}
+{{- $version := regexFind "^[0-9]+" .Capabilities.KubeVersion.Major -}}
+{{- printf "%s" $version -}}
+{{- end -}}
+
+{{- define "kube.version.minor" }}
+{{- $version := regexFind "^[0-9]+" .Capabilities.KubeVersion.Minor -}}
+{{- printf "%s" $version -}}
+{{- end -}}

--- a/charts/telepresence/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence/templates/agentInjectorWebhook.yaml
@@ -44,7 +44,7 @@ webhooks:
 {{- if .Values.managerRbac.namespaced }}
   namespaceSelector:
     matchExpressions:
-{{- if and (eq (int .Capabilities.KubeVersion.Major)  1) (lt (int .Capabilities.KubeVersion.Minor) 21) }}
+{{- if and (eq (int (include "kube.version.major" .))  1) (lt (int (include "kube.version.minor" .)) 21) }}
       - key: app.kubernetes.io/name
 {{- else }}
       - key: kubernetes.io/metadata.name


### PR DESCRIPTION
## Description

This pull request addresses an issue with the mutating webhook where it previously could not correctly apply the namespace selector if the cluster version contained non-numeric characters.

The problem was primarily seen in cases where the Kubernetes version, specifically the minor version, included non-numeric characters, such as "22+".

Changes in this PR ensure that the webhook now correctly interprets and handles such versions. The namespace selector will now function as expected even when the cluster version is formatted like Major:"1", Minor:"22+".

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
