### PR TITLE
Ensure that a smaller allow-proxy isn't dropped by larger subnet.

### DIFF
--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -767,11 +767,28 @@ func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInf
 		)
 	}
 
-	subnets = subnet.Unique(subnets)
-	dontProxy := slices.Clone(s.neverProxySubnets)
-	last := len(dontProxy) - 1
+	proxy, neverProxy, neverProxyOverrides := computeNeverProxyOverrides(ctx, subnets, s.neverProxySubnets)
+
+	// Fire and forget to send metrics out.
+	go func() {
+		scout.Report(ctx, "update_routes",
+			scout.Entry{Key: "subnets", Value: len(proxy)},
+			scout.Entry{Key: "allow_conflicting_subnets", Value: len(s.allowConflictingSubnets)},
+		)
+	}()
+	if s.tunVif == nil {
+		return nil
+	}
+	rt := s.tunVif.Router
+	rt.UpdateWhitelist(s.allowConflictingSubnets)
+	return rt.UpdateRoutes(ctx, proxy, neverProxy, neverProxyOverrides)
+}
+
+func computeNeverProxyOverrides(ctx context.Context, subnets, nvp []*net.IPNet) (proxy, neverProxy, neverProxyOverrides []*net.IPNet) {
+	neverProxy = slices.Clone(nvp)
+	last := len(neverProxy) - 1
 	for i := 0; i <= last; {
-		nps := dontProxy[i]
+		nps := neverProxy[i]
 		found := false
 		for _, ds := range subnets {
 			if subnet.Overlaps(ds, nps) {
@@ -783,28 +800,31 @@ func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInf
 			// This never-proxy is pointless because it's not a subnet that we are routing
 			dlog.Infof(ctx, "Dropping never-proxy %q because it is not routed", nps)
 			if last > i {
-				dontProxy[i] = dontProxy[last]
+				neverProxy[i] = neverProxy[last]
 			}
 			last--
 		} else {
 			i++
 		}
 	}
-	dontProxy = dontProxy[:last+1]
+	neverProxy = neverProxy[:last+1]
 
-	// Fire and forget to send metrics out.
-	go func() {
-		scout.Report(ctx, "update_routes",
-			scout.Entry{Key: "subnets", Value: len(subnets)},
-			scout.Entry{Key: "allow_conflicting_subnets", Value: len(s.allowConflictingSubnets)},
-		)
-	}()
-	if s.tunVif == nil {
-		return nil
-	}
-	rt := s.tunVif.Router
-	rt.UpdateWhitelist(s.allowConflictingSubnets)
-	return rt.UpdateRoutes(ctx, subnets, dontProxy)
+	proxy, neverProxyOverrides = subnet.Partition(subnets, func(i int, isn *net.IPNet) bool {
+		for r, rsn := range subnets {
+			if i == r {
+				continue
+			}
+			if subnet.Covers(rsn, isn) && !subnet.Equal(rsn, isn) {
+				for _, dsn := range neverProxy {
+					if subnet.Covers(dsn, isn) {
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return subnet.Unique(proxy), neverProxy, neverProxyOverrides
 }
 
 func validateSubnets(name string, sns []*manager.IPNet, allowLoopback func() bool) ([]*net.IPNet, error) {

--- a/pkg/vif/device.go
+++ b/pkg/vif/device.go
@@ -16,17 +16,15 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 
 	"github.com/datawire/dlib/dlog"
-	"github.com/telepresenceio/telepresence/v2/pkg/routing"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
 	vifBuffer "github.com/telepresenceio/telepresence/v2/pkg/vif/buffer"
 )
 
 type device struct {
 	*channel.Endpoint
-	ctx   context.Context
-	wg    sync.WaitGroup
-	dev   *nativeDevice
-	table routing.Table
+	ctx context.Context
+	wg  sync.WaitGroup
+	dev *nativeDevice
 }
 
 type Device interface {
@@ -49,7 +47,7 @@ const defaultDevOutQueueLen = 1024
 var _ Device = (*device)(nil)
 
 // OpenTun creates a new TUN device and ensures that it is up and running.
-func OpenTun(ctx context.Context, routingTable routing.Table) (Device, error) {
+func OpenTun(ctx context.Context) (Device, error) {
 	dev, err := openTun(ctx)
 	if err != nil {
 		return nil, err
@@ -59,7 +57,6 @@ func OpenTun(ctx context.Context, routingTable routing.Table) (Device, error) {
 		Endpoint: channel.New(defaultDevOutQueueLen, defaultDevMtu, ""),
 		ctx:      ctx,
 		dev:      dev,
-		table:    routingTable,
 	}, nil
 }
 
@@ -78,35 +75,12 @@ func (d *device) Attach(dp stack.NetworkDispatcher) {
 	}()
 }
 
-func (d *device) subnetToRoute(subnet *net.IPNet) (*routing.Route, error) {
-	gw := make(net.IP, len(subnet.IP))
-	copy(gw, subnet.IP)
-	gw[len(gw)-1] += 1
-	iface, err := net.InterfaceByName(d.Name())
-	if err != nil {
-		return nil, err
-	}
-	return &routing.Route{
-		LocalIP:   subnet.IP,
-		RoutedNet: subnet,
-		Interface: iface,
-		Gateway:   gw,
-	}, nil
-}
-
 // AddSubnet adds a subnet to this TUN device and creates a route for that subnet which
 // is associated with the device (removing the device will automatically remove the route).
 func (d *device) AddSubnet(ctx context.Context, subnet *net.IPNet) (err error) {
 	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "AddSubnet", trace.WithAttributes(attribute.Stringer("tel2.subnet", subnet)))
 	defer tracing.EndAndRecord(span, err)
-	if err := d.dev.addSubnet(ctx, subnet); err != nil {
-		return err
-	}
-	route, err := d.subnetToRoute(subnet)
-	if err != nil {
-		return err
-	}
-	return d.table.Add(ctx, route)
+	return d.dev.addSubnet(ctx, subnet)
 }
 
 func (d *device) Close() error {
@@ -135,13 +109,6 @@ func (d *device) SetMTU(mtu int) error {
 // RemoveSubnet removes a subnet from this TUN device and also removes the route for that subnet which
 // is associated with the device.
 func (d *device) RemoveSubnet(ctx context.Context, subnet *net.IPNet) (err error) {
-	route, err := d.subnetToRoute(subnet)
-	if err != nil {
-		return err
-	}
-	if err := d.table.Remove(ctx, route); err != nil {
-		return err
-	}
 	// Staticcheck screams if this is ctx, span := because it thinks the context argument is being overwritten before being used.
 	sCtx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "RemoveSubnet", trace.WithAttributes(attribute.Stringer("tel2.subnet", subnet)))
 	defer tracing.EndAndRecord(span, err)

--- a/pkg/vif/router_test.go
+++ b/pkg/vif/router_test.go
@@ -263,7 +263,7 @@ func (s *RoutingSuite) Test_GetRoute() {
 	s.Require().Equal(device, route.Interface.Name)
 	s.Require().Equal(cidr, route.RoutedNet)
 	s.Require().False(route.Default)
-	s.Require().NotNil(route.Gateway)
+	// s.Require().NotNil(route.Gateway) there's no gateway when scope == link, and that's OK.
 	s.Require().Equal(cidr.IP, route.LocalIP)
 }
 

--- a/pkg/vif/testdata/router/main.go
+++ b/pkg/vif/testdata/router/main.go
@@ -81,7 +81,7 @@ func main() {
 		}
 	}
 	dev.Router.UpdateWhitelist(whitelist)
-	err = dev.Router.UpdateRoutes(ctx, yesRoutes, noRoutes)
+	err = dev.Router.UpdateRoutes(ctx, yesRoutes, noRoutes, nil)
 	if err != nil {
 		return
 	}

--- a/pkg/vif/tunneling_device.go
+++ b/pkg/vif/tunneling_device.go
@@ -22,7 +22,7 @@ func NewTunnelingDevice(ctx context.Context, tunnelStreamCreator tunnel.StreamCr
 	if err != nil {
 		return nil, err
 	}
-	dev, err := OpenTun(ctx, routingTable)
+	dev, err := OpenTun(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
An allow-proxy hidden by a never-proxy in an existing subnet was lost when making the list of subnets unique. This commit removes the unique call and improves the proxy priority test.
