### PR TITLE
Add method to get all intercepts from the state

### DIFF
--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -48,6 +48,7 @@ type State interface {
 	ExpireSessions(context.Context, time.Time, time.Time)
 	GetAgent(string) *rpc.AgentInfo
 	GetAllClients() map[string]*rpc.ClientInfo
+	GetAllIntercepts() map[string]*rpc.InterceptInfo
 	GetClient(string) *rpc.ClientInfo
 	GetSession(string) SessionState
 	GetSessionConsumptionMetrics(string) *SessionConsumptionMetrics
@@ -387,6 +388,10 @@ func (s *state) GetClient(sessionID string) *rpc.ClientInfo {
 
 func (s *state) GetAllClients() map[string]*rpc.ClientInfo {
 	return s.clients.LoadAll()
+}
+
+func (s *state) GetAllIntercepts() map[string]*rpc.InterceptInfo {
+	return s.intercepts.LoadAll()
 }
 
 func (s *state) CountAgents() int {


### PR DESCRIPTION
## Description

Adds a method to the state to get all intercepts from implementations based on Telepresence.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
