### PR TITLE
Fix backward compatibility issue causing lack of mounts.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -47,6 +47,12 @@ items:
         body: >-
           Added a new config map that can take an array of environment variables that will
           then be excluded from an intercept that retrieves the environment of a pod.
+
+      - type: bugfix
+        title: Fixed traffic-agent backward incompatibility issue causing lack of remote mounts
+        body: >-
+          A traffic-agent of version 2.13.3 (or 1.13.15) would not propagate the directories under
+          <code>/var/run/secrets</code> when used with a traffic manager older than 2.13.3.
   - version: 2.13.3
     date: "2023-05-25"
     notes:

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.13.3 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.14.0-rc.1 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/pkg/vif/testdata/router/go.sum
+++ b/pkg/vif/testdata/router/go.sum
@@ -255,8 +255,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/telepresenceio/telepresence/rpc/v2 v2.13.3 h1:fK2p1OUXfG+TaFT8uVBWTAd/fYs9eZROKj9+uVmO2UE=
-github.com/telepresenceio/telepresence/rpc/v2 v2.13.3/go.mod h1:jM0Ke6ak8WGUqenJdrNxoAJF7L2gc/+HnyeXBN0qIK4=
+github.com/telepresenceio/telepresence/rpc/v2 v2.14.0-rc.1 h1:Dahza7smea9uMNtdBdTIzf+jfY/tXNhm2soG7ZySTzw=
+github.com/telepresenceio/telepresence/rpc/v2 v2.14.0-rc.1/go.mod h1:jM0Ke6ak8WGUqenJdrNxoAJF7L2gc/+HnyeXBN0qIK4=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=


### PR DESCRIPTION
## Description

A traffic-agent of version 2.13.3 (or 1.13.15) would not propagate the directories under `/var/run/secrets` when used with a traffic manager older than 2.13.3.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
