### PR TITLE
Remove docker scout message when pulling a docker image

### DIFF
--- a/pkg/client/docker/image.go
+++ b/pkg/client/docker/image.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
@@ -42,7 +43,7 @@ func PullImage(ctx context.Context, image string) error {
 
 	err = cmd.Run()
 	if err != nil {
-		fmt.Println(stderr.String())
+		fmt.Fprintln(os.Stderr, stderr.String())
 		return err
 	}
 

--- a/pkg/client/docker/image.go
+++ b/pkg/client/docker/image.go
@@ -43,7 +43,7 @@ func PullImage(ctx context.Context, image string) error {
 
 	err = cmd.Run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, stderr.String())
+		fmt.Fprint(os.Stderr, stderr.String())
 		return err
 	}
 

--- a/pkg/client/docker/image.go
+++ b/pkg/client/docker/image.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -34,5 +35,16 @@ func PullImage(ctx context.Context, image string) error {
 	// Docker run will put the pull logs in stderr, but docker pull will put them in stdout.
 	// We discard them here, so they don't spam the user. They'll get errors through stderr if it comes to it.
 	cmd.Stdout = io.Discard
-	return cmd.Run()
+
+	// Only print stderr if the return code is non-zero
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Println(stderr.String())
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description

Right now, when you run a spec it shows a message about docker scout : 

![image](https://github.com/telepresenceio/telepresence/assets/40805575/c8cb7aae-b113-4e6b-a283-47ccef234611)


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
