### PR TITLE
Make sure volume mounts are properly mounted on the laptop for replace intercepts.

### DIFF
--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -73,9 +73,13 @@ func AgentContainer(
 			dlog.Errorf(ctx, "unable to parse agent version from image name %s", config.AgentImage)
 		}
 	}
+	// TODO could this be where we get volumes wrong?
+	dlog.Debugf(ctx, "looking for volume mounts on pod %s.%s ...", pod.Name, pod.Namespace)
 	EachContainer(pod, config, func(app *core.Container, cc *Container) {
 		var volPaths []string
+		dlog.Debugf(ctx, "looking for volume mounts on container %s ...", cc.Name)
 		volPaths, mounts = appendAppContainerVolumeMounts(app, cc, mounts, pod.ObjectMeta.Annotations, agentVersion)
+		dlog.Debugf(ctx, "found %d volume mounts on container %s: %v", len(volPaths), cc.Name, volPaths)
 		if len(volPaths) > 0 {
 			evs = append(evs, core.EnvVar{
 				Name:  cc.EnvPrefix + EnvInterceptMounts,

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -73,13 +73,9 @@ func AgentContainer(
 			dlog.Errorf(ctx, "unable to parse agent version from image name %s", config.AgentImage)
 		}
 	}
-	// TODO could this be where we get volumes wrong?
-	dlog.Debugf(ctx, "looking for volume mounts on pod %s.%s ...", pod.Name, pod.Namespace)
 	EachContainer(pod, config, func(app *core.Container, cc *Container) {
 		var volPaths []string
-		dlog.Debugf(ctx, "looking for volume mounts on container %s ...", cc.Name)
 		volPaths, mounts = appendAppContainerVolumeMounts(app, cc, mounts, pod.ObjectMeta.Annotations, agentVersion)
-		dlog.Debugf(ctx, "found %d volume mounts on container %s: %v", len(volPaths), cc.Name, volPaths)
 		if len(volPaths) > 0 {
 			evs = append(evs, core.EnvVar{
 				Name:  cc.EnvPrefix + EnvInterceptMounts,


### PR DESCRIPTION
## Description

An attempt to fix https://github.com/telepresenceio/telepresence/issues/3483

The biggest contribution of the PR might be an integration test case that reproduces the issue (and fails for `release/v2`).

I'm uncertain about the soundness of the attempted fix. I'm not intimately familiar with the Telepresence codebase and don't fully understand the ins and outs of Kubernetes admission hooks. But at least it makes the code pass the provided test case.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
