### PR TITLE
Fix minor glitch in traffic-manager informer logic.

### DIFF
--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -97,7 +97,6 @@ func MainWithEnv(ctx context.Context) (err error) {
 	// Ensure that the manager has access to shard informer factories for all relevant namespaces.
 	if len(env.ManagedNamespaces) == 0 {
 		ctx = informer.WithFactory(ctx, "")
-		ctx = informer.WithFactory(ctx, env.ManagerNamespace)
 	} else {
 		for _, ns := range env.ManagedNamespaces {
 			ctx = informer.WithFactory(ctx, ns)

--- a/pkg/agentmap/discorvery.go
+++ b/pkg/agentmap/discorvery.go
@@ -102,7 +102,7 @@ func findServicesSelecting(ctx context.Context, namespace string, lbs labels.Lab
 	var ms []k8sapi.Object
 	var scanned int
 	if f := informer.GetFactory(ctx, namespace); f != nil {
-		ss, err := f.Core().V1().Services().Lister().List(labels.Everything())
+		ss, err := f.Core().V1().Services().Lister().Services(namespace).List(labels.Everything())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/informer/context.go
+++ b/pkg/informer/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"k8s.io/client-go/informers"
-	informerCore "k8s.io/client-go/informers/core/v1"
 
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 )
@@ -30,34 +29,6 @@ func GetFactory(ctx context.Context, ns string) informers.SharedInformerFactory 
 		if f, ok := ctx.Value(factoryKey("")).(informers.SharedInformerFactory); ok {
 			return f
 		}
-	}
-	return nil
-}
-
-func GetServices(ctx context.Context, ns string) informerCore.ServiceInformer {
-	if f := GetFactory(ctx, ns); f != nil {
-		return f.Core().V1().Services()
-	}
-	return nil
-}
-
-func GetPods(ctx context.Context, ns string) informerCore.PodInformer {
-	if f := GetFactory(ctx, ns); f != nil {
-		return f.Core().V1().Pods()
-	}
-	return nil
-}
-
-func GetNodes(ctx context.Context, ns string) informerCore.NodeInformer {
-	if f := GetFactory(ctx, ns); f != nil {
-		return f.Core().V1().Nodes()
-	}
-	return nil
-}
-
-func GetConfigMaps(ctx context.Context, ns string) informerCore.ConfigMapInformer {
-	if f := GetFactory(ctx, ns); f != nil {
-		return f.Core().V1().ConfigMaps()
 	}
 	return nil
 }


### PR DESCRIPTION
Don't add a namespaced informer factory when there's a global one.