### PR TITLE
add manager_version to metrics

### DIFF
--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -296,6 +296,8 @@ func NewSession(c context.Context, mi *rpc.OutboundInfo) (context.Context, *Sess
 	}
 	s := newSession(c, mi, mc, ver)
 	s.clientConn = conn
+	// store session in ctx for reporting
+	c = scout.WithSession(c, s)
 	return c, s, nil
 }
 
@@ -331,6 +333,8 @@ func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerPro
 		config:                  cfg,
 		done:                    make(chan struct{}),
 	}
+
+	// store session in
 
 	if dnsproxy.ManagerCanDoDNSQueryTypes(ver) {
 		s.dnsServer = dns.NewServer(mi.Dns, s.clusterLookup, false)
@@ -921,6 +925,10 @@ func (s *Session) waitForAgentIP(ctx context.Context, request *rpc.WaitForAgentI
 	return &empty.Empty{}, err
 }
 
-func (s *Session) Done() chan struct{} {
+func (s *Session) Done() <-chan struct{} {
 	return s.done
+}
+
+func (s *Session) ManagerVersion() semver.Version {
+	return s.managerVersion
 }

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -334,8 +334,6 @@ func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerPro
 		done:                    make(chan struct{}),
 	}
 
-	// store session in
-
 	if dnsproxy.ManagerCanDoDNSQueryTypes(ver) {
 		s.dnsServer = dns.NewServer(mi.Dns, s.clusterLookup, false)
 	} else {

--- a/pkg/client/scout/reporter.go
+++ b/pkg/client/scout/reporter.go
@@ -27,8 +27,10 @@ type bufEntry struct {
 	entries []Entry
 }
 
-type ReportAnnotator func(map[string]any)
-type ReportMutator func(context.Context, []Entry) []Entry
+type (
+	ReportAnnotator func(map[string]any)
+	ReportMutator   func(context.Context, []Entry) []Entry
+)
 
 // Reporter is a Metriton reporter.
 type Reporter interface {
@@ -369,7 +371,7 @@ func (r *reporter) Run(ctx context.Context) error {
 // attempt (correlated by the trace_id set at the start).
 func (r *reporter) Report(ctx context.Context, action string, entries ...Entry) {
 	for _, m := range r.reportMutators {
-		// IDEA allow rm to cancel report
+		// IDEA allow mutator to cancel report
 		entries = m(ctx, entries)
 	}
 	select {

--- a/pkg/client/scout/reporter_test.go
+++ b/pkg/client/scout/reporter_test.go
@@ -307,7 +307,7 @@ func TestInstallID(t *testing.T) {
 			}
 
 			// Then do...
-			scout := NewReporterForInstallType(ctx, "go-test", CLI, DefaultReportAnnotators).(*reporter)
+			scout := NewReporterForInstallType(ctx, "go-test", CLI, DefaultReportAnnotators, DefaultReportMutators).(*reporter)
 			scout.reporter.Endpoint = metriton.BetaEndpoint
 			actualID := scout.reporter.InstallID()
 			actualErr, _ := scout.reporter.BaseMetadata["install_id_error"].(string)

--- a/pkg/client/scout/session.go
+++ b/pkg/client/scout/session.go
@@ -34,7 +34,6 @@ func sessionReportMutator(ctx context.Context, e []Entry) []Entry {
 	select {
 	// session is dead
 	case <-session.Done():
-		return e
 	default:
 		v := session.ManagerVersion()
 		e = append(e, Entry{

--- a/pkg/client/scout/session.go
+++ b/pkg/client/scout/session.go
@@ -1,0 +1,47 @@
+package scout
+
+import (
+	"context"
+
+	"github.com/blang/semver"
+)
+
+type sessionKey struct{}
+
+type session interface {
+	ManagerVersion() semver.Version
+	Done() <-chan struct{}
+}
+
+func GetSession(ctx context.Context) session {
+	if s, ok := ctx.Value(sessionKey{}).(session); ok {
+		return s
+	}
+	return nil
+}
+
+func WithSession(ctx context.Context, s session) context.Context {
+	return context.WithValue(ctx, sessionKey{}, s)
+}
+
+func sessionReportMutator(ctx context.Context, e []Entry) []Entry {
+	// check if client is present in context
+	session := GetSession(ctx)
+	if session == nil {
+		return e
+	}
+
+	select {
+	// session is dead
+	case <-session.Done():
+		return e
+	default:
+		v := session.ManagerVersion()
+		e = append(e, Entry{
+			Key:   "manager_version",
+			Value: v.String(),
+		})
+	}
+
+	return e
+}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -193,7 +193,7 @@ func NewSession(
 	}
 
 	// store session in ctx for reporting
-	scout.WithSession(ctx, tmgr)
+	ctx = scout.WithSession(ctx, tmgr)
 	defer report(ctx)
 
 	tmgr.sessionConfig = client.GetDefaultConfig()

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -141,7 +141,7 @@ func NewSession(
 	dlog.Info(ctx, "-- Starting new session")
 
 	connectStart := time.Now()
-	defer func() {
+	report := func(ctx context.Context) {
 		if info.Error == connector.ConnectInfo_UNSPECIFIED {
 			scout.Report(ctx, "connect",
 				scout.Entry{
@@ -170,12 +170,13 @@ func NewSession(
 					Value: len(cr.MappedNamespaces),
 				})
 		}
-	}()
+	}
 
 	dlog.Info(ctx, "Connecting to k8s cluster...")
 	cluster, err := k8s.ConnectCluster(ctx, cr, config)
 	if err != nil {
 		dlog.Errorf(ctx, "unable to track k8s cluster: %+v", err)
+		report(ctx)
 		return ctx, nil, connectError(rpc.ConnectInfo_CLUSTER_FAILED, err)
 	}
 	dlog.Infof(ctx, "Connected to context %s, namespace %s (%s)", cluster.Context, cluster.Namespace, cluster.Server)
@@ -187,8 +188,13 @@ func NewSession(
 	tmgr, err := connectMgr(ctx, cluster, scout.InstallID(ctx), cr)
 	if err != nil {
 		dlog.Errorf(ctx, "Unable to connect to session: %s", err)
+		report(ctx)
 		return ctx, nil, connectError(rpc.ConnectInfo_TRAFFIC_MANAGER_FAILED, err)
 	}
+
+	// store session in ctx for reporting
+	scout.WithSession(ctx, tmgr)
+	defer report(ctx)
 
 	tmgr.sessionConfig = client.GetDefaultConfig()
 	cliCfg, err := tmgr.managerClient.GetClientConfig(ctx, &empty.Empty{})

--- a/tools/src/go-mkopensource/pin.go
+++ b/tools/src/go-mkopensource/pin.go
@@ -4,4 +4,3 @@
 package ignore
 
 import "github.com/datawire/go-mkopensource/cmd/go-mkopensource"
-

--- a/tools/src/test-report/logger.go
+++ b/tools/src/test-report/logger.go
@@ -91,5 +91,4 @@ func (l *Logger) ReportFailures() bool {
 		fmt.Fprintf(os.Stderr, "\n%s.%s\n%s\n%s\n", testID.Package, testID.Test, output, separator)
 	}
 	return true
-
 }

--- a/tools/src/test-report/reporter.go
+++ b/tools/src/test-report/reporter.go
@@ -38,7 +38,8 @@ type Reporter struct {
 }
 
 func NewReporter(ctx context.Context, progress *progressBar, onError func(error)) (*Reporter, error) {
-	r := &Reporter{reportCh: make(chan *Line, reportChanSz),
+	r := &Reporter{
+		reportCh:     make(chan *Line, reportChanSz),
 		doneCh:       make(chan struct{}),
 		onError:      onError,
 		requestQueue: make(chan *Line, requestQueueSz),


### PR DESCRIPTION
## Description

- add sessions to context
- check for sessions in context when reporting. Add traffic manager version to report if session is found

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
