### PR TITLE
Incorporate tests for verifying OSS binaries in the post-release phase

### DIFF
--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -1,0 +1,43 @@
+name: Test OSS Release binaries
+description: Test OSS Release binaries
+inputs:
+  release_version:
+    description: "The current release of Telepresence in the form of v2.x.x"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: check version binaries
+      shell: bash
+      run: |
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-amd64 -o ./telepresence
+        fi
+        if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence
+        fi
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence
+        fi
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence
+        fi
+        chmod +x ./telepresence
+
+        output=$(./telepresence version)
+
+        if [ $? -eq 0 ]; then
+            echo "Telepresence command executed successfully"
+        else
+            echo "Telepresence command failed"
+            exit 1
+        fi
+
+        echo "$output" | grep -q "${{ inputs.release_version }}"
+
+        if [ $? -eq 0 ]; then
+            echo "Version match!"
+        else
+            echo "Version does not match!"
+            exit 1
+        fi

--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -8,19 +8,21 @@ runs:
   using: composite
   steps:
     - name: check version binaries
+      env:
+        DOWNLOAD_URL: "https://app.getambassador.io/download/tel2oss/releases/download"
       shell: bash
       run: |
         if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-darwin-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Windows" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Linux" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         chmod +x ./telepresence
 

--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -35,7 +35,7 @@ runs:
             exit 1
         fi
 
-        echo "$output" | grep -q "${{ inputs.release_version }}"
+        echo "$output" | grep -q "Client\s*:\s*${{ inputs.release_version }}"
 
         if [ $? -eq 0 ]; then
             echo "Version match!"

--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -11,16 +11,16 @@ runs:
       shell: bash
       run: |
         if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "X64" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-amd64 -o ./telepresence
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "macOS" ] && [ "${{ runner.arch }}" = "ARM64" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Windows" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Linux" ]; then
-          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence
+          curl -fL https://app.getambassador.io/download/tel2oss/releases/download/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         chmod +x ./telepresence
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,3 +64,21 @@ jobs:
             And for more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start/).
 
             ![Assets](https://static.scarf.sh/a.png?x-pxid=d842651a-2e4d-465a-98e1-4808722c01ab)
+
+  test-release:
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        runners:
+          - ubuntu-latest
+          - macos-latest
+          - macOS-arm64
+          - windows-2019
+    runs-on: ${{ matrix.runners }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test release
+        uses: ./.github/actions/test-release
+        with:
+          release_version: ${{ github.ref_name }}


### PR DESCRIPTION
## Description

Incorporate tests for verifying OSS binaries in the post-release phase : 
- Validate links
- Validate `telepresence version` execution and output

Fix this [CA](https://www.notion.so/datawire/Add-automated-test-for-the-OSS-builds-in-a-post-build-action-to-ensure-the-version-is-reporting-corr-1dd318d8abc04008aa5ec5dc7ea14888)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
