### PR TITLE
Improve how to ignore mounts

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -49,6 +49,12 @@ items:
     date: (TBD)
     notes:
       - type: feature
+        title: Make it possible to specify ignored volume mounts using path prefix.
+        body: >-
+          Volume mounts like <code>/var/run/secrets/kubernetes.io</code> are not declared in the workload. Instead, they
+          are injected during pod-creation and their names are generated. It is nwo possible to ignore such mounts using a
+          matching path prefix.
+      - type: feature
         title: Make the telemount Docker Volume plugin configurable
         body: >-
           A <code>telemount</code> object was added to the <code>intercept</code> object in <code>config.yml</code>

--- a/cmd/traffic/cmd/manager/cluster/info.go
+++ b/cmd/traffic/cmd/manager/cluster/info.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/blang/semver"
@@ -16,13 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
-	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
 	"github.com/telepresenceio/telepresence/v2/pkg/subnet"
 )
@@ -312,59 +309,7 @@ func getInjectorSvcIP(ctx context.Context, env *managerutil.Env, client v1.CoreV
 }
 
 func (oi *info) watchPodSubnets(ctx context.Context, namespaces []string) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	nsc := len(namespaces)
-	if nsc == 0 {
-		// Create one of lister and one informer that have cluster wide scope
-		namespaces = []string{""}
-		nsc = 1
-	}
-	podListers := make([]PodLister, nsc)
-	podInformers := make([]cache.SharedIndexInformer, nsc)
-	wg := sync.WaitGroup{}
-	wg.Add(nsc)
-	for i, ns := range namespaces {
-		f := informer.GetFactory(ctx, ns)
-		podController := f.Core().V1().Pods()
-		podListers[i] = podController.Lister()
-		pi := podController.Informer()
-		podInformers[i] = pi
-		_ = pi.SetTransform(func(o any) (any, error) {
-			if pod, ok := o.(*corev1.Pod); ok {
-				pod.ManagedFields = nil
-				pod.OwnerReferences = nil
-				pod.Finalizers = nil
-
-				ps := &pod.Status
-				// We're just interested in the podIP/podIPs
-				ps.Conditions = nil
-				ps.ContainerStatuses = nil
-				ps.EphemeralContainerStatuses = nil
-				ps.HostIPs = nil
-				ps.HostIP = ""
-				ps.InitContainerStatuses = nil
-				ps.Message = ""
-				ps.ResourceClaimStatuses = nil
-				ps.NominatedNodeName = ""
-				ps.Reason = ""
-				ps.Resize = ""
-			}
-			return o, nil
-		})
-		_ = pi.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
-			dlog.Errorf(ctx, "Watcher for pods %s: %v", whereWeWatch(ns), err)
-		})
-		go func() {
-			defer wg.Done()
-			f.Start(ctx.Done())
-			f.WaitForCacheSync(ctx.Done())
-		}()
-	}
-	wg.Wait()
-
-	retriever := newPodWatcher(ctx, podListers, podInformers)
+	retriever := newPodWatcher(ctx, namespaces)
 	if !retriever.viable(ctx) {
 		dlog.Errorf(ctx, "Unable to derive subnets from IPs of pods")
 		return
@@ -463,11 +408,4 @@ func subnetsToRPC(subnets []*net.IPNet) []*rpc.IPNet {
 		rpcSubnets[i] = iputil.IPNetToRPC(s)
 	}
 	return rpcSubnets
-}
-
-func whereWeWatch(ns string) string {
-	if ns == "" {
-		return "cluster wide"
-	}
-	return "in namespace " + ns
 }

--- a/cmd/traffic/cmd/manager/cluster/info.go
+++ b/cmd/traffic/cmd/manager/cluster/info.go
@@ -113,9 +113,8 @@ func NewInfo(ctx context.Context) Info {
 		// We use a default clusterID because we don't want to fail if
 		// the traffic-manager doesn't have the ability to get the namespace
 		oi.clusterID = IDZero
-		dlog.Warnf(ctx,
-			"unable to get namespace \"default\", will use default clusterID: %s: %v. This is only necessary for compatibility with old licesnses.",
-			oi.clusterID, err)
+		dlog.Infof(ctx,
+			"unable to get namespace \"default\", but it is only necessary for compatibility with old licesnses: %v", err)
 	}
 
 	dummyIP := "1.1.1.1"

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -106,6 +106,8 @@ func MainWithEnv(ctx context.Context) (err error) {
 		}
 	}
 
