### PR TITLE
Fix problem with multiple service ports using the same target port

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,10 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Multiple services ports using the same target port would not get intercepted correctly.
+        body: Intercepts didn't work when multiple service ports were using the same container port. Telepresence would
+          think that one of the ports wasn't intercepted and therefore disable the intercept of the container port.
+      - type: bugfix
         title: Root daemon refuses to disconnect.
         body: The root daemon would sometimes hang forever when attempting to disconnect due to a deadlock in
           the VIF-device.

--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -180,9 +180,7 @@ func sidecar(ctx context.Context, s SimpleState, info *rpc.AgentInfo) error {
 				return fwd.Serve(tunnel.WithPool(ctx, tunnel.NewPool()), nil)
 			})
 			cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
-			for _, ic := range ics {
-				s.AddInterceptState(s.NewInterceptState(fwd, ic, cnMountPoint, env))
-			}
+			s.AddInterceptState(s.NewInterceptState(fwd, NewInterceptTarget(ics), cnMountPoint, env))
 		}
 	}
 	TalkToManagerLoop(ctx, s, info)

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
-	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/forwarder"
 	"github.com/telepresenceio/telepresence/v2/pkg/restapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -16,7 +15,7 @@ import (
 
 type fwdState struct {
 	*simpleState
-	intercept  *agentconfig.Intercept
+	intercept  InterceptTarget
 	forwarder  forwarder.Interceptor
 	mountPoint string
 	env        map[string]string
@@ -24,7 +23,7 @@ type fwdState struct {
 
 // NewInterceptState creates a InterceptState that performs intercepts by using an Interceptor which indiscriminately
 // intercepts all traffic to the port that it forwards.
-func (s *simpleState) NewInterceptState(forwarder forwarder.Interceptor, intercept *agentconfig.Intercept, mountPoint string, env map[string]string) InterceptState {
+func (s *simpleState) NewInterceptState(forwarder forwarder.Interceptor, intercept InterceptTarget, mountPoint string, env map[string]string) InterceptState {
 	return &fwdState{
 		simpleState: s,
 		mountPoint:  mountPoint,
@@ -34,7 +33,7 @@ func (s *simpleState) NewInterceptState(forwarder forwarder.Interceptor, interce
 	}
 }
 
-func (fs *fwdState) InterceptConfig() *agentconfig.Intercept {
+func (fs *fwdState) Target() InterceptTarget {
 	return fs.intercept
 }
 

--- a/cmd/traffic/cmd/agent/intercepttarget.go
+++ b/cmd/traffic/cmd/agent/intercepttarget.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
+)
+
+// InterceptTarget describes the mapping between service ports and one container port. All entries
+// must be guaranteed to all have the same Protocol, ContainerPort, and AgentPort. The slice must
+// be considered immutable once created using NewInterceptTarget.
+type InterceptTarget []*agentconfig.Intercept
+
+func NewInterceptTarget(ics []*agentconfig.Intercept) InterceptTarget {
+	// This is a parameter assertion. If it is triggered, then something is dead wrong in the caller code.
+	ni := len(ics)
+	if ni == 0 {
+		panic("attempt to add intercept create an InterceptTarget with no Intercepts")
+	}
+	if ni > 1 {
+		sv := ics[0]
+		for i := 1; i < ni; i++ {
+			ic := ics[i]
+			if sv.AgentPort != ic.AgentPort || sv.ContainerPort != ic.ContainerPort || sv.Protocol != ic.Protocol {
+				panic("attempt to add intercept to an InterceptTarget with different AgentPort or ContainerPort")
+			}
+		}
+	}
+	return ics
+}
+
+func (cp InterceptTarget) MatchForSpec(spec *manager.InterceptSpec) bool {
+	for _, sv := range cp {
+		if agentconfig.SpecMatchesIntercept(spec, sv) {
+			return true
+		}
+	}
+	return false
+}
+
+func (cp InterceptTarget) AgentPort() uint16 {
+	return cp[0].AgentPort
+}
+
+func (cp InterceptTarget) ContainerPort() uint16 {
+	return cp[0].ContainerPort
+}
+
+func (cp InterceptTarget) ContainerPortName() string {
+	return cp[0].ContainerPortName
+}
+
+func (cp InterceptTarget) Protocol() v1.Protocol {
+	return cp[0].Protocol
+}
+
+func (cp InterceptTarget) AppProtocol(ctx context.Context) (proto string) {
+	var foundSv *agentconfig.Intercept
+	for _, sv := range cp {
+		if sv.AppProtocol == "" {
+			continue
+		}
+		if foundSv == nil {
+			foundSv = sv
+			proto = foundSv.AppProtocol
+		} else if foundSv.AppProtocol != sv.AppProtocol {
+			svcPort := func(s *agentconfig.Intercept) string {
+				if s.ServicePortName != "" {
+					return fmt.Sprintf("%s:%s", s.ServiceName, s.ServicePortName)
+				}
+				return fmt.Sprintf("%s:%d", s.ServiceName, s.ServicePort)
+			}
+			dlog.Warningf(ctx, "port %s appProtocol %s differs from port %s appProtocol %s. %s will be used for container port %d",
+				svcPort(foundSv), proto,
+				svcPort(sv), sv.AppProtocol,
+				proto, sv.ContainerPort)
+		}
+	}
+	return proto
+}
+
+func (cp InterceptTarget) HasServicePortName(name string) bool {
+	for _, sv := range cp {
+		if sv.ServicePortName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (cp InterceptTarget) HasServicePort(port uint16) bool {
+	for _, sv := range cp {
+		if sv.ServicePort == port {
+			return true
+		}
+	}
+	return false
+}
+
+func (cp InterceptTarget) String() string {
+	sb := bytes.Buffer{}
+	l := len(cp)
+	if l > 1 {
+		sb.WriteByte('[')
+	}
+	for i, sv := range cp {
+		if i > 0 {
+			switch l {
+			case 2:
+				sb.WriteString(" and ")
+			case i + 1:
+				sb.WriteString(", and ")
+			default:
+				sb.WriteString(", ")
+			}
+		}
+		sb.WriteString(sv.ServiceName)
+		sb.WriteByte(':')
+		if sv.ServicePortName != "" {
+			sb.WriteString(sv.ServicePortName)
+		} else {
+			sb.WriteString(strconv.Itoa(int(sv.ServicePort)))
+		}
+	}
+	if l > 1 {
+		sb.WriteByte(']')
+	}
+	ioutil.Printf(&sb, " => container port %d/%s", cp.ContainerPort(), cp.Protocol())
+	return sb.String()
+}

--- a/cmd/traffic/cmd/agent/state_test.go
+++ b/cmd/traffic/cmd/agent/state_test.go
@@ -43,9 +43,7 @@ func makeFS(t *testing.T, ctx context.Context) (forwarder.Interceptor, agent.Sta
 	s := agent.NewSimpleState(c)
 	cn := c.AgentConfig().Containers[0]
 	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
-	for _, intercept := range cn.Intercepts {
-		s.AddInterceptState(s.NewInterceptState(f, intercept, cnMountPoint, map[string]string{}))
-	}
+	s.AddInterceptState(s.NewInterceptState(f, agent.NewInterceptTarget(cn.Intercepts), cnMountPoint, map[string]string{}))
 	return f, s
 }
 

--- a/cmd/traffic/cmd/manager/managerutil/agentimage.go
+++ b/cmd/traffic/cmd/manager/managerutil/agentimage.go
@@ -3,6 +3,7 @@ package managerutil
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"github.com/datawire/dlib/dlog"
@@ -49,6 +50,13 @@ func WithResolvedAgentImageRetriever(ctx context.Context, ir ImageRetriever) con
 	return context.WithValue(ctx, irKey{}, ir)
 }
 
+func GetAgentImageRetriever(ctx context.Context) ImageRetriever {
+	if ir, ok := ctx.Value(irKey{}).(ImageRetriever); ok {
+		return ir
+	}
+	return nil
+}
+
 // GetAgentImage returns the fully qualified name of the traffic-agent image, i.e. "docker.io/tel2:2.7.4",
 // or an empty string if no agent image has been configured.
 func GetAgentImage(ctx context.Context) string {
@@ -56,5 +64,6 @@ func GetAgentImage(ctx context.Context) string {
 		return ir.GetImage()
 	}
 	// The code isn't doing what it's supposed to do during startup.
+	dlog.Error(ctx, string(debug.Stack()))
 	panic("no ImageRetriever has been configured")
 }

--- a/cmd/traffic/cmd/manager/state/consumption.go
+++ b/cmd/traffic/cmd/manager/state/consumption.go
@@ -35,8 +35,16 @@ func (m *SessionConsumptionMetrics) ConnectDuration() time.Duration {
 	return time.Duration(atomic.LoadInt64(&m.connectDuration))
 }
 
+func (m *SessionConsumptionMetrics) SetConnectDuration(d time.Duration) {
+	atomic.StoreInt64(&m.connectDuration, int64(d))
+}
+
 func (m *SessionConsumptionMetrics) LastUpdate() time.Time {
 	return time.Unix(0, atomic.LoadInt64(&m.lastUpdate))
+}
+
+func (m *SessionConsumptionMetrics) SetLastUpdate(t time.Time) {
+	atomic.StoreInt64(&m.lastUpdate, t.UnixNano())
 }
 
 func (s *state) GetSessionConsumptionMetrics(sessionID string) *SessionConsumptionMetrics {
@@ -79,7 +87,7 @@ func (s *state) RefreshSessionConsumptionMetrics(sessionID string) {
 	now := time.Now()
 	wasInterrupted := now.After(lu.Add(SessionConsumptionMetricsStaleTTL))
 	if !wasInterrupted { // If it wasn't stale, we want to count duration since last metric update.
-		atomic.AddInt64(&scm.connectDuration, int64(now.Sub(lu)))
+		scm.SetConnectDuration(now.Sub(lu))
 	}
-	atomic.StoreInt64(&scm.lastUpdate, now.UnixNano())
+	scm.SetLastUpdate(now)
 }

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func Test_Integration(t *testing.T) {
-	moduleRoot, err := filepath.Abs("..")
+	ossRoot, err := filepath.Abs(".")
 	if err != nil {
 		t.Fatalf("unable to get absolute path of .oss: %v", err)
 	}
-	itest.RunTests(itest.TestContext(t, moduleRoot, moduleRoot))
+	itest.RunTests(itest.TestContext(t, ossRoot, filepath.Dir(ossRoot)))
 }

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -1011,7 +1011,7 @@ func DeleteNamespaces(ctx context.Context, namespaces ...string) {
 	wg.Wait()
 }
 
-// StartLocalHttpEchoServerWithAddress is like StartLocalHttpEchoServer but binds to a specific host instead of localhost.
+// StartLocalHttpEchoServerWithHost is like StartLocalHttpEchoServer but binds to a specific host instead of localhost.
 func StartLocalHttpEchoServerWithHost(ctx context.Context, name string, host string) (int, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(ctx)
 	lc := net.ListenConfig{}

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -198,7 +198,7 @@ func (s *cluster) Initialize(ctx context.Context) context.Context {
 func (s *cluster) tearDown(ctx context.Context) {
 	s.ensureQuit(ctx)
 	if s.kubeConfig != "" {
-		ctx = WithWorkingDir(ctx, filepath.Join(GetOSSRoot(ctx), "integration_test"))
+		ctx = WithWorkingDir(ctx, GetOSSRoot(ctx))
 		_ = Run(ctx, "kubectl", "delete", "-f", filepath.Join("testdata", "k8s", "client_rbac.yaml"))
 		_ = Run(ctx, "kubectl", "delete", "--wait=false", "ns", "-l", "purpose=tp-cli-testing")
 	}
@@ -569,7 +569,7 @@ func (s *cluster) InstallTrafficManagerVersion(ctx context.Context, version stri
 func (s *cluster) installChart(ctx context.Context, release bool, chartFilename string, values map[string]string) error {
 	settings := s.self.GetValuesForHelm(ctx, values, release)
 
-	ctx = WithWorkingDir(ctx, filepath.Join(GetOSSRoot(ctx), "integration_test"))
+	ctx = WithWorkingDir(ctx, GetOSSRoot(ctx))
 	nss := GetNamespaces(ctx)
 	args := []string{"install", "-n", nss.Namespace, "--wait"}
 	args = append(args, settings...)

--- a/integration_test/itest/context.go
+++ b/integration_test/itest/context.go
@@ -76,11 +76,11 @@ func GetOSSRoot(ctx context.Context) string {
 	if dir, ok := ctx.Value(ossRootKey{}).(string); ok {
 		return dir
 	}
-	moduleRoot, err := os.Getwd()
+	ossRoot, err := os.Getwd()
 	if err != nil {
 		panic("failed to get current directory")
 	}
-	return filepath.Dir(moduleRoot)
+	return ossRoot
 }
 
 // SetOSSRoot sets the OSS module root for the given context to dir.

--- a/integration_test/itest/harness.go
+++ b/integration_test/itest/harness.go
@@ -54,18 +54,21 @@ func (h *harness) HarnessContext() context.Context {
 }
 
 func (h *harness) RunSuite(s TestingSuite) {
-	ctx := h.HarnessContext()
-	suiteRx := dos.Getenv(ctx, "TEST_SUITE")
-	if suiteRx != "" {
-		r, err := regexp.Compile(suiteRx)
-		if err != nil {
-			getT(ctx).Fatal(err)
-		}
-		if !r.MatchString(s.SuiteName()) {
-			return
-		}
+	if suiteEnabled(h.HarnessContext(), s) {
+		h.HarnessT().Run(s.SuiteName(), func(t *testing.T) { suite.Run(t, s) })
 	}
-	h.HarnessT().Run(s.SuiteName(), func(t *testing.T) { suite.Run(t, s) })
+}
+
+func suiteEnabled(ctx context.Context, s TestingSuite) bool {
+	suiteRx := dos.Getenv(ctx, "TEST_SUITE")
+	if suiteRx == "" {
+		return true
+	}
+	r, err := regexp.Compile(suiteRx)
+	if err != nil {
+		getT(ctx).Fatal(err)
+	}
+	return r.MatchString(s.SuiteName())
 }
 
 // SetupSuite calls all functions that has been added with AddSetup in the order they

--- a/integration_test/itest/namespace.go
+++ b/integration_test/itest/namespace.go
@@ -117,7 +117,7 @@ func (s *nsPair) setup(ctx context.Context) bool {
 	if t.Failed() {
 		return false
 	}
-	err := Kubectl(ctx, s.Namespace, "apply", "-f", filepath.Join(GetOSSRoot(ctx), "integration_test", "testdata", "k8s", "client_sa.yaml"))
+	err := Kubectl(ctx, s.Namespace, "apply", "-f", filepath.Join(GetOSSRoot(ctx), "testdata", "k8s", "client_sa.yaml"))
 	assert.NoError(t, err, "failed to create connect ServiceAccount")
 	return !t.Failed()
 }

--- a/integration_test/itest/runner.go
+++ b/integration_test/itest/runner.go
@@ -144,9 +144,11 @@ func (r *runner) RunTests(c context.Context) { //nolint:gocognit
 				t := getT(c)
 				for _, f := range r.withCluster {
 					s := f(c)
-					t.Run(s.SuiteName(), func(t *testing.T) {
-						suite.Run(t, f(c))
-					})
+					if suiteEnabled(c, s) {
+						t.Run(s.SuiteName(), func(t *testing.T) {
+							suite.Run(t, f(c))
+						})
+					}
 				}
 			}()
 			for s, sr := range r.withSuffix {

--- a/integration_test/multi_connect_test.go
+++ b/integration_test/multi_connect_test.go
@@ -63,7 +63,7 @@ func (s *multiConnectSuite) SetupSuite() {
 	}()
 
 	ctx2 := itest.WithNamespaces(ctx, &itest.Namespaces{Namespace: s.mgrSpace2, ManagedNamespaces: []string{s.appSpace2}})
-	err := itest.Kubectl(ctx2, s.mgrSpace2, "apply", "-f", filepath.Join(itest.GetOSSRoot(ctx2), "integration_test", "testdata", "k8s", "client_sa.yaml"))
+	err := itest.Kubectl(ctx2, s.mgrSpace2, "apply", "-f", filepath.Join(itest.GetOSSRoot(ctx2), "testdata", "k8s", "client_sa.yaml"))
 	require.NoError(err, "failed to create connect ServiceAccount")
 
 	ctx2 = itest.WithUser(ctx2, s.mgrSpace2+":"+itest.TestUser)

--- a/integration_test/testdata/k8s/echo-same-target-port.yaml
+++ b/integration_test/testdata/k8s/echo-same-target-port.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-stp
+spec:
+  type: ClusterIP
+  selector:
+    service: echo-stp
+  ports:
+    - name: eighty
+      port: 80
+      targetPort: 8080
+    - name: eighty-eighty
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-stp
+  labels:
+    service: echo-stp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: echo-stp
+  template:
+    metadata:
+      labels:
+        service: echo-stp
+    spec:
+      containers:
+        - name: echo-stp
+          image: jmalloc/echo-server
+          ports:
+            - containerPort: 8080
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/pkg/client/cli/cmd/status.go
+++ b/pkg/client/cli/cmd/status.go
@@ -56,10 +56,10 @@ type UserDaemonStatus struct {
 	Namespace         string                   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	ManagerNamespace  string                   `json:"manager_namespace,omitempty" yaml:"manager_namespace,omitempty"`
 	MappedNamespaces  []string                 `json:"mapped_namespaces,omitempty" yaml:"mapped_namespaces,omitempty"`
-	Intercepts        []connectStatusIntercept `json:"intercepts,omitempty" yaml:"intercepts,omitempty"`
+	Intercepts        []ConnectStatusIntercept `json:"intercepts,omitempty" yaml:"intercepts,omitempty"`
 }
 
-type connectStatusIntercept struct {
+type ConnectStatusIntercept struct {
 	Name   string `json:"name,omitempty" yaml:"name,omitempty"`
 	Client string `json:"client,omitempty" yaml:"client,omitempty"`
 }
@@ -176,7 +176,7 @@ func BasicGetStatusInfo(ctx context.Context) (ioutil.WriterTos, error) {
 		us.KubernetesServer = status.ClusterServer
 		us.KubernetesContext = status.ClusterContext
 		for _, icept := range status.GetIntercepts().GetIntercepts() {
-			us.Intercepts = append(us.Intercepts, connectStatusIntercept{
+			us.Intercepts = append(us.Intercepts, ConnectStatusIntercept{
 				Name:   icept.Spec.Name,
 				Client: icept.Spec.Client,
 			})


### PR DESCRIPTION
Intercepts didn't work when multiple service ports were using the same container port. Telepresence would think that one of the ports wasn't intercepted and therefore disable the intercept of the container port.