### PR TITLE
Upgrade provision-cluster to latest

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -86,14 +86,13 @@ jobs:
           TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
         run: make client-image
       - name: Create cluster
-        uses: datawire/infra-actions/provision-cluster@v0.2.6
+        uses: datawire/infra-actions/provision-cluster@v0.2.8
         with:
           kubeconfig: ${{ env.KUBECONFIG }}
           kubeceptionToken: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
           kubeceptionProfile: small
           distribution: ${{ matrix.clusters.distribution }}
           version: ${{ matrix.clusters.version }}
-          gkeCredentials: '{"project_id": "foo"}' # See https://github.com/datawire/infra-actions/issues/66
       - name: Download prebuilt docker image
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Description

Upgrade `datawire/infra-actions/provision-cluster` to the latest.

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
