### PR TITLE
Ensure that the docker client uses the current docker context.

### DIFF
--- a/pkg/client/docker/context.go
+++ b/pkg/client/docker/context.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/client"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+)
+
+type clientKey struct{}
+
+func EnableClient(ctx context.Context) (context.Context, error) {
+	if ctx.Value(clientKey{}) != nil {
+		return ctx, nil
+	}
+	cmd := proc.CommandContext(ctx, "docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}")
+	stdout, err := proc.CaptureErr(ctx, cmd)
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	if err != nil {
+		return ctx, fmt.Errorf("unable to retrieve docker context: %v", err)
+	}
+	if host := strings.TrimSpace(string(stdout)); host != "" {
+		dlog.Debugf(ctx, "Using docker context %q", host)
+		opts = append(opts, client.WithHost(host))
+	}
+	cli, err := client.NewClientWithOpts(opts...)
+	if err != nil {
+		return ctx, err
+	}
+	return context.WithValue(ctx, clientKey{}, cli), nil
+}
+
+func GetClient(ctx context.Context) *client.Client {
+	if cli, ok := ctx.Value(clientKey{}).(*client.Client); ok {
+		return cli
+	}
+	return nil
+}

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -368,11 +368,10 @@ func handleLocalK8s(ctx context.Context, clusterName string, cl *api.Cluster) er
 
 	// Let's check if we have a container with port bindings for the
 	// given addrPort that is a known k8sapi provider
-	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
-	if err != nil {
-		return err
+	cli := GetClient(ctx)
+	if cli == nil {
+		return errors.New("docker client not initialized")
 	}
-	defer cli.Close()
 	cjs := runningContainers(ctx, cli)
 
 	var hostPort, network string

--- a/pkg/client/docker/network.go
+++ b/pkg/client/docker/network.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -15,11 +16,10 @@ import (
 
 // EnsureNetwork checks if a network with the given name exists, and creates it if that is not the case.
 func EnsureNetwork(ctx context.Context, name string) error {
-	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
-	if err != nil {
-		return err
+	cli := GetClient(ctx)
+	if cli == nil {
+		return errors.New("docker client not initialized")
 	}
-	defer cli.Close()
 	resource, err := cli.NetworkInspect(ctx, name, types.NetworkInspectOptions{})
 	if err != nil {
 		if !dockerClient.IsErrNotFound(err) {


### PR DESCRIPTION
The Docker client API has no knowledge of a docker context, so in this commit, a `docker context inspect` is used to find out the docker host of the current context. That host is then passed to the client API instead of the default host so that the client API speaks to the host of the current context, just like the docker binary does.