### PR TITLE
Use route instead of address for CIDRs with masks that don't allow "via"

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -48,6 +48,12 @@ items:
           to directly pass it to <code>telepresence connect</code> without needing a separate
           file. Simply use a dash "-" as the filename for the <code>--kubeconfig</code> flag.
       - type: bugfix
+        title: Containerized daemon created cache files owned by root
+        body: >-
+          When using <code>telepresence connect --docker</code> to create a containerized daemon, that
+          daemon would sometimes create files in the cache that were owned by root, which then caused
+          problems when connecting without the <code>--docker</code> flag.
+      - type: bugfix
         title: Remove large number of requests when traffic-manager is used in large clusters.
         body: >-
           The traffic-manager would make a very large number of API requests during cluster start-up

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -48,6 +48,15 @@ items:
           to directly pass it to <code>telepresence connect</code> without needing a separate
           file. Simply use a dash "-" as the filename for the <code>--kubeconfig</code> flag.
       - type: bugfix
+        title: Use route instead of address for CIDRs with masks that don't allow "via"
+        body: >-
+          A CIDR with a mask that leaves less than two bits (/31 or /32 for IPv4)
+          cannot be added as an address to the VIF, because such addresses must
+          have bits allowing a "via" IP.
+          
+          The logic was modified to allow such CIDRs to become static routes, using the
+          VIF base address as their "via", rather than being VIF addresses in their own right.
+      - type: bugfix
         title: Containerized daemon created cache files owned by root
         body: >-
           When using <code>telepresence connect --docker</code> to create a containerized daemon, that

