### PR TITLE
Restore legacy TLS annotation names.

### DIFF
--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -103,6 +103,18 @@ func AgentContainer(
 			MountPath: TempMountPoint,
 		},
 	)
+	if _, ok := pod.ObjectMeta.Annotations[LegacyTerminatingTLSSecretAnnotation]; ok {
+		mounts = append(mounts, core.VolumeMount{
+			Name:      TerminatingTLSVolumeName,
+			MountPath: TerminatingTLSMountPoint,
+		})
+	}
+	if _, ok := pod.ObjectMeta.Annotations[LegacyOriginatingTLSSecretAnnotation]; ok {
+		mounts = append(mounts, core.VolumeMount{
+			Name:      OriginatingTLSVolumeName,
+			MountPath: OriginatingTLSMountPoint,
+		})
+	}
 	if _, ok := pod.ObjectMeta.Annotations[TerminatingTLSSecretAnnotation]; ok {
 		mounts = append(mounts, core.VolumeMount{
 			Name:      TerminatingTLSVolumeName,

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -43,10 +43,12 @@ const (
 	// EnvAPIPort is the port number of the Telepresence API server, when it is enabled.
 	EnvAPIPort = "TELEPRESENCE_API_PORT"
 
-	DomainPrefix                   = "telepresence.getambassador.io/"
-	InjectAnnotation               = DomainPrefix + "inject-" + ContainerName
-	TerminatingTLSSecretAnnotation = DomainPrefix + "inject-terminating-tls-secret"
-	OriginatingTLSSecretAnnotation = DomainPrefix + "inject-originating-tls-secret"
+	DomainPrefix                         = "telepresence.getambassador.io/"
+	InjectAnnotation                     = DomainPrefix + "inject-" + ContainerName
+	TerminatingTLSSecretAnnotation       = DomainPrefix + "inject-terminating-tls-secret"
+	OriginatingTLSSecretAnnotation       = DomainPrefix + "inject-originating-tls-secret"
+	LegacyTerminatingTLSSecretAnnotation = "getambassador.io/inject-terminating-tls-secret"
+	LegacyOriginatingTLSSecretAnnotation = "getambassador.io/inject-originating-tls-secret"
 )
 
 type ReplacePolicy int


### PR DESCRIPTION
Users of Telepresence <2.9.0 that make use of the pod template TLS annotations are unable to upgrade because the annotation names have changed (now prefixed by "telepresence."). This commit will restore support for the old names (while retaining the new ones).