### PR TITLE
Use gosimports instead of goimports to enforce correct grouping.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,10 +58,6 @@ linters-settings:
   gocognit:
     min-complexity: 60
 
-  goimports:
-    # A comma-separated list
-    local-prefixes: github.com/telepresenceio,github.com/datawire
-
   lll:
     line-length: 180
     tab-width: 2
@@ -99,7 +95,6 @@ linters:
     - gofmt
     - gofumpt
     - goheader
-    - goimports
     - gomodguard
     - goprintffuncname
     - gosimple
@@ -138,6 +133,7 @@ linters:
     - goconst
     - goerr113
     - godox
+    - goimports
     - gomnd
     - gomoddirectives
     - gosec

--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -127,6 +127,7 @@ tools/protoc-gen-go      = $(TOOLSBINDIR)/protoc-gen-go$(EXE)
 tools/protoc-gen-go-grpc = $(TOOLSBINDIR)/protoc-gen-go-grpc$(EXE)
 tools/ko                 = $(TOOLSBINDIR)/ko$(EXE)
 tools/golangci-lint      = $(TOOLSBINDIR)/golangci-lint$(EXE)
+tools/gosimports         = $(TOOLSBINDIR)/gosimports$(EXE)
 tools/go-mkopensource    = $(TOOLSBINDIR)/go-mkopensource$(EXE)
 $(TOOLSBINDIR)/%$(EXE): $(TOOLSSRCDIR)/%/go.mod $(TOOLSSRCDIR)/%/pin.go
 	cd $(<D) && GOOS= GOARCH= go build -o $(abspath $@) $$(sed -En 's,^import "(.*)".*,\1,p' pin.go)

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -9,16 +9,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dhttp"

--- a/integration_test/testdata/apiserveraccess/main.go
+++ b/integration_test/testdata/apiserveraccess/main.go
@@ -25,10 +25,12 @@ import (
 // This service is meant for testing the cluster side Telepresence API service.
 //
 // Publish image to cluster:
-//   ko publish -B ./integration_test/testdata/apiserveraccess [--insecure-registry]
+//
+//	ko publish -B ./integration_test/testdata/apiserveraccess [--insecure-registry]
 //
 // Deploy it:
-//   kubectl apply -f ./k8s/apitest.yaml
+//
+//	kubectl apply -f ./k8s/apitest.yaml
 //
 // Run it locally using an intercept with -- so that TELEPRESENCE_INTERCEPT_ID is propagated in the env
 func main() {

--- a/pkg/client/cli/cmd/upload_traces.go
+++ b/pkg/client/cli/cmd/upload_traces.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 )
 
 func uploadTraces() *cobra.Command {

--- a/pkg/client/config_windows.go
+++ b/pkg/client/config_windows.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
-
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/client/logging/stat_darwin.go
+++ b/pkg/client/logging/stat_darwin.go
@@ -3,10 +3,7 @@ package logging
 import (
 	"fmt"
 	"os"
-
-	//nolint:depguard // We specifically need "syscall.Stat_t" rather than "unix.Stat_t" for
-	// fs.File.Sys().
-	"syscall"
+	"syscall" //nolint:depguard // We specifically need "syscall.Stat_t" rather than "unix.Stat_t" for fs.File.Sys().
 	"time"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"

--- a/pkg/client/logging/stat_windows.go
+++ b/pkg/client/logging/stat_windows.go
@@ -4,10 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-
-	//nolint:depguard // We specifically need "syscall.Win32FileAttributeData" rather than
-	// "windows.Win32FileAttributeData" for fs.File.Sys().
-	"syscall"
+	"syscall" //nolint:depguard // We specifically need "syscall.Win32FileAttributeData" rather than "windows.Win32FileAttributeData" for fs.File.Sys().
 	"time"
 
 	"github.com/hectane/go-acl/api"

--- a/pkg/client/userd/session.go
+++ b/pkg/client/userd/session.go
@@ -3,12 +3,11 @@ package userd
 import (
 	"context"
 
+	"github.com/blang/semver"
 	"google.golang.org/grpc"
 	core "k8s.io/api/core/v1"
 	typed "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-
-	"github.com/blang/semver"
 
 	"github.com/datawire/dlib/dgroup"
 	"github.com/telepresenceio/telepresence/rpc/v2/common"

--- a/pkg/dnet/testdata/mockserver/mockserver.go
+++ b/pkg/dnet/testdata/mockserver/mockserver.go
@@ -11,9 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-
-	//nolint:depguard // We really do want the socat to be minimal
-	"os/exec"
+	"os/exec" //nolint:depguard // We really do want the socat to be minimal
 	"path"
 	"regexp"
 	"strings"

--- a/pkg/dpipe/dpipe.go
+++ b/pkg/dpipe/dpipe.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	//nolint:depguard // We want no logging and no soft-context signal handling
-	"os/exec"
+	"os/exec" //nolint:depguard // We want no logging and no soft-context signal handling
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"

--- a/pkg/dpipe/dpipe_test.go
+++ b/pkg/dpipe/dpipe_test.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	//nolint:depguard // This short script has no logging and no Contexts.
-	"os/exec"
+	"os/exec" //nolint:depguard // This short script has no logging and no Contexts.
 	"runtime"
 	"testing"
 	"time"

--- a/pkg/dpipe/dpipe_unix.go
+++ b/pkg/dpipe/dpipe_unix.go
@@ -6,10 +6,8 @@ package dpipe
 import (
 	"context"
 	"os"
+	"os/exec" //nolint:depguard // We want no logging and no soft-context signal handling
 	"time"
-
-	//nolint:depguard // We want no logging and no soft-context signal handling
-	"os/exec"
 
 	"golang.org/x/sys/unix"
 )

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -8,9 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-
 	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
 func TestGetRoutingTable_defaultRoute(t *testing.T) {

--- a/pkg/vif/device.go
+++ b/pkg/vif/device.go
@@ -6,15 +6,14 @@ import (
 	"net"
 	"sync"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"gvisor.dev/gvisor/pkg/bufferv2"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/routing"

--- a/pkg/vif/device_linux.go
+++ b/pkg/vif/device_linux.go
@@ -8,9 +8,8 @@ import (
 	"runtime"
 	"unsafe"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/vif/buffer"
 )

--- a/tools/src/gosimports/go.mod
+++ b/tools/src/gosimports/go.mod
@@ -1,0 +1,11 @@
+module local
+
+go 1.19
+
+require github.com/rinchsan/gosimports v0.3.8
+
+require (
+	golang.org/x/mod v0.9.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
+)

--- a/tools/src/gosimports/go.sum
+++ b/tools/src/gosimports/go.sum
@@ -1,0 +1,8 @@
+github.com/rinchsan/gosimports v0.3.8 h1:X4Pb9yFf6teHvogorT04yK/0W2Df7eHO79biCcYrA4c=
+github.com/rinchsan/gosimports v0.3.8/go.mod h1:t0567k69sUHjLvJMPDsV31THZC+8UIbY1oL7NW+0I2c=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=

--- a/tools/src/gosimports/pin.go
+++ b/tools/src/gosimports/pin.go
@@ -1,0 +1,6 @@
+//go:build pin
+// +build pin
+
+package ignore
+
+import "github.com/rinchsan/gosimports/cmd/gosimports"


### PR DESCRIPTION
See https://github.com/rinchsan/gosimports for more info why this is a good idea (or look at the changes that gosimports detected and modified in this commit).