### PR TITLE
Fix windows oss check

### DIFF
--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -19,7 +19,8 @@ runs:
           curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-darwin-arm64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Windows" ]; then
-          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-windows-amd64.exe -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-windows-amd64.zip -o ./telepresence.zip || { echo "Curl command failed" ; exit 1; }
+          unzip ./telepresence.zip || { echo "Unzip command failed" ; exit 1; }
         fi
         if [ "${{ runner.os }}" = "Linux" ]; then
           curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }


### PR DESCRIPTION
## Description

The check is [failing](https://github.com/telepresenceio/telepresence/actions/runs/5755854515/job/15604322360) since the windows packaging has changed.


Tested [here](https://github.com/telepresenceio/telepresence/actions/runs/5790136705)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
