### PR TITLE
OSS - Bump to 1.21.2

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '~1.21.1'
+        go-version: '~1.21.2'
     - uses: azure/setup-kubectl@v3
       with:
         version: 'v1.25.3'

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -18,7 +18,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
       - name: Build dev image
         run: |
           make save-tel2-image

--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
 
       # we need fuseftp.bits
       - name: "Build dependencies"

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -16,7 +16,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
       - name: "Install mockgen"
         shell: bash
         run: go install github.com/golang/mock/mockgen@v1.6.0

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,7 +13,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
             #- uses: azure/setup-kubectl@v1
             #with:
             #version: 'v1.19.3'
@@ -49,7 +49,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
       - name: "Download winfsp"
         shell: bash
         run: |
@@ -84,7 +84,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
       - run: |
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
@@ -110,7 +110,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
-          go-version: '~1.21.1'
+          go-version: '~1.21.2'
       - run: |
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,10 @@ items:
   - version: 2.16.1
     date: (TBD)
     notes:
+      - type: security
+        title: Built with go 1.21.2
+        body: >-
+          Built Telepresence with go 1.21.2 to address CVEs.
       - type: bugfix
         title: Match service selector against pod template labels
         body: >-


### PR DESCRIPTION
## Description

Go was updated to 1.21.2 because of a [security issue at build time.](https://go.dev/doc/devel/release#go1.21.0)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
