### PR TITLE
Amend fix authenticator unable to start with KUBECONFIG set

### DIFF
--- a/pkg/client/cli/daemon/request.go
+++ b/pkg/client/cli/daemon/request.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
-	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 )
@@ -98,9 +97,8 @@ func (cr *Request) addKubeconfigEnv() {
 			cr.KubeFlags[key] = cfg
 		}
 	}
-	for _, kubeconfigEnv := range client.EnvVarOnlyKubeFlags {
-		addEnv(kubeconfigEnv)
-	}
+	addEnv("KUBECONFIG")
+	addEnv("GOOGLE_APPLICATION_CREDENTIALS")
 }
 
 // setContext deals with the global --context flag and assigns it to KubeFlags because it's

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -213,6 +213,18 @@ func startAuthenticatorService(ctx context.Context, portFile string, kubeFlags m
 	// remove any stale port file
 	_ = os.Remove(portFile)
 
+	// The GOOGLE_APPLICATION_CREDENTIALS and KUBECONFIG entries are copies of the environment variables
+	// sent to us from the CLI to give this long-running daemon a chance to update them. Here we set/unset
+	// our them in our environment accordingly and remove them from the flagMap
+	if err := client.TransferEnvFlag(ctx, kubeFlags, "GOOGLE_APPLICATION_CREDENTIALS"); err != nil {
+		return 0, err
+	}
+	// Using the --kubeconfig flag to send the info isn't sufficient because that flag doesn't allow for multiple
+	// path entries like the KUBECONFIG does.
+	if err := client.TransferEnvFlag(ctx, kubeFlags, "KUBECONFIG"); err != nil {
+		return 0, err
+	}
+
 	args := make([]string, 0, 4+len(kubeFlags)*2)
 	args = append(args, client.GetExe(), kubeauth.CommandName, "--portfile", portFile)
 	var err error

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -39,7 +39,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
-	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
@@ -203,12 +202,8 @@ func appendKubeFlags(kubeFlags map[string]string, args []string) ([]string, erro
 			if v != "false" {
 				args = append(args, "--"+k)
 			}
-			continue
 		default:
-			// Kubeconfig flags which are not env vars should not be propagated to the authenticator.
-			if !slice.Contains(client.EnvVarOnlyKubeFlags, k) {
-				args = append(args, "--"+k, v)
-			}
+			args = append(args, "--"+k, v)
 		}
 	}
 	return args, nil

--- a/pkg/client/docker/daemon_test.go
+++ b/pkg/client/docker/daemon_test.go
@@ -1,11 +1,6 @@
 package docker
 
-import (
-	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-)
+import "testing"
 
 func TestSafeContainerName(t *testing.T) {
 	tests := []struct {
@@ -53,25 +48,4 @@ func TestSafeContainerName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestAppendKubeFlagsAuthenticatorService(t *testing.T) {
-	// when
-	args, err := appendKubeFlags(map[string]string{
-		"kubeconfig":               "/some/path/to/kubeconfig",
-		"KUBECONFIG":               "/some/path/to/kubeconfig:/some/other/path/to/kubeconfig",
-		"insecure-skip-tls-verify": "true",
-		"as-group":                 "1000,1001",
-		"user":                     "john",
-	}, []string{"kubeauth-foreground"})
-
-	// then
-	assert.NoError(t, err)
-	assert.Len(t, args, 10)
-	argsStr := strings.Join(args, " ")
-	assert.Contains(t, argsStr, "kubeauth-foreground")
-	assert.Contains(t, argsStr, "--insecure-skip-tls-verify")
-	assert.Contains(t, argsStr, "--as-group 1000 --as-group 1001")
-	assert.Contains(t, argsStr, "--kubeconfig /some/path/to/kubeconfig")
-	assert.Contains(t, argsStr, "--user john")
 }

--- a/pkg/client/k8s_config.go
+++ b/pkg/client/k8s_config.go
@@ -165,8 +165,6 @@ func NewKubeconfig(c context.Context, flagMap map[string]string, managerNamespac
 	return newKubeconfig(c, flagMap, managerNamespaceOverride, configFlags)
 }
 
-var EnvVarOnlyKubeFlags = []string{"KUBECONFIG", "GOOGLE_APPLICATION_CREDENTIALS"} //nolint:gochecknoglobals // constant
-
 func DaemonKubeconfig(c context.Context, cr *connector.ConnectRequest) (*Kubeconfig, error) {
 	if cr.IsPodDaemon {
 		return NewInClusterConfig(c, cr.KubeFlags)
@@ -192,15 +190,14 @@ func DaemonKubeconfig(c context.Context, cr *connector.ConnectRequest) (*Kubecon
 		// If user unsets the env, we need to do that too
 		return os.Unsetenv(key)
 	}
-
-	for _, kubeconfigEnv := range EnvVarOnlyKubeFlags {
-		// Using a flag like --kubeconfig to send the info isn't sufficient because that flag doesn't allow for multiple
-		// path entries like the KUBECONFIG does.
-		if err := transferEnvFlag(kubeconfigEnv); err != nil {
-			return nil, err
-		}
+	if err := transferEnvFlag("GOOGLE_APPLICATION_CREDENTIALS"); err != nil {
+		return nil, err
 	}
-
+	// Using the --kubeconfig flag to send the info isn't sufficient because that flag doesn't allow for multiple
+	// path entries like the KUBECONFIG does.
+	if err := transferEnvFlag("KUBECONFIG"); err != nil {
+		return nil, err
+	}
 	configFlags, err := ConfigFlags(flagMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Description

This reverts commit fb627c5c4d5c1b864a0fd6b7f16312c979063014 and replace it with the proper fix.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
