### PR TITLE
Fix kubeconfig exec authentication with context names containing colon

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -47,6 +47,13 @@ items:
           custom DNS servers that resolve domains into loopback IPs. The flag may also be used in cases where the
           cluster's subnets are in conflict with the workstation's VPN.
       - type: bugfix
+        title: Kubeconfig exec authentication with context names containing colon didn't work on Windows
+        body: >-
+          The logic added to allow the root daemon to connect directly to the cluster using the user daemon as a proxy
+          for exec type authentication in the kube-config, didn't take into account that a context name sometimes
+          contains the colon ":" character. That character cannot be used in filenames on windows because it is the
+          drive letter separator.
+      - type: bugfix
         title: Provide agent name and tag as separate values in Helm chart
         body: >-
           The <code>AGENT_IMAGE</code> was a concatenation of the agent's name and tag. This is now changed so that the

--- a/integration_test/kubeauth_test.go
+++ b/integration_test/kubeauth_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 func (s *notConnectedSuite) Test_ConnectWithKubeconfigExec() {
@@ -70,8 +71,9 @@ func (s *notConnectedSuite) Test_ConnectWithKubeconfigExec() {
 	extCc := cc.DeepCopy()
 	extCc.AuthInfo = extAuthInfo
 
-	// Create a new Context that uses the new AuthInfo.
-	extContext := cfg.CurrentContext + "-exec"
+	// Create a new Context that uses the new AuthInfo. We use a nasty name here to ensure
+	// that it is correctly converted to a usable name.
+	extContext := "abc:def/xyz$32-#1?efd"
 	rq.Nil(cfg.Contexts[extContext])
 
 	cfg.Contexts[extContext] = extCc
@@ -90,6 +92,7 @@ func (s *notConnectedSuite) Test_ConnectWithKubeconfigExec() {
 
 		// Retrieve the current size of the connector.lgo so that we can scan the messages that appear after connect
 		ctx := s.Context()
+		rq := s.Require()
 		logSize := int64(0)
 		logName := "connector.log"
 		if useDocker {
@@ -136,6 +139,18 @@ func (s *notConnectedSuite) Test_ConnectWithKubeconfigExec() {
 			rq.Falsef(found, "did not expect a GetContextExecCredentials in the %s", logName)
 		} else {
 			rq.Truef(found, "unable to find expected GetContextExecCredentials in the %s", logName)
+		}
+
+		modifiedKubeConfig := filepath.Join(filelocation.AppUserCacheDir(ctx), "kube", ioutil.SafeName(extContext))
+		modCfg, err := clientcmd.LoadFromFile(modifiedKubeConfig)
+		if connectFromUserDaemon {
+			rq.ErrorIsf(err, os.ErrNotExist, "did not expect to find modified kubeconfig %s", modifiedKubeConfig)
+		} else {
+			rq.NoError(err)
+			defer func() {
+				_ = os.Remove(modifiedKubeConfig)
+			}()
+			rq.Equal(modCfg.CurrentContext, extContext)
 		}
 	}
 	s.Run("root-daemon", func() { connectWithExec(false, false) })

--- a/integration_test/multi_connect_test.go
+++ b/integration_test/multi_connect_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 type multiConnectSuite struct {
@@ -110,7 +111,7 @@ func (s *multiConnectSuite) Test_MultipleConnect() {
 	kc := itest.KubeConfig(ctx)
 	cfg, err := clientcmd.LoadFromFile(kc)
 	require.NoError(err)
-	ctxName := daemon.SafeContainerName(cfg.CurrentContext)
+	ctxName := ioutil.SafeName(cfg.CurrentContext)
 	s.doubleConnectCheck(ctx, ctx2, ctxName+"-"+s.AppNamespace()+"-cn", ctxName+"-"+s.appSpace2+"-cn", s.AppNamespace(), s.appSpace2, "")
 }
 

--- a/pkg/authenticator/patcher/patcher.go
+++ b/pkg/authenticator/patcher/patcher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -15,6 +14,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
 
@@ -95,7 +95,7 @@ func CreateExternalKubeConfig(ctx context.Context, kubeFlags map[string]string, 
 	}
 
 	// Store the file using its context name under the <telepresence cache>/kube directory
-	kubeConfigFile := strings.ReplaceAll(config.CurrentContext, "/", "-")
+	kubeConfigFile := ioutil.SafeName(config.CurrentContext)
 	kubeConfigDir := filepath.Join(filelocation.AppUserCacheDir(ctx), kubeConfigs)
 	if err = os.MkdirAll(kubeConfigDir, 0o700); err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func needsStubbedExec(rawConfig *clientcmdapi.Config) bool {
 // AnnotateConnectRequest is used when the CLI connects to a containerized user-daemon. It adds a ContainerKubeFlagOverrides
 // to the given ConnectRequest containing the path to the modified kubeconfig file to be used in the container.
 func AnnotateConnectRequest(cr *connector.ConnectRequest, cacheDir, kubeContext string) {
-	kubeConfigFile := strings.ReplaceAll(kubeContext, "/", "-")
+	kubeConfigFile := ioutil.SafeName(kubeContext)
 	if cr.ContainerKubeFlagOverrides == nil {
 		cr.ContainerKubeFlagOverrides = make(map[string]string)
 	}
@@ -160,7 +160,7 @@ func AnnotateConnectRequest(cr *connector.ConnectRequest, cacheDir, kubeContext 
 // AnnotateOutboundInfo is used when a non-containerized user-daemon connects to the root-daemon. The KubeFlags
 // are modified to contain the path to the modified kubeconfig file.
 func AnnotateOutboundInfo(ctx context.Context, oi *daemon.OutboundInfo, kubeContext string) {
-	kubeConfigFile := strings.ReplaceAll(kubeContext, "/", "-")
+	kubeConfigFile := ioutil.SafeName(kubeContext)
 	if oi.KubeFlags == nil {
 		oi.KubeFlags = make(map[string]string)
 	} else {

--- a/pkg/client/cli/daemon/identifier.go
+++ b/pkg/client/cli/daemon/identifier.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 type Identifier struct {
@@ -31,7 +32,7 @@ func NewIdentifier(name, contextName, namespace string, containerized bool) (*Id
 	return &Identifier{
 		KubeContext:   contextName,
 		Namespace:     namespace,
-		Name:          SafeContainerName(name),
+		Name:          ioutil.SafeName(name),
 		Containerized: containerized,
 	}, nil
 }

--- a/pkg/client/cli/daemon/identifier_test.go
+++ b/pkg/client/cli/daemon/identifier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 func TestDaemonInfoFileName(t *testing.T) {
@@ -69,8 +70,8 @@ func TestSafeContainerName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := daemon.SafeContainerName(tt.name); got != tt.want {
-				t.Errorf("SafeContainerName() = %v, want %v", got, tt.want)
+			if got := ioutil.SafeName(tt.name); got != tt.want {
+				t.Errorf("SafeName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/client/cli/daemon/info.go
+++ b/pkg/client/cli/daemon/info.go
@@ -33,27 +33,6 @@ func (info *Info) DaemonID() *Identifier {
 	return id
 }
 
-// SafeContainerName returns a string that can safely be used as an argument
-// to docker run --name. Only characters [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.
-// Others are replaced by an underscore, or if it's the very first character,
-// by the character 'a'.
-func SafeContainerName(name string) string {
-	n := strings.Builder{}
-	for i, c := range name {
-		switch {
-		case (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
-			n.WriteByte(byte(c))
-		case i > 0 && (c == '_' || c == '.' || c == '-'):
-			n.WriteByte(byte(c))
-		case i > 0:
-			n.WriteByte('_')
-		default:
-			n.WriteByte('a')
-		}
-	}
-	return n.String()
-}
-
 const (
 	daemonsDirName    = "daemons"
 	keepAliveInterval = 5 * time.Second

--- a/pkg/client/docker/daemon_test.go
+++ b/pkg/client/docker/daemon_test.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"testing"
 
-	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 func TestSafeContainerName(t *testing.T) {
@@ -47,8 +47,8 @@ func TestSafeContainerName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := daemon.SafeContainerName(tt.name); got != tt.want {
-				t.Errorf("SafeContainerName() = %v, want %v", got, tt.want)
+			if got := ioutil.SafeName(tt.name); got != tt.want {
+				t.Errorf("SafeName() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/ioutil/safename.go
+++ b/pkg/ioutil/safename.go
@@ -1,0 +1,23 @@
+package ioutil
+
+import "strings"
+
+// SafeName returns a string that can safely be used as a file name or docker container. Only
+// characters [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed. Others are replaced by an underscore, or
+// if it's the very first character, by the character 'a'.
+func SafeName(name string) string {
+	n := strings.Builder{}
+	for i, c := range name {
+		switch {
+		case (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+			n.WriteByte(byte(c))
+		case i > 0 && (c == '_' || c == '.' || c == '-'):
+			n.WriteByte(byte(c))
+		case i > 0:
+			n.WriteByte('_')
+		default:
+			n.WriteByte('a')
+		}
+	}
+	return n.String()
+}


### PR DESCRIPTION
The logic added to allow the root daemon to connect directly to the cluster using the user daemon as a proxy for exec type authentication in the kube-config, didn't take into account that a context name sometimes contains the colon ":" character. That character cannot be used in filenames on windows because it is the drive letter separator.

Closes #3488