### PR TITLE
Don't patch propes on replaced containers.

### DIFF
--- a/integration_test/testdata/k8s/hello-w-volumes.yaml
+++ b/integration_test/testdata/k8s/hello-w-volumes.yaml
@@ -128,6 +128,12 @@ spec:
               name: hello-secret-volume-1
             - mountPath: /etc/nginx/templates/
               name: nginx-config
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 3
         - name: hello-container-2
           image: nginx
           env:


### PR DESCRIPTION
A container that is being replaced by an `tel intercept --replace` invocation will have no liveness-, readiness, nor startup-probes. This means that the agent-injector must refrain from patching symbolic port names of those probes when injecting the traffic-agent.

This commit ensures that no patching takes place when the container is replaced.

Closes #3514 
