### PR TITLE
Add symbolic subnet names to the --proxy-via flag.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -35,17 +35,23 @@ items:
     notes:
       - type: feature
         title: Include the image for the traffic-agent in the output of the version and status commands.
-        body: ->
+        body: >-
           The version and status commands will now output the image that the traffic-agent will be using when injected
           by the agent-injector.
       - type: feature
         title: Custom DNS using the client DNS resolver.
-        body: ->
-          A new <code>telepresence connect --proxy-via CIDR=WORKLOAD</code> flag was introduced, allowing Telepresence
+        body: >-
+          <p>A new <code>telepresence connect --proxy-via CIDR=WORKLOAD</code> flag was introduced, allowing Telepresence
           to translate DNS responses matching specific subnets into virtual IPs that are used locally. Those virtual IPs
           are then routed (with reverse translation) via the pod's of a given workload. This makes it possible to handle
           custom DNS servers that resolve domains into loopback IPs. The flag may also be used in cases where the
-          cluster's subnets are in conflict with the workstation's VPN.
+          cluster's subnets are in conflict with the workstation's VPN.</p>
+          <p>The CIDR can also be a symbolic name that identifies a subnet or list of subnets:<table>
+          <tr><td><code>also</code></td><td>All subnets added with --also-proxy</td></tr>
+          <tr><td><code>service</code></td><td>The cluster's service subnet</td></tr>
+          <tr><td><code>pods</code></td><td>The cluster's pod subnets.</td></tr>
+          <tr><td><code>all</code></td><td>All of the above.</td></tr>
+          </table></p>
       - type: bugfix
         title: Kubeconfig exec authentication with context names containing colon didn't work on Windows
         body: >-

