### PR TITLE
Update links to point to CNCF slack

### DIFF
--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -1,9 +1,9 @@
 # Telepresence Project Governance
 
-The goal of the Telepresence project is to accelerate the "developer inner loop" for cloud-native application 
-development on Kubernetes. 
+The goal of the Telepresence project is to accelerate the "developer inner loop" for cloud-native application
+development on Kubernetes.
 
-Telepresence achieves this by creating a dynamic network bridge between a local development environment (e.g., a laptop) 
+Telepresence achieves this by creating a dynamic network bridge between a local development environment (e.g., a laptop)
 and a remote Kubernetes cluster.
 
 This governance explains how the project is run.
@@ -70,21 +70,21 @@ is the governing body for the project.
 
 ### Becoming a Maintainer
 
-* Express interest to the current maintainers (see [MAINTAINERS.md](MAINTAINERS.md)) that your organization is 
-interested in becoming a maintainer. Becoming a maintainer generally means that you are going to be spending 
+* Express interest to the current maintainers (see [MAINTAINERS.md](MAINTAINERS.md)) that your organization is
+interested in becoming a maintainer. Becoming a maintainer generally means that you are going to be spending
 substantial time on Telepresence for the foreseeable future.
 * We will expect you to start contributing increasingly complicated PRs, under the guidance of the existing maintainers.
 * We may ask you to do some PRs from our backlog.
-* As you gain experience with the code base and our standards, we will ask you to do code reviews for incoming PRs. 
+* As you gain experience with the code base and our standards, we will ask you to do code reviews for incoming PRs.
 All maintainers are expected to shoulder a proportional share of community reviews.
-* After a period of approximately 2-3 months of working together and making sure we see eye to eye, the existing 
-maintainers will confer and decide whether to grant maintainer status or not. 
+* After a period of approximately 2-3 months of working together and making sure we see eye to eye, the existing
+maintainers will confer and decide whether to grant maintainer status or not.
 We make no guarantees on the length of time this will take, but 2-3 months is the goal.
 
