### PR TITLE
Ensure that telepresence upgrade uses helm semantics for reuse/reset.

### DIFF
--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -11,33 +11,33 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 )
 
-func (s *installSuite) applyPolicyApp(ctx context.Context, name, namespace string, wg *sync.WaitGroup) {
+func (is *installSuite) applyPolicyApp(ctx context.Context, name, namespace string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	s.T().Helper()
+	is.T().Helper()
 	manifest := filepath.Join("testdata", "k8s", name+".yaml")
-	s.NoError(itest.Kubectl(ctx, namespace, "apply", "-f", manifest), "failed to apply %s", manifest)
-	s.NoError(itest.RolloutStatusWait(ctx, namespace, "deploy/"+name))
+	is.NoError(itest.Kubectl(ctx, namespace, "apply", "-f", manifest), "failed to apply %s", manifest)
+	is.NoError(itest.RolloutStatusWait(ctx, namespace, "deploy/"+name))
 }
 
-func (s *installSuite) assertInjected(ctx context.Context, name, namespace string, present bool, wg *sync.WaitGroup) {
+func (is *installSuite) assertInjected(ctx context.Context, name, namespace string, present bool, wg *sync.WaitGroup) {
 	defer wg.Done()
-	s.T().Helper()
+	is.T().Helper()
 	out, err := itest.KubectlOut(ctx, namespace, "get", "pods", "-l", "app="+name, "-o", "jsonpath={.items.*.spec.containers[?(@.name=='traffic-agent')].image}")
-	s.NoError(err)
+	is.NoError(err)
 	n := "tel2"
 	if ai := itest.GetAgentImage(ctx); ai != nil {
 		n = ai.Name
 	}
 	n = "/" + n + ":"
 	if present {
-		s.Contains(out, n)
+		is.Contains(out, n)
 	} else {
-		s.NotContains(out, n)
+		is.NotContains(out, n)
 	}
 }
 
-func (s *installSuite) injectPolicyTest(ctx context.Context, policy agentconfig.InjectPolicy) {
-	namespace := fmt.Sprintf("%s-%s", strings.ToLower(policy.String()), s.Suffix())
+func (is *installSuite) injectPolicyTest(ctx context.Context, policy agentconfig.InjectPolicy) {
+	namespace := fmt.Sprintf("%s-%s", strings.ToLower(policy.String()), is.Suffix())
 	itest.CreateNamespaces(ctx, namespace)
 	defer itest.DeleteNamespaces(ctx, namespace)
 
@@ -45,8 +45,8 @@ func (s *installSuite) injectPolicyTest(ctx context.Context, policy agentconfig.
 		Namespace:         namespace,
 		ManagedNamespaces: []string{namespace},
 	})
-	s.NoError(s.TelepresenceHelmInstall(ctx, false, "--set", "agentInjector.injectPolicy="+policy.String()))
-	defer s.UninstallTrafficManager(ctx, namespace)
+	is.NoError(is.TelepresenceHelmInstall(ctx, false, "--set", "agentInjector.injectPolicy="+policy.String()))
+	defer is.UninstallTrafficManager(ctx, namespace)
 
 	ctx = itest.WithUser(ctx, namespace+":"+itest.TestUser)
 	itest.TelepresenceOk(ctx, "connect", "--namespace", namespace, "--manager-namespace", namespace)
@@ -56,21 +56,21 @@ func (s *installSuite) injectPolicyTest(ctx context.Context, policy agentconfig.
 
 	wg := sync.WaitGroup{}
 	wg.Add(3)
-	go s.applyPolicyApp(ctx, "pol-enabled", namespace, &wg)
-	go s.applyPolicyApp(ctx, "pol-none", namespace, &wg)
-	go s.applyPolicyApp(ctx, "pol-disabled", namespace, &wg)
+	go is.applyPolicyApp(ctx, "pol-enabled", namespace, &wg)
+	go is.applyPolicyApp(ctx, "pol-none", namespace, &wg)
+	go is.applyPolicyApp(ctx, "pol-disabled", namespace, &wg)
 	wg.Wait()
-	if s.T().Failed() {
+	if is.T().Failed() {
 		return
 	}
 
 	// No pod should have a traffic-agent at this stage, except for the pol-enabled when the policy is WhenEnabled
 	wg.Add(3)
-	go s.assertInjected(ctx, "pol-enabled", namespace, true, &wg)   // always injected in advance
-	go s.assertInjected(ctx, "pol-none", namespace, false, &wg)     // never injected in advance
-	go s.assertInjected(ctx, "pol-disabled", namespace, false, &wg) // never injected
+	go is.assertInjected(ctx, "pol-enabled", namespace, true, &wg)   // always injected in advance
+	go is.assertInjected(ctx, "pol-none", namespace, false, &wg)     // never injected in advance
+	go is.assertInjected(ctx, "pol-disabled", namespace, false, &wg) // never injected
 	wg.Wait()
-	if s.T().Failed() {
+	if is.T().Failed() {
 		return
 	}
 
@@ -78,24 +78,24 @@ func (s *installSuite) injectPolicyTest(ctx context.Context, policy agentconfig.
 	wg.Add(1)
 	go func() {
 		_, _, err := itest.Telepresence(ctx, "intercept", "--mount", "false", "pol-disabled", "--", "true")
-		s.Error(err)
-		s.assertInjected(ctx, "pol-disabled", namespace, false, &wg)
+		is.Error(err)
+		is.assertInjected(ctx, "pol-disabled", namespace, false, &wg)
 	}()
 
 	// for OnDemand, an intercept on the pol-none must succeed inject the agent
 	if policy == agentconfig.OnDemand {
 		wg.Add(1)
 		_, _, err := itest.Telepresence(ctx, "intercept", "--mount", "false", "pol-none", "--", "true")
-		s.NoError(err)
-		s.assertInjected(ctx, "pol-none", namespace, true, &wg)
+		is.NoError(err)
+		is.assertInjected(ctx, "pol-none", namespace, true, &wg)
 	}
 	wg.Wait()
 }
 
-func (s *installSuite) TestInjectPolicy() {
+func (is *installSuite) TestInjectPolicy() {
 	for _, policy := range []agentconfig.InjectPolicy{agentconfig.OnDemand, agentconfig.WhenEnabled} {
-		s.Run(policy.String(), func() {
-			s.injectPolicyTest(s.Context(), policy)
+		is.Run(policy.String(), func() {
+			is.injectPolicyTest(is.Context(), policy)
 		})
 	}
 }

--- a/integration_test/limitrange_test.go
+++ b/integration_test/limitrange_test.go
@@ -13,27 +13,27 @@ import (
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 )
 
-func (s *installSuite) limitedRangeTest() {
+func (is *installSuite) limitedRangeTest() {
 	const svc = "echo"
-	ctx := itest.WithUser(s.Context(), s.ManagerNamespace()+":"+itest.TestUser)
-	s.TelepresenceConnect(ctx)
+	ctx := itest.WithUser(is.Context(), is.ManagerNamespace()+":"+itest.TestUser)
+	is.TelepresenceConnect(ctx)
 	itest.TelepresenceOk(ctx, "loglevel", "debug")
 
-	require := s.Require()
-	itest.ApplyEchoService(ctx, svc, s.AppNamespace(), 8083)
+	require := is.Require()
+	itest.ApplyEchoService(ctx, svc, is.AppNamespace(), 8083)
 	defer func() {
-		s.NoError(itest.Kubectl(ctx, s.AppNamespace(), "delete", "svc,deploy", svc))
-		s.Eventually(func() bool { return len(itest.RunningPods(ctx, svc, s.AppNamespace())) == 0 }, 2*time.Minute, 6*time.Second)
+		is.NoError(itest.Kubectl(ctx, is.AppNamespace(), "delete", "svc,deploy", svc))
+		is.Eventually(func() bool { return len(itest.RunningPods(ctx, svc, is.AppNamespace())) == 0 }, 2*time.Minute, 6*time.Second)
 	}()
 
 	_, _, err := itest.Telepresence(ctx, "intercept", "--mount", "false", svc)
 	if err != nil {
-		if out, err := itest.KubectlOut(ctx, s.AppNamespace(), "get", "pod", "-o", "yaml", "-l", "app="+svc); err == nil {
+		if out, err := itest.KubectlOut(ctx, is.AppNamespace(), "get", "pod", "-o", "yaml", "-l", "app="+svc); err == nil {
 			dlog.Info(ctx, out)
 		}
 	}
 	require.NoError(err)
-	s.Eventually(
+	is.Eventually(
 		func() bool {
 			stdout, _, err := itest.Telepresence(ctx, "list", "--intercepts")
 			return err == nil && strings.Contains(stdout, svc+": intercepted")
@@ -44,7 +44,7 @@ func (s *installSuite) limitedRangeTest() {
 	itest.TelepresenceOk(ctx, "leave", svc)
 
 	// Ensure that LimitRange is injected into traffic-agent
-	out, err := itest.KubectlOut(ctx, s.AppNamespace(), "get", "pods", "-l", "app="+svc, "-o",
+	out, err := itest.KubectlOut(ctx, is.AppNamespace(), "get", "pods", "-l", "app="+svc, "-o",
 		`jsonpath={range .items.*.spec.containers[?(@.name=='traffic-agent')]}{.resources}{","}{end}`)
 	require.NoError(err)
 	dlog.Infof(ctx, "resources = %s", out)
@@ -60,28 +60,28 @@ func (s *installSuite) limitedRangeTest() {
 	require.True(m != nil && m.Equal(oneGig))
 }
 
-func (s *installSuite) TestLimitRange() {
-	ctx := s.Context()
-	require := s.Require()
-	require.NoError(itest.Kubectl(ctx, s.ManagerNamespace(), "apply", "-f", filepath.Join("testdata", "k8s", "client_sa.yaml")))
+func (is *installSuite) TestLimitRange() {
+	ctx := is.Context()
+	require := is.Require()
+	require.NoError(itest.Kubectl(ctx, is.ManagerNamespace(), "apply", "-f", filepath.Join("testdata", "k8s", "client_sa.yaml")))
 	defer func() {
-		require.NoError(itest.Kubectl(ctx, s.ManagerNamespace(), "delete", "-f", filepath.Join("testdata", "k8s", "client_sa.yaml")))
+		require.NoError(itest.Kubectl(ctx, is.ManagerNamespace(), "delete", "-f", filepath.Join("testdata", "k8s", "client_sa.yaml")))
 	}()
 
-	defer s.UninstallTrafficManager(ctx, s.ManagerNamespace())
+	defer is.UninstallTrafficManager(ctx, is.ManagerNamespace())
 
-	require.NoError(itest.Kubectl(ctx, s.AppNamespace(), "apply", "-f", filepath.Join("testdata", "k8s", "memory-constraints.yaml")))
+	require.NoError(itest.Kubectl(ctx, is.AppNamespace(), "apply", "-f", filepath.Join("testdata", "k8s", "memory-constraints.yaml")))
 	defer func() {
-		require.NoError(itest.Kubectl(ctx, s.AppNamespace(), "delete", "-f", filepath.Join("testdata", "k8s", "memory-constraints.yaml")))
+		require.NoError(itest.Kubectl(ctx, is.AppNamespace(), "delete", "-f", filepath.Join("testdata", "k8s", "memory-constraints.yaml")))
 	}()
 
-	s.Run("Never", func() {
-		s.NoError(s.TelepresenceHelmInstall(s.Context(), false, "--set", "agentInjector.webhook.reinvocationPolicy=Never"))
-		s.limitedRangeTest()
+	is.Run("Never", func() {
+		is.NoError(is.TelepresenceHelmInstall(is.Context(), false, "--set", "agentInjector.webhook.reinvocationPolicy=Never"))
+		is.limitedRangeTest()
 	})
 
-	s.Run("IfNeeded", func() {
-		s.NoError(s.TelepresenceHelmInstall(s.Context(), true, "--set", "agentInjector.webhook.reinvocationPolicy=IfNeeded"))
-		s.limitedRangeTest()
+	is.Run("IfNeeded", func() {
+		is.NoError(is.TelepresenceHelmInstall(is.Context(), true, "--set", "agentInjector.webhook.reinvocationPolicy=IfNeeded"))
+		is.limitedRangeTest()
 	})
 }


### PR DESCRIPTION
Fixes a regression introduced by #3481 (not yet released) where helm values were not retained when running `telepresence upgrade` without provided values.