### PR TITLE
Untangle nested locking causing deadlock during root daemon disconnect.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,10 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Root daemon refuses to disconnect.
+        body: The root daemon would sometimes hang forever when attempting to disconnect due to a deadlock in
+          the VIF-device.
+      - type: bugfix
         title: Fix panic in user daemon when traffic-manager was unreachable
         body: The user daemon would panic if the traffic-manager was unreachable. It will now instead report
           a proper error to the client.

--- a/pkg/vif/device.go
+++ b/pkg/vif/device.go
@@ -37,6 +37,7 @@ type Device interface {
 	AddSubnet(context.Context, *net.IPNet) error
 	RemoveSubnet(context.Context, *net.IPNet) error
 	SetDNS(context.Context, string, net.IP, []string) (err error)
+	WaitForDevice()
 }
 
 const defaultDevMtu = 1500
@@ -147,7 +148,7 @@ func (d *device) RemoveSubnet(ctx context.Context, subnet *net.IPNet) (err error
 	return d.dev.removeSubnet(sCtx, subnet)
 }
 
-func (d *device) Wait() {
+func (d *device) WaitForDevice() {
 	d.wg.Wait()
 	dlog.Info(d.ctx, "Endpoint done")
 }

--- a/pkg/vif/tunneling_device.go
+++ b/pkg/vif/tunneling_device.go
@@ -54,5 +54,6 @@ func (vif *TunnelingDevice) Close(ctx context.Context) error {
 
 func (vif *TunnelingDevice) Run(ctx context.Context) error {
 	vif.stack.Wait()
+	vif.Device.Wait()
 	return nil
 }


### PR DESCRIPTION
On rare occasions, the VIF device would end up in a function that required a read lock of the `Endpoint` that the gvisor stack uses and that would be impossible due to the stack's Wait method calling the device's Wait method, which in turn waited for a `sync.WaitGroup` that never got done, because it should have been released by the caller of the first function. Classic deadlock.

This commit ensures that the `stack.Wait` never calls on the device's `Wait` and instead calls the device's `Endpoint.Wait` directly by renaming the device's `Wait` to `WaitForDevice`. That function is then called explicitly in serial with `stack.Wait`. This untangles the potential deadlock.