### PR TITLE
DNS improvements

### DIFF
--- a/build-aux/docker/images/Dockerfile.client
+++ b/build-aux/docker/images/Dockerfile.client
@@ -41,7 +41,9 @@ RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/telepresence
 # The telepresence target is the one that gets published. It aims to be a small as possible.
 FROM alpine as telepresence
 
-RUN apk add --no-cache ca-certificates iptables bash
+RUN apk add --no-cache ca-certificates iptables iptables-legacy bash
+RUN rm /sbin/iptables && ln -s /sbin/iptables-legacy /sbin/iptables
+RUN rm /sbin/ip6tables && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
 
 # the telepresence binary
 COPY --from=telepresence-build /usr/local/bin/telepresence /usr/local/bin

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -182,6 +182,10 @@ spec:
             value: "{{ join " " . }}"
           {{- end }}
           {{- end }}
+          {{- if not .metritonEnabled }}  # 0 is false
+          - name: SCOUT_DISABLE
+            value: "1"
+          {{- end }}
         {{- /*
         Client configuration
         */}}

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -96,6 +96,9 @@ grpc:
 # podCIDRs is the verbatim list of CIDRs used when the podCIDRStrategy is set to environment
 podCIDRs: []
 
+# Enable/disable metriton reporting to ambassador
+metritonEnabled: true
+
 # podCIDRStrategy controls what strategy the traffic-manager will use for finding out what
 # CIDRs the cluster is using for its pods. Valid values are:
 #

