### PR TITLE
Search all private subnets to find one open for dnsServerSubnet

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -71,6 +71,11 @@ items:
           been in use since versions prior to 2.6.0, when the client was responsible for installing the traffic-agent.
           These timeouts are now removed from the code-base, and a warning will be printed when attempts are made to use
           them.
+      - type: bugfix
+        title: Search all private subnets to find one open for dnsServerSubnet
+        body: >-
+          This resolves a bug that did not test all subnets in a private range, sometimes resulting in the warning,
+          "DNS doesn't seem to work properly."
   - version: 2.18.1
     date: (TBD)
     notes:

--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -231,7 +231,6 @@ func RandomIPv4Subnet(mask net.IPMask, avoid []*net.IPNet) (*net.IPNet, error) {
 		ip := ranges[i]
 
 		end := ranges[i+1]
-		inUse := false
 		for {
 			ip1 := make(net.IP, len(ip))
 			copy(ip1, ip)
@@ -240,6 +239,7 @@ func RandomIPv4Subnet(mask net.IPMask, avoid []*net.IPNet) (*net.IPNet, error) {
 				IP:   ip1,
 				Mask: mask,
 			}
+			inUse := false
 			for _, cidr := range cidrs {
 				if Overlaps(cidr, &sn) {
 					inUse = true


### PR DESCRIPTION
## Description

Resolves https://github.com/telepresenceio/telepresence/issues/3553

Search all private subnets to find one open for dnsServerSubnet

This resolves a bug that did not test all subnets in a private range, sometimes resulting in the warning, "DNS doesn't seem to work properly."

## Test

### Before
```
> go build -o bin .\cmd\telepresence\
  .\bin\telepresence quit -s
  .\bin\telepresence connect

Telepresence Daemons quitting...done
Launching Telepresence User Daemon
Launching Telepresence Root Daemon
Connected to context teleport.shared-services.wisely.io-olo-devenv, namespace user-pj (https://teleport.shared-services.wisely.io:3026)
Warning: DNS doesn't seem to work properly
```

### After

```
> go build -o bin .\cmd\telepresence\
  .\bin\telepresence quit -s
  .\bin\telepresence connect

Telepresence Daemons quitting...done
Launching Telepresence User Daemon
Launching Telepresence Root Daemon
Connected to context teleport.shared-services.wisely.io-olo-devenv, namespace user-pj (https://teleport.shared-services.wisely.io:3026)
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
