### PR TITLE
Add missing go.mod update in prepare-release

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -248,6 +248,10 @@ prepare-release: generate wix
 	  go mod edit -require=github.com/telepresenceio/telepresence/rpc/v2@$(TELEPRESENCE_VERSION) && \
 	  git add go.mod)
 
+	(cd tools/src/test-report && \
+	  go mod edit -require=github.com/telepresenceio/telepresence/rpc/v2@$(TELEPRESENCE_VERSION) && \
+	  git add go.mod)
+
 	sed -i.bak "s/^### (TBD).*/### $(TELEPRESENCE_VERSION)/" charts/telepresence/CHANGELOG.md
 	rm -f charts/telepresence/CHANGELOG.md.bak
 	git add charts/telepresence/CHANGELOG.md


### PR DESCRIPTION
## Description

During a release, the test-report go.mod is not automatically added to the prepare release commit : 
https://github.com/telepresenceio/telepresence/commit/bfd0b7eeef7fb8b2f820af597e193976f5f50dd2

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
