### PR TITLE
Fixed `.timeouts.agentArrival` template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - Bugfix: The mutating webhook now correctly applies the namespace selector even if the cluster version contains non-numeric characters. For example, it can now handle versions such as Major:"1", Minor:"22+".
 
-- Bugfix: `.timeouts.agentArrival` is now correctly honored.
+- Bugfix: `.intercept.disableGlobal` and `.timeouts.agentArrival` are now correctly honored.
 
 ### 2.13.2 (May 12, 2023)
 - Bugfix: Replaced `/` characters with a `-` when the authenticator service creates the kubeconfig in the Telepresence cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - Bugfix: The mutating webhook now correctly applies the namespace selector even if the cluster version contains non-numeric characters. For example, it can now handle versions such as Major:"1", Minor:"22+".
 
+- Bugfix: `.timeouts.agentArrival` is now correctly honored.
+
 ### 2.13.2 (May 12, 2023)
 - Bugfix: Replaced `/` characters with a `-` when the authenticator service creates the kubeconfig in the Telepresence cache.
   PR [3167](https://github.com/telepresenceio/telepresence/issues/3167).

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           - name: INTERCEPT_DISABLE_GLOBAL
             value: {{ quote (default .intercept.disableGlobal false) }}
           - name: AGENT_ARRIVAL_TIMEOUT
-            value: {{ quote (default .timeouts.agentArrival "30s") }}
+            value: {{ quote (default "30s" .timeouts.agentArrival) }}
         {{- /*
         Traffic agent injector configuration
         */}}

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           {{- end }}
           {{- end }}
           - name: INTERCEPT_DISABLE_GLOBAL
-            value: {{ quote (default .intercept.disableGlobal false) }}
+            value: {{ quote (default false .intercept.disableGlobal) }}
           - name: AGENT_ARRIVAL_TIMEOUT
             value: {{ quote (default "30s" .timeouts.agentArrival) }}
         {{- /*


### PR DESCRIPTION
## Description

We are using the `default` function wrongly, as a result, the value passed in is not being honored.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
