### PR TITLE
Fix authenticator unable to start with KUBECONFIG set

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -41,6 +41,12 @@ items:
         title: Added client builds for arm64 architecture.
         body: >-
           Updated the release workflow files in github actions to including building and publishing the client binaries for arm64 architecture.
+      - type: bugfix
+        title: KUBECONFIG env var can now be used with the docker mode.
+        body: >-
+          If provided, the KUBECONFIG environment variable was passed to the kubeauth-foreground service as a parameter. 
+          However, since it didn't exist, the CLI was throwing an error when using <code>telepresence connect --docker</code>.
+        docs: https://github.com/telepresenceio/telepresence/pull/3300
   - version: 2.14.2
     date: "2023-07-26"
     notes:

--- a/pkg/client/cli/daemon/request.go
+++ b/pkg/client/cli/daemon/request.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 )
@@ -97,8 +98,9 @@ func (cr *Request) addKubeconfigEnv() {
 			cr.KubeFlags[key] = cfg
 		}
 	}
-	addEnv("KUBECONFIG")
-	addEnv("GOOGLE_APPLICATION_CREDENTIALS")
+	for _, kubeconfigEnv := range client.EnvVarOnlyKubeFlags {
+		addEnv(kubeconfigEnv)
+	}
 }
 
 // setContext deals with the global --context flag and assigns it to KubeFlags because it's

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -39,6 +39,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
+	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
@@ -202,8 +203,12 @@ func appendKubeFlags(kubeFlags map[string]string, args []string) ([]string, erro
 			if v != "false" {
 				args = append(args, "--"+k)
 			}
+			continue
 		default:
-			args = append(args, "--"+k, v)
+			// Kubeconfig flags which are not env vars should not be propagated to the authenticator.
+			if !slice.Contains(client.EnvVarOnlyKubeFlags, k) {
+				args = append(args, "--"+k, v)
+			}
 		}
 	}
 	return args, nil


### PR DESCRIPTION
## Description

When executing `telepresence connect --docker` on a cluster that utilizes the `exec` parameter in the Kubeconfig, Telepresence initiates an intermediary service called `kubeauth-foreground`. This service manages authentication specifically when operating in docker mode.

However, when this process occurs while the `KUBECONFIG` environment variable is exposed, it leads to the transmission of a `--KUBECONFIG` parameter to the `kubeauth-foreground` service. 

This pull request addresses this concern by excluding this parameter from the process, as it holds no relevance in this context.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
