### PR TITLE
Created a way to exclude certain Environment Variables from being propagated to the client

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -41,7 +41,12 @@ items:
           exclude a given list of hostnames from resolution, while the mappings field can be used to resolve a hostname with
           another.
         docs: https://github.com/telepresenceio/telepresence/pull/3172
-
+        
+      - type: feature
+        title: Added the ability to exclude environment variables
+        body: >-
+          Added a new config map that can take an array of environment variables that will
+          then be excluded from an intercept that retrieves the environment of a pod.
   - version: 2.13.3
     date: "2023-05-25"
     notes:

--- a/charts/telepresence/templates/excluded-variables-configmap.yaml
+++ b/charts/telepresence/templates/excluded-variables-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.rbac.only }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telepresence-excluded-variables
+  namespace:  {{ include "traffic-manager.namespace" . }}
+  data: {{ range .Values.variables.excluded }}
+    {{ . }}: "true"
+  {{- end }}
+{{- end }}

--- a/charts/telepresence/templates/excluded-variables-configmap.yaml
+++ b/charts/telepresence/templates/excluded-variables-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: telepresence-excluded-variables
   namespace:  {{ include "traffic-manager.namespace" . }}
-  data: {{ range .Values.variables.excluded }}
-    {{ . }}: "true"
+data: {{ range .Values.variables.excluded }}
+  {{ . }}: "forbid"
   {{- end }}
 {{- end }}

--- a/charts/telepresence/templates/intercept-env-configmap.yaml
+++ b/charts/telepresence/templates/intercept-env-configmap.yaml
@@ -2,9 +2,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: telepresence-excluded-variables
+  name: telepresence-intercept-env
   namespace:  {{ include "traffic-manager.namespace" . }}
