### PR TITLE
Add IS_POD_DAEMON env var

### DIFF
--- a/pkg/client/envconfig.go
+++ b/pkg/client/envconfig.go
@@ -34,6 +34,7 @@ type Env struct {
 	// The address that the user daemon is listening to (unless it is started by the client and uses a named pipe or unix socket).
 	UserDaemonAddress string `env:"TELEPRESENCE_USER_DAEMON_ADDRESS, parser=possibly-empty-string,default="`
 	ScoutDisable      bool   `env:"SCOUT_DISABLE, parser=strconv.ParseBool, default=0"`
+	IsPodDaemon       bool   `env:"IS_POD_DAEMON, parser=strconv.ParseBool, default=0"`
 
 	lookupFunc func(key string) (string, bool)
 }


### PR DESCRIPTION
## Description

Incorporated IS_POD_DAEMON environment variable in the OSS repository for utilization in the proprietary version of Telepresence.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.md`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