--- a/integration_test/docker_daemon_test.go
+++ b/integration_test/docker_daemon_test.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func (s *dockerDaemonSuite) SetupSuite() {
-	if s.IsCI() && goRuntime.GOOS != "linux" {
+	if s.IsCI() && !(goRuntime.GOOS == "linux" && goRuntime.GOARCH == "amd64") {
 		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
 		return
 	}

--- a/integration_test/docker_run_test.go
+++ b/integration_test/docker_run_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *singleServiceSuite) Test_DockerRun_HostDaemon() {
-	if s.IsCI() && goRuntime.GOOS != "linux" {
+	if s.IsCI() && !(goRuntime.GOOS == "linux" && goRuntime.GOARCH == "amd64") {
 		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
 	}
 	require := s.Require()
@@ -138,7 +138,7 @@ func (s *singleServiceSuite) Test_DockerRun_HostDaemon() {
 }
 
 func (s *dockerDaemonSuite) Test_DockerRun_DockerDaemon() {
-	if s.IsCI() && goRuntime.GOOS != "linux" {
+	if s.IsCI() && !(goRuntime.GOOS == "linux" && goRuntime.GOARCH == "amd64") {
 		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
 	}
 	svc := "echo"

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -966,8 +966,8 @@ func DeleteNamespaces(ctx context.Context, namespaces ...string) {
 	wg.Add(len(namespaces))
 	for _, ns := range namespaces {
 		if t.Failed() {
-			if out, err := KubectlOut(ctx, ns, "get", "events"); err == nil {
-				dlog.Debugf(ctx, "Events from namespace %s\n%s", ns, out)
+			if out, err := KubectlOut(ctx, ns, "get", "events", "--field-selector", "type!=Normal"); err == nil {
+				dlog.Debugf(ctx, "Events where type != Normal from namespace %s\n%s", ns, out)
 			}
 		}
 		go func(ns string) {

--- a/integration_test/kubeauth_test.go
+++ b/integration_test/kubeauth_test.go
@@ -81,12 +81,8 @@ func (s *notConnectedSuite) Test_ConnectWithKubeconfigExec() {
 
 	connectWithExec := func(connectFromUserDaemon, useDocker bool) {
 		if useDocker && s.IsCI() {
-			if runtime.GOOS != "linux" {
+			if !(runtime.GOOS == "linux" && runtime.GOARCH == "amd64") {
 				s.T().Skip("CI can't run linux docker containers inside non-linux runners")
-			}
-			if runtime.GOARCH == "arm64" {
-				// rootless docker install doesn't permit access to host network (so no docker.host.internal)
-				s.T().Skip("CI can't run this test on arm64 because it uses a rootless docker install")
 			}
 		}
 

--- a/integration_test/multi_connect_test.go
+++ b/integration_test/multi_connect_test.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func (s *multiConnectSuite) SetupSuite() {
-	if s.IsCI() && goRuntime.GOOS != "linux" {
+	if s.IsCI() && !(goRuntime.GOOS == "linux" && goRuntime.GOARCH == "amd64") {
 		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
 	}
 	s.Suite.SetupSuite()

--- a/integration_test/proxy_via_test.go
+++ b/integration_test/proxy_via_test.go
@@ -1,14 +1,20 @@
 package integration_test
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 )
 
 type proxyViaSuite struct {
@@ -21,17 +27,19 @@ func (s *proxyViaSuite) SuiteName() string {
 }
 
 func init() {
-	itest.AddNamespacePairSuite("", func(h itest.NamespacePair) itest.TestingSuite {
+	itest.AddTrafficManagerSuite("", func(h itest.NamespacePair) itest.TestingSuite {
 		return &proxyViaSuite{Suite: itest.Suite{Harness: h}, NamespacePair: h}
 	})
 }
 
-func (s *proxyViaSuite) Test_ProxyVia() {
-	const domain = "mydomain.local"
-	const alias = "echo-home"
-	const fqnAlias = alias + "." + domain
+const (
+	domain   = "mydomain.local"
+	alias    = "echo-home"
+	fqnAlias = alias + "." + domain
+)
 
-	ctx := s.Context()
+func (s *proxyViaSuite) SetupSuite() {
+	s.Suite.SetupSuite()
 	tpl := struct {
 		AliasIP string
 		Aliases []string
@@ -42,26 +50,30 @@ func (s *proxyViaSuite) Test_ProxyVia() {
 	if s.IsIPv6() {
 		tpl.AliasIP = "::1"
 	}
-	s.ApplyTemplate(ctx, filepath.Join("testdata", "k8s", "echo-w-hostalias.goyaml"), &tpl)
-	svc := "echo"
-	defer func() {
-		s.DeleteSvcAndWorkload(ctx, "deploy", svc)
-	}()
+	s.ApplyTemplate(s.Context(), filepath.Join("testdata", "k8s", "echo-w-hostalias.goyaml"), &tpl)
+	s.NoError(s.RolloutStatusWait(s.Context(), "deploy/echo"))
+}
 
+func (s *proxyViaSuite) TearDownSuite() {
+	s.DeleteSvcAndWorkload(s.Context(), "deploy", "echo")
+}
+
+func (s *proxyViaSuite) Test_ProxyViaLoopBack() {
+	ctx := s.Context()
 	if s.IsIPv6() {
 		ctx = itest.WithConfig(ctx, func(config client.Config) {
 			config.Cluster().VirtualIPSubnet = "abac:0de0::/64"
 		})
 	}
 
-	err := s.TelepresenceHelmInstall(ctx, false, "--set", "client.dns.includeSuffixes={mydomain.local}")
+	err := s.TelepresenceHelmInstall(ctx, true, "--set", "client.dns.includeSuffixes={mydomain.local}")
 	s.Require().NoError(err)
-	defer s.UninstallTrafficManager(ctx, s.ManagerNamespace())
+	defer s.RollbackTM(ctx)
 
 	if s.IsIPv6() {
-		s.TelepresenceConnect(ctx, "--proxy-via", "::1/128="+svc)
+		s.TelepresenceConnect(ctx, "--proxy-via", "::1/128=echo")
 	} else {
-		s.TelepresenceConnect(ctx, "--proxy-via", "127.0.0.1/32="+svc)
+		s.TelepresenceConnect(ctx, "--proxy-via", "127.0.0.1/32=echo")
 	}
 	defer itest.TelepresenceQuitOk(ctx)
 
@@ -112,4 +124,131 @@ func (s *proxyViaSuite) Test_ProxyVia() {
 			rq.Regexp(tt.expectedOutput, out)
 		})
 	}
+}
+
+func (s *proxyViaSuite) Test_ProxyViaEverything() {
+	ctx := s.Context()
+	s.TelepresenceConnect(ctx)
+	st := itest.TelepresenceStatusOk(ctx)
+	itest.TelepresenceDisconnectOk(ctx)
+	sns := st.RootDaemon.Subnets
+	if len(sns) == 0 {
+		s.T().Skip("Test cannot run unless client maps at least one subnet")
+	}
+
+	if s.IsIPv6() {
+		ctx = itest.WithConfig(ctx, func(config client.Config) {
+			config.Cluster().VirtualIPSubnet = "abac:0de0::/64"
+		})
+	}
+
+	args := make([]string, 0, len(sns)*2)
+	for _, sn := range sns {
+		args = append(args, "--proxy-via", sn.String()+"=echo")
+	}
+	s.TelepresenceConnect(ctx, args...)
+	st = itest.TelepresenceStatusOk(ctx)
+	defer itest.TelepresenceDisconnectOk(ctx)
+	rq := s.Require()
+	rq.NotNil(st.RootDaemon)
+	rq.Len(st.RootDaemon.Subnets, 1) // Virtual subnet
+	out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", "echo")
+	dlog.Infof(ctx, "Output from echo service %s", out)
+	rq.NoError(err)
+}
+
+func (s *proxyViaSuite) Test_ProxyViaAll() {
+	ctx := s.Context()
+	rq := s.Require()
+	if s.IsIPv6() {
+		ctx = itest.WithConfig(ctx, func(config client.Config) {
+			config.Cluster().VirtualIPSubnet = "abac:0de0::/64"
+		})
+	}
+
+	s.TelepresenceConnect(ctx, "--proxy-via", "all=echo")
+	st := itest.TelepresenceStatusOk(ctx)
+	defer itest.TelepresenceDisconnectOk(ctx)
+	rq.NotNil(st.RootDaemon)
+	rq.Len(st.RootDaemon.Subnets, 1) // Virtual subnet
+	out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", "echo")
+	dlog.Infof(ctx, "Output from echo service %s", out)
+	rq.NoError(err)
+}
+
+func (s *proxyViaSuite) Test_NeverProxySubnetIsOmitted() {
+	ctx := s.Context()
+	s.TelepresenceConnect(ctx)
+	st := itest.TelepresenceStatusOk(ctx)
+	itest.TelepresenceDisconnectOk(ctx)
+	sns := st.RootDaemon.Subnets
+	if len(sns) == 0 {
+		s.T().Skip("Test cannot run unless client maps at least one subnet")
+	}
+	logFile := filepath.Join(filelocation.AppUserLogDir(s.Context()), "daemon.log")
+	rootLog, err := os.Open(logFile)
+	s.Require().NoError(err)
+	defer rootLog.Close()
+
+	for _, sn := range sns {
+		s.Run("subnet "+sn.String(), func() {
+			ctx := s.Context()
+			rq := s.Require()
+
+			fs, err := rootLog.Stat()
+			rq.NoError(err)
+			pos := fs.Size()
+
+			s.TelepresenceConnect(ctx, "--never-proxy", sn.String())
+			itest.TelepresenceDisconnectOk(ctx)
+			_, err = rootLog.Seek(pos, io.SeekStart)
+			rq.NoError(err)
+			scn := bufio.NewScanner(rootLog)
+			found := false
+
+			msg := fmt.Sprintf("Dropping never-proxy %q", sn.String())
+			for scn.Scan() {
+				txt := scn.Text()
+				if strings.Contains(txt, msg) {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "Unable to find %q", msg)
+		})
+	}
+	s.Run(fmt.Sprintf("subnets %s", sns), func() {
+		ctx := s.Context()
+		rq := s.Require()
+
+		fs, err := rootLog.Stat()
+		rq.NoError(err)
+		pos := fs.Size()
+
+		sb := strings.Builder{}
+		for i, sn := range sns {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(sn.String())
+		}
+		s.TelepresenceConnect(ctx, "--never-proxy", sb.String())
+		itest.TelepresenceDisconnectOk(ctx)
+		for _, sn := range sns {
+			_, err = rootLog.Seek(pos, io.SeekStart)
+			rq.NoError(err)
+			scn := bufio.NewScanner(rootLog)
+			found := false
+
+			msg := fmt.Sprintf("Dropping never-proxy %q", sn.String())
+			for scn.Scan() {
+				txt := scn.Text()
+				if strings.Contains(txt, msg) {
+					found = true
+					break
+				}
+			}
+			s.Truef(found, "Unable to find %q", msg)
+		}
+	})
 }

--- a/integration_test/proxy_via_test.go
+++ b/integration_test/proxy_via_test.go
@@ -118,10 +118,11 @@ func (s *proxyViaSuite) Test_ProxyViaLoopBack() {
 			dlog.Infof(ctx, "%s uses IP %s", tt.hostName, vip)
 			rq.Truef(virtualIPSubnet.Contains(vip), "virtualIPSubnet %s does not contain %s", virtualIPSubnet, vip)
 
-			out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", net.JoinHostPort(tt.hostName, "8080"))
-			rq.NoError(err)
-			dlog.Info(ctx, out)
-			rq.Regexp(tt.expectedOutput, out)
+			rq.Eventually(func() bool {
+				out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "2", net.JoinHostPort(tt.hostName, "8080"))
+				dlog.Info(ctx, out)
+				return err == nil && tt.expectedOutput.MatchString(out)
+			}, 10*time.Second, 2*time.Second)
 		})
 	}
 }
@@ -152,9 +153,11 @@ func (s *proxyViaSuite) Test_ProxyViaEverything() {
 	rq := s.Require()
 	rq.NotNil(st.RootDaemon)
 	rq.Len(st.RootDaemon.Subnets, 1) // Virtual subnet
-	out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", "echo")
-	dlog.Infof(ctx, "Output from echo service %s", out)
-	rq.NoError(err)
+	rq.Eventually(func() bool {
+		out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "2", "echo")
+		dlog.Infof(ctx, "Output from echo service %s", out)
+		return err == nil
+	}, 10*time.Second, 2*time.Second)
 }
 
 func (s *proxyViaSuite) Test_ProxyViaAll() {
@@ -171,9 +174,11 @@ func (s *proxyViaSuite) Test_ProxyViaAll() {
 	defer itest.TelepresenceDisconnectOk(ctx)
 	rq.NotNil(st.RootDaemon)
 	rq.Len(st.RootDaemon.Subnets, 1) // Virtual subnet
-	out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", "echo")
-	dlog.Infof(ctx, "Output from echo service %s", out)
-	rq.NoError(err)
+	rq.Eventually(func() bool {
+		out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "2", "echo")
+		dlog.Infof(ctx, "Output from echo service %s", out)
+		return err == nil
+	}, 10*time.Second, 2*time.Second)
 }
 
 func (s *proxyViaSuite) Test_NeverProxySubnetIsOmitted() {

--- a/pkg/client/cli/daemon/request_test.go
+++ b/pkg/client/cli/daemon/request_test.go
@@ -42,6 +42,48 @@ func Test_parseSubnetViaWorkload(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"all",
+			"all=workload",
+			prefixViaWL{
+				symbolic: "all",
+				workload: "workload",
+			},
+			false,
+		},
+		{
+			"also",
+			"also=workload",
+			prefixViaWL{
+				symbolic: "also",
+				workload: "workload",
+			},
+			false,
+		},
+		{
+			"pods",
+			"pods=workload",
+			prefixViaWL{
+				symbolic: "pods",
+				workload: "workload",
+			},
+			false,
+		},
+		{
+			"service",
+			"service=workload",
+			prefixViaWL{
+				symbolic: "service",
+				workload: "workload",
+			},
+			false,
+		},
+		{
+			"other",
+			"other=workload",
+			prefixViaWL{},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,6 +135,56 @@ func Test_parseProxyVias(t *testing.T) {
 			proxyVia: []string{"127.1.2.0/16=workload1", "127.1.3.0/16=workload2"},
 			want:     nil,
 			wantErr:  true,
+		},
+		{
+			name:     "symbolic-overlap",
+			proxyVia: []string{"also=workload1", "also=workload2"},
+			want:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "symbolic-overlap-all",
+			proxyVia: []string{"also=workload1", "all=workload2"},
+			want:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "multi-mixed",
+			proxyVia: []string{"127.1.2.0/16=workload1", "also=workload2"},
+			want: []*daemon.SubnetViaWorkload{
+				{
+					Subnet:   "127.1.2.0/16",
+					Workload: "workload1",
+				},
+				{
+					Subnet:   "also",
+					Workload: "workload2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "multi-mixed-all",
+			proxyVia: []string{"127.1.2.0/16=workload1", "all=workload2"},
+			want: []*daemon.SubnetViaWorkload{
+				{
+					Subnet:   "127.1.2.0/16",
+					Workload: "workload1",
+				},
+				{
+					Subnet:   "also",
+					Workload: "workload2",
+				},
+				{
+					Subnet:   "pods",
+					Workload: "workload2",
+				},
+				{
+					Subnet:   "service",
+					Workload: "workload2",
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/client/rootd/in_process.go
+++ b/pkg/client/rootd/in_process.go
@@ -121,7 +121,12 @@ func NewInProcSession(
 	mi *rpc.OutboundInfo,
 	mc manager.ManagerClient,
 	ver semver.Version,
-) *InProcSession {
+) (*InProcSession, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	return &InProcSession{Session: newSession(ctx, mi, &userdToManagerShortcut{mc}, ver), cancel: cancel}
+	session, err := newSession(ctx, mi, &userdToManagerShortcut{mc}, ver)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	return &InProcSession{Session: session, cancel: cancel}, nil
 }

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -761,9 +761,6 @@ func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInf
 			attribute.String("tel2.cluster-domain", d.ClusterDomain),
 		)
 	}
-	if s.tunVif == nil {
-		return nil
-	}
 
 	subnets = subnet.Unique(subnets)
 	dontProxy := slices.Clone(s.neverProxySubnets)
@@ -797,6 +794,9 @@ func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInf
 			scout.Entry{Key: "allow_conflicting_subnets", Value: len(s.allowConflictingSubnets)},
 		)
 	}()
+	if s.tunVif == nil {
+		return nil
+	}
 	rt := s.tunVif.Router
 	rt.UpdateWhitelist(s.allowConflictingSubnets)
 	return rt.UpdateRoutes(ctx, subnets, dontProxy)

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,7 +51,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/subnet"
-	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
 )
@@ -118,8 +118,11 @@ type Session struct {
 	// dnsLocalAddr is address of the local DNS Service.
 	dnsLocalAddr *net.UDPAddr
 
-	// Cluster subnets reported by the traffic-manager
-	clusterSubnets []*net.IPNet
+	// serviceSubnet reported by the traffic-manager
+	serviceSubnet *net.IPNet
+
+	// podSubnets reported by the traffic-manager
+	podSubnets []*net.IPNet
 
 	// Subnets configured by the user
 	alsoProxySubnets []*net.IPNet
@@ -331,8 +334,6 @@ func NewSession(c context.Context, mi *rpc.OutboundInfo) (context.Context, *Sess
 
 func nope() bool { return false }
 
-func yep() bool { return true }
-
 func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerProxyClient, ver semver.Version) (*Session, error) {
 	cfg := client.GetDefaultConfig()
 	cliCfg, err := mc.GetClientConfig(c, &empty.Empty{})
@@ -360,7 +361,7 @@ func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerPro
 		config:             cfg,
 		done:               make(chan struct{}),
 	}
-	s.alsoProxySubnets, err = validateSubnets("also-proxy", mi.AlsoProxySubnets, yep)
+	s.alsoProxySubnets, err = validateSubnets("also-proxy", mi.AlsoProxySubnets, s.alsoProxyVia)
 	if err != nil {
 		return nil, err
 	}
@@ -501,38 +502,38 @@ func (s *Session) configureDNS(dnsIP net.IP, dnsLocalAddr *net.UDPAddr) {
 	s.dnsLocalAddr = dnsLocalAddr
 }
 
-func (s *Session) refreshSubnets(ctx context.Context) (err error) {
-	if s.tunVif == nil {
-		dlog.Debug(ctx, "no tunnel, not refreshing subnets")
-		return nil
+// shouldProxySubnet returns true unless the given subnet is covered by a subnet in the neverProxySubnets list.
+func (s *Session) shouldProxySubnet(ctx context.Context, name string, sn *net.IPNet) bool {
+	if sn.IP.IsLoopback() {
+		dlog.Infof(ctx, "Will not proxy %s subnet %s, because it is loopback", name, sn)
+		return false
 	}
-	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "refreshSubnets")
-	defer tracing.EndAndRecord(span, err)
-
-	// Apply whitelist
-	s.tunVif.Router.UpdateWhitelist(s.allowConflictingSubnets)
-
-	// Fire and forget to send metrics out.
-	go func() {
-		scout.Report(ctx, "update_routes",
-			scout.Entry{Key: "cluster_subnets", Value: len(s.clusterSubnets)},
-			scout.Entry{Key: "also_proxy_subnets", Value: len(s.alsoProxySubnets)},
-			scout.Entry{Key: "never_proxy_subnets", Value: len(s.neverProxySubnets)},
-			scout.Entry{Key: "allow_conflicting_subnets", Value: len(s.allowConflictingSubnets)},
-		)
-	}()
-
-	// Create a unique slice of all desired subnets.
-	desired := make([]*net.IPNet, 0, len(s.clusterSubnets)+len(s.alsoProxySubnets)+1)
-	desired = append(desired, s.clusterSubnets...)
-	desired = append(desired, s.alsoProxySubnets...)
-	if s.vipGenerator != nil {
-		desired = append(desired, s.vipGenerator.Subnet())
-		dlog.Debugf(ctx, "Adding VIP subnet %q to TUN-device", s.vipGenerator.Subnet().String())
+	for _, lt := range s.localTranslationSubnets {
+		if subnet.Covers(&lt.IPNet, sn) {
+			dlog.Infof(ctx, "Will not proxy %s subnet %s, because it covered by --proxy-via %s=%s", name, sn, lt.IPNet, lt.workload)
+			return false
+		}
 	}
-	desired = subnet.Unique(desired)
-
-	return s.tunVif.Router.UpdateRoutes(ctx, desired, s.neverProxySubnets)
+	for _, nps := range s.neverProxySubnets {
+		if subnet.Covers(nps, sn) {
+			// Allow if there's an also-proxy that is smaller, contradicting the never-proxy
+			for _, aps := range s.alsoProxySubnets {
+				if subnet.Covers(nps, aps) && subnet.Covers(aps, sn) {
+					dlog.Infof(ctx, "Will proxy %s subnet %s, because it is covered by also-proxy %s overriding never-proxy %s", name, sn, nps, aps)
+					return true
+				}
+			}
+			dlog.Infof(ctx, "Will not proxy %s subnet %s, because it is covered by never-proxy %s", name, sn, nps)
+			return false
+		}
+	}
+	for _, npx := range s.subnetViaWorkloads {
+		if name == "service" && npx.Subnet == "service" || name == "pod" && npx.Subnet == "pods" {
+			dlog.Infof(ctx, "Will not proxy %s subnet %s, because it is covered by --proxy-via %s=%s", name, sn, npx.Subnet, npx.Workload)
+			return false
+		}
+	}
+	return true
 }
 
 // networkReady returns a channel that is close when both the VIF and DNS are ready.
@@ -586,6 +587,9 @@ func (s *Session) watchClusterInfo(ctx context.Context) error {
 				break
 			}
 			ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "ClusterInfoUpdate")
+			if err = s.readAdditionalRouting(ctx, mgrInfo); err != nil {
+				return err
+			}
 			select {
 			case <-s.vifReady:
 				if err := s.onClusterInfo(ctx, mgrInfo, span); err != nil {
@@ -650,87 +654,152 @@ func (s *Session) onFirstClusterInfo(ctx context.Context, mgrInfo *manager.Clust
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	s.readAdditionalRouting(ctx, mgrInfo)
-	willProxy := s.proxyClusterSvcs || s.proxyClusterPods || len(s.alsoProxySubnets) > 0
-
-	// We'll need to synthesize a subnet where we can attach the DNS service when the VIF isn't configured
-	// from cluster subnets. But not on darwin systems, because there the DNS is controlled by /etc/resolver
-	// entries appointing the DNS service directly via localhost:<port>.
-	if !willProxy && runtime.GOOS != "darwin" {
-		s.createSubnetForDNSOnly(ctx, mgrInfo)
-	}
-
-	// Do we need a VIF? A darwin system with full cluster access doesn't.
-	if willProxy || s.dnsServerSubnet != nil {
-		if s.tunVif, err = vif.NewTunnelingDevice(ctx, s.streamCreator()); err != nil {
-			return fmt.Errorf("NewTunnelVIF: %v", err)
-		}
-	}
+	span.SetAttributes(
+		attribute.Bool("tel2.proxy-svcs", s.proxyClusterSvcs),
+		attribute.Bool("tel2.proxy-pods", s.proxyClusterPods),
+	)
 	return s.onClusterInfo(ctx, mgrInfo, span)
 }
 
 func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInfo, span trace.Span) error {
 	dlog.Debugf(ctx, "WatchClusterInfo update")
-	dns := mgrInfo.Dns
-	if dns == nil {
+	if mgrInfo.Dns == nil {
 		// Older traffic-manager. Use deprecated mgrInfo fields for DNS
-		dns = &manager.DNS{
+		mgrInfo.Dns = &manager.DNS{
 			ClusterDomain: mgrInfo.ClusterDomain,
 		}
 	}
+	if mgrInfo.Routing == nil {
+		mgrInfo.Routing = &manager.Routing{}
+	}
 
-	s.readAdditionalRouting(ctx, mgrInfo)
+	s.serviceSubnet = nil
+	s.podSubnets = nil
 
 	var subnets []*net.IPNet
 	if s.proxyClusterSvcs {
 		if mgrInfo.ServiceSubnet != nil {
 			cidr := iputil.IPNetFromRPC(mgrInfo.ServiceSubnet)
-			dlog.Infof(ctx, "Adding Service subnet %s", cidr)
-			subnets = append(subnets, cidr)
+			if s.shouldProxySubnet(ctx, "service", cidr) {
+				dlog.Infof(ctx, "Adding service subnet %s", cidr)
+				subnets = append(subnets, cidr)
+			}
+			s.serviceSubnet = cidr
 		}
 	}
 
 	if s.proxyClusterPods {
 		for _, sn := range mgrInfo.PodSubnets {
 			cidr := iputil.IPNetFromRPC(sn)
-			dlog.Infof(ctx, "Adding pod subnet %s", cidr)
-			subnets = append(subnets, cidr)
+			if s.shouldProxySubnet(ctx, "pod", cidr) {
+				dlog.Infof(ctx, "Adding pod subnet %s", cidr)
+				subnets = append(subnets, cidr)
+			}
+			s.podSubnets = append(s.podSubnets, cidr)
 		}
 	}
 
-	var dnsIP net.IP
-	if s.dnsServerSubnet != nil {
-		// None of the cluster's subnets are routed, so add this subnet instead and unconditionally
-		// use the first available IP for our DNS server.
-		dlog.Infof(ctx, "Adding Service subnet %s (for DNS only)", s.dnsServerSubnet)
-		subnets = append(subnets, s.dnsServerSubnet)
-		dnsIP = make(net.IP, len(s.dnsServerSubnet.IP))
-		copy(dnsIP, s.dnsServerSubnet.IP)
-		dnsIP[len(dnsIP)-1] = 2
-	} else {
-		// We use the ManagerPodIp as the dnsIP. The reason for this is that no one should ever
-		// talk to the traffic-manager directly using the TUN device, so it's safe to use its
-		// IP to impersonate the DNS server. All traffic sent to that IP, will be routed to
-		// the local DNS server.
-		dnsIP = mgrInfo.ManagerPodIp
+	if s.vipGenerator != nil {
+		subnets = append(subnets, s.vipGenerator.Subnet())
+		dlog.Debugf(ctx, "Adding VIP subnet %q to TUN-device", s.vipGenerator.Subnet().String())
+		s.consolidateProxyViaWorkloads(ctx)
 	}
 
-	dlog.Infof(ctx, "Setting cluster DNS to %s", dnsIP)
-	dlog.Infof(ctx, "Setting cluster domain to %q", dns.ClusterDomain)
-	s.dnsServer.SetClusterDNS(dns, dnsIP)
-
-	s.clusterSubnets = subnet.Unique(subnets)
-	if err := s.refreshSubnets(ctx); err != nil {
-		return err
+	if !s.alsoProxyVia() {
+		subnets = append(subnets, s.alsoProxySubnets...)
 	}
 
-	span.SetAttributes(
-		attribute.Bool("tel2.proxy-svcs", s.proxyClusterSvcs),
-		attribute.Bool("tel2.proxy-pods", s.proxyClusterPods),
-		attribute.Stringer("tel2.cluster-dns", net.IP(dns.KubeIp)),
-		attribute.String("tel2.cluster-domain", dns.ClusterDomain),
-	)
-	return nil
+	// We use the ManagerPodIp as the dnsIP. The reason for this is that no one should ever
+	// talk to the traffic-manager directly using the TUN device, so it's safe to use its
+	// IP to impersonate the DNS server. All traffic sent to that IP, will be routed to
+	// the local DNS server.
+	dnsIP := net.IP(mgrInfo.ManagerPodIp)
+	dnsRouted := false
+	for _, sn := range subnets {
+		if sn.Contains(dnsIP) {
+			dnsRouted = true
+			break
+		}
+	}
+	if runtime.GOOS != "darwin" && !dnsRouted {
+		// We'll need to synthesize a subnet where we can attach the DNS service when the VIF isn't configured
+		// from cluster subnets. But not on darwin systems, because there the DNS is controlled by /etc/resolver
+		// entries appointing the DNS service directly via localhost:<port>.
+		if s.vipGenerator != nil {
+			var err error
+			dnsIP, err = s.vipGenerator.Next()
+			if err != nil {
+				return nil
+			}
+		} else {
+			if s.dnsServerSubnet == nil {
+				s.createSubnetForDNSOnly(ctx, mgrInfo)
+			}
+			dlog.Infof(ctx, "Adding Service subnet %s (for DNS only)", s.dnsServerSubnet)
+			subnets = append(subnets, s.dnsServerSubnet)
+			dnsIP = make(net.IP, len(s.dnsServerSubnet.IP))
+			copy(dnsIP, s.dnsServerSubnet.IP)
+			dnsIP[len(dnsIP)-1] = 2
+		}
+		dnsRouted = true
+	}
+
+	if len(subnets) > 0 && s.tunVif == nil {
+		var err error
+		if s.tunVif, err = vif.NewTunnelingDevice(ctx, s.streamCreator()); err != nil {
+			return fmt.Errorf("NewTunnelVIF: %w", err)
+		}
+	}
+
+	if dnsRouted {
+		d := mgrInfo.Dns
+		dlog.Infof(ctx, "Setting cluster DNS to %s", dnsIP)
+		dlog.Infof(ctx, "Setting cluster domain to %q", d.ClusterDomain)
+		s.dnsServer.SetClusterDNS(d, dnsIP)
+		span.SetAttributes(
+			attribute.Stringer("tel2.cluster-dns", dnsIP),
+			attribute.String("tel2.cluster-domain", d.ClusterDomain),
+		)
+	}
+	if s.tunVif == nil {
+		return nil
+	}
+
+	subnets = subnet.Unique(subnets)
+	dontProxy := slices.Clone(s.neverProxySubnets)
+	last := len(dontProxy) - 1
+	for i := 0; i <= last; {
+		nps := dontProxy[i]
+		found := false
+		for _, ds := range subnets {
+			if subnet.Overlaps(ds, nps) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// This never-proxy is pointless because it's not a subnet that we are routing
+			dlog.Infof(ctx, "Dropping never-proxy %q because it is not routed", nps)
+			if last > i {
+				dontProxy[i] = dontProxy[last]
+			}
+			last--
+		} else {
+			i++
+		}
+	}
+	dontProxy = dontProxy[:last+1]
+
+	// Fire and forget to send metrics out.
+	go func() {
+		scout.Report(ctx, "update_routes",
+			scout.Entry{Key: "subnets", Value: len(subnets)},
+			scout.Entry{Key: "allow_conflicting_subnets", Value: len(s.allowConflictingSubnets)},
+		)
+	}()
+	rt := s.tunVif.Router
+	rt.UpdateWhitelist(s.allowConflictingSubnets)
+	return rt.UpdateRoutes(ctx, subnets, dontProxy)
 }
 
 func validateSubnets(name string, sns []*manager.IPNet, allowLoopback func() bool) ([]*net.IPNet, error) {
@@ -749,9 +818,19 @@ func validateSubnets(name string, sns []*manager.IPNet, allowLoopback func() boo
 	return subnet.Unique(rs), nil
 }
 
+// alsoProxyVia will return true when the connection was made using --subnet-via all=<workload> or --subnet-via also=<workload>.
+func (s *Session) alsoProxyVia() bool {
+	for _, pvx := range s.subnetViaWorkloads {
+		if pvx.Subnet == "also" { // no need to test for "all". It's normalized into ["also", "pods", "service"]
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Session) readAdditionalRouting(ctx context.Context, mgrInfo *manager.ClusterInfo) error {
 	if r := mgrInfo.Routing; r != nil {
-		sns, err := validateSubnets("also-proxy", r.AlsoProxySubnets, yep)
+		sns, err := validateSubnets("also-proxy", r.AlsoProxySubnets, s.alsoProxyVia)
 		if err != nil {
 			return err
 		}
@@ -806,6 +885,9 @@ func (s *Session) checkSvcConnectivity(ctx context.Context, info *manager.Cluste
 	url = fmt.Sprintf("https://%s/healthz", url)
 	request, err := http.NewRequestWithContext(tCtx, http.MethodGet, url, nil)
 	if err != nil {
+		if ctx.Err() != nil {
+			return false // parent context cancelled
+		}
 		// As far as I can tell, this error means a) that the context was cancelled before the request could be allocated, or b) that the request is misconstructed, e.g. bad method.
 		// Neither of those two should really happen here (unless you set the timeout to a few microseconds, maybe), but we can't really continue. May as well route the cluster.
 		dlog.Errorf(ctx, "Unexpected: service conn check could not build request: %v. Will route services anyway.", err)
@@ -815,6 +897,9 @@ func (s *Session) checkSvcConnectivity(ctx context.Context, info *manager.Cluste
 	dlog.Debugf(ctx, "Performing service connectivity check on %s with Host %s and timeout %s", url, info.InjectorSvcHost, ct)
 	resp, err := client.Do(request)
 	if err != nil {
+		if ctx.Err() != nil {
+			return false // parent context cancelled
+		}
 		// This means either network errors (timeouts, failed to connect), or that the server doesn't speak HTTP.
 		dlog.Debugf(ctx, "Will proxy services (%v)", err)
 		return true
@@ -848,12 +933,18 @@ func (s *Session) checkPodConnectivity(ctx context.Context, info *manager.Cluste
 	dlog.Debugf(ctx, "Performing pod connectivity check on IP %s with timeout %s", ip, ct)
 	conn, err := grpc.DialContext(tCtx, net.JoinHostPort(ip, strconv.Itoa(int(port))), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
+		if ctx.Err() != nil {
+			return false // parent context cancelled
+		}
 		dlog.Debugf(ctx, "Will proxy pods (%v)", err)
 		return true
 	}
 	defer conn.Close()
 	mClient := manager.NewManagerClient(conn)
 	if _, err := mClient.Version(tCtx, &empty.Empty{}); err != nil {
+		if ctx.Err() != nil {
+			return false // parent context cancelled
+		}
 		dlog.Warnf(ctx, "Manager IP %s is connectable but not a traffic-manager instance (%v)."+
 			" Will proxy pods, but this may interfere with your VPN routes.", ip, err)
 		return true
@@ -1003,17 +1094,8 @@ func (s *Session) activateProxyViaWorkloads(ctx context.Context) error {
 	s.localTranslationTable = xsync.NewMapOf[iputil.IPKey, net.IP]()
 	s.virtualIPs = xsync.NewMapOf[iputil.IPKey, agentVIP]()
 	s.localTranslationSubnets = make([]agentSubnet, sl)
-	wlNames := make(map[string]struct{}, sl)
-	for i, svw := range s.subnetViaWorkloads {
-		_, ipn, err := net.ParseCIDR(svw.Subnet)
-		if err != nil {
-			return err
-		}
-		wlNames[svw.Workload] = struct{}{}
-		s.localTranslationSubnets[i] = agentSubnet{IPNet: *ipn, workload: svw.Workload}
-	}
-	for wlName := range wlNames {
-		_, err := s.managerClient.EnsureAgent(ctx, &manager.EnsureAgentRequest{
+	for _, wlName := range s.consolidateProxyViaWorkloads(ctx) {
+		_, err = s.managerClient.EnsureAgent(ctx, &manager.EnsureAgentRequest{
 			Session: s.session,
 			Name:    wlName,
 		})
@@ -1022,6 +1104,47 @@ func (s *Session) activateProxyViaWorkloads(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (s *Session) consolidateProxyViaWorkloads(ctx context.Context) []string {
+	desiredVips := make(map[string][]*net.IPNet)
+	snCount := 0
+	for _, pvx := range s.subnetViaWorkloads {
+		switch pvx.Subnet {
+		case "also":
+			desiredVips[pvx.Workload] = append(desiredVips[pvx.Workload], s.alsoProxySubnets...)
+			snCount += len(s.alsoProxySubnets)
+		case "pods":
+			desiredVips[pvx.Workload] = append(desiredVips[pvx.Workload], s.podSubnets...)
+			snCount += len(s.podSubnets)
+		case "service":
+			if s.serviceSubnet != nil {
+				desiredVips[pvx.Workload] = append(desiredVips[pvx.Workload], s.serviceSubnet)
+				snCount++
+			}
+		default:
+			_, sn, err := net.ParseCIDR(pvx.Subnet)
+			if err != nil {
+				dlog.Warnf(ctx, "unable to parse proxy-via subnet %s", pvx.Subnet)
+			} else {
+				desiredVips[pvx.Workload] = append(desiredVips[pvx.Workload], sn)
+				snCount++
+			}
+		}
+	}
+
+	wlNames := make([]string, len(desiredVips))
+	lcs := make([]agentSubnet, 0, snCount)
+	i := 0
+	for wlName, sns := range desiredVips {
+		wlNames[i] = wlName
+		i++
+		for _, sn := range sns {
+			lcs = append(lcs, agentSubnet{IPNet: *sn, workload: wlName})
+		}
+	}
+	s.localTranslationSubnets = lcs
+	return wlNames
 }
 
 func (s *Session) waitForProxyViaWorkloads(ctx context.Context) error {

--- a/pkg/client/rootd/stream_creator.go
+++ b/pkg/client/rootd/stream_creator.go
@@ -33,7 +33,7 @@ func (s *Session) streamCreator() tunnel.StreamCreator {
 			}
 			if id.SourcePort() == 53 {
 				srcIp := id.Source()
-				for _, sn := range s.clusterSubnets {
+				for _, sn := range s.podSubnets {
 					if sn.Contains(srcIp) && !srcIp.Equal(sn.IP.Mask(sn.Mask)) {
 						// This is call was made by the cluster's DNS service. Typically, seen when
 						// running a Kind cluster locally. Letting it through causes recursion and

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -1117,7 +1117,10 @@ func (s *session) connectRootDaemon(ctx context.Context, oi *rootdRpc.OutboundIn
 	svc := userd.GetService(ctx)
 	if svc.RootSessionInProcess() {
 		// Just run the root session in-process.
-		rootSession := rootd.NewInProcSession(ctx, oi, s.managerClient, s.managerVersion)
+		rootSession, err := rootd.NewInProcSession(ctx, oi, s.managerClient, s.managerVersion)
+		if err != nil {
+			return nil, err
+		}
 		if err = rootSession.Start(ctx, dgroup.NewGroup(ctx, dgroup.GroupConfig{})); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The `--proxy-via` can now use the symbolic names instead of subnets:

    also:    All subnets added with --also-proxy
    service: The cluster's service subnet
    pods:    The cluster's pod subnets.
    all:     All of the above.