--- a/integration_test/docker_daemon_test.go
+++ b/integration_test/docker_daemon_test.go
@@ -1,7 +1,10 @@
 package integration_test
 
 import (
+	"bufio"
 	"context"
+	"io"
+	"os"
 	"path/filepath"
 	goRuntime "runtime"
 	"strings"
@@ -65,6 +68,47 @@ func (s *dockerDaemonSuite) Test_DockerDaemon_hostDaemonNoConflict() {
 	s.TelepresenceConnect(ctx)
 	_, _, err := itest.Telepresence(ctx, "connect", "--docker", "--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace())
 	s.NoError(err)
+}
+
+func (s *dockerDaemonSuite) Test_DockerDaemon_alsoProxy32() {
+	ctx := s.Context()
+	s.TelepresenceConnect(ctx, "--docker", "--also-proxy", "169.254.169.254/32", "--name", "a")
+	itest.TelepresenceOk(ctx, "loglevel", "trace")
+	defer itest.TelepresenceOk(ctx, "loglevel", "debug")
+
+	rq := s.Require()
+	logFile := filepath.Join(filelocation.AppUserLogDir(s.Context()), "connector.log")
+	rootLog, err := os.Open(logFile)
+	rq.NoError(err)
+	defer rootLog.Close()
+
+	// Figure out where the current end of the logfile is. This must be done before any
+	// of the tests run because the queries that the DNS resolver receives are dependent
+	// on how the system's DNS resolver handle search paths and caching.
+	st, err := rootLog.Stat()
+	rq.NoError(err)
+	pos := st.Size()
+
+	// Make an attempt to curl the also-proxied IP.
+	_, _ = itest.Output(ctx, "docker", "run", "--network", "container:tp-a", "--rm", "curlimages/curl", "--silent", "--max-time", "1", "169.254.169.254")
+
+	// Verify that the attempt is visible in the root log.
+	_, err = rootLog.Seek(pos, io.SeekStart)
+	rq.NoError(err)
+	scn := bufio.NewScanner(rootLog)
+	found := false
+
+	// mustHaveWanted caters for cases where the default behavior from the system's resolver
+	// is to not send unwanted queries to our resolver at all (based on search and routes).
+	// It is forced to true for inclusion tests.
+	for scn.Scan() {
+		txt := scn.Text()
+		if strings.Contains(txt, "169.254.169.254:80, code STREAM_INFO") {
+			found = true
+			break
+		}
+	}
+	s.Truef(found, "Unable to find %q", "169.254.169.254:80, code STREAM_INFO")
 }
 
 func (s *dockerDaemonSuite) Test_DockerDaemon_daemonHostNotConflict() {

--- a/pkg/client/logging/stat_linux.go
+++ b/pkg/client/logging/stat_linux.go
@@ -11,6 +11,11 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 )
 
+type statable interface {
+	Fd() uintptr
+	Name() string
+}
+
 type fileInfo struct {
 	size  int64
 	uid   int
@@ -21,7 +26,7 @@ type fileInfo struct {
 }
 
 func osFStat(dfile dos.File) (SysInfo, error) {
-	file, ok := dfile.(*os.File)
+	file, ok := dfile.(statable)
 	if !ok {
 		return nil, fmt.Errorf("files of type %T don't support Fstat", dfile)
 	}
@@ -58,7 +63,7 @@ func osFStat(dfile dos.File) (SysInfo, error) {
 	}, nil
 }
 
-func oldFStat(file *os.File) (SysInfo, error) {
+func oldFStat(file statable) (SysInfo, error) {
 	var stat unix.Stat_t
 	if err := unix.Fstat(int(file.Fd()), &stat); err != nil {
 		return nil, fmt.Errorf("failed to stat %s: %w", file.Name(), err)

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -401,7 +401,7 @@ func (s *service) SetLogLevel(ctx context.Context, request *rpc.LogLevelRequest)
 			if request.Duration != nil {
 				duration = request.Duration.AsDuration()
 			}
-			if err = logging.SetAndStoreTimedLevel(ctx, s.timedLogLevel, request.LogLevel, duration, s.procName); err != nil {
+			if err = logging.SetAndStoreTimedLevel(ctx, s.timedLogLevel, request.LogLevel, duration, userd.ProcessName); err != nil {
 				err = status.Error(codes.Internal, err.Error())
 			} else if !s.rootSessionInProc {
 				err = s.withRootDaemon(ctx, func(ctx context.Context, rd daemon.DaemonClient) error {

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -57,7 +57,6 @@ type service struct {
 	rpc.UnsafeConnectorServer
 	srv           *grpc.Server
 	managerProxy  *mgrProxy
-	procName      string
 	timedLogLevel log.TimedLevel
 	ucn           int64
 	fuseFTPError  error
@@ -463,7 +462,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	s.rootSessionInProc = rootSessionInProc
 	s.daemonAddress = daemonAddress
 
-	if err := logging.LoadTimedLevelFromCache(c, s.timedLogLevel, s.procName); err != nil {
+	if err := logging.LoadTimedLevelFromCache(c, s.timedLogLevel, userd.ProcessName); err != nil {
 		return err
 	}
 

--- a/pkg/dos/filesystem.go
+++ b/pkg/dos/filesystem.go
@@ -237,6 +237,11 @@ func getFS(ctx context.Context) FileSystem {
 	if f, ok := ctx.Value(fsKey{}).(FileSystem); ok {
 		return f
 	}
+	of := newOS(ctx)
+	return &of
+}
+
+func newOS(ctx context.Context) osFs {
 	of := osFs{}
 	if env, ok := LookupEnv(ctx, "TELEPRESENCE_UID"); ok {
 		of.tpUID, _ = strconv.Atoi(env)
@@ -244,7 +249,7 @@ func getFS(ctx context.Context) FileSystem {
 	if env, ok := LookupEnv(ctx, "TELEPRESENCE_GID"); ok {
 		of.tpGID, _ = strconv.Atoi(env)
 	}
-	return &of
+	return of
 }
 
 // Abs is like filepath.Abs but delegates to the context's FS.

--- a/pkg/dos/lockedfile.go
+++ b/pkg/dos/lockedfile.go
@@ -13,7 +13,7 @@ type lockedFs struct {
 }
 
 func WithLockedFs(ctx context.Context) context.Context {
-	return WithFS(ctx, &lockedFs{})
+	return WithFS(ctx, &lockedFs{osFs: newOS(ctx)})
 }
 
 func (fs *lockedFs) Create(name string) (File, error) {


### PR DESCRIPTION
A CIDR with a mask that leaves less than two bits (/31 or /32 for IPv4)
cannot be added as an address to the VIF, because such addresses must
have bits allowing a "via" IP.

This commit changes the logic so that such CIDRs are added as static
routes, using the VIF base address as their "via" rather than VIF
addresses.