+	ctx = mutator.WithMap(ctx, mutator.Load(ctx))
+
 	mgr, g, err := NewServiceFunc(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to initialize traffic manager: %w", err)

--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -94,7 +94,13 @@ func MainWithEnv(ctx context.Context) (err error) {
 	}
 	ctx = k8sapi.WithK8sInterface(ctx, ki)
 
+	ctx = agentmap.WithWorkloadCache(ctx, 30*time.Second)
+
 	// Ensure that the manager has access to shard informer factories for all relevant namespaces.
+	//
+	// This will make the informers more verbose. Good for debugging
+	// l := klog.Level(6)
+	// _ = l.Set("6")
 	if len(env.ManagedNamespaces) == 0 {
 		ctx = informer.WithFactory(ctx, "")
 	} else {

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -186,9 +186,6 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 		return nil, fmt.Errorf("invalid value %q for annotation %s", ia, agentconfig.InjectAnnotation)
 	}
 
-	// Create patch operations to add the traffic-agent sidecar
-	dlog.Infof(ctx, "Injecting %s into pod %s.%s", agentconfig.ContainerName, pod.Name, pod.Namespace)
-
 	var patches PatchOps
 	config := scx.AgentConfig()
 	patches = disableAppContainer(ctx, pod, config, patches)

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -148,8 +148,6 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 		case scx == nil && isDelete:
 			return nil, nil
 		case scx == nil && ia != "enabled":
-			dlog.Debugf(ctx, `The %s.%s pod has not enabled %s container injection through %q configmap or through %q annotation; skipping`,
-				pod.Name, pod.Namespace, agentconfig.ContainerName, agentconfig.ConfigMap, agentconfig.InjectAnnotation)
 			return nil, nil
 		case scx != nil && scx.AgentConfig().Manual:
 			if !isDelete {

--- a/cmd/traffic/cmd/manager/mutator/service.go
+++ b/cmd/traffic/cmd/manager/mutator/service.go
@@ -124,14 +124,11 @@ func ServeMutator(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/traffic-agent", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		dlog.Debug(ctx, "Received webhook request...")
 		bytes, statusCode, err := serveMutatingFunc(ctx, r, ai.Inject)
 		if err != nil {
 			dlog.Errorf(ctx, "error handling webhook request: %v", err)
 			w.WriteHeader(statusCode)
 			bytes = []byte(err.Error())
-		} else {
-			dlog.Debug(ctx, "Webhook request handled successfully")
 		}
 		if _, err = w.Write(bytes); err != nil {
 			dlog.Errorf(ctx, "could not write response: %v", err)

--- a/cmd/traffic/cmd/manager/mutator/service.go
+++ b/cmd/traffic/cmd/manager/mutator/service.go
@@ -150,14 +150,11 @@ func ServeMutator(ctx context.Context) error {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	cw, err := Load(ctx)
-	if err != nil {
-		return err
-	}
+	cw := GetMap(ctx)
 	ai = NewAgentInjectorFunc(ctx, cw)
 	dgroup.ParentGroup(ctx).Go("agent-configs", func(ctx context.Context) error {
 		dtime.SleepWithContext(ctx, time.Second) // Give the server some time to start
-		return cw.Run(ctx)
+		return cw.Wait(ctx)
 	})
 
 	wrapped := otelhttp.NewHandler(mux, "agent-injector", otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -84,7 +84,7 @@ func (e *entry) workload(ctx context.Context) (agentconfig.SidecarExt, k8sapi.Wo
 		return nil, nil, fmt.Errorf("failed to decode ConfigMap entry %q into an agent config", e.value)
 	}
 	ac := scx.AgentConfig()
-	wl, err := k8sapi.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
+	wl, err := agentmap.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -905,7 +905,7 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustU
 		if wl == nil {
 			err = ax.err
 			if err == nil {
-				wl, err = tracing.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
+				wl, err = agentmap.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
 			}
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -645,7 +645,6 @@ func (c *configWatcher) store(ctx context.Context, acx agentconfig.SidecarExt, u
 		} else {
 			if oldYml, ok := cm.Data[ac.AgentName]; ok {
 				if oldYml == yml {
-					dlog.Debugf(ctx, "skipping update agent %s in %s.%s because it was not modified", ac.AgentName, agentconfig.ConfigMap, ns)
 					return false, nil
 				}
 				scx, err := agentconfig.UnmarshalYAML([]byte(oldYml))

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -179,7 +179,7 @@ func (s *service) ArriveAsClient(ctx context.Context, client *rpc.ClientInfo) (*
 
 // ArriveAsAgent establishes a session between an agent and the Manager.
 func (s *service) ArriveAsAgent(ctx context.Context, agent *rpc.AgentInfo) (*rpc.SessionInfo, error) {
-	dlog.Debug(ctx, "ArriveAsAgent called")
+	dlog.Debugf(ctx, "ArriveAsAgent %s called", agent.PodName)
 
 	if val := validateAgent(agent); val != "" {
 		return nil, status.Errorf(codes.InvalidArgument, val)
@@ -546,7 +546,7 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 
 func (s *service) PrepareIntercept(ctx context.Context, request *rpc.CreateInterceptRequest) (*rpc.PreparedIntercept, error) {
 	ctx = managerutil.WithSessionInfo(ctx, request.Session)
-	dlog.Debugf(ctx, "PrepareIntercept called")
+	dlog.Debugf(ctx, "PrepareIntercept %s called", request.InterceptSpec.Name)
 
 	span := trace.SpanFromContext(ctx)
 	tracing.RecordInterceptSpec(span, request.InterceptSpec)
@@ -574,7 +574,7 @@ func (s *service) CreateIntercept(ctx context.Context, ciReq *rpc.CreateIntercep
 	ctx = managerutil.WithSessionInfo(ctx, ciReq.GetSession())
 	sessionID := ciReq.GetSession().GetSessionId()
 	spec := ciReq.InterceptSpec
-	dlog.Debug(ctx, "CreateIntercept called")
+	dlog.Debugf(ctx, "CreateIntercept %s called", ciReq.InterceptSpec.Name)
 	span := trace.SpanFromContext(ctx)
 	tracing.RecordInterceptSpec(span, spec)
 

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -194,7 +194,6 @@ func (s *service) ArriveAsAgent(ctx context.Context, agent *rpc.AgentInfo) (*rpc
 }
 
 func (s *service) ReportMetrics(ctx context.Context, metrics *rpc.TunnelMetrics) (*empty.Empty, error) {
-	dlog.Debug(ctx, "ReportMetrics called")
 	s.state.AddSessionConsumptionMetrics(metrics)
 	return &empty.Empty{}, nil
 }

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -697,6 +697,7 @@ func (s *service) ReviewIntercept(ctx context.Context, rIReq *rpc.ReviewIntercep
 			intercept.Disposition = rIReq.Disposition
 			intercept.Message = rIReq.Message
 			intercept.PodIp = rIReq.PodIp
+			intercept.PodName = agent.PodName
 			intercept.FtpPort = rIReq.FtpPort
 			intercept.SftpPort = rIReq.SftpPort
 			intercept.MountPoint = rIReq.MountPoint

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -302,10 +303,13 @@ func getTestClientConn(ctx context.Context, t *testing.T) *grpc.ClientConn {
 		GitVersion: "v1.17.0",
 	}
 	ctx = k8sapi.WithK8sInterface(ctx, fakeClient)
+	ctx = agentmap.WithWorkloadCache(ctx, 30*time.Second)
+
 	ctx = informer.WithFactory(ctx, "")
 	f := informer.GetFactory(ctx, "")
 	f.Core().V1().Services().Informer()
 	f.Core().V1().ConfigMaps().Informer()
+	f.Core().V1().Pods().Informer()
 	f.Start(ctx.Done())
 	f.WaitForCacheSync(ctx.Done())
 

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -18,7 +18,6 @@ import (
 	k8sVersion "k8s.io/apimachinery/pkg/version"
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
@@ -26,6 +25,7 @@ import (
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
 	testdata "github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/test"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
@@ -304,11 +304,10 @@ func getTestClientConn(ctx context.Context, t *testing.T) *grpc.ClientConn {
 	ctx = k8sapi.WithK8sInterface(ctx, fakeClient)
 	ctx = informer.WithFactory(ctx, "")
 	f := informer.GetFactory(ctx, "")
-	si := f.Core().V1().Services().Informer()
-	ci := f.Core().V1().ConfigMaps().Informer()
-	go si.Run(ctx.Done())
-	go ci.Run(ctx.Done())
-	cache.WaitForCacheSync(ctx.Done(), si.HasSynced, ci.HasSynced)
+	f.Core().V1().Services().Informer()
+	f.Core().V1().ConfigMaps().Informer()
+	f.Start(ctx.Done())
+	f.WaitForCacheSync(ctx.Done())
 
 	env := managerutil.Env{
 		MaxReceiveSize:  resource.Quantity{},
@@ -319,6 +318,7 @@ func getTestClientConn(ctx context.Context, t *testing.T) *grpc.ClientConn {
 		}},
 	}
 	ctx = managerutil.WithEnv(ctx, &env)
+	ctx = mutator.WithMap(ctx, mutator.Load(ctx))
 
 	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -61,7 +61,7 @@ func (s *state) PrepareIntercept(
 	}
 
 	spec := cr.InterceptSpec
-	wl, err := tracing.GetWorkload(ctx, spec.Agent, spec.Namespace, spec.WorkloadKind)
+	wl, err := agentmap.GetWorkload(ctx, spec.Agent, spec.Namespace, spec.WorkloadKind)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			err = errcat.User.New(err)
@@ -89,7 +89,7 @@ func (s *state) PrepareIntercept(
 }
 
 func (s *state) EnsureAgent(ctx context.Context, n, ns string) error {
-	wl, err := tracing.GetWorkload(ctx, n, ns, "")
+	wl, err := agentmap.GetWorkload(ctx, n, ns, "")
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			err = errcat.User.New(err)

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -19,8 +19,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/watch"
-	typed "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/k8sapi/pkg/k8sapi"
@@ -31,7 +29,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/tracing"
-	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 // PrepareIntercept ensures that the given request can be matched against the intercept configuration of
@@ -150,79 +147,7 @@ func (s *state) dropAgentConfig(
 	ctx context.Context,
 	wl k8sapi.Workload,
 ) error {
-	ns := wl.GetNamespace()
-	cl, _ := s.cfgMapLocks.LoadOrCompute(ns, func() *sync.Mutex {
-		return &sync.Mutex{}
-	})
-	cl.Lock()
-	defer cl.Unlock()
-
-	cmAPI := k8sapi.GetK8sInterface(ctx).CoreV1().ConfigMaps(ns)
-	cm, err := loadConfigMap(ctx, cmAPI, ns)
-	if err != nil {
-		return err
-	}
-	delete(cm.Data, wl.GetName())
-	_, err = cmAPI.Update(ctx, cm, meta.UpdateOptions{})
-	return err
-}
-
-func (s *state) getOrCreateAgentConfig(
-	ctx context.Context,
-	wl k8sapi.Workload,
-	extended bool,
-	spec *managerrpc.InterceptSpec,
-) (sc agentconfig.SidecarExt, err error) {
-	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "state.getOrCreateAgentConfig")
-	defer tracing.EndAndRecord(span, err)
-
-	ns := wl.GetNamespace()
-	cl, _ := s.cfgMapLocks.LoadOrCompute(ns, func() *sync.Mutex {
-		return &sync.Mutex{}
-	})
-	cl.Lock()
-	defer cl.Unlock()
-
-	cmAPI := k8sapi.GetK8sInterface(ctx).CoreV1().ConfigMaps(ns)
-	cm, err := loadConfigMap(ctx, cmAPI, ns)
-	if err != nil {
-		return nil, err
-	}
-	return s.createOrUpdateAgentConfig(ctx, cmAPI, cm, wl, extended, spec)
-}
-
-func loadConfigMap(ctx context.Context, cmAPI typed.ConfigMapInterface, namespace string) (cm *core.ConfigMap, err error) {
-	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "state.loadConfigMap")
-	defer tracing.EndAndRecord(span, err)
-
-	cm, err = cmAPI.Get(ctx, agentconfig.ConfigMap, meta.GetOptions{})
-	if err == nil {
-		span.SetAttributes(attribute.Bool("tel2.cm-found", true))
-		return cm, nil
-	}
-	if !k8sErrors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to get ConfigMap %s.%s: %w", agentconfig.ConfigMap, namespace, err)
-	}
-	span.SetAttributes(attribute.Bool("tel2.cm-found", false))
-	cm, err = cmAPI.Create(ctx, &core.ConfigMap{
-		TypeMeta: meta.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: meta.ObjectMeta{
-			Name:      agentconfig.ConfigMap,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       agentconfig.ConfigMap,
-				"app.kubernetes.io/created-by": "traffic-manager",
-				"app.kubernetes.io/version":    strings.TrimPrefix(version.Version, "v"),
-			},
-		},
-	}, meta.CreateOptions{})
-	if err != nil {
-		err = fmt.Errorf("failed to create ConfigMap %s.%s: %w", agentconfig.ConfigMap, namespace, err)
-	}
-	return cm, err
+	return mutator.GetMap(ctx).Delete(ctx, wl.GetNamespace(), wl.GetName())
 }
 
 func (s *state) RestoreAppContainer(ctx context.Context, ii *managerrpc.InterceptInfo) (err error) {
@@ -237,77 +162,57 @@ func (s *state) RestoreAppContainer(ctx context.Context, ii *managerrpc.Intercep
 	defer func() {
 		tracing.EndAndRecord(span, err)
 	}()
+	return mutator.GetMap(ctx).Update(ctx, ns, func(cm *core.ConfigMap) (changed bool, err error) {
+		y, ok := cm.Data[n]
+		if !ok {
+			return false, nil
+		}
+		sce, err := unmarshalConfigMapEntry(y, n, ns)
+		if err != nil {
+			return false, err
+		}
+		cn, _, err := findIntercept(sce.AgentConfig(), spec)
+		if !(err == nil && cn.Replace) {
+			return false, nil
+		}
+		cn.Replace = false
 
-	cl, _ := s.cfgMapLocks.LoadOrCompute(ns, func() *sync.Mutex {
-		return &sync.Mutex{}
-	})
-	cl.Lock()
-	defer cl.Unlock()
-
-	cmAPI := k8sapi.GetK8sInterface(ctx).CoreV1().ConfigMaps(ns)
-	cm, err := loadConfigMap(ctx, cmAPI, ns)
-	if err != nil {
-		return err
-	}
-	if y, ok := cm.Data[n]; ok {
-		var sce agentconfig.SidecarExt
-		if sce, err = unmarshalConfigMapEntry(y, n, ns); err == nil {
-			var cn *agentconfig.Container
-			if cn, _, err = findIntercept(sce.AgentConfig(), spec); err == nil && cn.Replace {
-				cn.Replace = false
-
-				// The pods for this workload will be killed once the new updated sidecar
-				// reaches the configmap. We remove them now, so that they don't continue to
-				// review intercepts.
-				for sessionID := range s.getAgentsByName(n, ns) {
-					if as, ok := s.GetSession(sessionID).(*agentSessionState); ok {
-						as.active.Store(false)
-					}
-				}
-				err = updateSidecar(ctx, sce, cmAPI, cm, n, ns)
+		// The pods for this workload will be killed once the new updated sidecar
+		// reaches the configmap. We remove them now, so that they don't continue to
+		// review intercepts.
+		for sessionID := range s.getAgentsByName(n, ns) {
+			if as, ok := s.GetSession(sessionID).(*agentSessionState); ok {
+				as.active.Store(false)
 			}
 		}
-	}
-	return err
+		return updateSidecar(sce, cm, n)
+	})
 }
 
-func updateSidecar(ctx context.Context, sce agentconfig.SidecarExt, cmAPI typed.ConfigMapInterface, cm *core.ConfigMap, n, ns string) (err error) {
-	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "state.createOrUpdateAgentConfig.update", trace.WithAttributes(
-		attribute.String("tel2.workload-name", n),
-		attribute.String("tel2.cm-name", agentconfig.ConfigMap),
-		attribute.String("tel2.cm-namespace", ns),
-	))
-	defer tracing.EndAndRecord(span, err)
+func updateSidecar(sce agentconfig.SidecarExt, cm *core.ConfigMap, n string) (bool, error) {
 	yml, err := sce.Marshal()
 	if err != nil {
-		return err
+		return false, err
 	}
-	cm.Data[n] = string(yml)
-	if _, err := cmAPI.Update(ctx, cm, meta.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed update entry for %s in ConfigMap %s.%s: %w", n, agentconfig.ConfigMap, ns, err)
+	oldYaml := cm.Data[n]
+	newYaml := string(yml)
+	if oldYaml != newYaml {
+		cm.Data[n] = newYaml
+		return true, nil
 	}
-	return err
+	return false, nil
 }
 
-func (s *state) createOrUpdateAgentConfig(
+func (s *state) getOrCreateAgentConfig(
 	ctx context.Context,
-	cmAPI typed.ConfigMapInterface,
-	cm *core.ConfigMap,
 	wl k8sapi.Workload,
 	extended bool,
 	spec *managerrpc.InterceptSpec,
-) (sc agentconfig.SidecarExt, err error) {
-	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "state.createOrUpdateAgentConfig")
-	defer tracing.EndAndRecord(span, err)
-
+) (sce agentconfig.SidecarExt, err error) {
 	enabled, err := checkInterceptAnnotations(wl)
 	if err != nil {
 		return nil, err
 	}
-	span.SetAttributes(
-		attribute.Bool("tel2.enabled", enabled),
-		attribute.Bool("tel2.extended", extended),
-	)
 	if !enabled {
 		return nil, errcat.User.Newf("%s %s.%s is not interceptable", wl.GetKind(), wl.GetName(), wl.GetNamespace())
 	}
@@ -316,79 +221,64 @@ func (s *state) createOrUpdateAgentConfig(
 	if err = s.self.ValidateAgentImage(agentImage, extended); err != nil {
 		return nil, err
 	}
-	span.SetAttributes(
-		attribute.String("tel2.agent-image", agentImage),
-	)
-
-	var sce agentconfig.SidecarExt
-	doUpdate := false
-	y, cmFound := cm.Data[wl.GetName()]
-	if cmFound {
-		span.AddEvent("workload-config-found")
-		if sce, err = unmarshalConfigMapEntry(y, wl.GetName(), wl.GetNamespace()); err != nil {
-			return nil, err
-		}
-		ac := sce.AgentConfig()
-		if ac.Create {
-			// This may happen if someone else is doing the initial intercept at the exact (well, more or less) same time
-			if sce, err = waitForConfigMapUpdate(ctx, cmAPI, wl.GetName(), wl.GetNamespace()); err != nil {
-				return nil, err
-			}
-			ac = sce.AgentConfig()
-		}
-		// If the agentImage has changed, and the extended image is requested, then update
-		if ac.AgentImage != agentImage && extended {
-			span.AddEvent("agent-image-changed")
-			ac.AgentImage = agentImage
-			doUpdate = true
-		}
-	} else {
-		span.AddEvent("workload-config-not-found")
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
-		}
-		var gc agentmap.GeneratorConfig
-		if gc, err = agentmap.GeneratorConfigFunc(agentImage); err != nil {
-			return nil, err
-		}
-		if sce, err = gc.Generate(ctx, wl, nil); err != nil {
-			return nil, err
-		}
-		doUpdate = true
-	}
-
-	ac := sce.AgentConfig()
-	if spec != nil {
-		cn, _, err := findIntercept(ac, spec)
-		if err != nil {
-			return nil, err
-		}
-		if cn.Replace != agentconfig.ReplacePolicy(spec.Replace) {
-			span.AddEvent("container-replace-changed")
-			cn.Replace = agentconfig.ReplacePolicy(spec.Replace)
-			doUpdate = true
-		}
-	}
-	if doUpdate {
+	err = mutator.GetMap(ctx).Update(ctx, wl.GetNamespace(), func(cm *core.ConfigMap) (changed bool, err error) {
+		doUpdate := false
+		y, cmFound := cm.Data[wl.GetName()]
 		if cmFound {
-			// The pods for this workload be killed once the new updated sidecar
-			// reaches the configmap. We remove them now, so that they don't continue to
-			// review intercepts.
-			for sessionID := range s.getAgentsByName(wl.GetName(), wl.GetNamespace()) {
-				if as, ok := s.GetSession(sessionID).(*agentSessionState); ok {
-					as.active.Store(false)
-				}
+			if sce, err = unmarshalConfigMapEntry(y, wl.GetName(), wl.GetNamespace()); err != nil {
+				return false, err
+			}
+			ac := sce.AgentConfig()
+			// If the agentImage has changed, and the extended image is requested, then update
+			if ac.AgentImage != agentImage && extended {
+				ac.AgentImage = agentImage
+				doUpdate = true
 			}
 		} else {
-			if err = s.self.ValidateCreateAgent(ctx, wl, sce); err != nil {
-				return nil, err
+			if cm.Data == nil {
+				cm.Data = make(map[string]string)
+			}
+			var gc agentmap.GeneratorConfig
+			if gc, err = agentmap.GeneratorConfigFunc(agentImage); err != nil {
+				return false, err
+			}
+			if sce, err = gc.Generate(ctx, wl, nil); err != nil {
+				return false, err
+			}
+			doUpdate = true
+		}
+
+		ac := sce.AgentConfig()
+		if spec != nil {
+			cn, _, err := findIntercept(ac, spec)
+			if err != nil {
+				return false, err
+			}
+			if cn.Replace != agentconfig.ReplacePolicy(spec.Replace) {
+				cn.Replace = agentconfig.ReplacePolicy(spec.Replace)
+				doUpdate = true
 			}
 		}
-		if err = updateSidecar(ctx, sce, cmAPI, cm, wl.GetName(), wl.GetNamespace()); err != nil {
-			return nil, err
+		if doUpdate {
+			if cmFound {
+				// The pods for this workload be killed once the new updated sidecar
+				// reaches the configmap. We remove them now, so that they don't continue to
+				// review intercepts.
+				for sessionID := range s.getAgentsByName(wl.GetName(), wl.GetNamespace()) {
+					if as, ok := s.GetSession(sessionID).(*agentSessionState); ok {
+						as.active.Store(false)
+					}
+				}
+			} else {
+				if err = s.self.ValidateCreateAgent(ctx, wl, sce); err != nil {
+					return false, err
+				}
+			}
+			return updateSidecar(sce, cm, wl.GetName())
 		}
-	}
-	return sce, nil
+		return false, nil
+	})
+	return sce, err
 }
 
 func checkInterceptAnnotations(wl k8sapi.Workload) (bool, error) {
@@ -431,50 +321,6 @@ func checkInterceptAnnotations(wl k8sapi.Workload) (bool, error) {
 			wl.GetName(), wl.GetNamespace(), mutator.ManualInjectAnnotation)
 	}
 	return true, nil
-}
-
-// Wait for the cluster's mutating webhook injector to do its magic. It will update the
-// configMap once it's done.
-func waitForConfigMapUpdate(ctx context.Context, cmAPI typed.ConfigMapInterface, agentName, namespace string) (agentconfig.SidecarExt, error) {
-	wi, err := cmAPI.Watch(ctx, meta.SingleObject(meta.ObjectMeta{
-		Name:      agentconfig.ConfigMap,
-		Namespace: namespace,
-	}))
-	if err != nil {
-		return nil, fmt.Errorf("watch of ConfigMap  %s failed: %w", agentconfig.ConfigMap, ctx.Err())
-	}
-	defer wi.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			v := "canceled"
-			c := codes.Canceled
-			if ctx.Err() == context.DeadlineExceeded {
-				v = "timed out"
-				c = codes.DeadlineExceeded
-			}
-			return nil, status.Error(c, fmt.Sprintf("watch of ConfigMap %s[%s]: request %s", agentconfig.ConfigMap, agentName, v))
-		case ev, ok := <-wi.ResultChan():
-			if !ok {
-				return nil, status.Error(codes.Canceled, fmt.Sprintf("watch of ConfigMap  %s[%s]: channel closed", agentconfig.ConfigMap, agentName))
-			}
-			if !(ev.Type == watch.Added || ev.Type == watch.Modified) {
-				continue
-			}
-			if m, ok := ev.Object.(*core.ConfigMap); ok {
-				if y, ok := m.Data[agentName]; ok {
-					scx, err := unmarshalConfigMapEntry(y, agentName, namespace)
-					if err != nil {
-						return nil, err
-					}
-					if !scx.AgentConfig().Create {
-						return scx, nil
-					}
-				}
-			}
-		}
-	}
 }
 
 func watchFailedInjectionEvents(ctx context.Context, name, namespace string) (<-chan *events.Event, error) {

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -260,6 +260,7 @@ func (s *state) RemoveSession(ctx context.Context, sessionID string) {
 		agent, isAgent := s.agents.LoadAndDelete(sessionID)
 		if isAgent {
 			// remove it from the agentsByName index (if necessary)
+			dlog.Debugf(ctx, "Agent session %s. Explicit removal", agent.PodName)
 			s.agentsByName.Compute(agent.Name, func(ag *xsync.MapOf[string, *rpc.AgentInfo], loaded bool) (*xsync.MapOf[string, *rpc.AgentInfo], bool) {
 				if loaded {
 					ag.Delete(sessionID)

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -130,7 +130,6 @@ type state struct {
 	sessions                   *xsync.MapOf[string, SessionState]                         // info for all sessions, keyed by session id
 	agentsByName               *xsync.MapOf[string, *xsync.MapOf[string, *rpc.AgentInfo]] // indexed copy of `agents`
 	interceptStates            *xsync.MapOf[string, *interceptState]
-	cfgMapLocks                *xsync.MapOf[string, *sync.Mutex]
 	timedLogLevel              log.TimedLevel
 	llSubs                     *loglevelSubscribers
 	tunnelCounter              int32
@@ -153,7 +152,6 @@ func NewState(ctx context.Context) State {
 		backgroundCtx:   ctx,
 		sessions:        xsync.NewMapOf[string, SessionState](),
 		agentsByName:    xsync.NewMapOf[string, *xsync.MapOf[string, *rpc.AgentInfo]](),
-		cfgMapLocks:     xsync.NewMapOf[string, *sync.Mutex](),
 		interceptStates: xsync.NewMapOf[string, *interceptState](),
 		timedLogLevel:   log.NewTimedLevel(loglevel, log.SetLevel),
 		llSubs:          newLoglevelSubscribers(),

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +28,6 @@ func (s *suiteState) SetupTest() {
 		backgroundCtx:   s.ctx,
 		sessions:        xsync.NewMapOf[string, SessionState](),
 		agentsByName:    xsync.NewMapOf[string, *xsync.MapOf[string, *manager.AgentInfo]](),
-		cfgMapLocks:     xsync.NewMapOf[string, *sync.Mutex](),
 		interceptStates: xsync.NewMapOf[string, *interceptState](),
 		timedLogLevel:   log.NewTimedLevel("debug", log.SetLevel),
 		llSubs:          newLoglevelSubscribers(),

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.1.0
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	golang.org/x/net v0.21.0
-	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.17.0
 	golang.org/x/term v0.17.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
@@ -170,6 +169,7 @@ require (
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -37,7 +37,7 @@ func (s *multipleInterceptsSuite) TestGatherLogs_ManagerOnly() {
 	foundManager, foundAgents, yamlCount, fileNames := s.getZipData(outputFile)
 	require.True(foundManager)
 	require.Equal(0, foundAgents, fileNames)
-	require.Equal(1, yamlCount, fileNames)
+	require.GreaterOrEqual(yamlCount, 1, fileNames)
 }
 
 func (s *multipleInterceptsSuite) TestGatherLogs_AgentsOnly() {
@@ -49,8 +49,8 @@ func (s *multipleInterceptsSuite) TestGatherLogs_AgentsOnly() {
 	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--get-pod-yaml", "--traffic-manager=False")
 	foundManager, foundAgents, yamlCount, fileNames := s.getZipData(outputFile)
 	require.False(foundManager)
-	require.Equal(s.ServiceCount(), foundAgents, fileNames)
-	require.Equal(s.ServiceCount(), yamlCount, fileNames)
+	require.GreaterOrEqual(foundAgents, s.ServiceCount(), fileNames)
+	require.GreaterOrEqual(yamlCount, s.ServiceCount(), fileNames)
 }
 
 func (s *multipleInterceptsSuite) TestGatherLogs_OneAgentOnly() {
@@ -62,8 +62,8 @@ func (s *multipleInterceptsSuite) TestGatherLogs_OneAgentOnly() {
 	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--get-pod-yaml", "--traffic-manager=False", "--traffic-agents=hello-1")
 	foundManager, foundAgents, yamlCount, fileNames := s.getZipData(outputFile)
 	require.False(foundManager)
-	require.Equal(1, foundAgents, fileNames)
-	require.Equal(1, yamlCount, fileNames)
+	require.GreaterOrEqual(foundAgents, 1, fileNames)
+	require.GreaterOrEqual(yamlCount, 1, fileNames)
 }
 
 func (s *multipleInterceptsSuite) TestGatherLogs_NoPodYamlUnlessLogs() {
@@ -156,7 +156,7 @@ func (s *connectedSuite) TestGatherLogs_OnlyMappedLogs() {
 	itest.CleanLogDir(ctx, require, bothNsRx, s.ManagerNamespace(), svc)
 	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--traffic-manager=False")
 	_, foundAgents, _, fileNames := getZipData(require, outputFile, bothNsRx, s.ManagerNamespace(), svc)
-	require.Equal(2, foundAgents, fileNames)
+	require.GreaterOrEqual(foundAgents, 2, fileNames)
 
 	// Connect using mapped-namespaces
 	itest.TelepresenceDisconnectOk(ctx)
@@ -167,7 +167,7 @@ func (s *connectedSuite) TestGatherLogs_OnlyMappedLogs() {
 	itest.TelepresenceOk(ctx, "list") // To ensure that the mapped namespaces are active
 	itest.TelepresenceOk(ctx, "gather-logs", "--output-file", outputFile, "--traffic-manager=False")
 	_, foundAgents, _, fileNames = getZipData(require, outputFile, bothNsRx, s.ManagerNamespace(), svc)
-	require.Equal(1, foundAgents, fileNames)
+	require.GreaterOrEqual(foundAgents, 1, fileNames)
 }
 
 func (s *multipleInterceptsSuite) cleanLogDir(ctx context.Context) {

--- a/integration_test/gather_logs_test.go
+++ b/integration_test/gather_logs_test.go
@@ -175,6 +175,9 @@ func (s *multipleInterceptsSuite) cleanLogDir(ctx context.Context) {
 }
 
 func (s *multipleInterceptsSuite) svcRegex() string {
+	if s.ServiceCount() >= 10 {
+		return `hello-\d+`
+	}
 	return fmt.Sprintf("hello-[0-%d]", s.ServiceCount())
 }
 

--- a/integration_test/ignored_mounts_test.go
+++ b/integration_test/ignored_mounts_test.go
@@ -1,0 +1,95 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/intercept"
+)
+
+func (s *mountsSuite) Test_IgnoredMounts() {
+	type lm struct {
+		name        string
+		svcPort     int
+		ignored     []string
+		expected    []string
+		notExpected []string
+	}
+	tests := []lm{
+		{
+			"no ingored volumes",
+			80,
+			[]string{},
+			[]string{
+				"var/run/secrets/kubernetes.io/serviceaccount",
+				"var/run/secrets/datawire.io/auth",
+				"usr/share/nginx/html",
+				"etc/nginx/templates",
+			},
+			[]string{},
+		},
+		{
+			"ignore-by-name",
+			80,
+			[]string{
+				"hello-data-volume-1",
+				"nginx-config",
+			},
+			[]string{
+				"var/run/secrets/kubernetes.io/serviceaccount",
+				"var/run/secrets/datawire.io/auth",
+			},
+			[]string{
+				"usr/share/nginx/html",
+				"etc/nginx/templates",
+			},
+		},
+	}
+
+	localPort, cancel := itest.StartLocalHttpEchoServer(s.Context(), "hello")
+	defer cancel()
+
+	for _, tt := range tests {
+		tt := tt
+		s.Run(tt.name, func() {
+			tpl := struct {
+				Annotations map[string]string
+			}{
+				Annotations: map[string]string{
+					agentconfig.InjectIgnoreVolumeMounts: strings.Join(tt.ignored, ","),
+				},
+			}
+			ctx := s.Context()
+			s.ApplyTemplate(ctx, filepath.Join("testdata", "k8s", "hello-w-volumes.goyaml"), &tpl)
+			defer func() {
+				s.DeleteSvcAndWorkload(ctx, "deploy", "hello")
+			}()
+			require := s.Require()
+			stdout := itest.TelepresenceOk(ctx, "intercept", "hello", "--output", "json", "--detailed-output", "--port", fmt.Sprintf("%d:%d", localPort, tt.svcPort))
+			defer itest.TelepresenceOk(ctx, "leave", "hello")
+			var iInfo intercept.Info
+			require.NoError(json.Unmarshal([]byte(stdout), &iInfo))
+			s.CapturePodLogs(ctx, "hello", "traffic-agent", s.AppNamespace())
+			mountPoint := iInfo.Mount.LocalDir
+			for _, desired := range tt.expected {
+				st, err := os.Stat(filepath.Join(mountPoint, desired))
+				if !s.NoErrorf(err, "mount of %s should be successful", desired) {
+					s.T().FailNow()
+				}
+				require.True(st.IsDir())
+			}
+			for _, notDesired := range tt.notExpected {
+				st, err := os.Stat(filepath.Join(mountPoint, notDesired))
+				if !s.Errorf(err, "mount of %s should not be successful", notDesired) {
+					dlog.Infof(ctx, "stat gave us %s %t %s", st.Name(), st.IsDir(), st.Mode())
+				}
+			}
+		})
+	}
+}

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -667,15 +667,19 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 	type xClient struct {
 		Routing map[string][]string `json:"routing"`
 	}
+	type xTimeouts struct {
+		AgentArrival string `json:"agentArrival,omitempty"`
+	}
 	nsl := nss.UniqueList()
 	vx := struct {
-		LogLevel        string  `json:"logLevel"`
-		MetritonEnabled bool    `json:"metritonEnabled"`
-		Image           *Image  `json:"image,omitempty"`
-		Agent           *xAgent `json:"agent,omitempty"`
-		ClientRbac      xRbac   `json:"clientRbac"`
-		ManagerRbac     xRbac   `json:"managerRbac"`
-		Client          xClient `json:"client"`
+		LogLevel        string    `json:"logLevel"`
+		MetritonEnabled bool      `json:"metritonEnabled"`
+		Image           *Image    `json:"image,omitempty"`
+		Agent           *xAgent   `json:"agent,omitempty"`
+		ClientRbac      xRbac     `json:"clientRbac"`
+		ManagerRbac     xRbac     `json:"managerRbac"`
+		Client          xClient   `json:"client"`
+		Timeouts        xTimeouts `json:"timeouts,omitempty"`
 	}{
 		LogLevel:        "debug",
 		MetritonEnabled: false,
@@ -697,6 +701,7 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 				"allowConflictingSubnets": {"10.0.0.0/8"},
 			},
 		},
+		Timeouts: xTimeouts{AgentArrival: "60s"},
 	}
 	ss, err := sigsYaml.Marshal(&vx)
 	if err != nil {

--- a/integration_test/testdata/k8s/hello-w-volumes.goyaml
+++ b/integration_test/testdata/k8s/hello-w-volumes.goyaml
@@ -1,0 +1,157 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  default.conf.template: |
+    server {
+        listen       ${NGINX_PORT};
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-data-1
+data:
+  index.html: |
+    <html>
+      <body>
+        <p id="hello">Hello from volume 1!</p>
+       </body>
+    </html>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-data-2
+data:
+  index.html: |
+    <html>
+      <body>
+        <p id="hello">Hello from volume 2!</p>
+      </body>
+    </html>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hello-secret-1
+type: kubernetes.io/basic-auth
+stringData:
+  username: "hello-1"
+  password: "hello-1"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hello-secret-2
+type: kubernetes.io/basic-auth
+stringData:
+  username: "hello-2"
+  password: "hello-2"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  type: ClusterIP
+  selector:
+    app: hello
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: http2
+      port: 81
+      targetPort: http2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+  labels:
+    app: hello
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+{{- with .Annotations }}
+      annotations:
+  {{- toYaml . | nindent 8 }}
+{{- end}}
+    spec:
+      serviceAccountName: mount-test-account
+      volumes:
+        - name: hello-data-volume-1
+          configMap:
+            name: hello-data-1
+        - name: hello-data-volume-2
+          configMap:
+            name: hello-data-2
+        - name: hello-secret-volume-1
+          secret:
+            secretName: hello-secret-1
+        - name: hello-secret-volume-2
+          secret:
+            secretName: hello-secret-2
+        - name: nginx-config
+          configMap:
+            name: nginx
+      containers:
+        - name: hello-container-1
+          image: nginx
+          env:
+            - name: NGINX_HOST
+              value: "hello-1.com"
+            - name: NGINX_PORT
+              value: "80"
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - mountPath: "/usr/share/nginx/html"
+              name: hello-data-volume-1
+            - mountPath: "/var/run/secrets/datawire.io/auth"
+              name: hello-secret-volume-1
+            - mountPath: /etc/nginx/templates/
+              name: nginx-config
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 3
+        - name: hello-container-2
+          image: nginx
+          env:
+            - name: NGINX_HOST
+              value: "hello-2.com"
+            - name: NGINX_PORT
+              value: "81"
+          ports:
+            - containerPort: 81
+              name: http2
+          volumeMounts:
+            - mountPath: "/usr/share/nginx/html"
+              name: hello-data-volume-2
+            - mountPath: "/var/run/secrets/datawire.io/auth"
+              name: hello-secret-volume-2
+            - mountPath: /etc/nginx/templates/
+              name: nginx-config

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -343,7 +343,7 @@ func appendAppContainerVolumeMounts(
 	volPaths := make([]string, 0, len(app.VolumeMounts))
 	pfx := EnvPrefixApp + cc.EnvPrefix
 	for _, m := range app.VolumeMounts {
-		if _, ok := ignoredVolumeMounts[m.Name]; ok {
+		if ignoredVolumeMounts.IsVolumeIgnored(m.Name, m.MountPath) {
 			continue
 		}
 		if stripVarRunSecret && strings.HasPrefix(m.MountPath, "/var/run/secrets/") {
@@ -441,11 +441,30 @@ func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.Env
 	return es
 }
 
-func GetIgnoredVolumeMounts(annotations map[string]string) map[string]struct{} {
-	vmSlice := strings.Split(annotations[InjectIgnoreVolumeMounts], ",")
-	ivms := make(map[string]struct{}, len(vmSlice))
-	for _, vm := range vmSlice {
-		ivms[strings.TrimSpace(vm)] = struct{}{}
+type IgnoredVolumeMounts []string
+
+func (iv IgnoredVolumeMounts) IsVolumeIgnored(name, path string) bool {
+	for _, ig := range iv {
+		if name != "" && ig == name {
+			return true
+		}
+		if path != "" && strings.HasPrefix(path, ig) {
+			return true
+		}
 	}
-	return ivms
+	return false
+}
+
+func GetIgnoredVolumeMounts(annotations map[string]string) IgnoredVolumeMounts {
+	if vma, ok := annotations[InjectIgnoreVolumeMounts]; ok {
+		vmSlice := strings.Split(vma, ",")
+		vms := make(IgnoredVolumeMounts, 0, len(vmSlice))
+		for _, vm := range vmSlice {
+			if vm = strings.TrimSpace(vm); vm != "" {
+				vms = append(vms, vm)
+			}
+		}
+		return vms
+	}
+	return nil
 }

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -327,7 +327,7 @@ func appendAppContainerVolumeMounts(
 	annotations map[string]string,
 	av semver.Version,
 ) ([]string, []core.VolumeMount) {
-	ignoredVolumeMounts := getIgnoredVolumeMounts(annotations)
+	ignoredVolumeMounts := GetIgnoredVolumeMounts(annotations)
 
 	// Older agents will error if we include /var/run/secrets/ volumes here, so we don't.
 	stripVarRunSecret := false
@@ -441,8 +441,8 @@ func appendAppContainerEnvFrom(app *core.Container, cc *Container, es []core.Env
 	return es
 }
 
-func getIgnoredVolumeMounts(annotations map[string]string) map[string]struct{} {
-	vmSlice := strings.Split(annotations["telepresence.getambassador.io/inject-ignore-volume-mounts"], ",")
+func GetIgnoredVolumeMounts(annotations map[string]string) map[string]struct{} {
+	vmSlice := strings.Split(annotations[InjectIgnoreVolumeMounts], ",")
 	ivms := make(map[string]struct{}, len(vmSlice))
 	for _, vm := range vmSlice {
 		ivms[strings.TrimSpace(vm)] = struct{}{}

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -46,6 +46,7 @@ const (
 
 	DomainPrefix                         = "telepresence.getambassador.io/"
 	InjectAnnotation                     = DomainPrefix + "inject-" + ContainerName
+	InjectIgnoreVolumeMounts             = DomainPrefix + "inject-ignore-volume-mounts"
 	TerminatingTLSSecretAnnotation       = DomainPrefix + "inject-terminating-tls-secret"
 	OriginatingTLSSecretAnnotation       = DomainPrefix + "inject-originating-tls-secret"
 	LegacyTerminatingTLSSecretAnnotation = "getambassador.io/inject-terminating-tls-secret"

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -52,6 +52,7 @@ const (
 	LegacyTerminatingTLSSecretAnnotation = "getambassador.io/inject-terminating-tls-secret"
 	LegacyOriginatingTLSSecretAnnotation = "getambassador.io/inject-originating-tls-secret"
 	WorkloadNameLabel                    = "telepresence.io/workloadName"
+	WorkloadKindLabel                    = "telepresence.io/workloadKind"
 	WorkloadEnabledLabel                 = "telepresence.io/workloadEnabled"
 	K8SCreatedByLabel                    = "app.kubernetes.io/created-by"
 )

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -191,7 +191,7 @@ nextSvcPort:
 		if l := len(cn.VolumeMounts); l > 0 {
 			mounts = make([]string, 0, l)
 			for _, vm := range cn.VolumeMounts {
-				if _, ok := ignoredVolumeMounts[vm.Name]; !ok {
+				if !ignoredVolumeMounts.IsVolumeIgnored(vm.Name, vm.MountPath) {
 					mounts = append(mounts, vm.MountPath)
 				}
 			}

--- a/pkg/agentmap/workload_cache.go
+++ b/pkg/agentmap/workload_cache.go
@@ -1,0 +1,84 @@
+package agentmap
+
+import (
+	"context"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v3"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+)
+
+type workloadKey struct {
+	name      string
+	namespace string
+}
+
+type workloadValue struct {
+	wl    k8sapi.Workload
+	err   error
+	cTime int64
+}
+
+type workloadCache struct {
+	*xsync.MapOf[workloadKey, workloadValue]
+	maxAge time.Duration
+}
+
+type WorkloadCache interface {
+	GetWorkload(c context.Context, name, namespace, workloadKind string) (k8sapi.Workload, error)
+}
+
+type wlCacheKey struct{}
+
+func WithWorkloadCache(ctx context.Context, maxAge time.Duration) context.Context {
+	wc := NewWorkloadCache(ctx, maxAge)
+	return context.WithValue(ctx, wlCacheKey{}, wc)
+}
+
+func GetWorkloadCache(ctx context.Context) WorkloadCache {
+	if wc, ok := ctx.Value(wlCacheKey{}).(WorkloadCache); ok {
+		return wc
+	}
+	return nil
+}
+
+func NewWorkloadCache(ctx context.Context, maxAge time.Duration) WorkloadCache {
+	w := workloadCache{MapOf: xsync.NewMapOf[workloadKey, workloadValue](), maxAge: maxAge}
+	go w.gc(ctx)
+	return w
+}
+
+func (w workloadCache) gc(ctx context.Context) {
+	tc := time.NewTicker(w.maxAge * 5)
+	for {
+		select {
+		case <-ctx.Done():
+			tc.Stop()
+			return
+		case now := <-tc.C:
+			minCtime := now.UnixNano() - int64(w.maxAge)
+			w.Range(func(key workloadKey, v workloadValue) bool {
+				if v.cTime < minCtime {
+					w.Delete(key)
+				}
+				return true
+			})
+		}
+	}
+}
+
+func (w workloadCache) GetWorkload(c context.Context, name, namespace, workloadKind string) (k8sapi.Workload, error) {
+	dlog.Debugf(c, "GetWorkload(%s,%s,%s)", name, namespace, workloadKind)
+	wv, _ := w.Compute(workloadKey{name: name, namespace: namespace}, func(wv workloadValue, loaded bool) (workloadValue, bool) {
+		now := time.Now().UnixNano()
+		if loaded && wv.cTime >= now-int64(w.maxAge) {
+			return wv, false
+		}
+		wv.wl, wv.err = k8sapi.GetWorkload(c, name, namespace, workloadKind)
+		wv.cTime = now
+		return wv, false
+	})
+	return wv.wl, wv.err
+}

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -48,11 +48,11 @@ func (ac *client) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tunnel.C
 		return nil, err
 	}
 	atomic.AddInt32(&ac.tunnelCount, 1)
-	dlog.Debugf(ctx, "%s have %d active tunnels", ac, ac.tunnelCount)
+	dlog.Tracef(ctx, "%s(%s) have %d active tunnels", ac, net.IP(ac.info.PodIp), ac.tunnelCount)
 	go func() {
 		<-ctx.Done()
 		atomic.AddInt32(&ac.tunnelCount, -1)
-		dlog.Debugf(ctx, "%s have %d active tunnels", ac, ac.tunnelCount)
+		dlog.Tracef(ctx, "%s(%s) have %d active tunnels", ac, net.IP(ac.info.PodIp), ac.tunnelCount)
 	}()
 	return tc, nil
 }

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -26,11 +27,19 @@ import (
 )
 
 type client struct {
+	// Mutex protects the following fields (the rest is immutable)
+	//   info.intercepted
+	//   cli
+	//   cancelClient
+	//   cancelDialWatch
+	// cli and cancelClient are both safe to use without a mutex once the ready channel is closed.
+	sync.Mutex
+	cli             agent.AgentClient
 	session         *manager.SessionInfo
+	info            *manager.AgentPodInfo
+	ready           chan error
 	cancelClient    context.CancelFunc
 	cancelDialWatch context.CancelFunc
-	client          agent.AgentClient
-	info            *manager.AgentPodInfo
 	tunnelCount     int32
 }
 
@@ -43,7 +52,16 @@ func (ac *client) String() string {
 }
 
 func (ac *client) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tunnel.Client, error) {
-	tc, err := ac.client.Tunnel(ctx, opts...)
+	select {
+	case err, ok := <-ac.ready:
+		if ok {
+			return nil, err
+		}
+		// ready channel is closed. We are ready to go.
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	tc, err := ac.cli.Tunnel(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -57,66 +75,132 @@ func (ac *client) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tunnel.C
 	return tc, nil
 }
 
-func newAgentClient(ctx context.Context, session *manager.SessionInfo, info *manager.AgentPodInfo) (*client, error) {
+func (ac *client) connect(ctx context.Context, deleteMe func()) {
+	defer close(ac.ready)
 	pfDialer := dnet.GetPortForwardDialer(ctx)
 	if pfDialer == nil {
-		return nil, errors.ErrUnsupported
+		return
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	conn, cli, _, err := k8sclient.ConnectToAgent(ctx, pfDialer.Dial, info.PodName, info.Namespace, uint16(info.ApiPort))
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer dialCancel()
+
+	conn, cli, _, err := k8sclient.ConnectToAgent(dialCtx, pfDialer.Dial, ac.info.PodName, ac.info.Namespace, uint16(ac.info.ApiPort))
 	if err != nil {
-		cancel()
-		return nil, err
+		deleteMe()
+		ac.ready <- err
+		return
 	}
-	var ac *client
-	cancelClient := func() {
-		dlog.Debugf(ctx, "Cancelling port-forward to %s", ac)
-		cancel()
+
+	ac.Lock()
+	ac.cli = cli
+	ac.cancelClient = func() {
 		conn.Close()
 	}
-	ac = &client{
-		session:      session,
-		cancelClient: cancelClient,
-		client:       cli,
-		info:         info,
-	}
-	if info.Intercepted {
-		if err = ac.startDialWatcher(ctx); err != nil {
-			cancelClient()
-			return nil, err
+	intercepted := ac.info.Intercepted
+	ac.Unlock()
+	if intercepted {
+		if err = ac.startDialWatcherReady(ctx); err != nil {
+			deleteMe()
+			ac.ready <- err
 		}
 	}
-	return ac, nil
 }
 
 func (ac *client) busy() bool {
-	return ac.info.Intercepted || atomic.LoadInt32(&ac.tunnelCount) > 0
+	ac.Lock()
+	bzy := ac.cli == nil || ac.info.Intercepted || atomic.LoadInt32(&ac.tunnelCount) > 0
+	ac.Unlock()
+	return bzy
+}
+
+func (ac *client) intercepted() bool {
+	ac.Lock()
+	ret := ac.info.Intercepted
+	ac.Unlock()
+	return ret
 }
 
 func (ac *client) cancel() {
-	ac.cancelClient()
-	if ac.info.Intercepted {
-		ac.cancelDialWatch()
+	ac.Lock()
+	cc := ac.cancelClient
+	cdw := ac.cancelDialWatch
+	ac.Unlock()
+	if cc != nil {
+		cc()
+	}
+	if cdw != nil {
+		cdw()
+	}
+}
+
+func (ac *client) setIntercepted(ctx context.Context, k string, status bool) {
+	ac.Lock()
+	aci := ac.info.Intercepted
+	ac.Unlock()
+	if status {
+		if aci {
+			return
+		}
+		dlog.Debugf(ctx, "Agent %s changed to intercepted", k)
+		if err := ac.startDialWatcher(ctx); err != nil {
+			dlog.Errorf(ctx, "failed to start client watcher for %s: %v", k, err)
+		}
+		// This agent is now intercepting. Start a dial watcher.
+	} else {
+		if !aci {
+			return
+		}
+
+		// This agent is no longer intercepting. Stop the dial watcher
+		dlog.Debugf(ctx, "Agent %s changed to not intercepted", k)
+		ac.Lock()
+		cdw := ac.cancelDialWatch
+		ac.Unlock()
+		if cdw != nil {
+			cdw()
+		}
 	}
 }
 
 func (ac *client) startDialWatcher(ctx context.Context) error {
+	// Not called from the startup go routine, so wait for that routine to finish
+	select {
+	case err, ok := <-ac.ready:
+		if ok {
+			return err
+		}
+		// ready channel is closed. We are ready to go.
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return ac.startDialWatcherReady(ctx)
+}
+
+func (ac *client) startDialWatcherReady(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Create the dial watcher
 	dlog.Debugf(ctx, "watching dials from agent pod %s", ac)
-	watcher, err := ac.client.WatchDial(ctx, ac.session)
+	watcher, err := ac.cli.WatchDial(ctx, ac.session)
 	if err != nil {
 		cancel()
 		return err
 	}
+
+	ac.Lock()
+	ac.info.Intercepted = true
 	ac.cancelDialWatch = func() {
+		ac.Lock()
 		ac.info.Intercepted = false
+		ac.cancelDialWatch = nil
+		ac.Unlock()
 		cancel()
 	}
-	ac.info.Intercepted = true
+	ac.Unlock()
+
 	go func() {
-		err := tunnel.DialWaitLoop(ctx, tunnel.AgentProvider(ac.client), watcher, ac.session.SessionId)
+		err := tunnel.DialWaitLoop(ctx, tunnel.AgentProvider(ac.cli), watcher, ac.session.SessionId)
 		if err != nil {
 			dlog.Error(ctx, err)
 		}
@@ -125,7 +209,7 @@ func (ac *client) startDialWatcher(ctx context.Context) error {
 }
 
 type Clients interface {
-	GetClient(net.IP) (ag tunnel.Provider)
+	GetClient(net.IP) tunnel.Provider
 	WatchAgentPods(ctx context.Context, rmc manager.ManagerClient) error
 	WaitForIP(ctx context.Context, timeout time.Duration, ip net.IP) error
 	WaitForWorkload(ctx context.Context, timeout time.Duration, name string) error
@@ -166,7 +250,7 @@ func (s *clients) GetClient(ip net.IP) (pvd tunnel.Provider) {
 		switch {
 		case ip.Equal(c.info.PodIp):
 			primary = c
-		case c.info.Intercepted:
+		case c.intercepted():
 			secondary = c
 		default:
 			ternary = c
@@ -383,51 +467,52 @@ func (s *clients) updateClients(ctx context.Context, ais []*manager.AgentPodInfo
 		}
 	}
 
-	// Ensure that the clients still exists. Cancel the ones that don't.
-	s.clients.Range(func(k string, ac *client) bool {
+	deleteClient := func(k string) {
+		s.clients.Compute(k, func(oldValue *client, loaded bool) (*client, bool) {
+			if loaded {
+				dlog.Debugf(ctx, "Deleting agent %s", k)
+				oldValue.cancel()
+			}
+			return nil, true
+		})
+	}
+
+	// Cancel clients that no longer exist.
+	s.clients.Range(func(k string, _ *client) bool {
 		if _, ok := aim[k]; !ok {
-			dlog.Debugf(ctx, "Deleting agent %s", k)
-			s.clients.Delete(k)
-			ac.cancel()
+			deleteClient(k)
 		}
 		return true
 	})
 
 	// Refresh current clients
 	for k, ai := range aim {
-		ac, ok := s.clients.Load(k)
-		if ok {
-			if ai.Intercepted {
-				if ac.info.Intercepted {
-					continue
-				}
-				dlog.Debugf(ctx, "Agent %s changed to intercepted", k)
-				if err := ac.startDialWatcher(ctx); err != nil {
-					dlog.Errorf(ctx, "failed to start client watcher for %s: %v", k, err)
-				}
-				// This agent is now intercepting. Start a dial watcher.
-			} else {
-				if !ac.info.Intercepted {
-					continue
-				}
-				// This agent is no longer intercepting. Stop the dial watcher
-				dlog.Debugf(ctx, "Agent %s changed to not intercepted", k)
-				ac.cancelDialWatch()
-			}
+		if ac, ok := s.clients.Load(k); ok {
+			ac.setIntercepted(ctx, k, ai.Intercepted)
 		}
+	}
+
+	addClient := func(k string, ai *manager.AgentPodInfo) {
+		_, _ = s.clients.Compute(k, func(oldValue *client, loaded bool) (*client, bool) {
+			if loaded {
+				return oldValue, false
+			}
+			ac := &client{
+				ready:   make(chan error),
+				session: s.session,
+				info:    ai,
+			}
+			go ac.connect(ctx, func() {
+				deleteClient(k)
+			})
+			return ac, false
+		})
 	}
 
 	// Add clients for newly arrived intercepts
 	for k, ai := range aim {
 		if ai.Intercepted || s.isProxyVIA(ai) || s.hasWaiterFor(ai) {
-			if _, ok := s.clients.Load(k); !ok {
-				ac, err := newAgentClient(ctx, s.session, ai)
-				if err != nil {
-					dlog.Errorf(ctx, "failed to create client for %s: %v", k, err)
-					continue
-				}
-				s.clients.Store(k, ac)
-			}
+			addClient(k, ai)
 		}
 	}
 
@@ -437,8 +522,7 @@ func (s *clients) updateClients(ctx context.Context, ais []*manager.AgentPodInfo
 			return false
 		}
 		if !ac.busy() && !s.isProxyVIA(ac.info) && !s.hasWaiterFor(ac.info) {
-			s.clients.Delete(k)
-			ac.cancel()
+			deleteClient(k)
 		}
 		return true
 	})
@@ -450,12 +534,7 @@ func (s *clients) updateClients(ctx context.Context, ais []*manager.AgentPodInfo
 			break
 		}
 		k := ai.PodName + "." + ai.Namespace
-		ac, err := newAgentClient(ctx, s.session, ai)
-		if err != nil {
-			dlog.Errorf(ctx, "failed to create client for %s: %v", k, err)
-		} else {
-			s.clients.Store(k, ac)
-		}
+		addClient(k, ai)
 	}
 	return nil
 }

--- a/pkg/dnet/kpfconn.go
+++ b/pkg/dnet/kpfconn.go
@@ -81,7 +81,6 @@ type podAddress struct {
 // Dial dials a port of something in the cluster.  The address format is
 // "[objkind/]objname[.objnamespace]:port".
 func (pf *k8sPortForwardDialer) Dial(ctx context.Context, addr string) (conn net.Conn, err error) {
-	dlog.Debugf(pf.logCtx, "k8sPortForwardDialer.Dial(ctx, %q)", addr)
 	var pod *podAddress
 	if pod, err = pf.resolve(ctx, addr); err == nil {
 		if conn, err = pf.dial(pod); err == nil {


### PR DESCRIPTION
This PR contains some improvements to how Telepresence can ignore mounted volumes during an intercept. Most notably the ability to ignore using a path-prefix, which also affects mounts that are injected automatically (such as `/var/run/secrets/kubernetes.io`).

The PR also contains some performance and stability improvements related to the `telepresence-agents` configmap and how client's track the agents.

See commit comments for details.
