### PR TITLE
Add consumption state to the traffic-manager

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -178,7 +178,8 @@ release-binary: $(TELEPRESENCE)
 tel2-image: build-deps
 	mkdir -p $(BUILDDIR)
 	printf $(TELEPRESENCE_VERSION) > $(BUILDDIR)/version.txt ## Pass version in a file instead of a --build-arg to maximize cache usage
-	docker build --target tel2 --tag tel2 --tag $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f build-aux/docker/images/Dockerfile.traffic .
+	$(eval PLATFORM_ARG := $(if $(TELEPRESENCE_TEL2_IMAGE_PLATFORM), --platform=$(TELEPRESENCE_TEL2_IMAGE_PLATFORM),))
+	docker build $(PLATFORM_ARG) --target tel2 --tag tel2 --tag $(TELEPRESENCE_REGISTRY)/tel2:$(patsubst v%,%,$(TELEPRESENCE_VERSION)) -f build-aux/docker/images/Dockerfile.traffic .
 
 .PHONY: client-image
 client-image: build-deps

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -183,9 +183,12 @@ func (s *service) GetClientConfig(ctx context.Context, _ *empty.Empty) (*rpc.CLI
 func (s *service) Remain(ctx context.Context, req *rpc.RemainRequest) (*empty.Empty, error) {
 	// ctx = WithSessionInfo(ctx, req.GetSession())
 	// dlog.Debug(ctx, "Remain called")
+	sessionID := req.GetSession().GetSessionId()
 	if ok := s.state.MarkSession(req, s.clock.Now()); !ok {
-		return nil, status.Errorf(codes.NotFound, "Session %q not found", req.GetSession().GetSessionId())
+		return nil, status.Errorf(codes.NotFound, "Session %q not found", sessionID)
 	}
+
+	s.state.RefreshSessionConsumptionMetrics(sessionID)
 
 	return &empty.Empty{}, nil
 }

--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -1,0 +1,59 @@
+package state
+
+import (
+	"time"
+)
+
+// SessionConsumptionMetricsStaleTTL is the duration after which we consider the metrics to be staled, meaning
+// that they should not be updated anymore since the user doesn't really use Telepresence at the moment.
+const SessionConsumptionMetricsStaleTTL = 1 * time.Minute // TODO: Increase.
+
+type SessionConsumptionMetrics struct {
+	Duration   uint32
+	LastUpdate time.Time
+}
+
+func (s *state) unlockedAddSessionConsumption(sessionID string) {
+	s.sessionConsumptionMetrics[sessionID] = &SessionConsumptionMetrics{
+		Duration:   0,
+		LastUpdate: time.Now(),
+	}
+}
+
+func (s *state) unlockedRemoveSessionConsumption(sessionID string) {
+	delete(s.sessionConsumptionMetrics, sessionID)
+}
+
+func (s *state) GetSessionConsumptionMetrics(sessionID string) *SessionConsumptionMetrics {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sessionConsumptionMetrics[sessionID]
+}
+
+func (c *state) GetAllSessionConsumptionMetrics() map[string]*SessionConsumptionMetrics {
+	scmCopy := make(map[string]*SessionConsumptionMetrics)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for sessionID, val := range c.sessionConsumptionMetrics {
+		valCopy := *val
+		scmCopy[sessionID] = &valCopy
+	}
+	return scmCopy
+}
+
+// RefreshSessionConsumptionMetrics refreshes the metrics associated to a specific session.
+func (s *state) RefreshSessionConsumptionMetrics(sessionID string) {
+	lastMark := s.GetSession(sessionID).LastMarked()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	consumption := s.sessionConsumptionMetrics[sessionID]
+
+	// if last mark is more than SessionConsumptionMetricsStaleTTL old, it means the duration metric should stop being
+	// updated since the user machine is maybe in standby.
+	isStale := time.Now().After(lastMark.Add(SessionConsumptionMetricsStaleTTL))
+	if !isStale {
+		consumption.Duration += uint32(time.Since(consumption.LastUpdate).Seconds())
+	}
+
+	consumption.LastUpdate = time.Now()
+}

--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -7,7 +7,7 @@ import (
 
 // SessionConsumptionMetricsStaleTTL is the duration after which we consider the metrics to be staled, meaning
 // that they should not be updated anymore since the user doesn't really use Telepresence at the moment.
-const SessionConsumptionMetricsStaleTTL = 1 * time.Minute // TODO: Increase.
+const SessionConsumptionMetricsStaleTTL = 15 * time.Minute
 
 func NewSessionConsumptionMetrics() *SessionConsumptionMetrics {
 	return &SessionConsumptionMetrics{
@@ -91,8 +91,8 @@ func (s *state) RefreshSessionConsumptionMetrics(sessionID string) {
 	lastMarked := session.LastMarked()
 	consumption := s.sessions[sessionID].ConsumptionMetrics()
 
-	// if last mark is more than SessionConsumptionMetricsStaleTTL old, it means the duration metric should stop being
-	// updated since the user machine is maybe in standby.
+	// If the last mark is older than the SessionConsumptionMetricsStaleTTL, it indicates that the duration
+	// metric should no longer be updated, as the user's machine may be in standby.
 	isStale := time.Now().After(lastMarked.Add(SessionConsumptionMetricsStaleTTL))
 	if !isStale {
 		consumption.ConnectDuration += uint32(time.Since(consumption.LastUpdate).Seconds())

--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -24,9 +24,9 @@ type SessionConsumptionMetrics struct {
 	LastUpdate      time.Time
 
 	// data from client to the traffic manager.
-	fromClientBytes uint64
+	FromClientBytes uint64
 	// data from the traffic manager to the client.
-	toClientBytes uint64
+	ToClientBytes uint64
 
 	FromClientBytesChan chan uint64
 	ToClientBytesChan   chan uint64
@@ -42,12 +42,12 @@ func (sc *SessionConsumptionMetrics) RunCollect(ctx context.Context) {
 			if !ok {
 				return
 			}
-			sc.fromClientBytes += b
+			sc.FromClientBytes += b
 		case b, ok := <-sc.ToClientBytesChan:
 			if !ok {
 				return
 			}
-			sc.toClientBytes += b
+			sc.ToClientBytes += b
 		}
 	}
 }

--- a/cmd/traffic/cmd/manager/state/consumption_test.go
+++ b/cmd/traffic/cmd/manager/state/consumption_test.go
@@ -16,14 +16,14 @@ func (s *suiteState) TestRefreshSessionConsumptionMetrics() {
 	s.state.sessions["session-1"] = session1
 	s.state.sessions["session-2"] = &agentSessionState{}
 	s.state.sessions["session-3"] = session3
-	s.state.sessionConsumptionMetrics["session-1"] = &SessionConsumptionMetrics{
-		Duration:   42,
-		LastUpdate: now.Add(-time.Minute),
+	session1.consumptionMetrics = &SessionConsumptionMetrics{
+		ConnectDuration: 42,
+		LastUpdate:      now.Add(-time.Minute),
 	}
 	// staled metric
-	s.state.sessionConsumptionMetrics["session-3"] = &SessionConsumptionMetrics{
-		Duration:   36,
-		LastUpdate: session3.lastMarked,
+	session3.consumptionMetrics = &SessionConsumptionMetrics{
+		ConnectDuration: 36,
+		LastUpdate:      session3.lastMarked,
 	}
 
 	// when
@@ -32,7 +32,7 @@ func (s *suiteState) TestRefreshSessionConsumptionMetrics() {
 	s.state.RefreshSessionConsumptionMetrics("session-3") // should not refresh a stale metric.
 
 	// then
-	assert.Len(s.T(), s.state.GetAllSessionConsumptionMetrics(), 2)
-	assert.True(s.T(), (s.state.sessionConsumptionMetrics["session-1"].Duration) > 42)
-	assert.Equal(s.T(), 36, int(s.state.sessionConsumptionMetrics["session-3"].Duration))
+	assert.Len(s.T(), s.state.GetAllSessionConsumptionMetrics(), 3)
+	assert.True(s.T(), (s.state.sessions["session-1"].ConsumptionMetrics().ConnectDuration) > 42)
+	assert.Equal(s.T(), 36, int(s.state.sessions["session-3"].ConsumptionMetrics().ConnectDuration))
 }

--- a/cmd/traffic/cmd/manager/state/consumption_test.go
+++ b/cmd/traffic/cmd/manager/state/consumption_test.go
@@ -32,7 +32,10 @@ func (s *suiteState) TestRefreshSessionConsumptionMetrics() {
 	s.state.RefreshSessionConsumptionMetrics("session-3") // should not refresh a stale metric.
 
 	// then
-	assert.Len(s.T(), s.state.GetAllSessionConsumptionMetrics(), 3)
-	assert.True(s.T(), (s.state.sessions["session-1"].ConsumptionMetrics().ConnectDuration) > 42)
-	assert.Equal(s.T(), 36, int(s.state.sessions["session-3"].ConsumptionMetrics().ConnectDuration))
+	ccs1 := s.state.sessions["session-1"].(*clientSessionState)
+	ccs3 := s.state.sessions["session-3"].(*clientSessionState)
+
+	assert.Len(s.T(), s.state.GetAllSessionConsumptionMetrics(), 2)
+	assert.True(s.T(), (ccs1.ConsumptionMetrics().ConnectDuration) > 42)
+	assert.Equal(s.T(), 36, int(ccs3.ConsumptionMetrics().ConnectDuration))
 }

--- a/cmd/traffic/cmd/manager/state/consumption_test.go
+++ b/cmd/traffic/cmd/manager/state/consumption_test.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *suiteState) TestRefreshSessionConsumptionMetrics() {
+	// given
+	now := time.Now()
+	session1 := &clientSessionState{}
+	session1.SetLastMarked(now)
+	session3 := &clientSessionState{}
+	session3.SetLastMarked(now.Add(-24 * time.Hour * 30))
+	s.state.sessions["session-1"] = session1
+	s.state.sessions["session-2"] = &agentSessionState{}
+	s.state.sessions["session-3"] = session3
+	s.state.sessionConsumptionMetrics["session-1"] = &SessionConsumptionMetrics{
+		Duration:   42,
+		LastUpdate: now.Add(-time.Minute),
+	}
+	// staled metric
+	s.state.sessionConsumptionMetrics["session-3"] = &SessionConsumptionMetrics{
+		Duration:   36,
+		LastUpdate: session3.lastMarked,
+	}
+
+	// when
+	s.state.RefreshSessionConsumptionMetrics("session-1")
+	s.state.RefreshSessionConsumptionMetrics("session-2") // should not fail.
+	s.state.RefreshSessionConsumptionMetrics("session-3") // should not refresh a stale metric.
+
+	// then
+	assert.Len(s.T(), s.state.GetAllSessionConsumptionMetrics(), 2)
+	assert.True(s.T(), (s.state.sessionConsumptionMetrics["session-1"].Duration) > 42)
+	assert.Equal(s.T(), 36, int(s.state.sessionConsumptionMetrics["session-3"].Duration))
+}

--- a/cmd/traffic/cmd/manager/state/session.go
+++ b/cmd/traffic/cmd/manager/state/session.go
@@ -15,7 +15,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
 
-const agentSessionIDPrefix = "agent:"
+const AgentSessionIDPrefix = "agent:"
 
 type SessionState interface {
 	Cancel()
@@ -128,8 +128,8 @@ func (ss *sessionState) OnConnect(
 	name := fmt.Sprintf("%s: session %s -> %s", id, abp.stream.SessionID(), stream.SessionID())
 	tunnelProbes := &tunnel.BidiPipeProbes{}
 	if consumptionMetrics != nil {
-		tunnelProbes.BytesProbeA = consumptionMetrics.FromClientBytesChan
-		tunnelProbes.BytesProbeB = consumptionMetrics.ToClientBytesChan
+		tunnelProbes.BytesProbeA = consumptionMetrics.FromClientBytes
+		tunnelProbes.BytesProbeB = consumptionMetrics.ToClientBytes
 	}
 
 	bidiPipe := tunnel.NewBidiPipe(abp.stream, stream, name, counter, tunnelProbes)

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -333,10 +333,7 @@ func (s *state) addClient(sessionID string, client *rpc.ClientInfo, now time.Tim
 	}
 	s.sessions[sessionID] = newClientSessionState(s.ctx, now)
 
-	// Only store consumption for clientSession states.
-	if _, ok := s.sessions[sessionID].(*clientSessionState); ok {
-		s.unlockedAddSessionConsumption(sessionID)
-	}
+	s.unlockedAddSessionConsumption(sessionID)
 
 	return sessionID
 }

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -675,7 +675,7 @@ func (s *state) Tunnel(ctx context.Context, stream tunnel.Stream) error {
 		}
 	} else {
 		s.mu.RLock()
-		// When no intercept is running, a new dialer is opened to talk with resources from the traffic manager.
+		// When no intercept is active, a new dialer is opened to communicate with resources from the traffic manager.
 		scm = s.sessions[sessionID].ConsumptionMetrics()
 		s.mu.RUnlock()
 

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -218,7 +218,10 @@ func (s *state) RemoveSession(ctx context.Context, sessionID string) {
 	defer s.mu.Unlock()
 	dlog.Debugf(ctx, "Session %s removed. Explicit removal", sessionID)
 
-	s.unlockedRemoveSessionConsumption(sessionID)
+	if _, isClientSession := s.sessions[sessionID].(*clientSessionState); isClientSession {
+		s.unlockedRemoveSessionConsumption(sessionID)
+	}
+
 	s.unlockedRemoveSession(sessionID)
 }
 

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -26,14 +26,13 @@ type suiteState struct {
 func (s *suiteState) SetupTest() {
 	s.ctx = dlog.NewTestContext(s.T(), false)
 	s.state = &state{
-		ctx:                       s.ctx,
-		sessions:                  make(map[string]SessionState),
-		sessionConsumptionMetrics: make(map[string]*SessionConsumptionMetrics),
-		agentsByName:              make(map[string]map[string]*rpc.AgentInfo),
-		cfgMapLocks:               make(map[string]*sync.Mutex),
-		interceptStates:           make(map[string]*interceptState),
-		timedLogLevel:             log.NewTimedLevel("debug", log.SetLevel),
-		llSubs:                    newLoglevelSubscribers(),
+		ctx:             s.ctx,
+		sessions:        make(map[string]SessionState),
+		agentsByName:    make(map[string]map[string]*rpc.AgentInfo),
+		cfgMapLocks:     make(map[string]*sync.Mutex),
+		interceptStates: make(map[string]*interceptState),
+		timedLogLevel:   log.NewTimedLevel("debug", log.SetLevel),
+		llSubs:          newLoglevelSubscribers(),
 	}
 }
 
@@ -172,7 +171,6 @@ func (s *suiteState) TestAddClient() {
 
 	// then
 	assert.Len(s.T(), s.state.sessions, 1)
-	assert.Len(s.T(), s.state.sessionConsumptionMetrics, 1)
 }
 
 func (s *suiteState) TestRemoveSession() {
@@ -180,10 +178,6 @@ func (s *suiteState) TestRemoveSession() {
 	now := time.Now()
 	s.state.sessions["session-1"] = newClientSessionState(s.ctx, now)
 	s.state.sessions["session-2"] = newAgentSessionState(s.ctx, now)
-	s.state.sessionConsumptionMetrics["session-1"] = &SessionConsumptionMetrics{
-		Duration:   42,
-		LastUpdate: now.Add(-time.Minute),
-	}
 
 	// when
 	s.state.RemoveSession(s.ctx, "session-1")
@@ -191,7 +185,6 @@ func (s *suiteState) TestRemoveSession() {
 
 	// then
 	assert.Len(s.T(), s.state.sessions, 0)
-	assert.Len(s.T(), s.state.sessionConsumptionMetrics, 0)
 }
 
 func TestSuiteState(testing *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230726203957-2d275fd44a77
+	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230728122223-d33fe35836ab
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1

--- a/pkg/client/remotefs/bridge.go
+++ b/pkg/client/remotefs/bridge.go
@@ -73,7 +73,7 @@ func (m *bridgeMounter) dispatchToTunnel(ctx context.Context, conn net.Conn, pod
 		cancel()
 		return fmt.Errorf("failed to create stream: %v", err)
 	}
-	d := tunnel.NewConnEndpoint(s, conn, cancel)
+	d := tunnel.NewConnEndpoint(s, conn, cancel, nil, nil)
 	d.Start(ctx)
 	<-d.Done()
 	return nil

--- a/pkg/client/rootd/stream_creator.go
+++ b/pkg/client/rootd/stream_creator.go
@@ -24,7 +24,7 @@ func (s *Session) streamCreator() tunnel.StreamCreator {
 			pipeId := tunnel.NewConnID(p, id.Source(), s.dnsLocalAddr.IP, id.SourcePort(), uint16(s.dnsLocalAddr.Port))
 			dlog.Tracef(c, "Intercept DNS %s to %s", id, pipeId.DestinationAddr())
 			from, to := tunnel.NewPipe(pipeId, s.session.SessionId)
-			tunnel.NewDialerTTL(to, func() {}, dnsConnTTL).Start(c)
+			tunnel.NewDialerTTL(to, func() {}, dnsConnTTL, nil, nil).Start(c)
 			return from, nil
 		}
 		dlog.Debugf(c, "Opening tunnel for id %s", id)

--- a/pkg/forwarder/tcp.go
+++ b/pkg/forwarder/tcp.go
@@ -188,7 +188,7 @@ func (f *interceptor) interceptConn(ctx context.Context, conn net.Conn, iCept *m
 		cancel()
 		return fmt.Errorf("unable to send client session id. Id %s: %v", id, err)
 	}
-	d := tunnel.NewConnEndpoint(s, conn, cancel)
+	d := tunnel.NewConnEndpoint(s, conn, cancel, nil, nil)
 	d.Start(ctx)
 	<-d.Done()
 	return nil

--- a/pkg/tunnel/probe.go
+++ b/pkg/tunnel/probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -13,7 +14,7 @@ type CounterProbe struct {
 	name    string
 	channel chan uint64
 	timeout time.Duration
-	value   uint64
+	value   atomic.Uint64
 }
 
 const (
@@ -50,7 +51,7 @@ func (p *CounterProbe) RunCollect(ctx context.Context) {
 				p.Close()
 				return
 			}
-			p.value += b
+			p.value.Add(b)
 		}
 	}
 }
@@ -69,5 +70,5 @@ func (p *CounterProbe) GetName() string {
 }
 
 func (p *CounterProbe) GetValue() uint64 {
-	return p.value
+	return p.value.Load()
 }

--- a/pkg/tunnel/probe.go
+++ b/pkg/tunnel/probe.go
@@ -1,0 +1,73 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type CounterProbe struct {
+	lock sync.Mutex
+
+	name    string
+	channel chan uint64
+	timeout time.Duration
+	value   uint64
+}
+
+const (
+	probeChannelTimeout    = 100 * time.Millisecond
+	probeChannelBufferSize = 1024
+)
+
+func NewCounterProbe(name string) *CounterProbe {
+	return &CounterProbe{
+		lock:    sync.Mutex{},
+		name:    name,
+		channel: make(chan uint64, probeChannelBufferSize),
+		timeout: probeChannelTimeout,
+	}
+}
+
+func (p *CounterProbe) Increment(v uint64) error {
+	select {
+	case p.channel <- v:
+	case <-time.After(p.timeout):
+		return fmt.Errorf("timeout trying to increment probe channel")
+	}
+	return nil
+}
+
+func (p *CounterProbe) RunCollect(ctx context.Context) {
+	defer p.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case b, ok := <-p.channel:
+			if !ok {
+				p.Close()
+				return
+			}
+			p.value += b
+		}
+	}
+}
+
+func (p *CounterProbe) Close() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.channel != nil {
+		close(p.channel)
+		p.channel = nil
+	}
+}
+
+func (p *CounterProbe) GetName() string {
+	return p.name
+}
+
+func (p *CounterProbe) GetValue() uint64 {
+	return p.value
+}

--- a/pkg/tunnel/stream_test.go
+++ b/pkg/tunnel/stream_test.go
@@ -140,7 +140,7 @@ func produce(ctx context.Context, s Stream, msg Message, errs chan<- error) {
 	wrCh := make(chan Message)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	WriteLoop(ctx, s, wrCh, &wg)
+	WriteLoop(ctx, s, wrCh, &wg, nil)
 	go func() {
 		for i := 0; i < 100; i++ {
 			wrCh <- msg
@@ -149,7 +149,7 @@ func produce(ctx context.Context, s Stream, msg Message, errs chan<- error) {
 		wg.Wait()
 	}()
 
-	rdCh, errCh := ReadLoop(ctx, s)
+	rdCh, errCh := ReadLoop(ctx, s, nil)
 	select {
 	case <-ctx.Done():
 		errs <- ctx.Err()
@@ -169,9 +169,9 @@ func consume(ctx context.Context, s Stream, expectedPayload []byte, errs chan<- 
 	wrCh := make(chan Message)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	WriteLoop(ctx, s, wrCh, &wg)
+	WriteLoop(ctx, s, wrCh, &wg, nil)
 	defer close(wrCh)
-	rdCh, errCh := ReadLoop(ctx, s)
+	rdCh, errCh := ReadLoop(ctx, s, nil)
 	for {
 		select {
 		case <-ctx.Done():
@@ -326,7 +326,7 @@ func TestStream_Xfer(t *testing.T) {
 				case b = <-bCh:
 				}
 			}
-			fwd := NewBidiPipe(a, b, "pipe", &counter)
+			fwd := NewBidiPipe(a, b, "pipe", &counter, nil)
 			fwd.Start(ctx)
 			select {
 			case <-ctx.Done():

--- a/pkg/tunnel/udplistener.go
+++ b/pkg/tunnel/udplistener.go
@@ -119,7 +119,7 @@ func (p *udpStream) Stop(ctx context.Context) {
 
 func (p *udpStream) Start(ctx context.Context) {
 	p.TimedHandler.Start(ctx)
-	go readLoop(ctx, p)
+	go readLoop(ctx, p, nil)
 }
 
 type UdpReadResult struct {

--- a/pkg/vif/stack.go
+++ b/pkg/vif/stack.go
@@ -252,6 +252,6 @@ func dispatchToStream(ctx context.Context, id tunnel.ConnID, conn net.Conn, stre
 		cancel()
 		return
 	}
-	ep := tunnel.NewConnEndpoint(stream, conn, cancel)
+	ep := tunnel.NewConnEndpoint(stream, conn, cancel, nil, nil)
 	ep.Start(ctx)
 }

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230726203957-2d275fd44a77 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230728122223-d33fe35836ab // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/tools/src/test-report/go.mod
+++ b/tools/src/test-report/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230726203957-2d275fd44a77 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.14.3-0.20230728122223-d33fe35836ab // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect


### PR DESCRIPTION
## Description

This PR extends the traffic manager state to include consumption metrics, so we can later expose them to prometheus.

Benchmark:

**Before**
```cli
➜  ~ wrk -t12 -c400 -d30s http://echo-easy.blue
Running 30s test @ http://echo-easy.blue
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    62.96ms   12.13ms 276.85ms   88.41%
    Req/Sec   319.44    134.07   666.00     66.77%
  114157 requests in 30.09s, 20.03MB read
  Socket errors: connect 157, read 0, write 0, timeout 0
Requests/sec:   3794.00
Transfer/sec:    681.73KB
```
**After**
```cli
~ wrk -t12 -c400 -d30s http://echo-easy.blue
Running 30s test @ http://echo-easy.blue
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    64.58ms   15.99ms 322.08ms   92.70%
    Req/Sec   311.97    185.42   670.00     58.31%
  111306 requests in 30.06s, 19.53MB read
  Socket errors: connect 157, read 0, write 0, timeout 0
Requests/sec:   3702.29
Transfer/sec:    665.26KB
```

No major difference.
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
