### PR TITLE
Ensure that allow-conflicting-subnets is propagated to CLI commands.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,14 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.18.1
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Show allow-conflicting-subnets in telepresence status and telepresence config view.
+        body: >-
+          The <code>telepresence status</code> and <code>telepresence config view</code> commands didn't show the
+          <code>allowConflictingSubnets</code> CIDRs because the value wasn't propagated correctly to the CLI.
   - version: 2.18.0
     date: (TBD)
     notes:

--- a/integration_test/intercept_env_test.go
+++ b/integration_test/intercept_env_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 )
@@ -39,11 +40,17 @@ func (s *interceptEnvSuite) Test_ExcludeVariables() {
 	itest.TelepresenceOk(ctx, "intercept", "echo-easy", "--env-file", helloEnv)
 
 	// then
-	file, err := os.ReadFile(helloEnv)
-	s.Require().NoError(err)
+	var file string
+	s.Require().Eventually(func() bool {
+		if dt, err := os.ReadFile(helloEnv); err == nil {
+			file = string(dt)
+			return true
+		}
+		return false
+	}, 5*time.Second, 1*time.Second)
 
-	s.NotContains(string(file), "DATABASE_HOST")
-	s.NotContains(string(file), "DATABASE_PASSWORD")
-	s.Contains(string(file), "TEST=DATA")
-	s.Contains(string(file), "INTERCEPT=ENV")
+	s.NotContains(file, "DATABASE_HOST")
+	s.NotContains(file, "DATABASE_PASSWORD")
+	s.Contains(file, "TEST=DATA")
+	s.Contains(file, "INTERCEPT=ENV")
 }

--- a/integration_test/itest/status.go
+++ b/integration_test/itest/status.go
@@ -47,6 +47,8 @@ func TelepresenceStatus(ctx context.Context, args ...string) (*StatusResponse, e
 			DNS:          cd.DNS,
 			RoutingSnake: cd.RoutingSnake,
 		}
+	} else if status.RootDaemon == nil {
+		status.RootDaemon = &cmd.RootDaemonStatus{}
 	}
 	return &status, nil
 }

--- a/pkg/client/cli/cmd/config.go
+++ b/pkg/client/cli/cmd/config.go
@@ -73,6 +73,7 @@ func runConfigView(cmd *cobra.Command, _ []string) error {
 		}
 		cfg.Routing.AlsoProxy = kc.AlsoProxy
 		cfg.Routing.NeverProxy = kc.NeverProxy
+		cfg.Routing.AllowConflicting = kc.AllowConflictingSubnets
 		if dns := kc.DNS; dns != nil {
 			cfg.DNS.ExcludeSuffixes = dns.ExcludeSuffixes
 			cfg.DNS.IncludeSuffixes = dns.IncludeSuffixes

--- a/pkg/client/cli/cmd/status.go
+++ b/pkg/client/cli/cmd/status.go
@@ -330,6 +330,9 @@ func getStatusInfo(ctx context.Context, di *daemon.Info) (*StatusInfo, error) {
 			for _, subnet := range obc.NeverProxySubnets {
 				rs.RoutingSnake.NeverProxy = append(rs.RoutingSnake.NeverProxy, (*iputil.Subnet)(iputil.IPNetFromRPC(subnet)))
 			}
+			for _, subnet := range obc.AllowConflictingSubnets {
+				rs.RoutingSnake.AllowConflicting = append(rs.RoutingSnake.AllowConflicting, (*iputil.Subnet)(iputil.IPNetFromRPC(subnet)))
+			}
 		}
 	}
 
