### PR TITLE
Fix panic during reconnect.

### DIFF
--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -251,7 +251,7 @@ func EnsureUserDaemon(ctx context.Context, required bool) (context.Context, erro
 		}
 	}()
 
-	if daemon.GetUserClient(ctx) != nil {
+	if ud = daemon.GetUserClient(ctx); ud != nil {
 		return ctx, nil
 	}
 	if ctx, ud, err = launchConnectorDaemon(ctx, client.GetExe(), required); err != nil {


### PR DESCRIPTION
New logic in the intercept spec runner revealed a glitch in connect. It has never been triggered yet, but the fix is needed for new functionality in our pro version.