--- a/integration_test/itest/context.go
+++ b/integration_test/itest/context.go
@@ -175,7 +175,7 @@ func GetUser(ctx context.Context) string {
 
 func LookupEnv(ctx context.Context, key string) (value string, ok bool) {
 	if value, ok = getEnv(ctx)[key]; !ok {
-		value, ok = GetGlobalHarness(ctx).GlobalEnv()[key]
+		value, ok = GetGlobalHarness(ctx).GlobalEnv(ctx)[key]
 	}
 	return
 }

--- a/integration_test/kubeconfig_extension_test.go
+++ b/integration_test/kubeconfig_extension_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -215,6 +216,10 @@ func (s *notConnectedSuite) Test_ConflictingProxies() {
 }
 
 func (s *notConnectedSuite) Test_DNSSuffixRules() {
+	if s.IsCI() && runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+		s.T().Skip("The DNS on the linux-arm64 GitHub runner is not configured correctly")
+	}
+
 	const randomName = "zwslkjsdf"
 	const randomDomain = ".xnrqj"
 	tests := []struct {

--- a/integration_test/uhn_dns_test.go
+++ b/integration_test/uhn_dns_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -56,7 +55,6 @@ func (s *unqualifiedHostNameDNSSuite) Test_UHNExcludes() {
 
 	// when
 	s.TelepresenceConnect(ctx, "--context", "extra")
-	itest.TelepresenceOk(ctx, "intercept", serviceName, "--port", strconv.Itoa(port))
 
 	// then
 	for _, excluded := range excludes {

--- a/pkg/client/cli/cmd/config.go
+++ b/pkg/client/cli/cmd/config.go
@@ -42,9 +42,19 @@ func configView() *cobra.Command {
 func runConfigView(cmd *cobra.Command, _ []string) error {
 	var cfg client.SessionConfig
 	clientOnly, _ := cmd.Flags().GetBool("client-only")
+	if !clientOnly {
+		cmd.Annotations = map[string]string{
+			ann.Session: ann.Required,
+		}
+		if err := connect.InitCommand(cmd); err != nil {
+			// Unable to establish a session, so try to convey the local config instead. It
+			// may be helpful in diagnosing the problem.
+			cmd.Annotations = map[string]string{}
+			clientOnly = true
+		}
+	}
+
 	if clientOnly {
-		// Unable to establish a session, so try to convey the local config instead. It
-		// may be helpful in diagnosing the problem.
 		if err := connect.InitCommand(cmd); err != nil {
 			return err
 		}

--- a/pkg/client/cli/connect/daemon.go
+++ b/pkg/client/cli/connect/daemon.go
@@ -47,6 +47,9 @@ func launchDaemon(ctx context.Context, cr *daemon.Request) error {
 	if cr != nil && cr.RootDaemonProfilingPort > 0 {
 		args = append(args, "--pprof", strconv.Itoa(int(cr.RootDaemonProfilingPort)))
 	}
+	if os.Getenv("SCOUT_DISABLE") == "1" {
+		args = append(args, "--disable-metriton")
+	}
 	args = append(args, logDir, filelocation.AppUserConfigDir(ctx))
 	return proc.StartInBackgroundAsRoot(ctx, args...)
 }

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -107,13 +107,13 @@ func (s *Server) tryResolveD(c context.Context, dev vif.Device, configureDNS fun
 }
 
 func (s *Server) updateLinkDomains(c context.Context, paths []string, dev vif.Device) error {
-	namespaces := make(map[string]struct{})
+	routes := make(map[string]struct{})
 	search := make([]string, 0)
 	for i, path := range paths {
 		if strings.ContainsRune(path, '.') {
 			search = append(search, path)
 		} else {
-			namespaces[path] = struct{}{}
+			routes[path] = struct{}{}
 			// Turn namespace into a route
 			paths[i] = "~" + path
 		}
@@ -125,7 +125,7 @@ func (s *Server) updateLinkDomains(c context.Context, paths []string, dev vif.De
 	s.Lock()
 	paths = append(paths, "~"+s.clusterDomain, tel2SubDomainDot+s.clusterDomain)
 
-	s.namespaces = namespaces
+	s.routes = routes
 	s.search = search
 	s.Unlock()
 

--- a/pkg/client/rootd/dns/resolved_linux.go
+++ b/pkg/client/rootd/dns/resolved_linux.go
@@ -61,13 +61,6 @@ func (s *Server) tryResolveD(c context.Context, dev vif.Device, configureDNS fun
 			}
 			// No need to close listeners here. They are closed by the dnsServer
 		}()
-		// Some installation have default DNS configured with ~. routing path.
-		// If two interfaces with DefaultRoute: yes present, the one with the
-		// routing key used and SanityCheck fails. Hence, tel2SubDomain
-		// must be used as a route.
-		s.Lock()
-		s.routes = map[string]struct{}{tel2SubDomain: {}}
-		s.Unlock()
 		if err = s.updateLinkDomains(c, dev); err != nil {
 			dlog.Error(c, err)
 			initDone <- struct{}{}
@@ -111,7 +104,7 @@ func (s *Server) tryResolveD(c context.Context, dev vif.Device, configureDNS fun
 
 func (s *Server) updateLinkDomains(c context.Context, dev vif.Device) error {
 	s.Lock()
-	paths := make([]string, len(s.routes)+len(s.search)+len(s.includeSuffixes)+1)
+	paths := make([]string, len(s.search)+len(s.routes)+len(s.includeSuffixes)+1)
 
 	// Namespaces are copied verbatim. Entries that aren't prefixed with "~" are considered search path entries.
 	copy(paths, s.search)

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -61,6 +61,15 @@ const (
 	recursionTestInProgress
 )
 
+//nolint:gochecknoglobals // constant
+var DefaultExcludeSuffixes = []string{
+	".com",
+	".io",
+	".net",
+	".org",
+	".ru",
+}
+
 // Server is a DNS server which implements the github.com/miekg/dns Handler interface.
 type Server struct {
 	sync.RWMutex
@@ -140,13 +149,7 @@ func NewServer(config *rpc.DNSConfig, clusterLookup Resolver) *Server {
 		config = &rpc.DNSConfig{}
 	}
 	if len(config.ExcludeSuffixes) == 0 {
-		config.ExcludeSuffixes = []string{
-			".com",
-			".io",
-			".net",
-			".org",
-			".ru",
-		}
+		config.ExcludeSuffixes = DefaultExcludeSuffixes
 	}
 	if config.LookupTimeout.AsDuration() <= 0 {
 		config.LookupTimeout = durationpb.New(8 * time.Second)

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dlog"
-	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
 )
 
@@ -20,15 +20,15 @@ const (
 	recursionTestTimeout    = 500 * time.Millisecond
 )
 
-func (r *resolveFile) setSearchPaths(paths ...string) {
-	ps := make([]string, 0, len(paths)+1)
-	for _, p := range paths {
-		p = strings.TrimSuffix(p, ".")
-		if len(p) > 0 && p != r.domain {
-			ps = append(ps, p)
-		}
+func (r *resolveFile) equals(o *resolveFile) bool {
+	if r == nil || o == nil {
+		return r == o
 	}
-	r.search = ps
+	return r.port == o.port &&
+		r.domain == o.domain &&
+		slices.Equal(r.nameservers, o.nameservers) &&
+		slices.Equal(r.search, o.search) &&
+		slices.Equal(r.options, o.options)
 }
 
 func (r *resolveFile) write(fileName string) error {
@@ -49,7 +49,6 @@ func (r *resolveFile) write(fileName string) error {
 // or, if not on a Mac, follow this link: https://www.manpagez.com/man/5/resolver/
 func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net.IP, *net.UDPAddr)) error {
 	resolverDirName := filepath.Join("/etc", "resolver")
-	resolverFileName := filepath.Join(resolverDirName, "telepresence.local")
 
 	listener, err := newLocalUDPListener(c)
 	if err != nil {
@@ -71,42 +70,19 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 		return err
 	}
 
-	s.RLock()
-	kubernetesZone := s.clusterDomain
-	s.RUnlock()
-	if kubernetesZone == "" {
-		kubernetesZone = "cluster.local."
-	}
-
-	kubernetesZone = kubernetesZone[:len(kubernetesZone)-1] // strip trailing dot
-	rf := resolveFile{
-		port:        dnsAddr.Port,
-		domain:      kubernetesZone,
-		nameservers: []string{dnsAddr.IP.String()},
-		search:      []string{tel2SubDomainDot + kubernetesZone},
-	}
-
-	if err = rf.write(resolverFileName); err != nil {
-		return err
-	}
-	dlog.Infof(c, "Generated new %s", resolverFileName)
-
 	defer func() {
-		// Remove the main resolver file
-		_ = os.Remove(resolverFileName)
-
-		// Remove each namespace resolver file
-		for domain := range s.domains {
-			_ = os.Remove(domainResolverFile(resolverDirName, domain))
-		}
+		_ = s.removeResolverFiles(c, resolverDirName)
 		s.flushDNS()
 	}()
 
 	// Start local DNS server
 	g := dgroup.NewGroup(c, dgroup.GroupConfig{})
 	g.Go("Server", func(c context.Context) error {
+		if err := s.updateResolverFiles(c, resolverDirName, dnsAddr); err != nil {
+			return err
+		}
 		s.processSearchPaths(g, func(c context.Context, _ vif.Device) error {
-			return s.updateResolverFiles(c, resolverDirName, resolverFileName, dnsAddr)
+			return s.updateResolverFiles(c, resolverDirName, dnsAddr)
 		}, dev)
 		// Server will close the listener, so no need to close it here.
 		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
@@ -132,72 +108,78 @@ func (s *Server) removeResolverFiles(c context.Context, resolverDirName string) 
 	return nil
 }
 
-func (s *Server) updateResolverFiles(c context.Context, resolverDirName, resolverFileName string, dnsAddr *net.UDPAddr) error {
-	rf, err := readResolveFile(resolverFileName)
-	if err != nil {
-		return err
-	}
+func (s *Server) updateResolverFiles(c context.Context, resolverDirName string, dnsAddr *net.UDPAddr) error {
 	s.Lock()
 	defer s.Unlock()
 
-	// All routes and include suffixes become domains
-
-	domains := make(map[string]struct{}, len(s.routes)+len(s.includeSuffixes))
-	maps.Merge(domains, s.routes)
-	for _, sfx := range s.includeSuffixes {
-		domains[strings.TrimPrefix(sfx, ".")] = struct{}{}
+	nameservers := []string{dnsAddr.IP.String()}
+	port := dnsAddr.Port
+	newDomainResolveFile := func(domain string) *resolveFile {
+		return &resolveFile{
+			port:        port,
+			domain:      domain,
+			nameservers: nameservers,
+		}
 	}
 
-	// On Darwin, we provide resolution of NAME.NAMESPACE by adding one domain
-	// for each namespace in its own domain file under /etc/resolver. Each file
-	// is named "telepresence.<domain>.local"
-	var removals []string
-	var additions []string
+	// All routes and include suffixes become domains
+	domains := make(map[string]*resolveFile, len(s.routes)+len(s.includeSuffixes))
+	for route := range s.routes {
+		domains[route] = newDomainResolveFile(route)
+	}
+	for _, sfx := range s.includeSuffixes {
+		sfx = strings.TrimPrefix(sfx, ".")
+		domains[sfx] = newDomainResolveFile(sfx)
+	}
+	clusterDomain := strings.TrimSuffix(s.clusterDomain, ".")
+	domains[clusterDomain] = newDomainResolveFile(clusterDomain)
+	domains[tel2SubDomain] = newDomainResolveFile(tel2SubDomain)
+
+nextSearch:
+	for _, search := range s.search {
+		search = strings.TrimSuffix(search, ".")
+		if df, ok := domains[search]; ok {
+			df.search = append(df.search, search)
+			continue
+		}
+		for domain, df := range domains {
+			if strings.HasSuffix(search, "."+domain) {
+				df.search = append(df.search, search)
+				continue nextSearch
+			}
+		}
+	}
 
 	for domain := range s.domains {
 		if _, ok := domains[domain]; !ok {
-			removals = append(removals, domain)
+			nsFile := domainResolverFile(resolverDirName, domain)
+			dlog.Infof(c, "Removing %s", nsFile)
+			if err := os.Remove(nsFile); err != nil {
+				dlog.Error(c, err)
+			}
+			delete(s.domains, domain)
 		}
 	}
-	for domain := range domains {
-		if _, ok := s.domains[domain]; !ok {
-			additions = append(additions, domain)
-		}
-	}
-	s.domains = domains
 
-	for _, domain := range removals {
+	for domain, rf := range domains {
 		nsFile := domainResolverFile(resolverDirName, domain)
-		dlog.Infof(c, "Removing %s", nsFile)
-		if err = os.Remove(nsFile); err != nil {
+		if _, ok := s.domains[domain]; ok {
+			if oldRf, err := readResolveFile(nsFile); err != nil && rf.equals(oldRf) {
+				continue
+			}
+			dlog.Infof(c, "Regenerating %s", nsFile)
+		} else {
+			s.domains[domain] = struct{}{}
+			dlog.Infof(c, "Generating %s", nsFile)
+		}
+		if err := rf.write(nsFile); err != nil {
 			dlog.Error(c, err)
 		}
-	}
-	for _, domain := range additions {
-		df := resolveFile{
-			port:        dnsAddr.Port,
-			domain:      domain,
-			nameservers: []string{dnsAddr.IP.String()},
-		}
-		nsFile := domainResolverFile(resolverDirName, domain)
-		dlog.Infof(c, "Generated new %s", nsFile)
-		if err = df.write(nsFile); err != nil {
-			dlog.Error(c, err)
-		}
-	}
-
-	rf.setSearchPaths(s.search...)
-
-	// Versions prior to Big Sur will not trigger an update unless the resolver file
-	// is removed and recreated.
-	_ = os.Remove(resolverFileName)
-	if err = rf.write(resolverFileName); err != nil {
-		return err
 	}
 	s.flushDNS()
 	return nil
 }
 
 func domainResolverFile(resolverDirName, domain string) string {
-	return filepath.Join(resolverDirName, "telepresence."+domain+".local")
+	return filepath.Join(resolverDirName, "telepresence."+domain)
 }

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -140,19 +140,19 @@ func (s *Server) updateResolverFiles(c context.Context, resolverDirName, resolve
 	}
 
 	// paths that contain a dot are search paths, the ones that don't are namespaces.
-	namespaces := make(map[string]struct{})
+	routes := make(map[string]struct{})
 	search := make([]string, 0)
 	for _, path := range paths {
 		if strings.ContainsRune(path, '.') {
 			search = append(search, path)
 		} else if path != "" {
-			namespaces[path] = struct{}{}
+			routes[path] = struct{}{}
 		}
 	}
 
 	// All namespaces and include suffixes become domains
-	domains := make(map[string]struct{}, len(namespaces)+len(s.includeSuffixes))
-	maps.Merge(domains, namespaces)
+	domains := make(map[string]struct{}, len(routes)+len(s.includeSuffixes))
+	maps.Merge(domains, routes)
 	for _, sfx := range s.includeSuffixes {
 		domains[strings.TrimPrefix(sfx, ".")] = struct{}{}
 	}
@@ -180,7 +180,7 @@ func (s *Server) updateResolverFiles(c context.Context, resolverDirName, resolve
 	search = append([]string{tel2SubDomainDot + s.clusterDomain}, search...)
 
 	s.search = search
-	s.namespaces = namespaces
+	s.routes = routes
 	s.domains = domains
 
 	for _, domain := range removals {

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -61,10 +61,18 @@ func (s *Server) runOverridingServer(c context.Context, dev vif.Device) error {
 			dlog.Infof(c, "Automatically set -dns=%s", ip)
 		}
 
-		// The search entries in /etc/resolv.conf is not intended for this resolver so
+		// The search entries in /etc/resolv.conf are not intended for this resolver so
 		// ensure that we strip them off when we send queries to the cluster.
 		for _, sp := range rf.search {
-			s.dropSuffixes = append(s.dropSuffixes, sp+".")
+			if len(sp) > 0 {
+				if sp[0] == '.' {
+					sp = sp[1:]
+				}
+				if sp[len(sp)-1] != '.' {
+					sp += "."
+				}
+				s.dropSuffixes = append(s.dropSuffixes, strings.ToLower(sp))
+			}
 		}
 	}
 	if s.localIP == nil {

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -239,7 +239,7 @@ func runNatTableCmd(c context.Context, args ...string) error {
 	// want to leave things in a half-cleaned-up state.
 	args = append([]string{"-t", "nat"}, args...)
 	cmd := dexec.CommandContext(c, "iptables", args...)
-	cmd.DisableLogging = true
+	cmd.DisableLogging = dlog.MaxLogLevel(c) < dlog.LogLevelDebug
 	dlog.Debug(c, shellquote.ShellString("iptables", args))
 	return cmd.Run()
 }

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -96,17 +96,17 @@ func (s *Server) runOverridingServer(c context.Context, dev vif.Device) error {
 		defer close(serverDone)
 		// Server will close the listener, so no need to close it here.
 		s.processSearchPaths(g, func(c context.Context, paths []string, _ vif.Device) error {
-			namespaces := make(map[string]struct{})
+			routes := make(map[string]struct{})
 			search := make([]string, 0)
 			for _, path := range paths {
 				if strings.ContainsRune(path, '.') {
 					search = append(search, path)
 				} else if path != "" {
-					namespaces[path] = struct{}{}
+					routes[path] = struct{}{}
 				}
 			}
 			s.Lock()
-			s.namespaces = namespaces
+			s.routes = routes
 			s.search = search
 			s.Unlock()
 			s.flushDNS()

--- a/pkg/client/rootd/dns/server_windows.go
+++ b/pkg/client/rootd/dns/server_windows.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/datawire/dlib/dgroup"
@@ -33,32 +32,23 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 		// No need to close listener. It's closed by the dns server.
 		defer func() {
 			c, cancel := context.WithTimeout(context.WithoutCancel(c), 5*time.Second)
+			s.Lock()
 			_ = dev.SetDNS(c, s.clusterDomain, s.remoteIP, nil)
+			s.Unlock()
 			cancel()
 		}()
+		if err := s.updateRouterDNS(c, dev); err != nil {
+			return err
+		}
 		s.processSearchPaths(g, s.updateRouterDNS, dev)
 		return s.Run(c, make(chan struct{}), []net.PacketConn{listener}, nil, s.resolveInCluster)
 	})
 	return g.Wait()
 }
 
-func (s *Server) updateRouterDNS(c context.Context, paths []string, dev vif.Device) error {
-	routes := make(map[string]struct{})
-	search := []string{
-		tel2SubDomain + "." + s.clusterDomain,
-	}
-
-	for _, path := range paths {
-		if strings.ContainsRune(path, '.') {
-			search = append(search, path)
-		} else if path != "" {
-			routes[path] = struct{}{}
-		}
-	}
+func (s *Server) updateRouterDNS(c context.Context, dev vif.Device) error {
 	s.Lock()
-	s.routes = routes
-	s.search = search
-	err := dev.SetDNS(c, s.clusterDomain, s.remoteIP, search)
+	err := dev.SetDNS(c, s.clusterDomain, s.remoteIP, s.search)
 	s.Unlock()
 	s.flushDNS()
 	if err != nil {

--- a/pkg/client/rootd/dns/server_windows.go
+++ b/pkg/client/rootd/dns/server_windows.go
@@ -43,7 +43,7 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 }
 
 func (s *Server) updateRouterDNS(c context.Context, paths []string, dev vif.Device) error {
-	namespaces := make(map[string]struct{})
+	routes := make(map[string]struct{})
 	search := []string{
 		tel2SubDomain + "." + s.clusterDomain,
 	}
@@ -52,11 +52,11 @@ func (s *Server) updateRouterDNS(c context.Context, paths []string, dev vif.Devi
 		if strings.ContainsRune(path, '.') {
 			search = append(search, path)
 		} else if path != "" {
-			namespaces[path] = struct{}{}
+			routes[path] = struct{}{}
 		}
 	}
 	s.Lock()
-	s.namespaces = namespaces
+	s.routes = routes
 	s.search = search
 	err := dev.SetDNS(c, s.clusterDomain, s.remoteIP, search)
 	s.Unlock()

--- a/pkg/client/rootd/service.go
+++ b/pkg/client/rootd/service.go
@@ -53,9 +53,10 @@ func GetNewServiceFunc(ctx context.Context) NewServiceFunc {
 }
 
 const (
-	ProcessName = "daemon"
-	titleName   = "Daemon"
-	pprofFlag   = "pprof"
+	ProcessName         = "daemon"
+	titleName           = "Daemon"
+	pprofFlag           = "pprof"
+	metritonDisableFlag = "disable-metriton"
 )
 
 func help() string {
@@ -118,6 +119,7 @@ func Command() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.Uint16(pprofFlag, 0, "start pprof server on the given port")
+	flags.Bool(metritonDisableFlag, false, "disable metriton reporting")
 	return cmd
 }
 
@@ -461,6 +463,9 @@ func run(cmd *cobra.Command, args []string) error {
 				dlog.Error(c, err)
 			}
 		}()
+	}
+	if disableMetriton, _ := flags.GetBool(metritonDisableFlag); disableMetriton {
+		_ = os.Setenv("SCOUT_DISABLE", "1")
 	}
 
 	c = dgroup.WithGoroutineName(c, "/"+ProcessName)

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -363,7 +363,7 @@ func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerPro
 		config:                  cfg,
 		done:                    make(chan struct{}),
 	}
-	s.dnsServer = dns.NewServer(mi.Dns, s.clusterLookup, false)
+	s.dnsServer = dns.NewServer(mi.Dns, s.clusterLookup)
 	s.SetSearchPath(c, nil, nil)
 	dlog.Infof(c, "also-proxy subnets %v", as)
 	dlog.Infof(c, "never-proxy subnets %v", ns)


### PR DESCRIPTION
The Telepresence DNS server contained a lot of code that was created using a trial-and-error approach. Partly due to lack of knowledge of how different systems would handle DNS-routes and DNS-search-paths, and partly due to caution and a "change as little as possible" approach when fixing issues.

This PR is an attempt to fix all this. It unifies how the DNS-resolver handles the routes and searches, enforces a priority order for include- and exclude-suffixes, improves the recursion-check logic, and adds a more consistent behavior for A and AAAA queries.