### PR TITLE
Ensure that remote mounts work with --replace (and other fixes)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -61,6 +61,13 @@ items:
           also ensures that the user- and root-daemons are merged in this
           scenario when the container runs as root.
       - type: bugfix
+        title: Remote mounts when intercepting with the --replace flag.
+        body: >-
+          A <code>telepresence intercept --replace</code> did not correctly mount all volumes, because when the
+          intercepted container was removed, its mounts were no longer visible to the agent-injector when it
+          was subjected to a second invocation. The container is now kept in place, but with an image that
+          just sleeps infinitely.
+      - type: bugfix
         title: Kubeconfig exec authentication with context names containing colon didn't work on Windows
         body: >-
           The logic added to allow the root daemon to connect directly to the cluster using the user daemon as a proxy

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -68,6 +68,12 @@ items:
           was subjected to a second invocation. The container is now kept in place, but with an image that
           just sleeps infinitely.
       - type: bugfix
+        title: Intercepting with the --replace flag will no longer require all subsequent intercepts to use --replace.
+        body: >-
+          A <code>telepresence intercept --replace</code> will no longer switch the mode of the intercepted workload,
+          forcing all subsequent intercepts on that workload to use <code>--replace</code> until the agent is
+          uninstalled. Instead, <code>--replace</code> can be used interchangeably just like any other intercept flag.
+      - type: bugfix
         title: Kubeconfig exec authentication with context names containing colon didn't work on Windows
         body: >-
           The logic added to allow the root daemon to connect directly to the cluster using the user daemon as a proxy

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -28,7 +28,7 @@ following Free and Open Source software:
     github.com/datawire/dtest                                                    v0.0.0-20210928162311-722b199c4c2f    Apache License 2.0
     github.com/datawire/envconfig                                                v0.0.0-20221012222025-09524dc7d59b    Apache License 2.0
     github.com/datawire/go-ftpserver                                             v0.1.3                                Apache License 2.0
-    github.com/datawire/go-fuseftp/rpc                                           v0.4.2                                Apache License 2.0
+    github.com/datawire/go-fuseftp/rpc                                           v0.4.4                                Apache License 2.0
     github.com/datawire/k8sapi                                                   v0.1.4                                Apache License 2.0
     github.com/datawire/metriton-go-client                                       v0.1.1                                Apache License 2.0
     github.com/davecgh/go-spew                                                   v1.1.1                                ISC license

--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -82,7 +82,7 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 		return err
 	}
 
-	state.SetManager(session, manager, mgrVer)
+	state.SetManager(ctx, session, manager, mgrVer)
 
 	// Create the /tmp/agent directory if it doesn't exist
 	// We use this to place a file which conveys 'readiness'

--- a/cmd/traffic/cmd/agent/state.go
+++ b/cmd/traffic/cmd/agent/state.go
@@ -29,7 +29,7 @@ type State interface {
 	ManagerVersion() semver.Version
 	SessionInfo() *manager.SessionInfo
 	SetFileSharingPorts(ftp uint16, sftp uint16)
-	SetManager(sessionInfo *manager.SessionInfo, manager manager.ManagerClient, version semver.Version)
+	SetManager(ctx context.Context, sessionInfo *manager.SessionInfo, manager manager.ManagerClient, version semver.Version)
 	FtpPort() uint16
 	SftpPort() uint16
 }
@@ -164,7 +164,7 @@ func (s *state) InterceptInfo(ctx context.Context, callerID, path string, contai
 	return &restapi.InterceptInfo{}, nil
 }
 