@@ -494,8 +497,11 @@ func printDNS(kvf *ioutil.KeyValueFormatter, d *client.DNSSnake) {
 
 func printRouting(kvf *ioutil.KeyValueFormatter, r *client.RoutingSnake) {
 	printSubnets := func(title string, subnets []*iputil.Subnet) {
+		if len(subnets) == 0 {
+			return
+		}
 		out := &strings.Builder{}
-		fmt.Fprintf(out, "(%d subnets)", len(subnets))
+		ioutil.Printf(out, "(%d subnets)", len(subnets))
 		for _, subnet := range subnets {
 			ioutil.Printf(out, "\n- %s", subnet)
 		}
@@ -503,6 +509,7 @@ func printRouting(kvf *ioutil.KeyValueFormatter, r *client.RoutingSnake) {
 	}
 	printSubnets("Also Proxy", r.AlsoProxy)
 	printSubnets("Never Proxy", r.NeverProxy)
+	printSubnets("Allow conflicts for", r.AllowConflicting)
 }
 
 func (cs *UserDaemonStatus) WriteTo(out io.Writer) (int64, error) {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1017,16 +1017,18 @@ func LoadConfig(c context.Context) (cfg Config, err error) {
 }
 
 type Routing struct {
-	Subnets    []*iputil.Subnet `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	AlsoProxy  []*iputil.Subnet `json:"alsoProxy,omitempty" yaml:"alsoProxy,omitempty"`
-	NeverProxy []*iputil.Subnet `json:"neverProxy,omitempty" yaml:"neverProxy,omitempty"`
+	Subnets          []*iputil.Subnet `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	AlsoProxy        []*iputil.Subnet `json:"alsoProxy,omitempty" yaml:"alsoProxy,omitempty"`
+	NeverProxy       []*iputil.Subnet `json:"neverProxy,omitempty" yaml:"neverProxy,omitempty"`
+	AllowConflicting []*iputil.Subnet `json:"allowConflicting,omitempty" yaml:"allowConflicting,omitempty"`
 }
 
 // RoutingSnake is the same as Routing but with snake_case json/yaml names.
 type RoutingSnake struct {
-	Subnets    []*iputil.Subnet `json:"subnets,omitempty" yaml:"subnets,omitempty"`
-	AlsoProxy  []*iputil.Subnet `json:"also_proxy_subnets,omitempty" yaml:"also_proxy_subnets,omitempty"`
-	NeverProxy []*iputil.Subnet `json:"never_proxy_subnets,omitempty" yaml:"never_proxy_subnets,omitempty"`
+	Subnets          []*iputil.Subnet `json:"subnets,omitempty" yaml:"subnets,omitempty"`
+	AlsoProxy        []*iputil.Subnet `json:"also_proxy_subnets,omitempty" yaml:"also_proxy_subnets,omitempty"`
+	NeverProxy       []*iputil.Subnet `json:"never_proxy_subnets,omitempty" yaml:"never_proxy_subnets,omitempty"`
+	AllowConflicting []*iputil.Subnet `json:"allow_conflicting_subnets,omitempty" yaml:"allow_conflicting_subnets,omitempty"`
 }
 
 type DNS struct {

--- a/pkg/client/k8s_config.go
+++ b/pkg/client/k8s_config.go
@@ -434,6 +434,10 @@ func (kf *Kubeconfig) AddRemoteKubeConfigExtension(ctx context.Context, cfgYaml 
 			dlog.Debugf(ctx, "Applying remote neverProxy: %v", routing.NeverProxy)
 			kf.NeverProxy = append(kf.NeverProxy, routing.NeverProxy...)
 		}
+		if len(routing.AllowConflicting) > 0 {
+			dlog.Debugf(ctx, "Applying remote allowConflicting: %v", routing.AllowConflicting)
+			kf.AllowConflictingSubnets = append(kf.AllowConflictingSubnets, routing.AllowConflicting...)
+		}
 	}
 	return nil
 }

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -381,6 +381,12 @@ func (s *Session) getNetworkConfig() *rpc.NetworkConfig {
 			info.NeverProxySubnets[i] = iputil.IPNetToRPC(np)
 		}
 	}
+	if len(s.allowConflictingSubnets) > 0 {
+		info.AllowConflictingSubnets = make([]*manager.IPNet, len(s.allowConflictingSubnets))
+		for i, np := range s.allowConflictingSubnets {
+			info.AllowConflictingSubnets[i] = iputil.IPNetToRPC(np)
+		}
+	}
 	if s.tunVif != nil {
 		curSubnets := s.tunVif.Router.GetRoutedSubnets()
 		nc.Subnets = make([]*manager.IPNet, len(curSubnets))

--- a/pkg/client/userd/trafficmgr/config.go
+++ b/pkg/client/userd/trafficmgr/config.go
@@ -37,9 +37,10 @@ func (s *session) GetConfig(ctx context.Context) (*client.SessionConfig, error) 
 			LookupTimeout:   dns.LookupTimeout.AsDuration(),
 		},
 		Routing: client.Routing{
-			Subnets:    subnets(nc.Subnets),
-			AlsoProxy:  subnets(oi.AlsoProxySubnets),
-			NeverProxy: subnets(oi.NeverProxySubnets),
+			Subnets:          subnets(nc.Subnets),
+			AlsoProxy:        subnets(oi.AlsoProxySubnets),
+			NeverProxy:       subnets(oi.NeverProxySubnets),
+			AllowConflicting: subnets(oi.AllowConflictingSubnets),
 		},
 		ManagerNamespace: s.GetManagerNamespace(),
 	}, nil


### PR DESCRIPTION
The `status` and `config view` commands didn't show the `allowConflictingSubnets` CIDRs because the value wasn't propagated correctly in several places.

Closes datawire/telepresence-pro#515