### PR TITLE
Pin traffic manager golang version

### DIFF
--- a/build-aux/docker/images/Dockerfile.client
+++ b/build-aux/docker/images/Dockerfile.client
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as telepresence-build
+FROM golang:1.20.7-alpine as telepresence-build
 
 RUN apk add --no-cache gcc musl-dev fuse-dev libcap binutils-gold
 

--- a/build-aux/docker/images/Dockerfile.traffic
+++ b/build-aux/docker/images/Dockerfile.traffic
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as tel2-build
+FROM golang:1.20.7-alpine as tel2-build
 
 RUN apk add --no-cache gcc musl-dev fuse-dev libcap
 


### PR DESCRIPTION
## Description

Just pinning the traffic manager version since we always pull the latest right now.

The 1.21.0 was just released (and breaks the build) so let's keep the 1.20.7 for now.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
