### PR TITLE
Ensure that agents are considered busy when used as proxy-via.

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -69,7 +69,7 @@ runs:
       name: install winfsp and sshfs
       shell: powershell
       run: |
-        Start-Process msiexec -Wait -verb runAs -Args "/i build-output/winfsp.msi /passive /qn /L*V winfsp-install.log"
-        Start-Process msiexec -Wait -verb runAs -Args "/i build-output/sshfs-win.msi /passive /qn /L*V sshfs-win-install.log"
+        Start-Process msiexec -Wait -verb runAs -Args "/i build-output\\winfsp.msi /passive /qn /L*V winfsp-install.log"
+        Start-Process msiexec -Wait -verb runAs -Args "/i build-output\\sshfs-win.msi /passive /qn /L*V sshfs-win-install.log"
 
         [Environment]::SetEnvironmentVariable("Path", "C:\\;C:\\Program Files\\SSHFS-Win\\bin;$ENV:Path", "Machine")

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -34,16 +34,42 @@ runs:
           brew install jq
         fi
     - if: runner.os == 'Windows'
-      name: install Windows dependencies
+      name: install make and zip
+      uses: nick-fields/retry/@v3
+      with:
+        max_attempts: 3
+        timeout_minutes: 1
+        shell: powershell
+        command: choco install make zip
+    - if: runner.os == 'Windows'
+      name: download winfsp
+      uses: nick-fields/retry/@v3
+      with:
+        max_attempts: 3
+        timeout_minutes: 1
+        shell: bash
+        command: make winfsp.msi
+    - if: runner.os == 'Windows'
+      name: download sshfs
+      uses: nick-fields/retry/@v3
+      with:
+        max_attempts: 3
+        timeout_minutes: 1
+        shell: bash
+        command: make sshfs-win.msi
+    - if: runner.os == 'Windows'
+      name: download sshfs
+      uses: nick-fields/retry/@v3
+      with:
+        max_attempts: 3
+        timeout_minutes: 1
+        shell: bash
+        command: make wintun.dll
+    - if: runner.os == 'Windows'
+      name: install winfsp and sshfs
       shell: powershell
       run: |
-        choco install make zip
-
-        # Download sshfs
-        curl -o winfsp.msi https://github.com/billziss-gh/winfsp/releases/download/v1.11/winfsp-1.11.22176.msi
-        curl -o sshfs-win.msi https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x64.msi
-
-        Start-Process msiexec -Wait -verb runAs -Args "/i winfsp.msi /passive /qn /L*V winfsp-install.log"
-        Start-Process msiexec -Wait -verb runAs -Args "/i sshfs-win.msi /passive /qn /L*V sshfs-win-install.log"
+        Start-Process msiexec -Wait -verb runAs -Args "/i build-output/winfsp.msi /passive /qn /L*V winfsp-install.log"
+        Start-Process msiexec -Wait -verb runAs -Args "/i build-output/sshfs-win.msi /passive /qn /L*V sshfs-win-install.log"
 
         [Environment]::SetEnvironmentVariable("Path", "C:\\;C:\\Program Files\\SSHFS-Win\\bin;$ENV:Path", "Machine")

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -110,13 +110,17 @@ jobs:
         env:
           DEV_TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
           TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
-        shell: bash
-        run: |
-          set -ex
-          if [[ ${RUNNER_OS} == "Windows" ]]; then
-            export PATH="$PATH:/C/Program Files/SSHFS-Win/bin"
-          fi
-          make check-integration
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 3
+          shell: bash
+          timeout_minutes: 60
+          command: |
+            set -ex
+            if [[ ${RUNNER_OS} == "Windows" ]]; then
+              export PATH="$PATH:/C/Program Files/SSHFS-Win/bin"
+            fi
+            make check-integration
       - uses: ./.github/actions/upload-logs
         env:
           LOG_SUFFIX: "${{ runner.os }}-${{ runner.arch }}-${{ matrix.clusters.distribution }}-${{ matrix.clusters.version }}"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -29,12 +29,11 @@ jobs:
       - name: "Test amd64 build"
         run: make build
       - name: Run tests
-        uses: nick-fields/retry/@v2
+        uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
           timeout_minutes: 12
-          command: |
-            make check-unit
+          command: make check-unit
 
   windows:
     runs-on: windows-2019
@@ -47,22 +46,36 @@ jobs:
         with:
           go-version: stable
       - name: "Download winfsp"
