### PR TITLE
Fix DNS server panic on darwin based systems.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,14 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.18.2
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Panic in root-daemon on darwin workstations with full access to cluster network.
+        body: >-
+          A darwin machine with full access to the cluster's subnets will never create a TUN-device, and a check was
+          missing if the device actually existed, which caused a panic in the root daemon.
   - version: 2.18.1
     date: (TBD)
     notes:

--- a/integration_test/uhn_dns_test.go
+++ b/integration_test/uhn_dns_test.go
@@ -91,7 +91,7 @@ func (s *unqualifiedHostNameDNSSuite) Test_UHNMappings() {
 			AliasFor: aliasedService,
 		},
 		{
-			Name:     "my-alias.some-fantasist-root-domain.cluster.local",
+			Name:     "my-alias.vx-root-domain.cluster.local",
 			AliasFor: aliasedService,
 		},
 	}

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -444,9 +444,11 @@ func newLocalUDPListener(c context.Context) (net.PacketConn, error) {
 
 func (s *Server) processSearchPaths(g *dgroup.Group, processor func(context.Context, []string, vif.Device) error, dev vif.Device) {
 	g.Go("RecursionCheck", func(c context.Context) error {
-		s.RLock()
-		_ = dev.SetDNS(c, s.clusterDomain, s.remoteIP, []string{tel2SubDomain})
-		s.RUnlock()
+		if dev != nil {
+			s.RLock()
+			_ = dev.SetDNS(c, s.clusterDomain, s.remoteIP, []string{tel2SubDomain})
+			s.RUnlock()
+		}
 		if runtime.GOOS == "windows" {
 			// Give the DNS setting some time to take effect.
 			dtime.SleepWithContext(c, 500*time.Millisecond)

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -71,7 +71,9 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 		return err
 	}
 
+	s.RLock()
 	kubernetesZone := s.clusterDomain
+	s.RUnlock()
 	if kubernetesZone == "" {
 		kubernetesZone = "cluster.local."
 	}
@@ -149,14 +151,14 @@ func (s *Server) updateResolverFiles(c context.Context, resolverDirName, resolve
 	}
 
 	// All namespaces and include suffixes become domains
-	domains := make(map[string]struct{}, len(namespaces)+len(s.config.IncludeSuffixes))
+	domains := make(map[string]struct{}, len(namespaces)+len(s.includeSuffixes))
 	maps.Merge(domains, namespaces)
-	for _, sfx := range s.config.IncludeSuffixes {
+	for _, sfx := range s.includeSuffixes {
 		domains[strings.TrimPrefix(sfx, ".")] = struct{}{}
 	}
 
-	s.domainsLock.Lock()
-	defer s.domainsLock.Unlock()
+	s.Lock()
+	defer s.Unlock()
 
 	// On Darwin, we provide resolution of NAME.NAMESPACE by adding one domain
 	// for each namespace in its own domain file under /etc/resolver. Each file


### PR DESCRIPTION
A darwin machine with full access to the cluster's subnet never creates
a TUN-device, so a check is needed if the device actually exists when
setting DNS (which is a noop anyway on darwin).