### PR TITLE
adding missing socat linux-amd64 dep

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -88,7 +88,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
-          sudo apt-get install -y make jq
+          sudo apt-get install -y socat make jq
       - name: Lint
         run: make lint
       - name: "Test amd64 build"


### PR DESCRIPTION
## Description

Add `socat` to the list of libs to install in `linux-amd64` since I removed it in this [commit](https://github.com/telepresenceio/telepresence/commit/1587d2865c94e33b776518bc59fddd3869fa7b13). this missing dependency would cause the unit tests for `linux-amd64` to fail.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
