### PR TITLE
Make it possible to extend the set of daemon subcommands.

### DIFF
--- a/pkg/client/cli/cmd/telepresence.go
+++ b/pkg/client/cli/cmd/telepresence.go
@@ -62,9 +62,7 @@ func TelepresenceDaemon(ctx context.Context) *cobra.Command {
 		SilenceUsage:  true, // our FlagErrorFunc will handle it
 	}
 	cmd.SetContext(ctx)
-	cmd.AddCommand(kubeauth.Command())
-	cmd.AddCommand(userDaemon.Command())
-	cmd.AddCommand(rootd.Command())
+	AddSubCommands(cmd)
 	return cmd
 }
 
@@ -136,6 +134,10 @@ func WithSubCommands(ctx context.Context) context.Context {
 		config(), connectCmd(), currentClusterId(), gatherLogs(), gatherTraces(), genYAML(), helm(), interceptCmd(), leave(),
 		list(), loglevel(), quit(), statusCmd(), testVPN(), uninstall(), uploadTraces(), version(),
 	)
+}
+
+func WithDaemonSubCommands(ctx context.Context) context.Context {
+	return MergeSubCommands(ctx, kubeauth.Command(), userDaemon.Command(), rootd.Command())
 }
 
 type subCommandsKey struct{}

--- a/pkg/client/cli/main.go
+++ b/pkg/client/cli/main.go
@@ -46,6 +46,11 @@ func InitContext(ctx context.Context) context.Context {
 		ctx = connect.WithCommandInitializer(ctx, connect.CommandInitializer)
 		ctx = cmd.WithSubCommands(ctx)
 	}
+	if client.IsDaemon() {
+		ctx = cmd.WithDaemonSubCommands(ctx)
+	} else {
+		ctx = cmd.WithSubCommands(ctx)
+	}
 	return ctx
 }
 


### PR DESCRIPTION
This commit changes how the daemon subcommands are declared so that the same type of logic as the CLI frontend command is used. This makes it possible to extend the command set.