### PR TITLE
Fix agent image not found when creating an intercept

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -31,8 +31,16 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
-  - version: 2.14.1
+  - version: 2.14.2
     date: (TBD)
+    notes:
+      - type: bugfix
+        title: Telepresence now use the OSS agent in its latest version by default.
+        body: >-
+          The traffic manager admin was forced to set it manually during the chart installation.
+        docs: https://github.com/telepresenceio/telepresence/issues/3271
+  - version: 2.14.1
+    date: "2023-07-07"
     notes:
       - type: feature
         title: Envoy's http idle timout is now configurable.

--- a/cmd/traffic/cmd/manager/managerutil/agentimage.go
+++ b/cmd/traffic/cmd/manager/managerutil/agentimage.go
@@ -2,8 +2,11 @@ package managerutil
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type ImageRetriever interface {
@@ -29,7 +32,7 @@ func WithAgentImageRetriever(ctx context.Context, onChange func(context.Context,
 	env := GetEnv(ctx)
 	var img string
 	if env.AgentImage == "" {
-		env.AgentImage = "tel2"
+		env.AgentImage = fmt.Sprintf("tel2:%s", strings.TrimPrefix(version.Version, "v"))
 	}
 	img = env.QualifiedAgentImage()
 	ctx = WithResolvedAgentImageRetriever(ctx, ImageFromEnv(img))


### PR DESCRIPTION
## Description

We previously removed the code which was interrogating the ambassador API to get the last version of the traffic agent (the smart one). As a result, the image to use was supposed to be set by env var.

Unfortunately, this change is not intuitive.

This PR fixes the issue by using the default version of the Telepresence, which is the equivalent of using the "dumb" agent .


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
