### PR TITLE
Tighten how maps are synchronized in the traffic-manager.

### DIFF
--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -265,14 +265,6 @@ func TestConnect(t *testing.T) {
 	a.Len(hSnapI.Intercepts, 0)
 	t.Logf("=> agent[hello] intercept snapshot = %s", dumps(hSnapI))
 
-	// Removing a bogus intercept yields an error
-
-	_, err = client.RemoveIntercept(ctx, &rpc.RemoveInterceptRequest2{
-		Session: aliceSess2,
-		Name:    spec.Name, // no longer present, right?
-	})
-	a.Error(err)
-
 	_, err = client.RemoveIntercept(ctx, &rpc.RemoveInterceptRequest2{
 		Session: aliceSess1, // no longer a valid session, right?
 		Name:    spec.Name,  // doesn't matter...

--- a/cmd/traffic/cmd/manager/state/presence_test.go
+++ b/cmd/traffic/cmd/manager/state/presence_test.go
@@ -68,8 +68,8 @@ func TestPresence(t *testing.T) {
 	a.True(isPresent(sc))
 	a.False(isPresent("d"))
 
-	a.NoError(p.RemoveSession(ctx, sa))
-	a.NoError(p.RemoveSession(ctx, sc))
+	p.RemoveSession(ctx, sa)
+	p.RemoveSession(ctx, sc)
 
 	// B@1
 


### PR DESCRIPTION
This is a general refactoring to use `xsync.MapOf[K,V]` in favor of using a `sync.RWMutex` combined with a standard `map[K,V]`. The commit also removes some unnecessary complexity with respect to how sessions and intercepts were cleaned up.