### PR TITLE
Add --replace flag to intercept command

### DIFF
--- a/integration_test/intercept_flags_test.go
+++ b/integration_test/intercept_flags_test.go
@@ -1,0 +1,72 @@
+package integration_test
+
+import (
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+type interceptFlagSuite struct {
+	itest.Suite
+	itest.SingleService
+}
+
+func (s *interceptFlagSuite) SuiteName() string {
+	return "InterceptFlag"
+}
+
+func init() {
+	itest.AddSingleServiceSuite("-intercept-flag", "echo", func(h itest.SingleService) itest.TestingSuite {
+		return &interceptFlagSuite{Suite: itest.Suite{Harness: h}, SingleService: h}
+	})
+}
+
+func (s *interceptFlagSuite) SetupSuite() {
+	if s.CompatVersion() != "" {
+		s.T().Skip("Not part of compatibility suite")
+	}
+	s.Suite.SetupSuite()
+}
+
+func (s *interceptFlagSuite) Test_ContainerReplace() {
+	ctx := s.Context()
+	require := s.Require()
+	iceptName := "container-replaced"
+	port, cancel := itest.StartLocalHttpEchoServer(ctx, iceptName)
+	defer cancel()
+	expectedOutput := regexp.MustCompile(iceptName + ` from intercept at`)
+
+	stdout := itest.TelepresenceOk(ctx, "intercept", "--replace", "--port", strconv.Itoa(port), s.ServiceName())
+	defer func() {
+		itest.TelepresenceOk(ctx, "leave", s.ServiceName())
+		s.Eventually(func() bool {
+			out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", s.ServiceName())
+			if err != nil {
+				dlog.Error(ctx, err)
+				return false
+			}
+			dlog.Info(ctx, out)
+			return !expectedOutput.MatchString(out)
+		}, 1*time.Minute, 6*time.Second)
+		require.Contains(stdout, "1/1")
+	}()
+	require.Contains(stdout, "Using Deployment "+s.ServiceName())
+
+	require.Eventually(func() bool {
+		out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", s.ServiceName())
+		if err != nil {
+			dlog.Error(ctx, err)
+			return false
+		}
+		dlog.Info(ctx, out)
+		return expectedOutput.MatchString(out)
+	}, 1*time.Minute, 6*time.Second)
+
+	stdout, err := itest.KubectlOut(ctx, s.AppNamespace(), "get", "pod", "-lapp="+s.ServiceName())
+	require.NoError(err)
+	require.NotContains(stdout, "2/2")
+	require.Contains(stdout, "1/1")
+}

--- a/pkg/client/cli/intercept/command.go
+++ b/pkg/client/cli/intercept/command.go
@@ -24,6 +24,8 @@ type Command struct {
 	LocalOnly      bool   // --local-only
 	LocalMountPort uint16 // --local-mount-port
 
+	Replace bool // whether --replace was passed
+
 	EnvFile  string   // --env-file
 	EnvJSON  string   // --env-json
 	Mount    string   // --mount // "true", "false", or desired mount point // only valid if !localOnly
@@ -104,6 +106,10 @@ func (a *Command) AddFlags(cmd *cobra.Command) {
 
 	flagSet.Uint16Var(&a.LocalMountPort, "local-mount-port", 0,
 		`Do not mount remote directories. Instead, expose this port on localhost to an external mounter`)
+
+	flagSet.BoolVarP(&a.Replace, "replace", "", false,
+		`Indicates if the traffic-agent should replace application containers in workload pods. `+
+			`The default behavior is for the agent sidecar to be installed alongside existing containers.`)
 
 	// Hide these flags. They are still functional but deprecated. Using them will yield a deprecation message.
 	flagSet.Lookup("local-only").Hidden = true

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -80,7 +80,8 @@ func (s *state) Cmd() *cobra.Command {
 
 func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRequest, error) {
 	spec := &manager.InterceptSpec{
-		Name: s.Name(),
+		Name:    s.Name(),
+		Replace: s.Replace,
 	}
 	ir := &connector.CreateInterceptRequest{
 		Spec:         spec,


### PR DESCRIPTION
## Description

This PR adds a `--replace` flag to the `telepresence intercept` command which, when specified, will replace application containers in the intercepted workload.

This PR builds on the server-side machinery implemented in https://github.com/telepresenceio/telepresence/pull/3330.

Having the possibility to replace workload containers should provide a solution for tickets like https://github.com/telepresenceio/telepresence/issues/1646 and https://github.com/telepresenceio/telepresence/issues/1608.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
