### PR TITLE
Add os.Executable() override to the dos package.

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                         Version                               License(s)
     ----                                                                         -------                               ----------
-    the Go language standard library ("std")                                     v1.21                                 3-clause BSD license
+    the Go language standard library ("std")                                     v1.22                                 3-clause BSD license
     github.com/AdaLogics/go-fuzz-headers                                         v0.0.0-20230811130428-ced1acdcaa24    Apache License 2.0
     github.com/Azure/go-ansiterm                                                 v0.0.0-20230124172434-306776ec8161    MIT license
     github.com/BurntSushi/toml                                                   v1.3.2                                MIT license

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -298,7 +298,7 @@ func EnsureUserDaemon(ctx context.Context, required bool) (context.Context, erro
 	if ud = daemon.GetUserClient(ctx); ud != nil {
 		return ctx, nil
 	}
-	if ctx, ud, err = launchConnectorDaemon(ctx, client.GetExe(), required); err != nil {
+	if ctx, ud, err = launchConnectorDaemon(ctx, client.GetExe(ctx), required); err != nil {
 		return ctx, err
 	}
 	ctx = daemon.WithUserClient(ctx, ud)
@@ -307,7 +307,7 @@ func EnsureUserDaemon(ctx context.Context, required bool) (context.Context, erro
 
 func ensureDaemonVersion(ctx context.Context) error {
 	// Ensure that the already running daemon has the correct version
-	return versionCheck(ctx, client.GetExe(), daemon.GetUserClient(ctx))
+	return versionCheck(ctx, client.GetExe(ctx), daemon.GetUserClient(ctx))
 }
 
 func EnsureSession(ctx context.Context, useLine string, required bool) (context.Context, error) {

--- a/pkg/client/cli/connect/daemon.go
+++ b/pkg/client/cli/connect/daemon.go
@@ -43,7 +43,7 @@ func launchDaemon(ctx context.Context, cr *daemon.Request) error {
 		_ = fh.Close()
 	}
 
-	args := []string{client.GetExe(), "daemon-foreground"}
+	args := []string{client.GetExe(ctx), "daemon-foreground"}
 	if cr != nil && cr.RootDaemonProfilingPort > 0 {
 		args = append(args, "--pprof", strconv.Itoa(int(cr.RootDaemonProfilingPort)))
 	}

--- a/pkg/client/const.go
+++ b/pkg/client/const.go
@@ -1,11 +1,14 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 )
 
 const (
@@ -19,9 +22,9 @@ func DisplayVersion() string {
 }
 
 // GetExe returns the name of the running executable.
-func GetExe() string {
+func GetExe(ctx context.Context) string {
 	// Figure out our executable
-	exeName, err := os.Executable()
+	exeName, err := dos.Executable(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -161,7 +161,7 @@ func startAuthenticatorService(ctx context.Context, portFile string, kubeFlags m
 	_ = os.Remove(portFile)
 
 	args := make([]string, 0, 4+len(kubeFlags)*2)
-	args = append(args, client.GetExe(), kubeauth.CommandName, "--portfile", portFile)
+	args = append(args, client.GetExe(ctx), kubeauth.CommandName, "--portfile", portFile)
 	var err error
 	if args, err = client.AppendKubeFlags(kubeFlags, args); err != nil {
 		return 0, err
@@ -184,7 +184,7 @@ func startAuthenticatorService(ctx context.Context, portFile string, kubeFlags m
 		}
 		return port, nil
 	}
-	return 0, fmt.Errorf(`timeout while waiting for "%s %s" to create a port file`, client.GetExe(), kubeauth.CommandName)
+	return 0, fmt.Errorf(`timeout while waiting for "%s %s" to create a port file`, client.GetExe(ctx), kubeauth.CommandName)
 }
 
 func ensureAuthenticatorService(ctx context.Context, kubeFlags map[string]string, configFiles []string) (uint16, error) {

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -230,7 +230,7 @@ func NewSession(
 				if _, ok := s.Server().GetServiceInfo()[authenticator.Authenticator_ServiceDesc.ServiceName]; !ok {
 					authGrpc.RegisterAuthenticatorServer(s.Server(), config.ConfigFlags.ToRawKubeConfigLoader())
 				}
-				return client.GetExe(), s.ListenerAddress(ctx), nil
+				return client.GetExe(ctx), s.ListenerAddress(ctx), nil
 			}, nil)
 			if err != nil {
 				return ctx, nil, connectError(rpc.ConnectInfo_DAEMON_FAILED, err)
@@ -910,7 +910,7 @@ func (s *session) Status(c context.Context) *rpc.ConnectInfo {
 		Version: &common.VersionInfo{
 			ApiVersion: client.APIVersion,
 			Version:    client.Version(),
-			Executable: client.GetExe(),
+			Executable: client.GetExe(c),
 			Name:       client.DisplayName,
 		},
 		ManagerNamespace: cfg.GetManagerNamespace(),

--- a/pkg/dos/exe.go
+++ b/pkg/dos/exe.go
@@ -1,0 +1,36 @@
+package dos
+
+import (
+	"context"
+	"os"
+)
+
+// Exe is an abstraction of the executable related functions with the same name in the os package.
+type Exe interface {
+	Executable() (string, error)
+}
+
+type exeKey struct{}
+
+func WithExe(ctx context.Context, exe Exe) context.Context {
+	return context.WithValue(ctx, exeKey{}, exe)
+}
+
+// ExeAPI returns the Exe that has been registered with the given context, or
+// the instance that delegates to the corresponding functions in the os package.
+func ExeAPI(ctx context.Context) Exe {
+	if e, ok := ctx.Value(exeKey{}).(Exe); ok {
+		return e
+	}
+	return osExe{}
+}
+
+func Executable(ctx context.Context) (string, error) {
+	return ExeAPI(ctx).Executable()
+}
+
+type osExe struct{}
+
+func (osExe) Executable() (string, error) {
+	return os.Executable()
+}

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -2097,8 +2097,9 @@ type License struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	License   string `protobuf:"bytes,1,opt,name=license,proto3" json:"license,omitempty"`
-	Host      string `protobuf:"bytes,2,opt,name=host,proto3" json:"host,omitempty"`
+	License string `protobuf:"bytes,1,opt,name=license,proto3" json:"license,omitempty"`
+	Host    string `protobuf:"bytes,2,opt,name=host,proto3" json:"host,omitempty"`
+	// cluster_id is really the id of the namespace where the traffic-manager is installed.
 	ClusterId string `protobuf:"bytes,3,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	ErrMsg    string `protobuf:"bytes,4,opt,name=err_msg,json=errMsg,proto3" json:"err_msg,omitempty"`
 }


### PR DESCRIPTION
Adds the function `dos.Executable(context.Context)` and changes the `client.GetExe()` to use that function. This enables tests to override and give an alternative name for the executable.