### PR TITLE
Environment interpolation expressions were prefixed twice.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,12 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Environment interpolation expressions were prefixed twice.
+        body: >-
+          Telepresence would sometimes prefix environment interpolation expressions in the traffic-agent twice so
+          that an expression that looked like <code>$(SOME_NAME)</code> in the app-container, ended up as <code>
+          $(_TEL_APP_A__TEL_APP_A_SOME_NAME)</code> in the corresponding expression in the traffic-agent.
+      - type: bugfix
         title: Panic in root-daemon on darwin workstations with full access to cluster network.
         body: >-
           A darwin machine with full access to the cluster's subnets will never create a TUN-device, and a check was

--- a/integration_test/env_interpolate_test.go
+++ b/integration_test/env_interpolate_test.go
@@ -1,0 +1,47 @@
+package integration_test
+
+import (
+	"encoding/json"
+
+	core "k8s.io/api/core/v1"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+func (s *connectedSuite) Test_PrefixInterpolated() {
+	ctx := s.Context()
+	svc := "echo-interpolate"
+	rq := s.Require()
+	s.ApplyApp(ctx, svc, "deploy/"+svc)
+	defer func() {
+		s.DeleteSvcAndWorkload(ctx, "deploy", svc)
+		s.NoError(s.Kubectl(ctx, "delete", "configmap", "interpolate-config"))
+	}()
+
+	itest.TelepresenceOk(ctx, "intercept", "--mount", "false", svc)
+	out, err := s.KubectlOut(ctx, "get", "pod", "-o", "json", "-l", "service="+svc)
+	rq.NoError(err)
+
+	var pods core.PodList
+	err = json.Unmarshal([]byte(out), &pods)
+	rq.NoError(err)
+	var ag *core.Container
+outer:
+	for _, pod := range pods.Items {
+		cns := pod.Spec.Containers
+		for ci := range cns {
+			cn := &cns[ci]
+			if cn.Name == "traffic-agent" {
+				ag = cn
+				break outer
+			}
+		}
+	}
+	rq.NotNil(ag)
+	for _, vm := range ag.VolumeMounts {
+		if vm.Name == "my-volume" {
+			rq.Equal("$(_TEL_APP_A_SOME_NAME)_$(_TEL_APP_A_OTHER_NAME)", vm.SubPathExpr)
+			break
+		}
+	}
+}

--- a/integration_test/testdata/k8s/echo-interpolate.yaml
+++ b/integration_test/testdata/k8s/echo-interpolate.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: interpolate-config
+data:
+  SOME_NAME: "hello"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-interpolate
+spec:
+  type: ClusterIP
+  selector:
+    service: echo-interpolate
+  ports:
+    - name: proxied
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-interpolate
+  labels:
+    service: echo-interpolate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: echo-interpolate
+  template:
+    metadata:
+      labels:
+        service: echo-interpolate
+    spec:
+      containers:
+        - name: echo-interpolate
+          image: jmalloc/echo-server
+          envFrom:
+            - configMapRef:
+                name: interpolate-config
+          env:
+            - name: OTHER_NAME
+              value: "hi"
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - mountPath: /var/log/my-volume
+              name: my-volume
+              subPathExpr: $(SOME_NAME)_$(OTHER_NAME)
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+      volumes:
+        - emptyDir: {}
+          name: my-volume

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -1,7 +1,6 @@
 package agentconfig
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"strconv"
@@ -36,10 +35,9 @@ func AgentContainer(
 
 	evs := make([]core.EnvVar, 0, len(config.Containers)*5)
 	efs := make([]core.EnvFromSource, 0, len(config.Containers)*3)
-	subst := make(map[string]string, len(evs)+len(efs))
 	EachContainer(pod, config, func(app *core.Container, cc *Container) {
-		evs = appendAppContainerEnv(app, cc, evs, subst)
-		efs = appendAppContainerEnvFrom(app, cc, efs, subst)
+		evs = appendAppContainerEnv(app, cc, evs)
+		efs = appendAppContainerEnvFrom(app, cc, efs)
 	})
 	if config.APIPort > 0 {
 		evs = append(evs, core.EnvVar{
@@ -155,39 +153,44 @@ func AgentContainer(
 		ac.Resources = *r
 	}
 
-	// Assign the security context of the first container (with both intercepts
-	// and a set security context) to the traffic agent.
-outerLoop:
-	for _, cc := range config.Containers {
-		if cc.Intercepts == nil {
-			continue
-		}
-
-		for _, app := range pod.Spec.Containers {
-			if app.Name == cc.Name {
-				if app.SecurityContext != nil {
-					ac.SecurityContext = app.SecurityContext
-					break outerLoop
-				}
-				break
-			}
-		}
-	}
-
-	// Replace all occurrences of "$(ENV" with "$(PFX_ENV"
-	aj, err := json.Marshal(&ac)
+	// Assign the security context of the first container to the traffic agent.
+	appSc, err := firstAppSecurityContext(pod, config)
 	if err != nil {
 		dlog.Error(ctx, err)
 		return nil
 	}
-	for k, pk := range subst {
-		aj = bytes.ReplaceAll(aj, []byte("$("+k), []byte("$("+pk))
-	}
-	if err = json.Unmarshal(aj, &ac); err != nil {
-		dlog.Error(ctx, err)
-		return nil
-	}
+	ac.SecurityContext = appSc
 	return ac
+}
+
+// Find security context of the first container (with both intercepts and a set security context) and ensure
+// that any env interpolations in it are prefixed with the env-prefix of the corresponding config container.
+func firstAppSecurityContext(pod *core.Pod, config *Sidecar) (*core.SecurityContext, error) {
+	cns := pod.Spec.Containers
+	for _, cc := range config.Containers {
+		if len(cc.Intercepts) > 0 {
+			for i := range cns {
+				app := &cns[i]
+				if app.Name != cc.Name {
+					continue
+				}
+				if app.SecurityContext == nil {
+					break
+				}
+				js, err := json.Marshal(app.SecurityContext)
+				if err != nil {
+					return nil, err
+				}
+				sc := core.SecurityContext{}
+				err = json.Unmarshal([]byte(prefixInterpolated(string(js), EnvPrefixApp+cc.EnvPrefix)), &sc)
+				if err != nil {
+					return nil, err
+				}
+				return &sc, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 func InitContainer(config *Sidecar) *core.Container {
@@ -297,7 +300,7 @@ func appendSecretVolume(env dos.Env, annotation, volumeName string, pod *core.Po
 func EachContainer(pod *core.Pod, config *Sidecar, f func(*core.Container, *Container)) {
 	cns := pod.Spec.Containers
 	for _, cc := range config.Containers {
-		for i := range pod.Spec.Containers {
+		for i := range cns {
 			if app := &cns[i]; app.Name == cc.Name {
 				f(app, cc)
 				break
@@ -327,6 +330,7 @@ func appendAppContainerVolumeMounts(
 	}
 
 	volPaths := make([]string, 0, len(app.VolumeMounts))
+	pfx := EnvPrefixApp + cc.EnvPrefix
 	for _, m := range app.VolumeMounts {
 		if _, ok := ignoredVolumeMounts[m.Name]; ok {
 			continue
@@ -335,27 +339,92 @@ func appendAppContainerVolumeMounts(
 			continue
 		}
 		volPaths = append(volPaths, m.MountPath)
-		m.MountPath = cc.MountPoint + "/" + strings.TrimPrefix(m.MountPath, "/")
+		m.Name = prefixInterpolated(m.Name, pfx)
+		m.MountPath = prefixInterpolated(cc.MountPoint+"/"+strings.TrimPrefix(m.MountPath, "/"), pfx)
+		m.SubPath = prefixInterpolated(m.SubPath, pfx)
+		m.SubPathExpr = prefixInterpolated(m.SubPathExpr, pfx)
 		mounts = append(mounts, m)
 	}
 	return volPaths, mounts
 }
 
-func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar, subst map[string]string) []core.EnvVar {
+// prefixInterpolated will prefix all environment variable names that are referenced using $(NAME) expressions
+// in the given string with the given prefix and return the result. Escaped expressions in the form $$(NAME),
+// unbalanced, or otherwise invalid expressions are not prefixed.
+func prefixInterpolated(str, pfx string) string {
+	const (
+		stNormal = iota
+		stDollarSeen
+		stDollarParenSeen
+	)
+	st := stNormal
+	var bd, ev strings.Builder
+	for _, c := range str {
+		switch c {
+		case '$':
+			switch st {
+			case stDollarParenSeen:
+				// '$' is not a legal character in an environment interpolation expression so
+				// terminate that expression without prefixing it.
+				bd.WriteString(ev.String())
+				ev.Reset()
+				st = stDollarSeen
+			case stDollarSeen:
+				st = stNormal
+			default:
+				st = stDollarSeen
+			}
+			bd.WriteByte('$')
+		case '(':
+			switch st {
+			case stDollarParenSeen:
+				// '(' is not a legal character in an environment interpolation expression so
+				// terminate that expression without prefixing it.
+				bd.WriteString(ev.String())
+				ev.Reset()
+				st = stNormal
+			case stDollarSeen:
+				st = stDollarParenSeen
+			default:
+				st = stNormal
+			}
+			bd.WriteByte('(')
+		case ')':
+			if st == stDollarParenSeen && ev.Len() > 0 {
+				bd.WriteString(pfx)
+				bd.WriteString(ev.String())
+				ev.Reset()
+			}
+			st = stNormal
+			bd.WriteByte(')')
+		default:
+			switch st {
+			case stDollarParenSeen:
+				ev.WriteRune(c)
+			default:
+				bd.WriteRune(c)
+				st = stNormal
+			}
+		}
+	}
+	if ev.Len() > 0 {
+		// Unbalanced interpolation. Just leave it as is.
+		bd.WriteString(ev.String())
+	}
+	return bd.String()
+}
+
+func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar) []core.EnvVar {
 	for _, e := range app.Env {
-		pn := EnvPrefixApp + cc.EnvPrefix + e.Name
-		subst[e.Name] = pn
-		e.Name = pn
+		e.Name = EnvPrefixApp + cc.EnvPrefix + e.Name
 		es = append(es, e)
 	}
 	return es
 }
 
-func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.EnvFromSource, subst map[string]string) []core.EnvFromSource {
+func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.EnvFromSource) []core.EnvFromSource {
 	for _, e := range app.EnvFrom {
-		pn := EnvPrefixApp + cc.EnvPrefix + e.Prefix
-		subst[e.Prefix] = pn
-		e.Prefix = pn
+		e.Prefix = EnvPrefixApp + cc.EnvPrefix + e.Prefix
 		es = append(es, e)
 	}
 	return es

--- a/pkg/agentconfig/container_test.go
+++ b/pkg/agentconfig/container_test.go
@@ -1,0 +1,71 @@
+package agentconfig
+
+import (
+	"testing"
+)
+
+func Test_prefixInterpolated(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			"empty",
+			"",
+			"",
+		},
+		{
+			"empty_ipl",
+			"$()",
+			"$()",
+		},
+		{
+			"alone",
+			"$(IPL)",
+			"$(_TEL_APP_A_IPL)",
+		},
+		{
+			"normal",
+			"Normal $(IPL) text",
+			"Normal $(_TEL_APP_A_IPL) text",
+		},
+		{
+			"escaped_ipl",
+			"Escaped $$(IPL) text",
+			"Escaped $$(IPL) text",
+		},
+		{
+			"nested_ipl",
+			"Nested $(IP$(IPL)) text",
+			"Nested $(IP$(_TEL_APP_A_IPL)) text",
+		},
+		{
+			"invalid_env",
+			"Nested $(IP$) text",
+			"Nested $(IP$) text",
+		},
+		{
+			"unbalanced",
+			"Unbalanced $(IPL text",
+			"Unbalanced $(IPL text",
+		},
+		{
+			"adjacent",
+			"Adjacent $(IP1)$(IP2) text",
+			"Adjacent $(_TEL_APP_A_IP1)$(_TEL_APP_A_IP2) text",
+		},
+		{
+			"dollar-separated",
+			"Dollar $(IP1)$$$(IP2) separated",
+			"Dollar $(_TEL_APP_A_IP1)$$$(_TEL_APP_A_IP2) separated",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prefixInterpolated(tt.arg, "_TEL_APP_A_"); got != tt.want {
+				t.Errorf("prefixInterpolated(%q) = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Telepresence would sometimes prefix environment interpolation expressions in the traffic-agent twice so that an expression that looked like `$(SOME_NAME)` in the app-container, ended up as `$(_TEL_APP_A__TEL_APP_A_SOME_NAME)` in the corresponding expression in the traffic-agent.