### PR TITLE
add arm64 client builds to release and publish process

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -16,7 +16,7 @@ runs:
       run: |
         sudo rm -f /etc/apt/sources.list.d/google-chrome.list
         sudo apt-get update
-        sudo apt-get install -y sshfs socat libfuse-dev
+        sudo apt-get install -y sshfs socat libfuse-dev make jq
         sudo sh -c 'echo user_allow_other >> /etc/fuse.conf'
     - if: runner.os == 'macOS'
       name: install macOS dependencies

--- a/.github/actions/test-release/action.yaml
+++ b/.github/actions/test-release/action.yaml
@@ -22,6 +22,9 @@ runs:
           curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-windows-amd64.zip -o ./telepresence.zip || { echo "Curl command failed" ; exit 1; }
           unzip ./telepresence.zip || { echo "Unzip command failed" ; exit 1; }
         fi
+        if [ "${{ runner.os }}" = "Linux" ] && [ "${{ runner.arch }}" ==  @(arm64|ARM64) ]; then
+          curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-linux-arm64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
+        fi
         if [ "${{ runner.os }}" = "Linux" ]; then
           curl -fL ${{ env.DOWNLOAD_URL }}/${{ inputs.release_version }}/telepresence-linux-amd64 -o ./telepresence || { echo "Curl command failed" ; exit 1; }
         fi

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         runners:
           - ubuntu-latest
+          - ubuntu-arm64
           - macos-latest
           - windows-2019
           - macOS-arm64
@@ -51,6 +52,18 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: image
+      - if: runner.os == 'Linux' && runner.arch == 'arm64'
+        name: install dependencies for arm64
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update -y
+          sudo apt-get install -y socat gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu make jq uidmap
+      - if: runner.os == 'Linux' && runner.arch == 'arm64'
+        name: install docker for arm64
+        run: |
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh get-docker.sh
+          dockerd-rootless-setuptool.sh install
       - run: make build
       - uses: ./.github/actions/prepare-cluster
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         runners:
           - ubuntu-latest
+          - ubuntu-arm64
           - macos-latest
           - macOS-arm64
           - windows-2019
@@ -27,7 +28,8 @@ jobs:
       - name: set version
         shell: bash
         run: echo "TELEPRESENCE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-      - run: make release-binary
+      - name: generate binaries
+        run: make release-binary
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
@@ -39,9 +41,29 @@ jobs:
         run: |
           docker login -u="${{ secrets.DOCKERHUB_USERNAME }}" -p="${{ secrets.DOCKERHUB_PASSWORD }}"
           make push-tel2-image
-  release:
-    runs-on: ubuntu-latest
+
+  test-release:
     needs: build-release
+    strategy:
+      fail-fast: false
+      matrix:
+        runners:
+          - ubuntu-latest
+          - ubuntu-arm64
+          - macos-latest
+          - macOS-arm64
+          - windows-2019
+    runs-on: ${{ matrix.runners }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test release
+        uses: ./.github/actions/test-release
+        with:
+          release_version: ${{ github.ref_name }}
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: test-release
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -66,6 +88,7 @@ jobs:
             ## Official Release Artifacts
             ### Linux
                - 📦 [telepresence-linux-amd64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-linux-amd64)
+               - 📦 [telepresence-linux-arm64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-linux-arm64)
             ### OSX Darwin
                - 📦 [telepresence-darwin-amd64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-darwin-amd64)
                - 📦 [telepresence-darwin-arm64](https://app.getambassador.io/download/tel2oss/releases/download/${{ github.ref_name }}/telepresence-darwin-arm64)
@@ -76,21 +99,3 @@ jobs:
             And for more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start/).
 
             ![Assets](https://static.scarf.sh/a.png?x-pxid=d842651a-2e4d-465a-98e1-4808722c01ab)
-
-  test-release:
-    needs: release
-    strategy:
-      fail-fast: false
-      matrix:
-        runners:
-          - ubuntu-latest
-          - macos-latest
-          - macOS-arm64
-          - windows-2019
-    runs-on: ${{ matrix.runners }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Test release
-        uses: ./.github/actions/test-release
-        with:
-          release_version: ${{ github.ref_name }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -4,7 +4,7 @@ on:
 env:
   HOMEBREW_NO_INSTALL_FROM_API:
 jobs:
-  "macos":
+  macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,8 @@ jobs:
           timeout_minutes: 12
           command: |
             make check-unit
-  "windows":
+
+  windows:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +74,8 @@ jobs:
             $ENV:DTEST_KUBECONFIG = "${{ steps.kluster.outputs.kubeconfig }}"
             $ENV:DTEST_REGISTRY = "docker.io/datawire"
             make check-unit
-  "linux":
+
+  linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -89,10 +91,34 @@ jobs:
           sudo apt-get install -y socat gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Lint
         run: make lint
-      - name: "Test arm64 build"
-        run: GOARCH=arm64 CC=aarch64-linux-gnu-gcc make build
       - name: "Test amd64 build"
         run: make build
+      - name: Run tests
+        uses: nick-invision/retry/@v2.4.0
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          command: |
+            make check-unit
+
+  linux-arm64:
+    runs-on: ubuntu-arm64
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: "${{ github.event.pull_request.head.sha }}"
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.20.7'
+      - run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y socat gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu make jq
+      - name: Lint
+        run: make lint
+      - name: "Test arm64 build"
+        run: GOARCH=arm64 CC=aarch64-linux-gnu-gcc make build
       - name: Run tests
         uses: nick-invision/retry/@v2.4.0
         with:

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -37,6 +37,10 @@ items:
         title: Add ASLR to telepresence binaries
         body: >-
           ASLR hardens binary sercurity against fixed memory attacks.
+      - type: feature
+        title: Added client builds for arm64 architecture.
+        body: >-
+          Updated the release workflow files in github actions to including building and publishing the client binaries for arm64 architecture.
   - version: 2.14.2
     date: "2023-07-26"
     notes:


### PR DESCRIPTION
## Description

Upstream issue - https://github.com/telepresenceio/telepresence/issues/3259

Added support for `arm64` client builds to our CI/CD process.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [X] I made sure to update `./CHANGELOG.yml`.
 - [X] I made sure to add any docs changes required for my change (including release notes).
 - [X] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
