### PR TITLE
Make extension point for Manager client from the agent

### DIFF
--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -44,6 +44,8 @@ func (is interceptsStringer) String() string {
 	return sb.String()
 }
 
+var NewExtendedManagerClient func(conn *grpc.ClientConn, ossManager rpc.ManagerClient) rpc.ManagerClient //nolint:gochecknoglobals // extension point
+
 func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, state State) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -60,6 +62,9 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 	defer conn.Close()
 
 	manager := rpc.NewManagerClient(conn)
+	if NewExtendedManagerClient != nil {
+		manager = NewExtendedManagerClient(conn, manager)
+	}
 
 	ver, err := manager.Version(ctx, &empty.Empty{})
 	if err != nil {


### PR DESCRIPTION
## Description

This PR adds the possibility for a program based on Telepresence, and more specifically its traffic-agent, to extend the client of the traffic manager (especially in situations where the server was extended aswell).

This PR also makes the `unlockedRemoveSession` method public so we can reimplement it, and make sure it's being called instead of the OSS one if it exists.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
