### PR TITLE
Fix backward compatibility issue causing lack of mounts.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -47,6 +47,12 @@ items:
         body: >-
           Added a new config map that can take an array of environment variables that will
           then be excluded from an intercept that retrieves the environment of a pod.
+
+      - type: bugfix
+        title: Fixed traffic-agent backward incompatibility issue causing lack of remote mounts
+        body: >-
+          A traffic-agent of version 2.13.3 (or 1.13.15) would not propagate the directories under
+          <code>/var/run/secrets</code> when used with a traffic manager older than 2.13.3.
   - version: 2.13.3
     date: "2023-05-25"
     notes:


### PR DESCRIPTION
## Description

A traffic-agent of version 2.13.3 (or 1.13.15) would not propagate the directories under `/var/run/secrets` when used with a traffic manager older than 2.13.3.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
