### PR TITLE
Have KillProcessGroup differ between os.Kill and os.Interrupt on Windows

### DIFF
--- a/pkg/dpipe/dpipe_windows.go
+++ b/pkg/dpipe/dpipe_windows.go
@@ -9,5 +9,5 @@ import (
 )
 
 func killProcess(ctx context.Context, cmd *exec.Cmd) {
-	proc.KillProcessGroup(ctx, cmd, os.Interrupt)
+	proc.KillProcessGroup(ctx, cmd, os.Kill)
 }


### PR DESCRIPTION
The signal argument to `proc.KillProcessGroup` was ignored on Windows. This commit changes this so that an os.Interrupt will generate a control-break instead of terminating the process.