### PR TITLE
close WatchDial when connection is lost

### DIFF
--- a/cmd/traffic/cmd/manager/state/session.go
+++ b/cmd/traffic/cmd/manager/state/session.go
@@ -20,7 +20,7 @@ type SessionState interface {
 	Done() <-chan struct{}
 	LastMarked() time.Time
 	SetLastMarked(lastMarked time.Time)
-	Dials() chan *rpc.DialRequest
+	Dials() <-chan *rpc.DialRequest
 	EstablishBidiPipe(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
 	OnConnect(context.Context, tunnel.Stream) (tunnel.Endpoint, error)
 }
@@ -118,7 +118,7 @@ func (ss *sessionState) Cancel() {
 	close(ss.dials)
 }
 
-func (ss *sessionState) Dials() chan *rpc.DialRequest {
+func (ss *sessionState) Dials() <-chan *rpc.DialRequest {
 	return ss.dials
 }
 

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -605,7 +605,7 @@ func (s *State) getRandomAgentSession(clientSessionID string, podIP net.IP) Sess
 	return agent
 }
 
-func (s *State) WatchDial(sessionID string) chan *rpc.DialRequest {
+func (s *State) WatchDial(sessionID string) <-chan *rpc.DialRequest {
 	s.mu.RLock()
 	ss, ok := s.sessions[sessionID]
 	s.mu.RUnlock()


### PR DESCRIPTION
## Description

WatchDial outlived a connection loss and cancelled state. Therefore, on reconnect it would receive the latest dialRequest. The logic to transfer the dr from the zombie WatchDial to the new WatchDial could send on a closed channel, causing a panic. The bad logic was replaced with killing the zombie.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
