### PR TITLE
Fix replacePolicy glitch causing ReplacePolicyCurrent to be stored.

### DIFF
--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -320,6 +320,9 @@ func (s *state) loadAgentConfig(
 		if gc, err = agentmap.GeneratorConfigFunc(agentImage); err != nil {
 			return nil, err
 		}
+		if replacePolicy == agentconfig.ReplacePolicyCurrent {
+			replacePolicy = agentconfig.ReplacePolicyNever
+		}
 		if sce, err = gc.Generate(ctx, wl, replacePolicy, nil); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
THe `ReplacePolicyCurrent` is intended for queries only. It must never be stored in the `telepresence-agents` configmap.