### PR TITLE
Enforce file locks on cache files.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,11 @@ items:
   - version: 2.16.0
     date: (TBD)
     notes:
+      - type: bugfix
+        title: Add file locking to the Telepresence cache
+        body: >-
+          Files in the Telepresence cache are accesses by multiple processes. The processes will now use advisory
+          locks on the files to guarantee consistency.
       - type: change
         title: Lock connection to namespace
         body: >-

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -111,6 +111,7 @@ following Free and Open Source software:
     github.com/prometheus/common                                                 v0.43.0                               Apache License 2.0
     github.com/prometheus/procfs                                                 v0.9.0                                Apache License 2.0
     github.com/rivo/uniseg                                                       v0.4.4                                MIT license
+    github.com/rogpeppe/go-internal                                              v1.10.0                               3-clause BSD license
     github.com/rubenv/sql-migrate                                                v1.4.0                                MIT license
     github.com/russross/blackfriday/v2                                           v2.1.0                                2-clause BSD license
     github.com/sabhiram/go-gitignore                                             v0.0.0-20210923224102-525f6e181f06    MIT license

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/moby/term v0.5.0
 	github.com/pkg/sftp v1.13.5
 	github.com/prometheus/client_golang v1.15.1
+	github.com/rogpeppe/go-internal v1.10.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sirupsen/logrus v1.9.2
 	github.com/spf13/afero v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -593,6 +593,7 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rubenv/sql-migrate v1.4.0 h1:y4ndB3hq5tmjvQ8jcuqhLgeEqoxIjEidN5RaCkKOAAE=
 github.com/rubenv/sql-migrate v1.4.0/go.mod h1:lRxHt4vTgRJtpGbulUUYHA9dzfbBJXRt+PwUF/jeNYo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/client/cache/cache.go
+++ b/pkg/client/cache/cache.go
@@ -13,6 +13,7 @@ import (
 )
 
 func SaveToUserCache(ctx context.Context, object any, file string) error {
+	ctx = dos.WithLockedFs(ctx)
 	jsonContent, err := json.Marshal(object)
 	if err != nil {
 		return err
@@ -29,8 +30,9 @@ func SaveToUserCache(ctx context.Context, object any, file string) error {
 }
 
 func LoadFromUserCache(ctx context.Context, dest any, file string) error {
+	ctx = dos.WithLockedFs(ctx)
 	path := filepath.Join(filelocation.AppUserCacheDir(ctx), file)
-	jsonContent, err := os.ReadFile(path)
+	jsonContent, err := dos.ReadFile(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -41,15 +43,17 @@ func LoadFromUserCache(ctx context.Context, dest any, file string) error {
 }
 
 func DeleteFromUserCache(ctx context.Context, file string) error {
-	if err := os.Remove(filepath.Join(filelocation.AppUserCacheDir(ctx), file)); err != nil && !os.IsNotExist(err) {
+	ctx = dos.WithLockedFs(ctx)
+	if err := dos.Remove(ctx, filepath.Join(filelocation.AppUserCacheDir(ctx), file)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
 }
 
 func ExistsInCache(ctx context.Context, fileName string) (bool, error) {
+	ctx = dos.WithLockedFs(ctx)
 	path := filepath.Join(filelocation.AppUserCacheDir(ctx), fileName)
-	if _, err := os.Stat(path); err != nil {
+	if _, err := dos.Stat(ctx, path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}

--- a/pkg/dos/lockedfile.go
+++ b/pkg/dos/lockedfile.go
@@ -1,0 +1,55 @@
+package dos
+
+import (
+	"context"
+	"io/fs"
+	"os"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+type lockedFs struct {
+	osFs
+}
+
+func WithLockedFs(ctx context.Context) context.Context {
+	return WithFS(ctx, &lockedFs{})
+}
+
+func (fs *lockedFs) Create(name string) (File, error) {
+	f, err := lockedfile.Create(name)
+	if err != nil {
+		// It's important to return a File nil here, not a File that represents an *os.File nil.
+		return nil, err
+	}
+	return fs.chownFile(f)
+}
+
+func (*lockedFs) Open(name string) (File, error) {
+	f, err := lockedfile.Open(name)
+	if err != nil {
+		// It's important to return a File nil here, not a File that represents an *os.File nil.
+		return nil, err
+	}
+	return f, nil
+}
+
+func (fs *lockedFs) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
+	if fs.mustChown() {
+		if (flag & os.O_CREATE) == os.O_CREATE {
+			if _, err := os.Stat(name); os.IsNotExist(err) {
+				f, err := lockedfile.OpenFile(name, flag, perm)
+				if err != nil {
+					return nil, err
+				}
+				return fs.chownFile(f)
+			}
+		}
+	}
+	f, err := lockedfile.OpenFile(name, flag, perm)
+	if err != nil {
+		// It's important to return a File nil here, not a File that represents an *os.File nil.
+		return nil, err
+	}
+	return f, nil
+}

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/telepresenceio/telepresence/rpc/v2 v2.15.0 // indirect


### PR DESCRIPTION
## Description

Introduces a new `lockedFS` to the `dos` package that uses the rogpeppe clone of the go internal `lockedfile` package to do advisory locking on the files. The Telepresence cache then uses this file system for all file accesses in the cache.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
