### PR TITLE
Restore ability to run the telepresence CLI in a docker container.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -53,6 +53,14 @@ items:
           <tr><td><code>all</code></td><td>All of the above.</td></tr>
           </table></p>
       - type: bugfix
+        title: Restore ability to run the telepresence CLI in a docker container.
+        body: >-
+          The improvements made to be able to run the telepresence daemon in docker
+          using <code>telepresence connect --docker</code> made it impossible to run
+          both the CLI and the daemon in docker. This commit fixes that and
+          also ensures that the user- and root-daemons are merged in this
+          scenario when the container runs as root.
+      - type: bugfix
         title: Kubeconfig exec authentication with context names containing colon didn't work on Windows
         body: >-
           The logic added to allow the root daemon to connect directly to the cluster using the user daemon as a proxy

--- a/integration_test/testdata/cli-container/Dockerfile
+++ b/integration_test/testdata/cli-container/Dockerfile
@@ -1,0 +1,5 @@
+FROM telepresence
+
+RUN apk add --no-cache bash curl
+
+ENTRYPOINT ["/bin/bash"]

--- a/pkg/proc/docker.go
+++ b/pkg/proc/docker.go
@@ -1,9 +1,17 @@
 package proc
 
-import "os"
+import (
+	"os"
+)
+
+var runningInContainer bool //nolint:gochecknoglobals // this is a constant
+
+func init() {
+	_, err := os.Stat("/.dockerenv")
+	runningInContainer = err == nil
+}
 
 // RunningInContainer returns true if the current process runs from inside a docker container.
 func RunningInContainer() bool {
-	_, err := os.Stat("/.dockerenv")
-	return err == nil
+	return runningInContainer
 }


### PR DESCRIPTION
The improvements made to be able to run the telepresence daemon in docker using `telepresence connect --docker` made it impossible to run both the CLI and the daemon in docker. This commit fixes that and also ensures that the user- and root-daemons are merged in this scenario when the container runs as root.