### PR TITLE
Removal of timeouts that are no longer in use

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -38,6 +38,13 @@ items:
         body: >-
           Tracing must now be enabled explicitly in order to use the <code>telepresence gather-traces</code>
           command.
+      - type: change
+        title: Removal of timeouts that are no longer in use
+        body: >-
+          The <code>config.yml</code> values <code>timeouts.agentInstall</code> and <code>timeouts.apply</code> haven't
+          been in use since versions prior to 2.6.0, when the client was responsible for installing the traffic-agent.
+          These timeouts are now removed from the code-base, and a warning will be printed when attempts are made to use
+          them.
   - version: 2.18.1
     date: (TBD)
     notes:

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -338,8 +338,6 @@ func (s *cluster) withBasicConfig(c context.Context, t *testing.T) context.Conte
 	config.LogLevels().RootDaemon = logrus.DebugLevel
 
 	to := config.Timeouts()
-	to.PrivateAgentInstall = PodCreateTimeout(c)
-	to.PrivateApply = PodCreateTimeout(c)
 	to.PrivateClusterConnect = 60 * time.Second
 	to.PrivateEndpointDial = 10 * time.Second
 	to.PrivateHelm = PodCreateTimeout(c)

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -20,8 +20,6 @@ import (
 func TestGetConfig(t *testing.T) {
 	configs := []string{
 		/* sys1 */ `
-timeouts:
-  agentInstall: 2m10s
 logLevels:
   userDaemon: info
   rootDaemon: debug
@@ -30,7 +28,6 @@ cluster:
 `,
 		/* sys2 */ `
 timeouts:
-  apply: 33s
   connectivityCheck: 0ms
 logLevels:
   userDaemon: debug
@@ -78,11 +75,9 @@ cluster:
 
 	cfg = GetConfig(c)
 	to := cfg.Timeouts()
-	assert.Equal(t, 2*time.Minute+10*time.Second, to.PrivateAgentInstall) // from sys1
-	assert.Equal(t, 33*time.Second, to.PrivateApply)                      // from sys2
-	assert.Equal(t, 25*time.Second, to.PrivateClusterConnect)             // from user
-	assert.Equal(t, 17*time.Second, to.PrivateProxyDial)                  // from user
-	assert.Equal(t, time.Duration(0), to.PrivateConnectivityCheck)        // from sys2
+	assert.Equal(t, 25*time.Second, to.PrivateClusterConnect)      // from user
+	assert.Equal(t, 17*time.Second, to.PrivateProxyDial)           // from user
+	assert.Equal(t, time.Duration(0), to.PrivateConnectivityCheck) // from sys2
 
 	assert.Equal(t, logrus.DebugLevel, cfg.LogLevels().UserDaemon) // from sys2
 	assert.Equal(t, logrus.TraceLevel, cfg.LogLevels().RootDaemon) // from user


### PR DESCRIPTION
The `config.yml` values `timeouts.agentInstall` and `timeouts.apply` haven't been in use since versions prior to 2.6.0, when the client was responsible for installing the traffic-agent. These timeouts are now removed from the code-base, and a warning will be printed when attempts are made to use them.