### PR TITLE
Add `telepresence list-namespaces` and `telepresence list-contexts` cmds

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -38,6 +38,10 @@ items:
         body: >-
           The behavior changed so that a connected Telepresence client is bound to a namespace. The namespace can then
           not be changed unless the client disconnects and reconnects.
+      - type: feature
+        title: Add `telepresence list-namespaces` and `telepresence list-contexts` commands
+        body: >-
+          These commands can be used to check accessable namespaces and for automation.
       - type: change
         title: Implicit connect warning
         body: >-

--- a/pkg/client/cli/cmd/list_contexts.go
+++ b/pkg/client/cli/cmd/list_contexts.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
+)
+
+type listContextsCommand struct {
+	rq *daemon.Request
+}
+
+func listContexts() *cobra.Command {
+	lcc := &listContextsCommand{}
+
+	cmd := &cobra.Command{
+		Use:   "list-contexts",
+		Args:  cobra.NoArgs,
+		Short: "Show all contexts",
+		RunE:  lcc.run,
+	}
+	lcc.rq = daemon.InitRequest(cmd)
+	return cmd
+}
+
+func (lcc *listContextsCommand) run(cmd *cobra.Command, _ []string) error {
+	config, err := lcc.rq.GetConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	kcmap := config.Contexts
+
+	if output.WantsFormatted(cmd) {
+		output.Object(ctx, kcmap, false)
+	} else {
+		for name, kc := range kcmap {
+			fmt.Fprintf(output.Out(ctx), "- name: %s\n  default namespace: %s\n", name, kc.Namespace)
+		}
+	}
+	return nil
+}

--- a/pkg/client/cli/cmd/list_namespaces.go
+++ b/pkg/client/cli/cmd/list_namespaces.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
+)
+
+type listNamespacesCommand struct {
+	rq *daemon.Request
+}
+
+func listNamespaces() *cobra.Command {
+	lnc := &listNamespacesCommand{}
+
+	cmd := &cobra.Command{
+		Use:   "list-namespaces",
+		Args:  cobra.NoArgs,
+		Short: "Show all namespaces",
+		RunE:  lnc.run,
+	}
+	lnc.rq = daemon.InitRequest(cmd)
+	return cmd
+}
+
+func (lnc *listNamespacesCommand) run(cmd *cobra.Command, _ []string) error {
+	nss, err := lnc.rq.GetAllNamespaces(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	if output.WantsFormatted(cmd) {
+		output.Object(ctx, nss, false)
+	} else {
+		for _, ns := range nss {
+			fmt.Fprintln(output.Out(ctx), ns)
+		}
+	}
+	return nil
+}

--- a/pkg/client/cli/cmd/telepresence.go
+++ b/pkg/client/cli/cmd/telepresence.go
@@ -135,7 +135,7 @@ func OnlySubcommands(cmd *cobra.Command, args []string) error {
 func WithSubCommands(ctx context.Context) context.Context {
 	return MergeSubCommands(ctx,
 		config(), connectCmd(), currentClusterId(), gatherLogs(), gatherTraces(), genYAML(), helm(), interceptCmd(), leave(),
-		list(), loglevel(), quit(), statusCmd(), testVPN(), uninstall(), uploadTraces(), version(),
+		list(), loglevel(), quit(), statusCmd(), testVPN(), uninstall(), uploadTraces(), version(), listNamespaces(), listContexts(),
 	)
 }
 


### PR DESCRIPTION
## Description

Adding `list-namespaces` and `list-contexts` commands. These commands do not rely on a daemon.

TODO
- tests
- metrics?

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