-        shell: bash
-        run: |
-          curl -L -o winfsp.msi https://github.com/winfsp/winfsp/releases/download/v1.11/winfsp-1.11.22176.msi
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 1
+          shell: bash
+          command: make winfsp.msi
+      - name: "Download wintun"
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 1
+          shell: bash
+          command: make wintun.dll
+      - name: install make
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 5
+          timeout_minutes: 1
+          command: choco install make
       - name: "Install winfsp"
         shell: powershell
         run: |
-          Start-Process msiexec -Wait -verb runAs -Args "/i winfsp.msi /passive /qn /L*V winfsp-install.log"
+          Start-Process msiexec -Wait -verb runAs -Args "/i build-output/winfsp.msi /passive /qn /L*V winfsp-install.log"
           [Environment]::SetEnvironmentVariable("Path", "C:\\Program Files (x86)\\WinFsp\\inc\\fuse;$ENV:Path", "Machine")
-      - name: install make
-        run: choco install make
       - name: Build
         run: make build
       - name: Lint
         run: make lint
       - name: Run tests
-        uses: nick-fields/retry/@v2
+        uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
           timeout_minutes: 12
@@ -90,7 +103,7 @@ jobs:
       - name: "Test amd64 build"
         run: make build
       - name: Run tests
-        uses: nick-fields/retry/@v2
+        uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
           timeout_minutes: 10
@@ -116,7 +129,7 @@ jobs:
       - name: "Test arm64 build"
         run: GOARCH=arm64 CC=aarch64-linux-gnu-gcc make build
       - name: Run tests
-        uses: nick-fields/retry/@v2
+        uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
           timeout_minutes: 10

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: "Install winfsp"
         shell: powershell
         run: |
-          Start-Process msiexec -Wait -verb runAs -Args "/i build-output/winfsp.msi /passive /qn /L*V winfsp-install.log"
+          Start-Process msiexec -Wait -verb runAs -Args "/i build-output\\winfsp.msi /passive /qn /L*V winfsp-install.log"
           [Environment]::SetEnvironmentVariable("Path", "C:\\Program Files (x86)\\WinFsp\\inc\\fuse;$ENV:Path", "Machine")
       - name: Build
         run: make build

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -159,6 +159,16 @@ $(BUILDDIR)/wintun-$(WINTUN_VERSION)/wintun/bin/$(GOHOSTARCH)/wintun.dll:
 $(BINDIR)/wintun.dll: $(BUILDDIR)/wintun-$(WINTUN_VERSION)/wintun/bin/$(GOHOSTARCH)/wintun.dll
 	mkdir -p $(@D)
 	cp $< $@
+
+wintun.dll: $(BINDIR)/wintun.dll
+
+winfsp.msi:
+	mkdir -p $(BUILDDIR)
+	curl --fail -L https://github.com/winfsp/winfsp/releases/download/v1.11/winfsp-1.11.22176.msi -o $(BUILDDIR)/winfsp.msi
+
+sshfs-win.msi:
+	mkdir -p $(BUILDDIR)
+	curl --fail -L https://github.com/billziss-gh/sshfs-win/releases/download/v3.7.21011/sshfs-win-3.7.21011-x64.msi -o $(BUILDDIR)/sshfs-win.msi
 endif
 
 $(TELEPRESENCE): build-deps FORCE

--- a/integration_test/testdata/k8s/echo-one.yaml
+++ b/integration_test/testdata/k8s/echo-one.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "echo-one"
+spec:
+  type: ClusterIP
+  selector:
+    app: echo-one
+  ports:
+    - name: proxied
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "echo-one"
+  labels:
+    app: echo-one
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-one
+  template:
+    metadata:
+      labels:
+        app: echo-one
+    spec:
+      containers:
+        - name: echo-one
+          image: jmalloc/echo-server
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -1188,6 +1188,7 @@ func (s *Session) waitForProxyViaWorkloads(ctx context.Context) error {
 		ws = slice.AppendUnique(ws, svw.Workload)
 	}
 	for _, wl := range ws {
+		s.agentClients.SetProxyVia(wl)
 		dlog.Debugf(ctx, "Waiting for proxy-via agent in %s", wl)
 		go func(wl string) {
 			waitCh <- s.agentClients.WaitForWorkload(ctx, to, wl)


### PR DESCRIPTION
An agent connection established from the root daemon was only considered busy when it was intercepted, or when it was the last connection remaining. This meant that when a proxyVia arrived and more connections was present, it wasn't considered busy, and therefore ignored.

This commit ensures that agents used for proxy-via are considered busy at all times.