### PR TITLE
Inject SecurityContext into traffic agent

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -65,6 +65,13 @@ items:
         body: >-
           A deprecation warning will be printed if a command other than <code>telepresence connect</code> causes an
           implicit connect to happen. Implicit connects will be removed in a future release.
+  - version: 2.15.1
+    date: (TBD)
+    notes:
+      - type: security
+        title: Set security context for traffic agent
+        body: >-
+          Openshift users reported that the traffic agent injection was failing due to a missing security context.
   - version: 2.15.0
     date: "2023-08-29"
     notes:

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -65,7 +65,7 @@ items:
         body: >-
           A deprecation warning will be printed if a command other than <code>telepresence connect</code> causes an
           implicit connect to happen. Implicit connects will be removed in a future release.
-  - version: 2.15.1
+  - version: 2.15.2
     date: (TBD)
     notes:
       - type: security

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -141,7 +141,7 @@ func AgentContainer(
 	if r := config.Resources; r != nil {
 		ac.Resources = *r
 	}
-	// use the primary container's constraints to ensure psp compliance for the agent
+	// use the primary container's sc to ensure psp compliance for the agent
 	if sc := pod.Spec.Containers[0].SecurityContext; sc != nil {
 		ac.SecurityContext = sc
 	}

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -141,6 +141,10 @@ func AgentContainer(
 	if r := config.Resources; r != nil {
 		ac.Resources = *r
 	}
+	// use the primary container's constraints to ensure psp compliance for the agent
+	if sc := pod.Spec.Containers[0].SecurityContext; sc != nil {
+		ac.SecurityContext = sc
+	}
 
 	// Replace all occurrences of "$(ENV" with "$(PFX_ENV"
 	aj, err := json.Marshal(&ac)


### PR DESCRIPTION
## Description

This PR fix the openshift CFI issue.

In OpenShift, SecurityContextConstraints (SCCs) are assigned to ServiceAccounts (SAs) that run the pods, which means that different applications may not necessarily use the same SCC, resulting in variations in SecurityContexts across applications.

OpenShift sets the SecurityContext during the deployment of the pod. However, utilizing the SecurityContext from an existing container has been found to resolve the issue and reinstate the proper functioning of the traffic agent.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
