### PR TITLE
Add OS agnostic SIGTERM

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: nick-invision/retry/@v2.4.0
         with:
           max_attempts: 3
-          timeout_minutes: 10
+          timeout_minutes: 12
           command: |
             # We want to validate that tests still pass, even if the metrics host
             # points to a broken IP
@@ -76,7 +76,7 @@ jobs:
         uses: nick-invision/retry/@v2.4.0
         with:
           max_attempts: 3
-          timeout_minutes: 10
+          timeout_minutes: 12
           command: |
             $ENV:DTEST_KUBECONFIG = "${{ steps.kluster.outputs.kubeconfig }}"
             $ENV:DTEST_REGISTRY = "docker.io/datawire"

--- a/pkg/proc/exec_unix.go
+++ b/pkg/proc/exec_unix.go
@@ -15,6 +15,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
 )
 
+const SIGTERM = unix.SIGTERM
+
 var CommandContext = dexec.CommandContext //nolint:gochecknoglobals // OS-specific function replacement
 
 var SignalsToForward = []os.Signal{unix.SIGINT, unix.SIGTERM} //nolint:gochecknoglobals // OS-specific constant list

--- a/pkg/proc/exec_windows.go
+++ b/pkg/proc/exec_windows.go
@@ -17,6 +17,9 @@ import (
 
 var SignalsToForward = []os.Signal{os.Interrupt} //nolint:gochecknoglobals // OS-specific constant list
 
+// SIGTERM uses os.Interrupt on Windows as a best effort.
+var SIGTERM = os.Interrupt //nolint:gochecknoglobals // OS-specific constant
+
 func CommandContext(ctx context.Context, name string, args ...string) *dexec.Cmd {
 	cmd := dexec.CommandContext(ctx, name, args...)
 	createNewProcessGroup(cmd.Cmd)


### PR DESCRIPTION
Uses os.Interrupt on Windows. SIGTERM is needed when terminating scripts and will evaluate to Ctrl-Break on windows, which is probably fine.