### PR TITLE
The DNS search path on Windows is now restored when Telepresence quits

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -35,21 +35,30 @@ items:
     notes:
       - type: bugfix
         title: The DNS search path on Windows is now restored when Telepresence quits
-        body: The DNS search path that Telepresence uses to simulate the DNS lookup functionality in the connected
+        body: >-
+          The DNS search path that Telepresence uses to simulate the DNS lookup functionality in the connected
           cluster namespace was not removed by a <code>telepresence quit</code>, resulting in connectivity problems
           from the workstation. Telepresence will now remove the entries that it has added to the search list when
           it quits.
       - type: bugfix
+        title: The user-daemon would sometimes get killed when used by multiple simultaneous CLI clients.
+        body: >-
+          The user-daemon would die with a fatal &quot;fatal error: concurrent map writes&quot; error in the
+          <code>connector.log</code>, effectively killing the ongoing connection.
+      - type: bugfix
         title: Multiple services ports using the same target port would not get intercepted correctly.
-        body: Intercepts didn't work when multiple service ports were using the same container port. Telepresence would
+        body: >-
+          Intercepts didn't work when multiple service ports were using the same container port. Telepresence would
           think that one of the ports wasn't intercepted and therefore disable the intercept of the container port.
       - type: bugfix
         title: Root daemon refuses to disconnect.
-        body: The root daemon would sometimes hang forever when attempting to disconnect due to a deadlock in
+        body: >-
+          The root daemon would sometimes hang forever when attempting to disconnect due to a deadlock in
           the VIF-device.
       - type: bugfix
         title: Fix panic in user daemon when traffic-manager was unreachable
-        body: The user daemon would panic if the traffic-manager was unreachable. It will now instead report
+        body: >-
+          The user daemon would panic if the traffic-manager was unreachable. It will now instead report
           a proper error to the client.
       - type: change
         title: Removal of backward support for versions predating 2.6.0

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,12 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: The DNS search path on Windows is now restored when Telepresence quits
+        body: The DNS search path that Telepresence uses to simulate the DNS lookup functionality in the connected
+          cluster namespace was not removed by a <code>telepresence quit</code>, resulting in connectivity problems
+          from the workstation. Telepresence will now remove the entries that it has added to the search list when
+          it quits.
+      - type: bugfix
         title: Multiple services ports using the same target port would not get intercepted correctly.
         body: Intercepts didn't work when multiple service ports were using the same container port. Telepresence would
           think that one of the ports wasn't intercepted and therefore disable the intercept of the container port.

