### PR TITLE
Make sure connect duration isn't counted when offline

### DIFF
--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -74,7 +74,6 @@ func (s *state) RefreshSessionConsumptionMetrics(sessionID string) {
 		return
 	}
 
-	lastMarked := session.LastMarked()
 	var scm *SessionConsumptionMetrics
 	if css, ok := s.sessions[sessionID].(*clientSessionState); ok {
 		scm = css.ConsumptionMetrics()
@@ -82,10 +81,9 @@ func (s *state) RefreshSessionConsumptionMetrics(sessionID string) {
 		return
 	}
 
-	// If the last mark is older than the SessionConsumptionMetricsStaleTTL, it indicates that the duration
-	// metric should no longer be updated, as the user's machine may be in standby.
-	isStale := time.Now().After(lastMarked.Add(SessionConsumptionMetricsStaleTTL))
-	if !isStale {
+	// If last update is more than SessionConsumptionMetricsStaleTTL old, probably that the reporting was interrupted.
+	wasInterrupted := time.Now().After(scm.LastUpdate.Add(SessionConsumptionMetricsStaleTTL))
+	if !wasInterrupted { // If it wasn't stale, we want to count duration since last metric update.
 		scm.ConnectDuration += uint32(time.Since(scm.LastUpdate).Seconds())
 	}
 


### PR DESCRIPTION
## Description

This PR is in regard of the internal consumption objects in the traffic manager.

Previous code was using lastMarked as a reference, when it should be the last metric update (lastMark will always be almost equals to `time.Now()` since it's updated just before the `RefreshSessionConsumptionMetrics` function.

This is to be sure that when a user disconnects its wifi, or put their laptop to sleep, this time span isn't counted.
When the user comes back online, the traffic manager sees that it's been an hour since the last report, so doesn't use that last time ref to increase the connection time, until the next report.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