-func (s *state) SetManager(sessionInfo *manager.SessionInfo, manager manager.ManagerClient, version semver.Version) {
+func (s *state) SetManager(_ context.Context, sessionInfo *manager.SessionInfo, manager manager.ManagerClient, version semver.Version) {
 	s.manager = manager
 	s.sessionInfo = sessionInfo
 	s.mgrVer = version

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -179,7 +179,7 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 		if gc, err = agentmap.GeneratorConfigFunc(img); err != nil {
 			return nil, err
 		}
-		if scx, err = gc.Generate(ctx, wl, 0, scx); err != nil {
+		if scx, err = gc.Generate(ctx, wl, scx); err != nil {
 			return nil, err
 		}
 
@@ -245,7 +245,7 @@ func disableAppContainer(ctx context.Context, pod *core.Pod, config *agentconfig
 podContainers:
 	for i, pc := range pod.Spec.Containers {
 		for _, cc := range config.Containers {
-			if cc.Name == pc.Name && cc.Replace == agentconfig.ReplacePolicyActive {
+			if cc.Name == pc.Name && cc.Replace {
 				if pc.Image == sleeperImage && slices.Equal(pc.Args, sleeperArgs) {
 					continue podContainers
 				}

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -196,7 +196,7 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 
 	var patches PatchOps
 	config := scx.AgentConfig()
-	patches = deleteAppContainer(ctx, pod, config, patches)
+	patches = disableAppContainer(ctx, pod, config, patches)
 	patches = addInitContainer(pod, config, patches)
 	patches = addAgentContainer(ctx, pod, config, patches)
 	patches = addPullSecrets(pod, config, patches)
@@ -237,16 +237,51 @@ func needInitContainer(config *agentconfig.Sidecar) bool {
 	return false
 }
 
-func deleteAppContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Sidecar, patches PatchOps) PatchOps {
+const sleeperImage = "alpine:latest"
+
+var sleeperArgs = []string{"sleep", "infinity"} //nolint:gochecknoglobals // constant
+
+func disableAppContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Sidecar, patches PatchOps) PatchOps {
 podContainers:
 	for i, pc := range pod.Spec.Containers {
 		for _, cc := range config.Containers {
 			if cc.Name == pc.Name && cc.Replace == agentconfig.ReplacePolicyActive {
+				if pc.Image == sleeperImage && slices.Equal(pc.Args, sleeperArgs) {
+					continue podContainers
+				}
 				patches = append(patches, PatchOperation{
-					Op:   "remove",
-					Path: fmt.Sprintf("/spec/containers/%d", i),
+					Op:    "replace",
+					Path:  fmt.Sprintf("/spec/containers/%d/image", i),
+					Value: sleeperImage,
 				})
-				dlog.Debugf(ctx, "Deleted container %s", pc.Name)
+				argsOp := "add"
+				if len(pc.Args) > 0 {
+					argsOp = "replace"
+				}
+				patches = append(patches, PatchOperation{
+					Op:    argsOp,
+					Path:  fmt.Sprintf("/spec/containers/%d/args", i),
+					Value: sleeperArgs,
+				})
+				if pc.StartupProbe != nil {
+					patches = append(patches, PatchOperation{
+						Op:   "remove",
+						Path: fmt.Sprintf("/spec/containers/%d/startupProbe", i),
+					})
+				}
+				if pc.LivenessProbe != nil {
+					patches = append(patches, PatchOperation{
+						Op:   "remove",
+						Path: fmt.Sprintf("/spec/containers/%d/livenessProbe", i),
+					})
+				}
+				if pc.ReadinessProbe != nil {
+					patches = append(patches, PatchOperation{
+						Op:   "remove",
+						Path: fmt.Sprintf("/spec/containers/%d/readinessProbe", i),
+					})
+				}
+				dlog.Debugf(ctx, "Disabled container %s", pc.Name)
 				continue podContainers
 			}
 		}

--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -1800,5 +1800,5 @@ func generateForPod(t *testing.T, ctx context.Context, pod *core.Pod, gc agentma
 	default:
 		t.Fatalf("bad workload type %T", wi)
 	}
-	return gc.Generate(ctx, wl, 0, nil)
+	return gc.Generate(ctx, wl, nil)
 }

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -149,7 +149,7 @@ func isRolloutNeeded(ctx context.Context, wl k8sapi.Workload, ac *agentconfig.Si
 					wl.GetName(), wl.GetNamespace(), cn.Name)
 				return true
 			}
-			if cn.Replace == agentconfig.ReplacePolicyActive {
+			if cn.Replace {
 				// Ensure that the replaced container is disabled
 				if !(found.Image == sleeperImage && slices.Equal(found.Args, sleeperArgs)) {
 					dlog.Debugf(ctx, "Rollout of %s.%s is necessary. The desired pod's container %s should be disabled",
@@ -304,7 +304,7 @@ func regenerateAgentMaps(ctx context.Context, ns string, gc agentmap.GeneratorCo
 				changed = true
 				continue
 			}
-			ncx, err := gc.Generate(ctx, wl, 0, acx)
+			ncx, err := gc.Generate(ctx, wl, acx)
 			if err != nil {
 				return err
 			}
@@ -413,7 +413,7 @@ func (c *configWatcher) handleAdd(ctx context.Context, e entry) {
 			dlog.Error(ctx, err)
 			return
 		}
-		if acx, err := gc.Generate(ctx, wl, 0, ac); err != nil {
+		if acx, err := gc.Generate(ctx, wl, ac); err != nil {
 			dlog.Error(ctx, err)
 		} else if err = c.self.Store(ctx, acx, false); err != nil { // Calling Store() will generate a new event, so we skip rollout here
 			dlog.Error(ctx, err)
@@ -873,7 +873,7 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, isDele
 			continue
 		}
 		dlog.Debugf(ctx, "Regenerating config entry for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
-		acn, err := cfg.Generate(ctx, wl, 0, ac)
+		acn, err := cfg.Generate(ctx, wl, ac)
 		if err != nil {
 			dlog.Error(ctx, err)
 			continue

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -25,7 +25,6 @@ import (
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/watchable"
-	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
@@ -63,7 +62,7 @@ type State interface {
 	NewInterceptInfo(string, *rpc.SessionInfo, *rpc.CreateInterceptRequest) *rpc.InterceptInfo
 	PostLookupDNSResponse(context.Context, *rpc.DNSAgentResponse)
 	EnsureAgent(context.Context, string, string) error
-	PrepareIntercept(context.Context, *rpc.CreateInterceptRequest, agentconfig.ReplacePolicy) (*rpc.PreparedIntercept, error)
+	PrepareIntercept(context.Context, *rpc.CreateInterceptRequest) (*rpc.PreparedIntercept, error)
 	RemoveIntercept(context.Context, string)
 	DropIntercept(string)
 	FinalizeIntercept(ctx context.Context, intercept *rpc.InterceptInfo)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/datawire/dtest v0.0.0-20210928162311-722b199c4c2f
 	github.com/datawire/envconfig v0.0.0-20221012222025-09524dc7d59b
 	github.com/datawire/go-ftpserver v0.1.3
-	github.com/datawire/go-fuseftp/rpc v0.4.2
+	github.com/datawire/go-fuseftp/rpc v0.4.4
 	github.com/datawire/k8sapi v0.1.4
 	github.com/datawire/metriton-go-client v0.1.1
 	github.com/docker/docker v24.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/datawire/envconfig v0.0.0-20221012222025-09524dc7d59b h1:QXkFwAQPkOoX
 github.com/datawire/envconfig v0.0.0-20221012222025-09524dc7d59b/go.mod h1:3SpNv+sKT10l7Gt88j8Eyk4Rd5FhMCnEYbfPo4Ee/e4=
 github.com/datawire/go-ftpserver v0.1.3 h1:3kEzcPLG9jcP5oUpXHEKF2P8v0GxcpzSjNfwxEWZG+U=
 github.com/datawire/go-ftpserver v0.1.3/go.mod h1:H9RuaneDn4sT3AaZwBmgYVfMTFLtbUmNs7Lj1UTWDYc=
-github.com/datawire/go-fuseftp/rpc v0.4.2 h1:GkIhf9RmPbhBZQZ3leHGQJ5OuPi2U9e3sFjhd5EiQtE=
-github.com/datawire/go-fuseftp/rpc v0.4.2/go.mod h1:KuWviT8YX7bg84uPBIsZEjWFBNU7siR8KoqZL7EjmqA=
+github.com/datawire/go-fuseftp/rpc v0.4.4 h1:CnafKfnXRcvK9SH40wH1SMbqbsiqJLiVy3OwGcbF7NM=
+github.com/datawire/go-fuseftp/rpc v0.4.4/go.mod h1:KuWviT8YX7bg84uPBIsZEjWFBNU7siR8KoqZL7EjmqA=
 github.com/datawire/k8sapi v0.1.4 h1:9UKQp6M1zgQ9FRUZvDaggCUuK0CvjfpA9xYsH4tdFNw=
 github.com/datawire/k8sapi v0.1.4/go.mod h1:5peSHrQ3YOqeBwVBlyV0lG08Gku0r1JEc1xfT20yGr8=
 github.com/datawire/metriton-go-client v0.1.1 h1:T+gFOmIWBg4Cc8B5OTst0lllflaT1Pdh/LaxA1YouTQ=

--- a/integration_test/colliding_mounts_test.go
+++ b/integration_test/colliding_mounts_test.go
@@ -155,7 +155,7 @@ func (s *mountsSuite) Test_CollidingMounts() {
 			defer itest.TelepresenceOk(ctx, "leave", "hello")
 			require.Contains(stdout, "Using Deployment hello")
 			if i == 0 {
-				s.CapturePodLogs(ctx, "app=hello", "traffic-agent", s.AppNamespace())
+				s.CapturePodLogs(ctx, "hello", "traffic-agent", s.AppNamespace())
 			} else {
 				// Mounts are sometimes slow
 				dtime.SleepWithContext(ctx, 3*time.Second)

--- a/integration_test/colliding_mounts_test.go
+++ b/integration_test/colliding_mounts_test.go
@@ -152,8 +152,8 @@ func (s *mountsSuite) Test_CollidingMounts() {
 			ctx := s.Context()
 			require := s.Require()
 			stdout := itest.TelepresenceOk(ctx, "intercept", "hello", "--mount", tt.mountPoint, "--port", fmt.Sprintf("%d:%d", tt.svcPort, tt.svcPort))
-			require.Contains(stdout, "Using Deployment hello")
 			defer itest.TelepresenceOk(ctx, "leave", "hello")
+			require.Contains(stdout, "Using Deployment hello")
 			if i == 0 {
 				s.CapturePodLogs(ctx, "app=hello", "traffic-agent", s.AppNamespace())
 			} else {

--- a/integration_test/env_interpolate_test.go
+++ b/integration_test/env_interpolate_test.go
@@ -20,7 +20,7 @@ func (s *connectedSuite) Test_PrefixInterpolated() {
 
 	itest.TelepresenceOk(ctx, "intercept", "--mount", "false", svc)
 	defer itest.TelepresenceOk(ctx, "leave", svc)
-	out, err := s.KubectlOut(ctx, "get", "pod", "-o", "json", "-l", "service="+svc)
+	out, err := s.KubectlOut(ctx, "get", "pod", "-o", "json", "-l", "app="+svc)
 	rq.NoError(err)
 
 	var pods core.PodList

--- a/integration_test/env_interpolate_test.go
+++ b/integration_test/env_interpolate_test.go
@@ -19,6 +19,7 @@ func (s *connectedSuite) Test_PrefixInterpolated() {
 	}()
 
 	itest.TelepresenceOk(ctx, "intercept", "--mount", "false", svc)
+	defer itest.TelepresenceOk(ctx, "leave", svc)
 	out, err := s.KubectlOut(ctx, "get", "pod", "-o", "json", "-l", "service="+svc)
 	rq.NoError(err)
 

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -137,7 +137,7 @@ func (s *connectedSuite) TestGatherLogs_OnlyMappedLogs() {
 		10*time.Second,
 		2*time.Second,
 	)
-	s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", svc), "traffic-agent", otherOne)
+	s.CapturePodLogs(ctx, svc, "traffic-agent", otherOne)
 	itest.TelepresenceDisconnectOk(ctx)
 
 	itest.TelepresenceOk(ctx, "connect", "--namespace", otherTwo, "--manager-namespace", s.ManagerNamespace())
@@ -150,7 +150,7 @@ func (s *connectedSuite) TestGatherLogs_OnlyMappedLogs() {
 		10*time.Second,
 		2*time.Second,
 	)
-	s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", svc), "traffic-agent", otherTwo)
+	s.CapturePodLogs(ctx, svc, "traffic-agent", otherTwo)
 	itest.TelepresenceOk(ctx, "leave", svc)
 
 	bothNsRx := fmt.Sprintf("(?:%s|%s)", otherOne, otherTwo)

--- a/integration_test/headless_test.go
+++ b/integration_test/headless_test.go
@@ -26,7 +26,7 @@ func (s *connectedSuite) Test_SuccessfullyInterceptsHeadlessService() {
 	require := s.Require()
 	stdout := itest.TelepresenceOk(ctx, "intercept", "--mount", "false", svc, "--port", strconv.Itoa(svcPort))
 	require.Contains(stdout, "Using StatefulSet echo-headless")
-	s.CapturePodLogs(ctx, "service=echo-headless", "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, "echo-headless", "traffic-agent", s.AppNamespace())
 
 	defer itest.TelepresenceOk(ctx, "leave", "echo-headless")
 

--- a/integration_test/intercept_flags_test.go
+++ b/integration_test/intercept_flags_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"time"
 
 	"github.com/datawire/dlib/dlog"
@@ -32,6 +33,10 @@ func init() {
 }
 
 func (s *interceptFlagSuite) SetupSuite() {
+	if s.IsCI() && runtime.GOOS == "darwin" {
+		s.T().Skip("Mount tests don't run on darwin due to macFUSE issues")
+		return
+	}
 	if s.CompatVersion() != "" {
 		s.T().Skip("Not part of compatibility suite")
 	}

--- a/integration_test/intercept_flags_test.go
+++ b/integration_test/intercept_flags_test.go
@@ -1,17 +1,23 @@
 package integration_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/intercept"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 )
 
 type interceptFlagSuite struct {
 	itest.Suite
-	itest.SingleService
+	itest.NamespacePair
+	serviceName string
 }
 
 func (s *interceptFlagSuite) SuiteName() string {
@@ -19,8 +25,8 @@ func (s *interceptFlagSuite) SuiteName() string {
 }
 
 func init() {
-	itest.AddSingleServiceSuite("-intercept-flag", "echo", func(h itest.SingleService) itest.TestingSuite {
-		return &interceptFlagSuite{Suite: itest.Suite{Harness: h}, SingleService: h}
+	itest.AddTrafficManagerSuite("-intercept-flag", func(h itest.NamespacePair) itest.TestingSuite {
+		return &interceptFlagSuite{Suite: itest.Suite{Harness: h}, NamespacePair: h}
 	})
 }
 
@@ -29,44 +35,130 @@ func (s *interceptFlagSuite) SetupSuite() {
 		s.T().Skip("Not part of compatibility suite")
 	}
 	s.Suite.SetupSuite()
+	ctx := s.Context()
+	s.serviceName = "hello"
+	s.KubectlOk(ctx, "create", "serviceaccount", testIamServiceAccount)
+	s.ApplyApp(ctx, "hello-w-volumes", "deploy/"+s.serviceName)
+	s.TelepresenceConnect(ctx)
 }
 
+func (s *interceptFlagSuite) TearDownSuite() {
+	ctx := s.Context()
+	itest.TelepresenceQuitOk(ctx)
+	s.DeleteSvcAndWorkload(ctx, "deploy", s.serviceName)
+	s.KubectlOk(ctx, "delete", "serviceaccount", testIamServiceAccount)
+}
+
+// Test_ContainerReplace tests that:
+//
+//   - Two containers in a pod can be intercepted in sequence. One with replace, and one without.
+//   - Containers can be intercepted  interchangeably with or without --replace
+//   - Volumes are mounted
+//   - Intercept responses are produced from the intercept handlers
+//   - Responses after the intercepts end are from the cluster
 func (s *interceptFlagSuite) Test_ContainerReplace() {
 	ctx := s.Context()
 	require := s.Require()
-	iceptName := "container-replaced"
-	port, cancel := itest.StartLocalHttpEchoServer(ctx, iceptName)
-	defer cancel()
-	expectedOutput := regexp.MustCompile(iceptName + ` from intercept at`)
 
-	stdout := itest.TelepresenceOk(ctx, "intercept", "--replace", "--port", strconv.Itoa(port), s.ServiceName())
-	defer func() {
-		itest.TelepresenceOk(ctx, "leave", s.ServiceName())
-		s.Eventually(func() bool {
-			out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", s.ServiceName())
-			if err != nil {
-				dlog.Error(ctx, err)
-				return false
+	n1 := "container_replaced"
+	localPort1, cancel1 := itest.StartLocalHttpEchoServer(ctx, n1)
+	defer cancel1()
+
+	n2 := "container_kept"
+	localPort2, cancel2 := itest.StartLocalHttpEchoServer(ctx, n2)
+	defer cancel2()
+
+	tests := []struct {
+		name      string
+		iceptName string
+		replace   bool
+		localPort int
+		port      uint16
+	}{
+		{
+			name:      n1,
+			iceptName: n1,
+			replace:   true,
+			localPort: localPort1,
+			port:      80,
+		},
+		{
+			name:      n2,
+			iceptName: n2,
+			replace:   false,
+			localPort: localPort2,
+			port:      81,
+		},
+		{
+			name:      "container_replace_kept",
+			iceptName: n1,
+			replace:   false,
+			localPort: localPort1,
+			port:      80,
+		},
+		{
+			name:      "container_kept_replaced",
+			iceptName: n2,
+			replace:   true,
+			localPort: localPort2,
+			port:      81,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		s.Run(tt.name, func() {
+			ctx := s.Context()
+			expectedOutput := regexp.MustCompile(tt.iceptName + ` from intercept at`)
+			args := []string{"intercept"}
+			if tt.replace {
+				args = append(args, "--replace")
 			}
-			dlog.Info(ctx, out)
-			return !expectedOutput.MatchString(out)
-		}, 1*time.Minute, 6*time.Second)
-		require.Contains(stdout, "1/1")
-	}()
-	require.Contains(stdout, "Using Deployment "+s.ServiceName())
+			args = append(args, "--port", fmt.Sprintf("%d:%d", tt.localPort, tt.port), "--output", "json", "--detailed-output", "--workload", s.serviceName, tt.iceptName)
+			jsOut := itest.TelepresenceOk(ctx, args...)
+			defer func() {
+				itest.TelepresenceOk(ctx, "leave", tt.iceptName)
+				s.Eventually(func() bool {
+					out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", iputil.JoinHostPort(s.serviceName, tt.port))
+					if err != nil {
+						dlog.Error(ctx, err)
+						return false
+					}
+					if !expectedOutput.MatchString(out) {
+						return true
+					}
+					dlog.Info(ctx, out)
+					return false
+				}, 1*time.Minute, 6*time.Second)
+			}()
 
-	require.Eventually(func() bool {
-		out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", s.ServiceName())
-		if err != nil {
-			dlog.Error(ctx, err)
-			return false
-		}
-		dlog.Info(ctx, out)
-		return expectedOutput.MatchString(out)
-	}, 1*time.Minute, 6*time.Second)
+			var ii intercept.Info
+			require.NoError(json.Unmarshal([]byte(jsOut), &ii))
+			require.Equal(ii.Name, tt.iceptName)
 
-	stdout, err := itest.KubectlOut(ctx, s.AppNamespace(), "get", "pod", "-lapp="+s.ServiceName())
-	require.NoError(err)
-	require.NotContains(stdout, "2/2")
-	require.Contains(stdout, "1/1")
+			// Ensure that all directories are mounted.
+			require.NotNil(ii.Mount)
+			mounts := ii.Mount.Mounts
+			require.True(len(mounts) > 2)
+			dlog.Infof(ctx, "Mounts = %v", mounts)
+			for _, mount := range mounts {
+				st, err := os.Stat(filepath.Join(ii.Mount.LocalDir, mount))
+				require.NoError(err)
+				require.True(st.IsDir())
+			}
+
+			require.Eventually(func() bool {
+				out, err := itest.Output(ctx, "curl", "--silent", "--max-time", "1", iputil.JoinHostPort(s.serviceName, tt.port))
+				if err != nil {
+					dlog.Error(ctx, err)
+					return false
+				}
+				if expectedOutput.MatchString(out) {
+					return true
+				}
+				dlog.Info(ctx, out)
+				return false
+			}, 1*time.Minute, 6*time.Second)
+		})
+	}
 }

--- a/integration_test/intercept_flags_test.go
+++ b/integration_test/intercept_flags_test.go
@@ -59,7 +59,6 @@ func (s *interceptFlagSuite) TearDownSuite() {
 //   - Responses after the intercepts end are from the cluster
 func (s *interceptFlagSuite) Test_ContainerReplace() {
 	ctx := s.Context()
-	require := s.Require()
 
 	const (
 		n1 = "container_replaced"
@@ -149,6 +148,7 @@ func (s *interceptFlagSuite) Test_ContainerReplace() {
 			}()
 
 			var ii intercept.Info
+			require := s.Require()
 			require.NoError(json.Unmarshal([]byte(jsOut), &ii))
 			require.Equal(ii.Name, tt.iceptName)
 

--- a/integration_test/intercept_localhost_test.go
+++ b/integration_test/intercept_localhost_test.go
@@ -40,7 +40,7 @@ func (s *interceptLocalhostSuite) SetupSuite() {
 	s.Require().NoError(err)
 	dlog.Infof(ctx, "ip: %s: route: %s", s.defaultRoute.LocalIP, s.defaultRoute)
 	s.port, s.cancelLocal = itest.StartLocalHttpEchoServerWithHost(ctx, s.ServiceName(), s.defaultRoute.LocalIP.String())
-	s.CapturePodLogs(ctx, "app=echo", "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, "echo", "traffic-agent", s.AppNamespace())
 }
 
 func (s *interceptLocalhostSuite) TearDownSuite() {

--- a/integration_test/intercept_mount_test.go
+++ b/integration_test/intercept_mount_test.go
@@ -57,7 +57,7 @@ func (s *interceptMountSuite) SetupSuite() {
 	port, s.cancelLocal = itest.StartLocalHttpEchoServer(ctx, s.ServiceName())
 	stdout := itest.TelepresenceOk(ctx, "intercept", s.ServiceName(), "--mount", s.mountPoint, "--port", strconv.Itoa(port))
 	s.Contains(stdout, "Using Deployment "+s.ServiceName())
-	s.CapturePodLogs(ctx, "app=echo", "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, "echo", "traffic-agent", s.AppNamespace())
 }
 
 func (s *interceptMountSuite) TearDownSuite() {
@@ -191,7 +191,7 @@ func (s *singleServiceSuite) Test_NoInterceptorResponse() {
 	}, 10*time.Second, time.Second)
 
 	time.Sleep(2000 * time.Millisecond) // List is really fast now, so give the mount some time to become effective
-	s.CapturePodLogs(ctx, "app="+s.ServiceName(), "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, s.ServiceName(), "traffic-agent", s.AppNamespace())
 
 	mountPoint := filepath.Join(nwd, "rel-dir")
 	st, err := os.Stat(mountPoint)

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -788,7 +788,7 @@ func TelepresenceOk(ctx context.Context, args ...string) string {
 	t := getT(ctx)
 	t.Helper()
 	stdout, stderr, err := Telepresence(ctx, args...)
-	assert.NoError(t, err, "telepresence was unable to run, stdout %s", stdout)
+	require.NoError(t, err, "telepresence was unable to run, stdout %s", stdout)
 	if err == nil {
 		if strings.HasPrefix(stderr, "Warning:") && !strings.ContainsRune(stderr, '\n') {
 			// Accept warnings, but log them.
@@ -990,7 +990,12 @@ func StartLocalHttpEchoServerWithHost(ctx context.Context, name string, host str
 				fmt.Fprintf(w, "%s from intercept at %s", name, r.URL.Path)
 			}),
 		}
-		_ = sc.Serve(ctx, l)
+		err := sc.Serve(ctx, l)
+		if err != nil {
+			dlog.Errorf(ctx, "http server on %s exited with error: %v", host, err)
+		} else {
+			dlog.Errorf(ctx, "http server on %s exited", host)
+		}
 	}()
 	return l.Addr().(*net.TCPAddr).Port, cancel
 }

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -47,6 +47,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
+	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
@@ -460,61 +461,97 @@ func (s *cluster) RootdPProf() uint16 {
 }
 
 func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string) {
-	var pods string
+	var pods []string
 	for i := 0; ; i++ {
-		var err error
-		pods, err = KubectlOut(ctx, ns, "get", "pods", "--field-selector", "status.phase=Running", "-l", app, "-o", "jsonpath={.items[*].metadata.name}")
-		if err != nil {
-			dlog.Errorf(ctx, "failed to get %s pod in namespace %s: %v", app, ns, err)
-			return
+		runningPods := RunningPods(ctx, app, ns)
+		if len(runningPods) > 0 {
+			if container == "" {
+				pods = runningPods
+			} else {
+				for _, pod := range runningPods {
+					cns, err := KubectlOut(ctx, ns, "get", "pods", pod, "-o", "jsonpath={.spec.containers[*].name}")
+					if err == nil && slice.Contains(strings.Split(cns, " "), container) {
+						pods = append(pods, pod)
+					}
+				}
+			}
 		}
-		pods = strings.TrimSpace(pods)
-		if pods != "" || i == 5 {
+		if len(pods) > 0 || i == 5 {
 			break
 		}
 		dtime.SleepWithContext(ctx, 2*time.Second)
 	}
-	if pods == "" {
-		dlog.Errorf(ctx, "found no %s pods in namespace %s", app, ns)
+
+	if len(pods) == 0 {
+		if container == "" {
+			dlog.Errorf(ctx, "found no %s pods in namespace %s", app, ns)
+		} else {
+			dlog.Errorf(ctx, "found no %s pods in namespace %s with a %s container", app, ns, container)
+		}
 		return
 	}
-
-	// Let command die when the pod that it logs die
-	ctx = context.WithoutCancel(ctx)
-
 	present := struct{}{}
 
 	// Use another logger to avoid errors due to logs arriving after the tests complete.
 	ctx = dlog.WithLogger(ctx, dlog.WrapLogrus(logrus.StandardLogger()))
-	dlog.Infof(ctx, "Capturing logs for pods %q", pods)
-	for _, pod := range strings.Split(pods, " ") {
-		if _, ok := s.logCapturingPods.LoadOrStore(pod, present); ok {
-			continue
-		}
-		logFile, err := os.Create(
-			filepath.Join(filelocation.AppUserLogDir(ctx), fmt.Sprintf("%s-%s.log", dtime.Now().Format("20060102T150405"), pod)))
-		if err != nil {
-			s.logCapturingPods.Delete(pod)
-			dlog.Errorf(ctx, "unable to create pod logfile %s: %v", logFile.Name(), err)
-			return
-		}
+	pod := pods[0]
+	key := pod
+	if container != "" {
+		key += "/" + container
+	}
+	if _, ok := s.logCapturingPods.LoadOrStore(key, present); ok {
+		return
+	}
 
-		args := []string{"--namespace", ns, "logs", "-f", pod}
-		if container != "" {
-			args = append(args, "-c", container)
-		}
-		cmd := Command(ctx, "kubectl", args...)
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-		go func(pod string) {
-			defer func() {
-				_ = logFile.Close()
-				s.logCapturingPods.Delete(pod)
-			}()
-			if err := cmd.Run(); err != nil {
-				dlog.Errorf(ctx, "log capture failed: %v", err)
+	logFile, err := os.Create(
+		filepath.Join(filelocation.AppUserLogDir(ctx), fmt.Sprintf("%s-%s.log", dtime.Now().Format("20060102T150405"), pod)))
+	if err != nil {
+		s.logCapturingPods.Delete(pod)
+		dlog.Errorf(ctx, "unable to create pod logfile %s: %v", logFile.Name(), err)
+		return
+	}
+
+	args := []string{"--namespace", ns, "logs", "-f", pod}
+	if container != "" {
+		args = append(args, "-c", container)
+	}
+	// Let command die when the pod that it logs die
+	cmd := Command(context.WithoutCancel(ctx), "kubectl", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	ready := make(chan struct{})
+	go func() {
+		defer func() {
+			_ = logFile.Close()
+			s.logCapturingPods.Delete(pod)
+		}()
+		err := cmd.Start()
+		if err == nil {
+			if container == "" {
+				dlog.Infof(ctx, "Capturing logs for pod %s", pod)
+			} else {
+				dlog.Infof(ctx, "Capturing logs for pod %s, container %s", pod, container)
 			}
-		}(pod)
+			close(ready)
+			err = cmd.Wait()
+		}
+		if err != nil {
+			if container == "" {
+				dlog.Errorf(ctx, "log capture for pod %s failed: %v", pod, err)
+			} else {
+				dlog.Errorf(ctx, "log capture for pod %s, container %s failed: %v", pod, container, err)
+			}
+			select {
+			case <-ready:
+			default:
+				close(ready)
+			}
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		dlog.Infof(ctx, "log capture for pod %s interrupted prior to start", pod)
+	case <-ready:
 	}
 }
 
@@ -598,7 +635,7 @@ func (s *cluster) installChart(ctx context.Context, release bool, chartFilename 
 	if err == nil {
 		err = RolloutStatusWait(ctx, nss.Namespace, "deploy/traffic-manager")
 		if err == nil {
-			s.self.CapturePodLogs(ctx, "app=traffic-manager", "", nss.Namespace)
+			s.self.CapturePodLogs(ctx, "traffic-manager", "", nss.Namespace)
 		}
 	}
 	return err
@@ -685,7 +722,7 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 	if err = RolloutStatusWait(ctx, nss.Namespace, "deploy/traffic-manager"); err != nil {
 		return err
 	}
-	s.self.CapturePodLogs(ctx, "app=traffic-manager", "", nss.Namespace)
+	s.self.CapturePodLogs(ctx, "traffic-manager", "", nss.Namespace)
 	return nil
 }
 

--- a/integration_test/itest/namespace.go
+++ b/integration_test/itest/namespace.go
@@ -150,7 +150,7 @@ func (s *nsPair) RollbackTM(ctx context.Context) {
 	t := getT(ctx)
 	require.NoError(t, err)
 	require.NoError(t, RolloutStatusWait(ctx, s.Namespace, "deploy/traffic-manager"))
-	s.CapturePodLogs(ctx, "app=traffic-manager", "", s.Namespace)
+	s.CapturePodLogs(ctx, "traffic-manager", "", s.Namespace)
 }
 
 func (s *nsPair) AppNamespace() string {

--- a/integration_test/itest/traffic_manager.go
+++ b/integration_test/itest/traffic_manager.go
@@ -30,7 +30,7 @@ func (th *trafficManager) setup(ctx context.Context) bool {
 	if t.Failed() {
 		return false
 	}
-	th.CapturePodLogs(ctx, "app=traffic-manager", "", th.ManagerNamespace())
+	th.CapturePodLogs(ctx, "traffic-manager", "", th.ManagerNamespace())
 	return true
 }
 

--- a/integration_test/large_files_test.go
+++ b/integration_test/large_files_test.go
@@ -118,7 +118,7 @@ func (s *largeFilesSuite) createIntercepts(ctx context.Context) {
 			require.NotNil(info.Mount)
 			s.mountPoint[i] = info.Mount.LocalDir
 			s.NoError(itest.RolloutStatusWait(ctx, s.AppNamespace(), "deploy/"+svc))
-			s.CapturePodLogs(ctx, "service="+svc, "traffic-agent", s.AppNamespace())
+			s.CapturePodLogs(ctx, svc, "traffic-agent", s.AppNamespace())
 		}(i)
 	}
 	wg.Wait()

--- a/integration_test/multiport_test.go
+++ b/integration_test/multiport_test.go
@@ -152,7 +152,7 @@ func (s *connectedSuite) Test_UnnamedUdpAndTcpPort() {
 		itest.TelepresenceOk(ctx, "loglevel", "trace")
 		defer itest.TelepresenceOk(ctx, "loglevel", "debug")
 		itest.TelepresenceOk(ctx, "intercept", "--mount", "false", "--service", "echo-udp", "-p", fmt.Sprintf("%d:%s", localPort, svcPort), dep)
-		s.CapturePodLogs(ctx, "app="+dep, "traffic-agent", s.AppNamespace())
+		s.CapturePodLogs(ctx, dep, "traffic-agent", s.AppNamespace())
 		defer itest.TelepresenceOk(ctx, "leave", dep)
 
 		pingPong := func(conn net.Conn, msg string) {

--- a/integration_test/podscaling_test.go
+++ b/integration_test/podscaling_test.go
@@ -50,7 +50,7 @@ func (s *interceptMountSuite) Test_RestartInterceptedPod() {
 	// Scale up again (start intercepted pod)
 	assert.NoError(s.Kubectl(ctx, "scale", "deploy", s.ServiceName(), "--replicas", "1"))
 	assert.Eventually(func() bool { return len(s.runningPods(ctx)) == 1 }, itest.PodCreateTimeout(ctx), 6*time.Second)
-	s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", s.ServiceName()), "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, s.ServiceName(), "traffic-agent", s.AppNamespace())
 
 	// Verify that intercept becomes active
 	assert.Eventually(func() bool {
@@ -98,12 +98,12 @@ func (s *interceptMountSuite) Test_StopInterceptedPodOfMany() {
 			func() bool {
 				return len(s.runningPods(ctx)) == 1
 			}, 15*time.Second, time.Second)
-		s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", s.ServiceName()), "traffic-agent", s.AppNamespace())
+		s.CapturePodLogs(ctx, s.ServiceName(), "traffic-agent", s.AppNamespace())
 	}()
 
 	// Wait for second pod to arrive
 	assert.Eventually(func() bool { return len(s.runningPods(ctx)) == 2 }, itest.PodCreateTimeout(ctx), 6*time.Second)
-	s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", s.ServiceName()), "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, s.ServiceName(), "traffic-agent", s.AppNamespace())
 
 	// Delete the currently intercepted pod
 	require.NoError(s.Kubectl(ctx, "delete", "pod", currentPod))
@@ -119,7 +119,7 @@ func (s *interceptMountSuite) Test_StopInterceptedPodOfMany() {
 			}
 			return len(pods) == 2
 		}, 15*time.Second, time.Second)
-	s.CapturePodLogs(ctx, fmt.Sprintf("app=%s", s.ServiceName()), "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, s.ServiceName(), "traffic-agent", s.AppNamespace())
 
 	// Verify that intercept is still active
 	rx := regexp.MustCompile(fmt.Sprintf(`Intercept name\s*: ` + s.ServiceName() + `\s+State\s*: ([^\n]+)\n`))

--- a/integration_test/testdata/k8s/echo-auto-inject.yaml
+++ b/integration_test/testdata/k8s/echo-auto-inject.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-auto-inject
+    app: echo-auto-inject
   ports:
     - name: proxied
       port: 80
@@ -17,18 +17,18 @@ kind: Deployment
 metadata:
   name: echo-auto-inject
   labels:
-    service: echo-auto-inject
+    app: echo-auto-inject
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-auto-inject
+      app: echo-auto-inject
   template:
     metadata:
       annotations:
         telepresence.getambassador.io/inject-traffic-agent: enabled
       labels:
-        service: echo-auto-inject
+        app: echo-auto-inject
     spec:
       containers:
         - name: echo-auto-inject

--- a/integration_test/testdata/k8s/echo-easy.yaml
+++ b/integration_test/testdata/k8s/echo-easy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-easy
+    app: echo-easy
   ports:
     - name: proxied
       port: 80
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: "echo-easy"
   labels:
-    service: echo-easy
+    app: echo-easy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-easy
+      app: echo-easy
   template:
     metadata:
       labels:
-        service: echo-easy
+        app: echo-easy
     spec:
       containers:
         - name: echo-easy

--- a/integration_test/testdata/k8s/echo-headless.yaml
+++ b/integration_test/testdata/k8s/echo-headless.yaml
@@ -7,7 +7,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    service: echo-headless
+    app: echo-headless
   ports:
   - name: http
     port: 8080
@@ -18,17 +18,17 @@ kind: StatefulSet
 metadata:
   name: echo-headless
   labels:
-    service: echo-headless
+    app: echo-headless
 spec:
   replicas: 1
   serviceName: echo-headless
   selector:
     matchLabels:
-      service: echo-headless
+      app: echo-headless
   template:
     metadata:
       labels:
-        service: echo-headless
+        app: echo-headless
     spec:
       containers:
         - name: echo-headless

--- a/integration_test/testdata/k8s/echo-interpolate.yaml
+++ b/integration_test/testdata/k8s/echo-interpolate.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-interpolate
+    app: echo-interpolate
   ports:
     - name: proxied
       port: 80
@@ -24,16 +24,16 @@ kind: Deployment
 metadata:
   name: echo-interpolate
   labels:
-    service: echo-interpolate
+    app: echo-interpolate
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-interpolate
+      app: echo-interpolate
   template:
     metadata:
       labels:
-        service: echo-interpolate
+        app: echo-interpolate
     spec:
       containers:
         - name: echo-interpolate

--- a/integration_test/testdata/k8s/echo-manual-inject-deploy.yaml
+++ b/integration_test/testdata/k8s/echo-manual-inject-deploy.yaml
@@ -3,16 +3,16 @@ kind: Deployment
 metadata:
   name: "manual-inject"
   labels:
-    service: manual-inject
+    app: manual-inject
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: manual-inject
+      app: manual-inject
   template:
     metadata:
       labels:
-        service: manual-inject
+        app: manual-inject
     spec:
       containers:
         - name: echo-container

--- a/integration_test/testdata/k8s/echo-manual-inject-svc.yaml
+++ b/integration_test/testdata/k8s/echo-manual-inject-svc.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: manual-inject
+    app: manual-inject
   ports:
     - port: 80

--- a/integration_test/testdata/k8s/echo-same-target-port.yaml
+++ b/integration_test/testdata/k8s/echo-same-target-port.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-stp
+    app: echo-stp
   ports:
     - name: eighty
       port: 80
@@ -20,16 +20,16 @@ kind: Deployment
 metadata:
   name: echo-stp
   labels:
-    service: echo-stp
+    app: echo-stp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-stp
+      app: echo-stp
   template:
     metadata:
       labels:
-        service: echo-stp
+        app: echo-stp
     spec:
       containers:
         - name: echo-stp

--- a/integration_test/testdata/k8s/echo-w-hostalias.goyaml
+++ b/integration_test/testdata/k8s/echo-w-hostalias.goyaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo
+    app: echo
   ports:
     - name: proxied
       port: 80
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: echo
   labels:
-    service: echo
+    app: echo
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo
+      app: echo
   template:
     metadata:
       labels:
-        service: echo
+        app: echo
     spec:
       hostAliases:
         - ip: "{{ .AliasIP }}"

--- a/integration_test/testdata/k8s/echo-w-sidecars.yaml
+++ b/integration_test/testdata/k8s/echo-w-sidecars.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-w-sidecars
+    app: echo-w-sidecars
   ports:
     - name: proxied
       port: 80
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: echo-w-sidecars
   labels:
-    service: echo-w-sidecars
+    app: echo-w-sidecars
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-w-sidecars
+      app: echo-w-sidecars
   template:
     metadata:
       labels:
-        service: echo-w-sidecars
+        app: echo-w-sidecars
     spec:
       containers:
         - name: echo-main

--- a/integration_test/testdata/k8s/echo-w-subdomain.yaml
+++ b/integration_test/testdata/k8s/echo-w-subdomain.yaml
@@ -5,7 +5,7 @@ metadata:
   name: subsonic
 spec:
   selector:
-    service: subsonic
+    app: subsonic
   clusterIP: None
   ports:
     - name: proxied
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: echo-subsonic
   labels:
-    service: subsonic
+    app: subsonic
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: subsonic
+      app: subsonic
   template:
     metadata:
       labels:
-        service: subsonic
+        app: subsonic
     spec:
       hostname: echo
       subdomain: subsonic

--- a/integration_test/testdata/k8s/echo_with_env.yaml
+++ b/integration_test/testdata/k8s/echo_with_env.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: echo-easy
+    app: echo-easy
   ports:
     - name: proxied
       port: 80
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: "echo-easy"
   labels:
-    service: echo-easy
+    app: echo-easy
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: echo-easy
+      app: echo-easy
   template:
     metadata:
       labels:
-        service: echo-easy
+        app: echo-easy
     spec:
       containers:
         - name: echo-easy

--- a/integration_test/testdata/k8s/hello-pv-volume.yaml
+++ b/integration_test/testdata/k8s/hello-pv-volume.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: {{ .Name }}
+    app: {{ .Name }}
   ports:
     - name: proxied
       port: 80
@@ -45,16 +45,16 @@ kind: Deployment
 metadata:
   name: {{ .Name }}
   labels:
-    service: {{ .Name }}
+    app: {{ .Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: {{ .Name }}
+      app: {{ .Name }}
   template:
     metadata:
       labels:
-        service: {{ .Name }}
+        app: {{ .Name }}
     spec:
       volumes:
         - name: scratch-volume

--- a/integration_test/testdata/k8s/hello-w-volumes.yaml
+++ b/integration_test/testdata/k8s/hello-w-volumes.yaml
@@ -68,7 +68,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: hello
+    app: hello
   ports:
     - name: http
       port: 80
@@ -82,17 +82,16 @@ kind: Deployment
 metadata:
   name: hello
   labels:
-    service: hello
+    app: hello
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: hello
+      app: hello
   template:
     metadata:
       labels:
         app: hello
-        service: hello
     spec:
       serviceAccountName: mount-test-account
       volumes:

--- a/integration_test/testdata/k8s/rs-echo.yaml
+++ b/integration_test/testdata/k8s/rs-echo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: rs-echo
+    app: rs-echo
   ports:
     - name: http
       port: 80
@@ -17,16 +17,16 @@ kind: ReplicaSet
 metadata:
   name: rs-echo
   labels:
-    service: rs-echo
+    app: rs-echo
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: rs-echo
+      app: rs-echo
   template:
     metadata:
       labels:
-        service: rs-echo
+        app: rs-echo
     spec:
       containers:
         - name: rs-echo

--- a/integration_test/testdata/k8s/ss-echo.yaml
+++ b/integration_test/testdata/k8s/ss-echo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    service: ss-echo
+    app: ss-echo
   ports:
     - name: http
       port: 80
@@ -17,17 +17,17 @@ kind: StatefulSet
 metadata:
   name: ss-echo
   labels:
-    service: ss-echo
+    app: ss-echo
 spec:
   serviceName: "ss-echo"
   replicas: 2
   selector:
     matchLabels:
-      service: ss-echo
+      app: ss-echo
   template:
     metadata:
       labels:
-        service: ss-echo
+        app: ss-echo
     spec:
       containers:
         - name: ss-echo

--- a/integration_test/testdata/k8s/with-probes.yaml
+++ b/integration_test/testdata/k8s/with-probes.yaml
@@ -7,14 +7,14 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      service: with-probes
+      app: with-probes
   template:
     metadata:
       annotations:
         consul.hashicorp.com/connect-inject: 'false'
         sidecar.istio.io/inject: 'false'
       labels:
-        service: with-probes
+        app: with-probes
     spec:
       containers:
         - name: sample-app
@@ -42,11 +42,11 @@ kind: Service
 metadata:
   name: with-probes
   labels:
-    service: with-probes
+    app: with-probes
 spec:
   ports:
     - port: 80
       name: http
       targetPort: http
   selector:
-    service: with-probes
+    app: with-probes

--- a/integration_test/to_pod_test.go
+++ b/integration_test/to_pod_test.go
@@ -64,7 +64,7 @@ func (s *connectedSuite) Test_ToPodUDPPortForwarding() {
 	require.Contains(stdout, svc+": intercepted")
 	itest.TelepresenceOk(ctx, "loglevel", "trace")
 	defer itest.TelepresenceOk(ctx, "loglevel", "debug")
-	s.CapturePodLogs(ctx, "app="+svc, "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, svc, "traffic-agent", s.AppNamespace())
 
 	conn, err := net.Dial("udp", "localhost:8080")
 	require.NoError(err)

--- a/integration_test/workloads_test.go
+++ b/integration_test/workloads_test.go
@@ -28,7 +28,7 @@ func (s *connectedSuite) successfulIntercept(tp, svc, port string) {
 	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
 	require.Contains(stdout, svc+": intercepted")
 	require.NotContains(stdout, "Volume Mount Point")
-	s.CapturePodLogs(ctx, "service="+svc, "traffic-agent", s.AppNamespace())
+	s.CapturePodLogs(ctx, svc, "traffic-agent", s.AppNamespace())
 	itest.TelepresenceOk(ctx, "leave", svc)
 	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
 	require.NotContains(stdout, svc+": intercepted")

--- a/pkg/agentconfig/container_test.go
+++ b/pkg/agentconfig/container_test.go
@@ -1,7 +1,11 @@
 package agentconfig
 
 import (
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_prefixInterpolated(t *testing.T) {
@@ -68,4 +72,18 @@ func Test_prefixInterpolated(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ReplacePolicy(t *testing.T) {
+	var cn Container
+	require.NoError(t, json.Unmarshal([]byte(`{"replace": 0}`), &cn))
+	assert.False(t, bool(cn.Replace))
+	require.NoError(t, json.Unmarshal([]byte(`{"replace": 1}`), &cn))
+	assert.True(t, bool(cn.Replace))
+	require.NoError(t, json.Unmarshal([]byte(`{"replace": 2}`), &cn))
+	assert.False(t, bool(cn.Replace))
+	require.NoError(t, json.Unmarshal([]byte(`{"replace": false}`), &cn))
+	assert.False(t, bool(cn.Replace))
+	require.NoError(t, json.Unmarshal([]byte(`{"replace": true}`), &cn))
+	assert.True(t, bool(cn.Replace))
 }

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -1,6 +1,7 @@
 package agentconfig
 
 import (
+	"encoding/json"
 	"reflect"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -54,21 +55,20 @@ const (
 	K8SCreatedByLabel                    = "app.kubernetes.io/created-by"
 )
 
-type ReplacePolicy int
+type ReplacePolicy bool
 
-const (
-	// ReplacePolicyNever means that --replace is false.
-	ReplacePolicyNever ReplacePolicy = iota
-
-	// ReplacePolicyActive means that --replace is true, and the intercept is active.
-	ReplacePolicyActive
-
-	// ReplacePolicyInactive means that --replace is true, but the intercept is inactive.
-	ReplacePolicyInactive
-
-	// ReplacePolicyCurrent is used when we just want to keep the current setting.
-	ReplacePolicyCurrent
-)
+func (r *ReplacePolicy) UnmarshalJSON(data []byte) error {
+	var v bool
+	if err := json.Unmarshal(data, &v); err != nil {
+		var i int
+		if intErr := json.Unmarshal(data, &i); intErr != nil {
+			return err
+		}
+		v = i == 1
+	}
+	*r = ReplacePolicy(v)
+	return nil
+}
 
 // Intercept describes the mapping between a service port and an intercepted container port.
 type Intercept struct {

--- a/pkg/client/cli/cmd/genyaml.go
+++ b/pkg/client/cli/cmd/genyaml.go
@@ -277,7 +277,7 @@ func genConfigMapSubCommand(yamlInfo *genYAMLCommand) *cobra.Command {
 }
 
 func (i *genConfigMap) generateConfigMap(ctx context.Context, wl k8sapi.Workload) (*agentconfig.Sidecar, error) {
-	ac, err := i.BasicGeneratorConfig.Generate(ctx, wl, agentconfig.ReplacePolicyNever, nil)
+	ac, err := i.BasicGeneratorConfig.Generate(ctx, wl, nil)
 	if err != nil {
 		return nil, errcat.NoDaemonLogs.New(err)
 	}


### PR DESCRIPTION
This PR refactors some parts of the implementation for the `--replace` flag. In particular:

- Replacing means replacing the container image for something that sleeps forever.
- A `--replace` will no longer affect intercepts on other containers.
- The `--replace` option can be used interchangeably, without uninstalling the agent.