### PR TITLE
Restore use of pull_request_target everywhere.

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,6 +1,6 @@
 name: "Integration Tests"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 jobs:

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - release/v2
-  pull_request: {}
+  pull_request_target:
 jobs:
   trivy-container-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -1,6 +1,6 @@
 name: "License verification"
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 jobs:
   dependency_info_linux:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,6 +1,6 @@
 name: "Build and Unit test"
 on:
-  pull_request:
+  pull_request_target:
 env:
   HOMEBREW_NO_INSTALL_FROM_API:
 jobs:


### PR DESCRIPTION
Using `pull_request` as the target is unsafe so this commit reverts to using `pull_request_target`.