### PR TITLE
Simplify consumption metrics collection.

### DIFF
--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"context"
 	"time"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -29,16 +28,6 @@ type SessionConsumptionMetrics struct {
 	FromClientBytes *tunnel.CounterProbe
 	// data from the traffic manager to the client.
 	ToClientBytes *tunnel.CounterProbe
-}
-
-func (s *SessionConsumptionMetrics) RunCollect(ctx context.Context) {
-	go s.FromClientBytes.RunCollect(ctx)
-	go s.ToClientBytes.RunCollect(ctx)
-}
-
-func (s *SessionConsumptionMetrics) Close() {
-	s.FromClientBytes.Close()
-	s.ToClientBytes.Close()
 }
 
 func (s *state) GetSessionConsumptionMetrics(sessionID string) *SessionConsumptionMetrics {

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -266,11 +266,6 @@ func (s *state) unlockedRemoveSession(sessionID string) {
 		} else {
 			s.clients.Delete(sessionID)
 		}
-
-		if css, ok := sess.(*clientSessionState); ok {
-			defer css.ConsumptionMetrics().Close()
-		}
-
 		delete(s.sessions, sessionID)
 	}
 }
@@ -330,11 +325,6 @@ func (s *state) addClient(sessionID string, client *rpc.ClientInfo, now time.Tim
 	}
 
 	s.sessions[sessionID] = newClientSessionState(s.ctx, now)
-
-	if css, ok := s.sessions[sessionID].(*clientSessionState); ok {
-		css.ConsumptionMetrics().RunCollect(s.ctx)
-	}
-
 	return sessionID
 }
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.10
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.11
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1

--- a/pkg/tunnel/probe.go
+++ b/pkg/tunnel/probe.go
@@ -1,68 +1,20 @@
 package tunnel
 
 import (
-	"context"
-	"fmt"
-	"sync"
 	"sync/atomic"
-	"time"
 )
 
 type CounterProbe struct {
-	lock sync.Mutex
-
-	name    string
-	channel chan uint64
-	timeout time.Duration
-	value   atomic.Uint64
+	name  string
+	value uint64
 }
-
-const (
-	probeChannelTimeout    = 100 * time.Millisecond
-	probeChannelBufferSize = 1024
-)
 
 func NewCounterProbe(name string) *CounterProbe {
-	return &CounterProbe{
-		lock:    sync.Mutex{},
-		name:    name,
-		channel: make(chan uint64, probeChannelBufferSize),
-		timeout: probeChannelTimeout,
-	}
+	return &CounterProbe{name: name}
 }
 
-func (p *CounterProbe) Increment(v uint64) error {
-	select {
-	case p.channel <- v:
-	case <-time.After(p.timeout):
-		return fmt.Errorf("timeout trying to increment probe channel")
-	}
-	return nil
-}
-
-func (p *CounterProbe) RunCollect(ctx context.Context) {
-	defer p.Close()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case b, ok := <-p.channel:
-			if !ok {
-				p.Close()
-				return
-			}
-			p.value.Add(b)
-		}
-	}
-}
-
-func (p *CounterProbe) Close() {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	if p.channel != nil {
-		close(p.channel)
-		p.channel = nil
-	}
+func (p *CounterProbe) Increment(v uint64) {
+	atomic.AddUint64(&p.value, v)
 }
 
 func (p *CounterProbe) GetName() string {
@@ -70,5 +22,5 @@ func (p *CounterProbe) GetName() string {
 }
 
 func (p *CounterProbe) GetValue() uint64 {
-	return p.value.Load()
+	return atomic.LoadUint64(&p.value)
 }

--- a/pkg/tunnel/stream.go
+++ b/pkg/tunnel/stream.go
@@ -92,10 +92,7 @@ func ReadLoop(ctx context.Context, s Stream, p *CounterProbe) (<-chan Message, <
 		for {
 			m, err := s.Receive(ctx)
 			if m != nil && p != nil {
-				errInc := p.Increment(uint64(len(m.Payload())))
-				if errInc != nil {
-					dlog.Error(ctx, errInc)
-				}
+				p.Increment(uint64(len(m.Payload())))
 			}
 
 			switch {
@@ -160,10 +157,7 @@ func WriteLoop(
 
 				err := s.Send(ctx, m)
 				if m != nil && p != nil {
-					errInc := p.Increment(uint64(len(m.Payload())))
-					if errInc != nil {
-						dlog.Error(ctx, errInc)
-					}
+					p.Increment(uint64(len(m.Payload())))
 				}
 
 				switch {

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.10 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.11 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/tools/src/test-report/go.mod
+++ b/tools/src/test-report/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.10 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0-rc.11 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230302034142-4b1e35fe2254 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect


### PR DESCRIPTION
The approach of using a channel to increment a counter would sometimes result in the channel being filled up, because a depart could arrive although data remained to be sent. The result would then be a very large number of unhelpful errors saying:

    timeout trying to increment probe channel

This commit simplifies the metrics collection so that instead of using a channel, it just uses an `atomic.AddUint64` and `atomic.LoadUint64`, thereby removing any chance of congestion.