-A new Maintainer can apply by sending a message in our [slack workspace](https://datawire-oss.slack.com/),
-in the [#telepresence-dev channel](https://datawire-oss.slack.com/archives/CC5D1UTTN).
+A new Maintainer can apply by sending a message in our [OSS Slack workspace](https://communityinviter.com/apps/cloud-native/cncf),
+in the [#telepresence-oss](https://cloud-native.slack.com/archives/C06B36KJ85P) channel.
 
-A simple majority vote of existing Maintainers approves the application.  
+A simple majority vote of existing Maintainers approves the application.
 
 Maintainers nominations will be evaluated without prejudice
 to employer or demographics.
@@ -111,7 +111,7 @@ and can be rapidly returned to Maintainer status if their availability changes.
 ## Meetings
 
 Time zones permitting, Maintainers are expected to participate in the public
-developer meeting. 
+developer meeting.
 
 Details can be found [here](./MEETING_SCHEDULE.md#monthly-contributors-meeting).
 
@@ -151,13 +151,13 @@ holes and breaches according to the [security policy](./SECURITY.md).
 
 ## Voting
 
-In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons 
-involved. If a dispute cannot be decided independently, the maintainers can be called in to decide an issue. If the 
-maintainers themselves cannot decide an issue, the issue will be resolved by voting. 
+In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons
+involved. If a dispute cannot be decided independently, the maintainers can be called in to decide an issue. If the
+maintainers themselves cannot decide an issue, the issue will be resolved by voting.
 The voting process is a simple majority in which each maintainer receives one vote.
 
 A vote can be taken on [#telepresence-dev](https://datawire-oss.slack.com/archives/CC5D1UTTN) or
-[#telepresence-dev-private](https://datawire-oss.slack.com/archives/C061Q45SU4F) for security or conduct matters.  
+[#telepresence-dev-private](https://datawire-oss.slack.com/archives/C061Q45SU4F) for security or conduct matters.
 
 Any Maintainer may demand a vote be taken.
 
@@ -172,8 +172,8 @@ a 2/3 vote of the Maintainers.
 
 ## Adding new projects to the Telepresence GitHub organization
 
-New projects will be added to the Telepresence organization via GitHub issue discussion in one of the existing projects 
-in the organization. Once sufficient discussion has taken place (~3-5 business days but depending on the volume 
-of conversation), the maintainers of *the project where the issue was opened* (since different projects in the 
-organization may have different maintainers) will decide whether the new project should be added. See the section 
+New projects will be added to the Telepresence organization via GitHub issue discussion in one of the existing projects
+in the organization. Once sufficient discussion has taken place (~3-5 business days but depending on the volume
+of conversation), the maintainers of *the project where the issue was opened* (since different projects in the
+organization may have different maintainers) will decide whether the new project should be added. See the section
 above on voting if the maintainers cannot easily decide.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 [<img src="https://cncf-branding.netlify.app/img/projects/telepresence/horizontal/color/telepresence-horizontal-color.png" width="80"/>](https://cncf-branding.netlify.app/img/projects/telepresence/horizontal/color/telepresence-horizontal-color.png)
 
-Telepresence gives developers infinite scale development environments for Kubernetes. 
+Telepresence gives developers infinite scale development environments for Kubernetes.
 
-Website: [https://www.getambassador.io/products/telepresence/](https://www.getambassador.io/products/telepresence/)  
-Slack: [Discuss](https://a8r.io/slack) in the #telepresence channel (https://datawire-oss.slack.com/archives/CAUBBJSQZ)
+Docs:
+    OSS: [https://www.getambassador.io/docs/telepresence-oss/](https://www.getambassador.io/docs/telepresence-oss)
+    Licensed: [https://www.getambassador.io/docs/telepresence ](https://www.getambassador.io/docs/telepresence )
+Slack:
+    Discuss in the [OSS CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) in the [#telepresence-oss](https://cloud-native.slack.com/archives/C06B36KJ85P) channel
+    Licensed: [a8r.io/slack](https://a8r.io/slack)
 
 **With Telepresence:**
 
@@ -28,7 +32,7 @@ A few quick ways to start using Telepresence
 * **Meetings:** Check out our community [meeting schedule](https://github.com/telepresenceio/telepresence/blob/release/v2/MEETING_SCHEDULE.md) for opportunities to interact with Telepresence developers
 
 ## Documentation
-Telepresence documentation is available on the Ambassador Labs webside:  
+Telepresence documentation is available on the Ambassador Labs webside:
 [Documentation](https://www.getambassador.io/docs/telepresence/)
 
 ## Telepresence 2
@@ -223,7 +227,7 @@ The traffic-agent is installed too, in the hello pod. Here together with an init
 `targetPort`.
 
 ```console
-$ kubectl describe pod hello-774455b6f5-6x6vs 
+$ kubectl describe pod hello-774455b6f5-6x6vs
 Name:         hello-774455b6f5-6x6vs
 Namespace:    default
 Priority:     0
@@ -295,10 +299,10 @@ Containers:
       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-wzhhs (ro)
 Conditions:
   Type              Status
-  Initialized       True 
-  Ready             True 
-  ContainersReady   True 
-  PodScheduled      True 
+  Initialized       True
+  Ready             True
+  ContainersReady   True
+  PodScheduled      True
 Volumes:
   kube-api-access-wzhhs:
     Type:                    Projected (a volume that contains injected data from multiple sources)
@@ -316,7 +320,7 @@ Volumes:
     Optional:  false
   export-volume:
     Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
-    Medium:      
+    Medium:
     SizeLimit:   <unset>
 QoS Class:       BestEffort
 Node-Selectors:  <none>
@@ -357,5 +361,5 @@ encountered. The files are named `daemon.log` and `connector.log`. The location 
 - Linux `~/.cache/telepresence/logs`
 - Windows `"%USERPROFILE%\AppData\Local\logs"`
 
-Visit the troubleshooting section in the Telepresence documentation for more advice:  
+Visit the troubleshooting section in the Telepresence documentation for more advice:
 [Troubleshooting](https://www.getambassador.io/docs/telepresence/latest/troubleshooting/)


### PR DESCRIPTION
## Description

Telepresence Slack is moving to the CNCF.  This PR updates the links to point to the CNCF Slack.

## Checklist
 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
