### PR TITLE
Added markdown content and links to the github releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,17 @@ jobs:
         with:
           artifacts: "binaries/*"
           token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            ## Official Release Artifacts
+            ### Linux
+               - 📦 [telepresence-linux-amd64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-amd64)
+            ### OSX Darwin
+               - 📦 [telepresence-darwin-amd64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-amd64)
+               - 📦 [telepresence-darwin-arm64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-arm64)
+            ### Windows
+               - 📦 [telepresence-windows-amd64.exe](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-windows-amd64.exe)
+
+            For more builds across platforms and architectures, see the `Assets` section below.
+            And for more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start/).
+
+            ![Assets](https://static.scarf.sh/a.png?x-pxid=d842651a-2e4d-465a-98e1-4808722c01ab)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,12 +52,12 @@ jobs:
           body: |
             ## Official Release Artifacts
             ### Linux
-               - 📦 [telepresence-linux-amd64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-amd64)
+               - 📦 [telepresence-linux-amd64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-linux-amd64)
             ### OSX Darwin
-               - 📦 [telepresence-darwin-amd64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-amd64)
-               - 📦 [telepresence-darwin-arm64](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-arm64)
+               - 📦 [telepresence-darwin-amd64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-darwin-amd64)
+               - 📦 [telepresence-darwin-arm64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-darwin-arm64)
             ### Windows
-               - 📦 [telepresence-windows-amd64.exe](https://ambassador-labs.gateway.scarf.sh/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-windows-amd64.exe)
+               - 📦 [telepresence-windows-amd64.exe](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-windows-amd64.exe)
 
             For more builds across platforms and architectures, see the `Assets` section below.
             And for more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start/).


### PR DESCRIPTION
## Description

Added markdown content and links to the GitHub releases. This will enable page views and download statistics for Telepresence OSS as part of the C3 Data Eng story. This change should not impact Telepresence's code base and should only add automation around the current release body manual edits that were done as experiments. Here's an example: https://github.com/telepresenceio/telepresence/releases/tag/v2.13.2

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
