### PR TITLE
Fix glitch when configuring the agent image from the client.

### DIFF
--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -180,7 +180,7 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 		}
 
 		scx.RecordInSpan(span)
-		if err = a.agentConfigs.store(ctx, scx, true); err != nil {
+		if err = a.agentConfigs.store(ctx, scx); err != nil {
 			return nil, err
 		}
 	default:

--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -1846,7 +1846,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 				require.NoError(t, err)
 				var scx agentconfig.SidecarExt
 				if scx, actualErr = generateForPod(t, ctx, test.pod, gc); actualErr == nil {
-					actualErr = cw.store(ctx, scx, true)
+					actualErr = cw.store(ctx, scx)
 				}
 			}
 			if actualErr == nil {

--- a/integration_test/itest/harness.go
+++ b/integration_test/itest/harness.go
@@ -55,6 +55,7 @@ func (h *harness) HarnessContext() context.Context {
 
 func (h *harness) RunSuite(s TestingSuite) {
 	if suiteEnabled(h.HarnessContext(), s) {
+		s.setContext(s.AmendSuiteContext(h.HarnessContext()))
 		h.HarnessT().Run(s.SuiteName(), func(t *testing.T) { suite.Run(t, s) })
 	}
 }

--- a/integration_test/itest/image.go
+++ b/integration_test/itest/image.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Image struct {
-	Name     string `json:"name"`
+	Name     string `json:"name,omitempty"`
 	Tag      string `json:"tag,omitempty"`
 	Registry string `json:"registry,omitempty"`
 }

--- a/integration_test/itest/runner.go
+++ b/integration_test/itest/runner.go
@@ -146,7 +146,9 @@ func (r *runner) RunTests(c context.Context) { //nolint:gocognit
 					s := f(c)
 					if suiteEnabled(c, s) {
 						t.Run(s.SuiteName(), func(t *testing.T) {
-							suite.Run(t, f(c))
+							ts := f(c)
+							ts.setContext(ts.AmendSuiteContext(c))
+							suite.Run(t, ts)
 						})
 					}
 				}

--- a/integration_test/itest/suite.go
+++ b/integration_test/itest/suite.go
@@ -9,19 +9,31 @@ import (
 type TestingSuite interface {
 	suite.TestingSuite
 	Harness
+	AmendSuiteContext(context.Context) context.Context
 	Context() context.Context
 	Assert() *Assertions
 	Require() *Requirements
 	SuiteName() string
+	setContext(ctx context.Context)
 }
 
 type Suite struct {
 	suite.Suite
 	Harness
+	ctx context.Context
+}
+
+func (s *Suite) AmendSuiteContext(ctx context.Context) context.Context {
+	return ctx
+}
+
+//nolint:unused // Linter is confused about this one.
+func (s *Suite) setContext(ctx context.Context) {
+	s.ctx = ctx
 }
 
 func (s *Suite) Context() context.Context {
-	return WithT(s.HarnessContext(), s.T())
+	return WithT(s.ctx, s.T())
 }
 
 func (s *Suite) Assert() *Assertions {

--- a/pkg/client/cli/helm/install.go
+++ b/pkg/client/cli/helm/install.go
@@ -76,6 +76,13 @@ func GetValues(ctx context.Context) map[string]any {
 	if wai, wr := imgConfig.AgentImage(ctx), imgConfig.WebhookRegistry(ctx); wai != "" || wr != "" {
 		image := make(map[string]any)
 		if wai != "" {
+			i := strings.LastIndexByte(wai, '/')
+			if i >= 0 {
+				if wr == "" {
+					wr = wai[:i]
+				}
+				wai = wai[i+1:]
+			}
 			parts := strings.Split(wai, ":")
 			name := wai
 			tag := ""


### PR DESCRIPTION
The code that parses the agent image in case it is given as the
`AGENT_IMAGE` environment variable, or as the `images.agentImage` didn't
consider that a registry may contain colon.