### PR TITLE
Ensure that agent.appProtocolStrategy is propagated correctly.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -53,6 +53,11 @@ items:
           <tr><td><code>all</code></td><td>All of the above.</td></tr>
           </table></p>
       - type: bugfix
+        title: Ensure that agent.appProtocolStrategy is propagated correctly.
+        body: >-
+          The <code>agent.appProtocolStrategy</code> was inadvertently dropped when moving license related code fromm the
+          OSS repository the repository for the Enterprise version of Telepresence. It has now been restored.
+      - type: bugfix
         title: Include non-default zero values in output of telepresence config view.
         body: >-
           The <code>telepresence config view</code> command will now print zero values in the output when

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -83,6 +83,7 @@ func (e *Env) GeneratorConfig(qualifiedAgentImage string) (agentmap.GeneratorCon
 		Resources:           e.AgentResources,
 		PullPolicy:          e.AgentImagePullPolicy,
 		PullSecrets:         e.AgentImagePullSecrets,
+		AppProtocolStrategy: e.AgentAppProtocolStrategy,
 	}, nil
 }
 


### PR DESCRIPTION
The `agent.appProtocolStrategy` was inadvertently dropped when moving license related code fromm the OSS repository the repository for the Enterprise version of Telepresence. It has now been restored.
