### PR TITLE
fix: match service selector against pod template labels

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,16 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.16.1
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Match service selector against pod template labels
+        body: >-
+          When listing intercepts (typically by calling <code>telepresence list</code>) selectors of services are matched
+          against workloads. Previously the match was made against the labels of the workload, but now they are matched
+          against the labels pod template of the workload. Since the service would actually be matched against pods this
+          is more correct. The most common case when this makes a difference is that statefulsets now are listed when they should.
   - version: 2.16.0
     date: "2023-10-02"
     notes:

--- a/pkg/client/userd/trafficmgr/workloads.go
+++ b/pkg/client/userd/trafficmgr/workloads.go
@@ -346,7 +346,7 @@ func (nw *namespacedWASWatcher) findMatchingWorkloads(c context.Context, svc *co
 			case statefulsets:
 				wl = k8sapi.StatefulSet(o.(*apps.StatefulSet))
 			}
-			if selector.Matches(labels.Set(wl.GetLabels())) {
+			if selector.Matches(labels.Set(wl.GetPodTemplate().Labels)) {
 				owl, err := nw.maybeReplaceWithOwner(c, wl)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
## Description

Match service selector against pod template labels instead of against the labels of the workload itself. This ought to be more correct since the service match against pods and not workloads.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
