### PR TITLE
Fix wrongly sent connect_error metric

### DIFF
--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -134,21 +134,21 @@ func NewSession(
 	ctx context.Context,
 	cr *rpc.ConnectRequest,
 	config *client.Kubeconfig,
-) (_ context.Context, _ userd.Session, cErr *connector.ConnectInfo) {
+) (_ context.Context, _ userd.Session, ret *connector.ConnectInfo) {
 	dlog.Info(ctx, "-- Starting new session")
 	scout.Report(ctx, "connect")
 
 	defer func() {
-		if cErr != nil {
+		if ret != nil && ret.Error != connector.ConnectInfo_UNSPECIFIED {
 			scout.Report(ctx, "connect_error", scout.Entry{
 				Key:   "error",
-				Value: cErr.ErrorText,
+				Value: ret.ErrorText,
 			}, scout.Entry{
 				Key:   "error_type",
-				Value: cErr.Error.String(),
+				Value: ret.Error.String(),
 			}, scout.Entry{
 				Key:   "error_category",
-				Value: cErr.ErrorCategory,
+				Value: ret.ErrorCategory,
 			})
 		}
 	}()
@@ -229,7 +229,7 @@ func NewSession(
 	})
 
 	tmgr.AddNamespaceListener(ctx, tmgr.updateDaemonNamespaces)
-	ret := &rpc.ConnectInfo{
+	ret = &rpc.ConnectInfo{
 		Error:            rpc.ConnectInfo_UNSPECIFIED,
 		ClusterContext:   cluster.Kubeconfig.Context,
 		ClusterServer:    cluster.Kubeconfig.Server,


### PR DESCRIPTION
## Description

The `connect_error` metric is sent even if the connect was successful. This PR fixes it by checking the error status`UNSPECIFIED`  which means [success](https://github.com/telepresenceio/telepresence/blob/a212c3b84d55c140406a80a99296ff4832c04cb2/rpc/connector/connector.proto#L169).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
