### PR TITLE
add ASLR

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,13 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.14.3
+    date: "TBD"
+    notes:
+      - type: security
+        title: Add ASLR to telepresence binaries
+        body: >-
+          ASLR hardens binary sercurity against fixed memory attacks.
   - version: 2.14.2
     date: "2023-07-26"
     notes:

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -161,7 +161,8 @@ endif
 ifeq ($(DOCKER_BUILD),1)
 	CGO_ENABLED=$(CGO_ENABLED) $(sdkroot) go build -tags docker -trimpath -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $@ ./cmd/telepresence
 else
-	CGO_ENABLED=$(CGO_ENABLED) $(sdkroot) go build -trimpath -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $@ ./cmd/telepresence
+# -buildmode=pie addresses https://github.com/datawire/telepresence2-proprietary/issues/315
+	CGO_ENABLED=$(CGO_ENABLED) $(sdkroot) go build -buildmode=pie -trimpath -ldflags=-X=$(PKG_VERSION).Version=$(TELEPRESENCE_VERSION) -o $@ ./cmd/telepresence
 endif
 
 # Make local authenticator. This is for test only as it's really only intended to run from within a container


### PR DESCRIPTION
## Description
Add ASLR to tele binaries

- add -buildmode=pie flag to build command

closes https://github.com/datawire/telepresence2-proprietary/issues/315

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
