### PR TITLE
2.15.0 rc.8

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -31,7 +31,7 @@ docDescription: >-
   customizable development environments.
 items:
   - version: 2.15.0
-    date: "TBD"
+    date: "2023-08-22"
     notes:
       - type: security
         title: Add ASLR to telepresence binaries

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -263,8 +263,8 @@ prepare-release: generate wix
 
 	git commit --signoff --message='Prepare $(TELEPRESENCE_VERSION)'
 
-	git tag -s --annotate --message='$(TELEPRESENCE_VERSION)' $(TELEPRESENCE_VERSION)
-	git tag -s --annotate --message='$(TELEPRESENCE_VERSION)' rpc/$(TELEPRESENCE_VERSION)
+	git tag --annotate --message='$(TELEPRESENCE_VERSION)' $(TELEPRESENCE_VERSION)
+	git tag --annotate --message='$(TELEPRESENCE_VERSION)' rpc/$(TELEPRESENCE_VERSION)
 
 # Prerequisites:
 # The awscli command must be installed and configured with credentials to upload

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.7
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.8
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.7 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.8 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/tools/src/test-report/go.mod
+++ b/tools/src/test-report/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.7 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.8 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect


### PR DESCRIPTION
## Description

I removed the `git tag -s` added by raj during last rc, because now it generates some errors if you don't have a gpg key associated to your github account

![image](https://github.com/telepresenceio/telepresence/assets/40805575/6f2e2509-4a64-47da-a01a-1ae83f14cde1)


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
