### PR TITLE
Fix static routing configuration when there's no gateway

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -96,3 +96,7 @@ items:
         title: Fix wrong default value for disableGlobal and agentArrival
         body: >-
           Params .intercept.disableGlobal and .timeouts.agentArrival are now correctly honored.
+      - type: bugfix
+        title: Fix static route configuration error when no gateway is specified (linux)
+        body: >-
+          When directly connected to a network, the static route configuration no longer passes '<nil>' as the gateway.

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -65,9 +65,9 @@ func (r *Route) Routes(ip net.IP) bool {
 
 func (r *Route) String() string {
 	if r.Default {
-		return fmt.Sprintf("default via %s dev %s, gw %s", r.LocalIP, r.Interface.Name, r.Gateway)
+		return fmt.Sprintf("default, gw %s, dev %s, src %s", r.Gateway, r.Interface.Name, r.LocalIP)
 	}
-	return fmt.Sprintf("%s via %s dev %s, gw %s", r.RoutedNet, r.LocalIP, r.Interface.Name, r.Gateway)
+	return fmt.Sprintf("%s, gw %s, dev %s, src %s", r.RoutedNet, r.Gateway, r.Interface.Name, r.LocalIP)
 }
 
 // AddStatic adds a specific route. This can be used to prevent certain IP addresses

--- a/pkg/routing/routing_linux.go
+++ b/pkg/routing/routing_linux.go
@@ -165,9 +165,15 @@ func GetRoute(ctx context.Context, routedNet *net.IPNet) (*Route, error) {
 }
 
 func (r *Route) addStatic(ctx context.Context) error {
-	return dexec.CommandContext(ctx, "ip", "route", "add", r.RoutedNet.String(), "via", r.Gateway.String(), "dev", r.Interface.Name).Run()
+	if r.Gateway != nil {
+		return dexec.CommandContext(ctx, "ip", "route", "add", r.RoutedNet.String(), "via", r.Gateway.String(), "dev", r.Interface.Name).Run()
+	}
+	return dexec.CommandContext(ctx, "ip", "route", "add", r.RoutedNet.String(), "dev", r.Interface.Name).Run()
 }
 
 func (r *Route) removeStatic(ctx context.Context) error {
-	return dexec.CommandContext(ctx, "ip", "route", "del", r.RoutedNet.String(), "via", r.Gateway.String(), "dev", r.Interface.Name).Run()
+	if r.Gateway != nil {
+		return dexec.CommandContext(ctx, "ip", "route", "del", r.RoutedNet.String(), "via", r.Gateway.String(), "dev", r.Interface.Name).Run()
+	}
+	return dexec.CommandContext(ctx, "ip", "route", "del", r.RoutedNet.String(), "dev", r.Interface.Name).Run()
 }


### PR DESCRIPTION
## Description

The local daemon fails to configure static routes in some cases when connected to a vpn on linux.

```
2023-06-01 04:11:09.2748 info    daemon/session/network : started command ["ip" "route" "add" "10.161.100.3/32" "via" "<nil>" "dev" "ppp0"] : dexec.pid="1233446"
2023-06-01 04:11:09.2749 info    daemon/session/network :  : dexec.pid="1233446" dexec.stream="stdin" dexec.err="EOF"
2023-06-01 04:11:09.2771 info    daemon/session/network :  : dexec.pid="1233446" dexec.stream="stdout+stderr" dexec.data="Error: inet address is expected rather than \"<nil>\".\n"
2023-06-01 04:11:09.2775 info    daemon/session/network : finished with error: exit status 1 : dexec.pid="1233446"
2023-06-01 04:11:09.2776 error   daemon/session/network : failed to add static route 10.161.100.3/32 via 10.19.248.25 dev ppp0, gw <nil>: exit status 1
```

And the error message in the log lists the `src` ip on the `via` field instead of the `gw` ip which is what is used in the `ip route` command.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.md`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
