### PR TITLE
Restore TLS annotation value expansion.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -55,11 +55,10 @@ items:
       - type: bugfix
         title: Backward compatibility for pod template TLS annotations.
         body: >-
-          Users of Telepresence < 2.9.0 that make use of the pod template
-          TLS annotations were unable to upgrade because the annotation names
-          have changed (now prefixed by "telepresence."). This fix restores
-          support for the old names (while retaining the new ones).
-
+          Users of Telepresence < 2.9.0 that make use of the pod template TLS annotations were unable to upgrade because
+          the annotation names have changed (now prefixed by "telepresence."), and the environment expansion of the
+          annotation values was dropped. This fix restores support for the old names (while retaining the new ones) and
+          the environment expansion.
   - version: 2.16.0
     date: "2023-10-02"
     notes:

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -11,6 +11,7 @@ import (
 	core "k8s.io/api/core/v1"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 )
 
 // AgentContainer will return a configured traffic-agent.
@@ -257,22 +258,33 @@ func AgentVolumes(agentName string, pod *core.Pod) []core.Volume {
 			},
 		},
 	}
-	if secret, ok := pod.ObjectMeta.Annotations[TerminatingTLSSecretAnnotation]; ok {
-		volumes = append(volumes, core.Volume{
-			Name: TerminatingTLSVolumeName,
-			VolumeSource: core.VolumeSource{
-				Secret: &core.SecretVolumeSource{
-					SecretName: secret,
-				},
-			},
-		})
+
+	// The name of the TLS secret in the annotations might contain environment variable expansions. The expansions
+	// allowed here are "$AGENT_NAME" and "$_TEL_AGENT_NAME". The latter is for backward compatibility with older
+	// agents where this expansion happened in the traffic-agent.
+	env := dos.MapEnv{
+		"AGENT_NAME":      agentName,
+		"_TEL_AGENT_NAME": agentName,
 	}
-	if secret, ok := pod.ObjectMeta.Annotations[OriginatingTLSSecretAnnotation]; ok {
+	vCount := len(volumes)
+	volumes = appendSecretVolume(env, TerminatingTLSSecretAnnotation, TerminatingTLSVolumeName, pod, volumes)
+	volumes = appendSecretVolume(env, OriginatingTLSSecretAnnotation, OriginatingTLSVolumeName, pod, volumes)
+
+	if vCount == len(volumes) {
+		// Check for legacy names too.
+		volumes = appendSecretVolume(env, LegacyTerminatingTLSSecretAnnotation, TerminatingTLSVolumeName, pod, volumes)
+		volumes = appendSecretVolume(env, LegacyOriginatingTLSSecretAnnotation, OriginatingTLSVolumeName, pod, volumes)
+	}
+	return volumes
+}
+
+func appendSecretVolume(env dos.Env, annotation, volumeName string, pod *core.Pod, volumes []core.Volume) []core.Volume {
+	if secret, ok := pod.ObjectMeta.Annotations[annotation]; ok {
 		volumes = append(volumes, core.Volume{
-			Name: OriginatingTLSVolumeName,
+			Name: volumeName,
 			VolumeSource: core.VolumeSource{
 				Secret: &core.SecretVolumeSource{
-					SecretName: secret,
+					SecretName: env.ExpandEnv(secret),
 				},
 			},
 		})


### PR DESCRIPTION
Users of Telepresence <2.9.0 that make use of the pod template TLS annotations are unable to upgrade because the annotation values are no longer exposed to environment expansion. It used to be possible to name a secret "$_TEL_AGENT_NAME-tls-cert" and get that expanded.

This commit restores this behavior in the traffic-manager by using a fake environment that contains the `_TEL_AGENT_NAME` env-var. It also adds a `AGENT_NAME` env-var so that the old name (which is very special and no longer in use) can be replaced.