### PR TITLE
Enable debugging of code running in containers

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,11 @@ items:
     date: "2023-10-03"
     notes:
       - type: feature
+        title: Add <code>--docker-debug</code> flag to the <code>telepresence intercept</code> command.
+        body: >-
+          This flag is similar to <code>--docker-build</code> but will start the container with more relaxed security
+          using the <code>docker run</code> flags <code>--security-opt apparmor=unconfined --cap-add SYS_PTRACE</code>.
+      - type: feature
         title: Add a <code>--export</code> option to the <code>telepresence connect</code> command.
         body: >-
           In some situations it is necessary to make some ports available to the

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,13 @@ items:
     date: "2023-10-03"
     notes:
       - type: feature
+        title: Add a <code>--export</code> option to the <code>telepresence connect</code> command.
+        body: >-
+          In some situations it is necessary to make some ports available to the
+          host from a containerized telepresence daemon. This commit adds a
+          repeatable <code>--expose &lt;docker port exposure&gt;</code> flag to the connect
+          command.
+      - type: feature
         title: Prevent agent-injector webhook from selecting from kube-xxx namespaces.
         body: >-
           The <code>kube-system</code> and <code>kube-node-lease</code> namespaces should not be affected by a

--- a/pkg/client/cli/cmd/status.go
+++ b/pkg/client/cli/cmd/status.go
@@ -43,6 +43,7 @@ type RootDaemonStatus struct {
 type UserDaemonStatus struct {
 	Running           bool                     `json:"running,omitempty" yaml:"running,omitempty"`
 	Name              string                   `json:"name,omitempty" yaml:"name,omitempty"`
+	ContainerNetwork  string                   `json:"container_network,omitempty" yaml:"container_network,omitempty"`
 	Version           string                   `json:"version,omitempty" yaml:"version,omitempty"`
 	APIVersion        int32                    `json:"api_version,omitempty" yaml:"api_version,omitempty"`
 	Executable        string                   `json:"executable,omitempty" yaml:"executable,omitempty"`
@@ -161,6 +162,9 @@ func BasicGetStatusInfo(ctx context.Context) (ioutil.WriterTos, error) {
 	us.Version = version.Version
 	us.APIVersion = version.ApiVersion
 	us.Executable = version.Executable
+	if userD.Containerized() {
+		us.ContainerNetwork = "container:" + userD.DaemonID.ContainerName()
+	}
 
 	status, err := userD.Status(ctx, &empty.Empty{})
 	if err != nil {
@@ -347,7 +351,10 @@ func (cs *UserDaemonStatus) print(kvf *ioutil.KeyValueFormatter) {
 	}
 	kvf.Add("Kubernetes server", cs.KubernetesServer)
 	kvf.Add("Kubernetes context", cs.KubernetesContext)
-	kvf.Add("ConnectionName", cs.ConnectionName)
+	if cs.ContainerNetwork != "" {
+		kvf.Add("Container network", cs.ContainerNetwork)
+	}
+	kvf.Add("Connection name", cs.ConnectionName)
 	kvf.Add("Namespace", cs.Namespace)
 	kvf.Add("Manager namespace", cs.ManagerNamespace)
 	if len(cs.MappedNamespaces) > 0 {

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"time"
 
@@ -162,6 +163,9 @@ func DiscoverDaemon(ctx context.Context, match *regexp.Regexp, kubeContext, name
 			}
 		}
 		return nil, err
+	}
+	if len(cr.ExposedPorts) > 0 && !slices.Equal(info.ExposedPorts, cr.ExposedPorts) {
+		return nil, errcat.User.New("exposed ports differ. Please quit and reconnect")
 	}
 	conn, err := DialDaemon(ctx, info)
 	if err != nil {
@@ -345,10 +349,11 @@ func connectSession(ctx context.Context, useLine string, userD *daemon.UserClien
 		daemonID := userD.DaemonID
 		err = daemon.SaveInfo(ctx,
 			&daemon.Info{
-				InDocker:    false,
-				Name:        daemonID.Name,
-				KubeContext: daemonID.KubeContext,
-				Namespace:   daemonID.Namespace,
+				InDocker:     false,
+				Name:         daemonID.Name,
+				KubeContext:  daemonID.KubeContext,
+				Namespace:    daemonID.Namespace,
+				ExposedPorts: request.ExposedPorts,
 			}, daemonID.InfoFileName())
 		if err != nil {
 			return nil, errcat.NoDaemonLogs.New(err)

--- a/pkg/client/cli/daemon/info.go
+++ b/pkg/client/cli/daemon/info.go
@@ -18,12 +18,13 @@ import (
 )
 
 type Info struct {
-	Options     map[string]string `json:"options,omitempty"`
-	InDocker    bool              `json:"in_docker,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	KubeContext string            `json:"kube_context,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	DaemonPort  int               `json:"daemon_port,omitempty"`
+	Options      map[string]string `json:"options,omitempty"`
+	InDocker     bool              `json:"in_docker,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	KubeContext  string            `json:"kube_context,omitempty"`
+	Namespace    string            `json:"namespace,omitempty"`
+	DaemonPort   int               `json:"daemon_port,omitempty"`
+	ExposedPorts []string          `json:"exposed_ports,omitempty"`
 }
 
 func (info *Info) DaemonID() *Identifier {

--- a/pkg/client/cli/daemon/request.go
+++ b/pkg/client/cli/daemon/request.go
@@ -27,6 +27,9 @@ type Request struct {
 	// If set, then use a containerized daemon for the connection.
 	Docker bool
 
+	// Ports exposed by a containerized daemon. Only valid when Docker == true
+	ExposedPorts []string
+
 	// Match expression to use when finding an existing connection by name
 	Use *regexp.Regexp
 
@@ -63,6 +66,9 @@ func InitRequest(cmd *cobra.Command) *Request {
 	nwFlags.StringVar(&cr.ManagerNamespace, "manager-namespace", "", `The namespace where the traffic manager is to be found. `+
 		`Overrides any other manager namespace set in config`)
 	nwFlags.Bool(global.FlagDocker, false, "Start, or connect to, daemon in a docker container")
+	nwFlags.StringArrayVar(&cr.ExposedPorts,
+		"expose", nil, ``+
+			`Port that a containerized daemon will expose. See docker run -p for more info. Can be repeated`)
 	flags.AddFlagSet(nwFlags)
 
 	dbgFlags := pflag.NewFlagSet("Debug and Profiling flags", 0)

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -77,6 +77,10 @@ func DaemonOptions(ctx context.Context, daemonID *daemon.Identifier) ([]string, 
 		"-v", fmt.Sprintf("%s:%s", filelocation.AppUserCacheDir(ctx), dockerTpCache),
 		"-v", fmt.Sprintf("%s:%s", filelocation.AppUserLogDir(ctx), dockerTpLog),
 	}
+	cr := daemon.GetRequest(ctx)
+	for _, ep := range cr.ExposedPorts {
+		opts = append(opts, "-p", ep)
+	}
 	if runtime.GOOS == "linux" {
 		opts = append(opts, "--add-host", "host.docker.internal:host-gateway")
 	}


### PR DESCRIPTION
## Description

Adds what's needed in order to facilitate a debugger that runs in a container with relaxed security that exports a port that a debugger frontend can connect to.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
