### PR TITLE
Fix problem setting TM-namespace using the kubeconfig extension.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -31,6 +31,15 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.14.1
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Fixed problem setting traffic manager namespace using the kubeconfig extension.
+        body: >-
+          Fixes a regression introduced in version 2.10.5, making it impossible to set the traffic-manager namespace
+          using the telepresence.io kubeconfig extension.
+        docs: https://www.getambassador.io/docs/telepresence/latest/reference/config#manager
   - version: 2.14.0
     date: "2023-06-12"
     notes:

--- a/pkg/client/k8s_config.go
+++ b/pkg/client/k8s_config.go
@@ -260,7 +260,9 @@ func newKubeconfig(c context.Context, flagMap map[string]string, managerNamespac
 		k.KubeconfigExtension.Manager = &ManagerConfig{}
 	}
 
-	k.KubeconfigExtension.Manager.Namespace = managerNamespaceOverride
+	if managerNamespaceOverride != "" {
+		k.KubeconfigExtension.Manager.Namespace = managerNamespaceOverride
+	}
 
 	if k.KubeconfigExtension.Manager.Namespace == "" {
 		k.KubeconfigExtension.Manager.Namespace = GetEnv(c).ManagerNamespace


### PR DESCRIPTION
## Description

Fixes a regression introduced in version 2.10.5, making it impossible to set the traffic-manager namespace using the telepresence.io kubeconfig extension.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