--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -118,7 +118,7 @@ func (s *helmSuite) Test_HelmMultipleInstalls() {
 		s.Contains(stdout, "Connected to context")
 		s.Eventually(func() bool {
 			return itest.Run(ctx, "curl", "--silent", "--connect-timeout", "1", fmt.Sprintf("%s.%s", svc, s.appSpace2)) == nil
-		}, 7*time.Second, 1*time.Second)
+		}, 15*time.Second, 3*time.Second)
 	})
 
 	s.Run("Can intercept", func() {

--- a/integration_test/restore_dns_search_windows_test.go
+++ b/integration_test/restore_dns_search_windows_test.go
@@ -1,0 +1,40 @@
+package integration_test
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+func (s *notConnectedSuite) getGlobalSearchList() []string {
+	const (
+		tcpParamKey   = `System\CurrentControlSet\Services\Tcpip\Parameters`
+		searchListKey = `SearchList`
+	)
+	rk, err := registry.OpenKey(registry.LOCAL_MACHINE, tcpParamKey, registry.QUERY_VALUE)
+	if os.IsNotExist(err) {
+		err = nil
+	}
+	s.Require().NoError(err)
+	defer rk.Close()
+	csv, _, err := rk.GetStringValue(searchListKey)
+	if os.IsNotExist(err) {
+		err = nil
+	}
+	s.Require().NoError(err)
+	return strings.Split(csv, ",")
+}
+
+func (s *notConnectedSuite) Test_DNSSearchRestored() {
+	beforeConnect := s.getGlobalSearchList()
+	ctx := s.Context()
+	s.TelepresenceConnect(ctx)
+	afterConnect := s.getGlobalSearchList()
+	s.Assert().NotEqual(beforeConnect, afterConnect)
+	itest.TelepresenceQuitOk(ctx)
+	afterQuit := s.getGlobalSearchList()
+	s.Assert().Equal(beforeConnect, afterQuit)
+}

--- a/pkg/client/rootd/dns/server_windows.go
+++ b/pkg/client/rootd/dns/server_windows.go
@@ -31,6 +31,11 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 	g.Go("Server", func(c context.Context) error {
 		// No need to close listener. It's closed by the dns server.
+		defer func() {
+			c, cancel := context.WithTimeout(context.WithoutCancel(c), 5*time.Second)
+			_ = dev.SetDNS(c, s.clusterDomain, s.config.RemoteIp, nil)
+			cancel()
+		}()
 		s.processSearchPaths(g, s.updateRouterDNS, dev)
 		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
 	})

--- a/pkg/client/scout/os_metadata_darwin.go
+++ b/pkg/client/scout/os_metadata_darwin.go
@@ -10,12 +10,10 @@ import (
 	"github.com/datawire/dlib/dlog"
 )
 
-func getOsMetadata(ctx context.Context) map[string]any {
-	osMeta := map[string]any{
-		"os_version":       "unknown",
-		"os_build_version": "unknown",
-		"os_name":          "unknown",
-	}
+func setOsMetadata(ctx context.Context, osMeta map[string]any) {
+	osMeta["os_version"] = "unknown"
+	osMeta["os_build_version"] = "unknown"
+	osMeta["os_name"] = "unknown"
 	cmd := dexec.CommandContext(ctx, "sw_vers")
 	cmd.DisableLogging = true
 	if r, err := cmd.Output(); err != nil {
@@ -36,5 +34,4 @@ func getOsMetadata(ctx context.Context) map[string]any {
 			}
 		}
 	}
-	return osMeta
 }

--- a/pkg/client/scout/os_metadata_linux.go
+++ b/pkg/client/scout/os_metadata_linux.go
@@ -28,8 +28,7 @@ func isWSL(ctx context.Context) bool {
 	return strings.Contains(v, "WSL") || strings.Contains(v, "Windows")
 }
 
-func getOsMetadata(ctx context.Context) map[string]any {
-	osMeta := map[string]any{}
+func setOsMetadata(ctx context.Context, osMeta map[string]any) {
 	osMeta["os_docker"] = isDocker(ctx)
 	osMeta["os_wsl"] = isWSL(ctx)
 	f, err := os.Open("/etc/os-release")
@@ -38,7 +37,7 @@ func getOsMetadata(ctx context.Context) map[string]any {
 	}
 	if err != nil {
 		dlog.Warnf(ctx, "Unable to open /etc/os-release or /usr/lib/os-release: %v", err)
-		return osMeta
+		return
 	}
 	scanner := bufio.NewScanner(f)
 	osRelease := map[string]string{}
@@ -49,7 +48,7 @@ func getOsMetadata(ctx context.Context) map[string]any {
 	}
 	if err := scanner.Err(); err != nil {
 		dlog.Warnf(ctx, "Unable to scan contents of /etc/os-release: %v", err)
-		return osMeta
+		return
 	}
 	// Different Linuxes will report things in different ways, so this will scan the
 	// contents of osRelease and look for each of the different keys that a value might be under
@@ -65,5 +64,4 @@ func getOsMetadata(ctx context.Context) map[string]any {
 	osMeta["os_name"] = getFromOSRelease("ID", "NAME")
 	osMeta["os_version"] = getFromOSRelease("VERSION", "VERSION_ID")
 	osMeta["os_build_version"] = getFromOSRelease("BUILD_ID")
-	return osMeta
 }

--- a/pkg/client/scout/os_metadata_test.go
+++ b/pkg/client/scout/os_metadata_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestOsMetadata(t *testing.T) {
 	ctx := dlog.NewTestContext(t, false)
-	osMeta := getOsMetadata(ctx)
+	osMeta := make(map[string]any)
+	setOsMetadata(ctx, osMeta)
 	for _, k := range []string{"os_version", "os_name"} {
 		v := osMeta[k]
 		if v == "" || v == "unknown" {

--- a/pkg/client/scout/os_metadata_windows.go
+++ b/pkg/client/scout/os_metadata_windows.go
@@ -10,14 +10,13 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
 
-func getOsMetadata(ctx context.Context) map[string]any {
+func setOsMetadata(ctx context.Context, osMeta map[string]any) {
 	cmd := proc.CommandContext(ctx, "wmic", "os", "get", "Caption,Version,BuildNumber", "/value")
 	cmd.DisableLogging = true
 	r, err := cmd.Output()
-	osMeta := map[string]any{}
 	if err != nil {
 		dlog.Warnf(ctx, "Error running wmic: %v", err)
-		return osMeta
+		return
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(r))
 	for scanner.Scan() {
@@ -42,5 +41,4 @@ func getOsMetadata(ctx context.Context) map[string]any {
 	if err := scanner.Err(); err != nil {
 		dlog.Warnf(ctx, "Unable to scan wmic output: %v", err)
 	}
-	return osMeta
 }


### PR DESCRIPTION
## Description

The DNS search path that Telepresence uses to simulate the DNS lookup functionality in the connected cluster namespace was not removed by a `telepresence quit`, resulting in connectivity problems from the workstation. Telepresence will now remove the entries that it has added to the search list when it quits.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
