### PR TITLE
Fix race condition when obtaining routes.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,11 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Routing table race condition
+        body: ->
+          A race condition would sometimes occur when a Telepresence TUN device was deleted and another created in rapid
+          succession that caused the routing table to reference interfaces that no longer existed.
+      - type: bugfix
         title: Stop lingering daemon container
         body: >-
           When using <code>telepresence connect --docker</code>, a lingering container could be present, causing errors


### PR DESCRIPTION
## Description

Under certain conditions, the routing table may reference interfaces that no longer exists. This caused failures in our CI-tests such as "Unable to get interface at index NN". THe situation occurred when a session was terminated just before an attempt was made to obtain the table.

This commit adds a retry and a delay to the process of obtaining a consistent table. If no interface is found at an index, the table is re-fetched and rescanned.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
