### PR TITLE
Allow the creation of an intercept matching a removed one

### DIFF
--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -509,8 +509,12 @@ func (s *state) AddIntercept(ctx context.Context, sessionID, clusterID string, c
 		}
 	}
 
-	if _, hasConflict := s.intercepts.LoadOrStore(cept.Id, cept); hasConflict {
-		return nil, status.Errorf(codes.AlreadyExists, "Intercept named %q already exists", spec.Name)
+	if existingValue, hasConflict := s.intercepts.LoadOrStore(cept.Id, cept); hasConflict {
+		if existingValue.Disposition != rpc.InterceptDispositionType_REMOVED {
+			return nil, status.Errorf(codes.AlreadyExists, "Intercept named %q already exists", spec.Name)
+		} else {
+			s.intercepts.Store(cept.Id, cept)
+		}
 	}
 
 	state := newInterceptState(cept.Id)


### PR DESCRIPTION
## Description

```bash
➜  telepresence2-proprietary git:(thallgren/disposition-removed) ✗ tp leave echo-easy-1                                                                                             
telepresence leave: error: Intercept named "echo-easy-1" not found
➜  telepresence2-proprietary git:(thallgren/disposition-removed) ✗ tp intercept echo-easy-1 --workload=echo-easy --http-header=test-integration=1 --service=echo-easy --port 8080:80

telepresence intercept: error: connector.CreateIntercept: rpc error: code = AlreadyExists desc = Intercept named "echo-easy-1" already exists
```