-data: {{ range .Values.variables.excluded }}
-  {{ . }}: "forbid"
+data:
+  excluded: |
+  {{- range .Values.intercept.environment.excluded }}
+    {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -56,6 +56,7 @@ rules:
   - delete
   resourceNames:
   - telepresence-agents
+  - telepresence-excluded-variables
 - apiGroups:
   - "apps"
   resources:

--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -56,7 +56,7 @@ rules:
   - delete
   resourceNames:
   - telepresence-agents
-  - telepresence-excluded-variables
+  - telepresence-intercept-env
 - apiGroups:
   - "apps"
   resources:

--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -54,6 +54,7 @@ rules:
   - delete
   resourceNames:
   - telepresence-agents
+  - telepresence-excluded-variables
 - apiGroups:
   - "apps"
   resources:

--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -54,7 +54,7 @@ rules:
   - delete
   resourceNames:
   - telepresence-agents
-  - telepresence-excluded-variables
+  - telepresence-intercept-env
 - apiGroups:
   - "apps"
   resources:

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -170,6 +170,8 @@ managerRbac:
 
 intercept:
   disableGlobal: false
+  environment:
+    excluded: []
 
 timeouts:
   # The duration the traffic manager should wait for an agent to arrive (i.e., to be registered in the traffic manager's state)
@@ -348,6 +350,3 @@ client:
 
     # Tell client's DNS resolver to always send names with these suffixes to the cluster side resolver
     includeSuffixes: []
-
-variables:
-  excluded: []

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -348,3 +348,6 @@ client:
 
     # Tell client's DNS resolver to always send names with these suffixes to the cluster side resolver
     includeSuffixes: []
+
+variables:
+  excluded: []

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -852,16 +853,15 @@ func (m *service) removeExlcudedEnvVars(ctx context.Context, envVars map[string]
 		return envVars
 	}
 
-	cm, err := clientset.CoreV1().ConfigMaps(managerutil.GetEnv(ctx).ManagerNamespace).Get(ctx, "telepresence-excluded-variables", v1.GetOptions{})
+	cm, err := clientset.CoreV1().ConfigMaps(managerutil.GetEnv(ctx).ManagerNamespace).Get(ctx, "telepresence-intercept-env", v1.GetOptions{})
 	if err != nil {
 		dlog.Errorf(ctx, "cannot read excluded variables configmap: %v", err)
 		return envVars
 	}
 
-	if cm != nil {
-		for key := range cm.Data {
-			delete(envVars, key)
-		}
+	keys := strings.Split(cm.Data["excluded"], "\n")
+	for _, key := range keys {
+		delete(envVars, key)
 	}
 
 	return envVars

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -19,6 +19,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	empty "google.golang.org/protobuf/types/known/emptypb"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
@@ -805,6 +808,8 @@ func (m *service) ReviewIntercept(ctx context.Context, rIReq *rpc.ReviewIntercep
 		return nil, status.Errorf(codes.NotFound, "Agent session %q not found", sessionID)
 	}
 
+	rIReq.Environment = m.removeExlcudedEnvVars(ctx, rIReq.Environment)
+
 	intercept := m.state.UpdateIntercept(ceptID, func(intercept *rpc.InterceptInfo) {
 		// Sanity check: The reviewing agent must be an agent for the intercept.
 		if intercept.Spec.Namespace != agent.Namespace || intercept.Spec.Agent != agent.Name {
@@ -832,6 +837,36 @@ func (m *service) ReviewIntercept(ctx context.Context, rIReq *rpc.ReviewIntercep
 	}
 
 	return &empty.Empty{}, nil
+}
+
+func (m *service) removeExlcudedEnvVars(ctx context.Context, envVars map[string]string) map[string]string {
+	k8sConfig, err := rest.InClusterConfig()
+	if err != nil {
+		dlog.Errorf(ctx, "Unable to create in cluster config: %w", err)
+		return envVars
+	}
+
+	clientset, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		dlog.Errorf(ctx, "unable to create kubernetes clientset: %w", err)
+		return envVars
+	}
+
+	cm, err := clientset.CoreV1().ConfigMaps(managerutil.GetEnv(ctx).ManagerNamespace).Get(ctx, "telepresence-excluded-variables", v1.GetOptions{})
+	if err != nil {
+		dlog.Errorf(ctx, "cannot read excluded variables configmap: %w", err)
+		return envVars
+	}
+
+	if cm != nil {
+		for key := range cm.Data {
+			if _, ok := envVars[key]; ok {
+				delete(envVars, key)
+			}
+		}
+	}
+
+	return envVars
 }
 
 func (m *service) Tunnel(server rpc.Manager_TunnelServer) error {

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -842,27 +842,25 @@ func (m *service) ReviewIntercept(ctx context.Context, rIReq *rpc.ReviewIntercep
 func (m *service) removeExlcudedEnvVars(ctx context.Context, envVars map[string]string) map[string]string {
 	k8sConfig, err := rest.InClusterConfig()
 	if err != nil {
-		dlog.Errorf(ctx, "Unable to create in cluster config: %w", err)
+		dlog.Errorf(ctx, "Unable to create in cluster config: %v", err)
 		return envVars
 	}
 
 	clientset, err := kubernetes.NewForConfig(k8sConfig)
 	if err != nil {
-		dlog.Errorf(ctx, "unable to create kubernetes clientset: %w", err)
+		dlog.Errorf(ctx, "unable to create kubernetes clientset: %v", err)
 		return envVars
 	}
 
 	cm, err := clientset.CoreV1().ConfigMaps(managerutil.GetEnv(ctx).ManagerNamespace).Get(ctx, "telepresence-excluded-variables", v1.GetOptions{})
 	if err != nil {
-		dlog.Errorf(ctx, "cannot read excluded variables configmap: %w", err)
+		dlog.Errorf(ctx, "cannot read excluded variables configmap: %v", err)
 		return envVars
 	}
 
 	if cm != nil {
 		for key := range cm.Data {
-			if _, ok := envVars[key]; ok {
-				delete(envVars, key)
-			}
+			delete(envVars, key)
 		}
 	}
 

--- a/integration_test/intercept_env_test.go
+++ b/integration_test/intercept_env_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"os"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+type interceptEnvSuite struct {
+	itest.Suite
+	itest.NamespacePair
+}
+
+func (s *interceptEnvSuite) SuiteName() string {
+	return "InterceptEnv"
+}
+
+func init() {
+	itest.AddTrafficManagerSuite("", func(h itest.NamespacePair) itest.TestingSuite {
+		return &interceptEnvSuite{Suite: itest.Suite{Harness: h}, NamespacePair: h}
+	})
+}
+
+func (s *interceptEnvSuite) TearDownTest() {
+	itest.TelepresenceQuitOk(s.Context())
+}
+
+func (s *interceptEnvSuite) Test_ExcludeVariables() {
+	// given
+	ctx := s.Context()
+	err := s.TelepresenceHelmInstall(ctx, true, "--set", "intercept.environment.excluded={DATABASE_HOST,DATABASE_PASSWORD}")
+	s.Assert().NoError(err)
+	s.ApplyApp(ctx, "echo_with_env", "deploy/echo-easy")
+
+	defer s.DeleteSvcAndWorkload(ctx, "deploy", "echo-easy")
+	defer os.RemoveAll("echo.env") //nolint:errcheck // dont need to catch the err
+
+	// when
+	itest.TelepresenceOk(ctx, "intercept", "echo-easy", "--namespace", s.AppNamespace(), "--env-file", "echo.env")
+
+	// then
+	file, err := os.ReadFile("echo.env")
+	s.Assert().NoError(err)
+
+	s.Assert().NotContains(string(file), "DATABASE_HOST")
+	s.Assert().NotContains(string(file), "DATABASE_PASSWORD")
+	s.Assert().Contains(string(file), "TEST=DATA")
+	s.Assert().Contains(string(file), "INTERCEPT=ENV")
+}

--- a/integration_test/testdata/k8s/echo_with_env.yaml
+++ b/integration_test/testdata/k8s/echo_with_env.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "echo-easy"
+spec:
+  type: ClusterIP
+  selector:
+    service: echo-easy
+  ports:
+    - name: proxied
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "echo-easy"
+  labels:
+    service: echo-easy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: echo-easy
+  template:
+    metadata:
+      labels:
+        service: echo-easy
+    spec:
+      containers:
+        - name: echo-easy
+          image: jmalloc/echo-server
+          env:
+            - name: TEST
+              value: "DATA"
+            - name: INTERCEPT
+              value: "ENV"
+            - name: DATABASE_HOST
+              value: "HOST_NAME"
+            - name: DATABASE_PASSWORD
+              value: "SUPER_SECRET_PASSWORD"
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi


### PR DESCRIPTION
## Description
Added a new configmap that is customizable with an array of env var keys, that we then remove when reviewing an intercept at the traffic-manager so that administrators of the cluster can forbid certain variables.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
