### PR TITLE
Fix missing POD_CIDRS route

### DIFF
--- a/cmd/traffic/cmd/manager/cluster/info.go
+++ b/cmd/traffic/cmd/manager/cluster/info.go
@@ -362,6 +362,7 @@ func (oi *info) setSubnetsFromEnv(ctx context.Context) bool {
 	subnets := managerutil.GetEnv(ctx).PodCIDRs
 	if len(subnets) > 0 {
 		oi.PodSubnets = subnetsToRPC(subnets)
+		oi.ciSubs.notify(ctx, oi.clusterInfo())
 		dlog.Infof(ctx, "Using subnets from POD_CIDRS environment variable")
 		return true
 	}

--- a/pkg/vif/router.go
+++ b/pkg/vif/router.go
@@ -105,8 +105,8 @@ func (rt *Router) ValidateRoutes(ctx context.Context, routes []*net.IPNet) error
 	return nil
 }
 
-func (rt *Router) UpdateRoutes(ctx context.Context, plaseProxy, dontProxy []*net.IPNet) (err error) {
-	if err := rt.ValidateRoutes(ctx, plaseProxy); err != nil {
+func (rt *Router) UpdateRoutes(ctx context.Context, pleaseProxy, dontProxy []*net.IPNet) (err error) {
+	if err := rt.ValidateRoutes(ctx, pleaseProxy); err != nil {
 		return err
 	}
 	for _, n := range dontProxy {
@@ -128,7 +128,7 @@ func (rt *Router) UpdateRoutes(ctx context.Context, plaseProxy, dontProxy []*net
 	// Remove all no longer desired subnets from the routedSubnets
 	var removed []*net.IPNet
 	rt.routedSubnets, removed = subnet.Partition(rt.routedSubnets, func(_ int, sn *net.IPNet) bool {
-		for _, d := range plaseProxy {
+		for _, d := range pleaseProxy {
 			if subnet.Equal(sn, d) {
 				return true
 			}
@@ -137,7 +137,7 @@ func (rt *Router) UpdateRoutes(ctx context.Context, plaseProxy, dontProxy []*net
 	})
 
 	// Remove already routed subnets from the pleaseProxy list
-	added, _ := subnet.Partition(plaseProxy, func(_ int, sn *net.IPNet) bool {
+	added, _ := subnet.Partition(pleaseProxy, func(_ int, sn *net.IPNet) bool {
 		for _, d := range rt.routedSubnets {
 			if subnet.Equal(sn, d) {
 				return false


### PR DESCRIPTION
`PodSubnets` in `ciSubs` is empty after this line:

https://github.com/telepresenceio/telepresence/blob/75a6d58c11a2a5e3b27bd015e34b2c5fb8158552/cmd/traffic/cmd/manager/cluster/info.go#L228
 
It's not updated if `podCIDRStrategy` is `environment`, and `WatchClusterInfo` will always return empty `PodSubnets`

Fix #3471