### PR TITLE
Update changelog and make the doc URL in the help extendable

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,9 +30,17 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
-  - version: 2.16.2
+  - version: 2.17.0
     date: "(TBD)"
     notes:
+      - type: feature
+        title: Additional Prometheus metrics to track intercept/connect activity
+        body: >-
+          This feature adds the following metrics to the Prometheus endpoint: <code>connect_count</code>, 
+          <code>connect_active_status</code>, <code>intercept_count</code>, and <code>intercept_active_status</code. 
+          These are labeled by client/install_id. 
+          Additionally, the <code>intercept_count</code> metric has been renamed to <code>active_intercept_count</code> 
+          for clarity.
       - type: feature
         title: Make the Telepresence client docker image configurable.
         body: >-
@@ -77,12 +85,12 @@ items:
     date: "2023-10-03"
     notes:
       - type: feature
-        title: Add <code>--docker-debug</code> flag to the <code>telepresence intercept</code> command.
+        title: Add --docker-debug flag to the telepresence intercept command.
         body: >-
           This flag is similar to <code>--docker-build</code> but will start the container with more relaxed security
           using the <code>docker run</code> flags <code>--security-opt apparmor=unconfined --cap-add SYS_PTRACE</code>.
       - type: feature
-        title: Add a <code>--export</code> option to the <code>telepresence connect</code> command.
+        title: Add a --export option to the telepresence connect command.
         body: >-
           In some situations it is necessary to make some ports available to the
           host from a containerized telepresence daemon. This commit adds a

--- a/pkg/client/cli/cmd/usage.go
+++ b/pkg/client/cli/cmd/usage.go
@@ -12,6 +12,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/global"
 )
 
+var CLIHelpDocumentationURL = "https://www.telepresence.io" //nolint:gochecknoglobals // extension point
+
 const (
 	help = `Telepresence can connect to a cluster and route all outbound traffic from your
 workstation to that cluster so that software running locally can communicate
@@ -59,7 +61,7 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.
 
-For complete documentation and quick-start guides, check out our website at https://www.telepresence.io{{end}}
+For complete documentation and quick-start guides, check out our website at {{ getDocumentationURL }}{{end}}
 `
 )
 
@@ -135,6 +137,9 @@ func addUsageTemplate(cmd *cobra.Command) {
 			}
 		}
 		return flags.FlagUsagesWrapped(cols)
+	})
+	cobra.AddTemplateFunc("getDocumentationURL", func() string {
+		return CLIHelpDocumentationURL
 	})
 
 	// Set a usage template that is derived from the default but replaces the "Available Commands"

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -334,7 +334,7 @@ func connectSession(ctx context.Context, useLine string, userD *daemon.UserClien
 		maxDiff := uint64(3)
 		if diff > maxDiff {
 			ioutil.Printf(output.Info(ctx),
-				"Manager version (%s) is more than %v minor versions diff from client version (%s), please consider upgrading.\n",
+				"The Traffic Manager version (%s) is more than %v minor versions diff from client version (%s), please consider upgrading.\n",
 				version.Version, maxDiff, client.Version())
 		}
 		return nil


### PR DESCRIPTION
## Description

* Adds an extension point to target a different documentation when building on top of Telepresence OSS.
* Add missing changelog for Prometheus metrics.
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
