### PR TITLE
 Fix panic due to root daemon not running.

### DIFF
--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -19,7 +19,7 @@ jobs:
           go-version: stable
       - name: "Install mockgen"
         shell: bash
-        run: go install github.com/golang/mock/mockgen@v1.6.0
+        run: go install go.uber.org/mock/mockgen@latest
       - name: "Generate dependency information"
         shell: bash
         run: make generate

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,16 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.18.2
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Fix panic due to root daemon not running.
+        body: >-
+          If a <code>telepresence connect</code> was made at a time when the root daemon was not running (an abnormal
+          condition) and a subsequent intercept was then made, a panic would occur when the port-forward to the agent
+          was set up. This is now fixed so that the initial <code>telepresence connect</code> is refused unless the root
+          daemon is running.
   - version: 2.18.1
     date: (TBD)
     notes:

--- a/packaging/windows-package.sh
+++ b/packaging/windows-package.sh
@@ -50,8 +50,8 @@ zip -r -j "${BINDIR}/telepresence.zip" "${ZIPDIR}"
 # Generate installer
 cp "${SCRIPT_DIR}/sidebar.png" "${ZIPDIR}/sidebar.png"
 TELEPRESENCE_PLAIN_VERSION=${TELEPRESENCE_VERSION#"v"}
-sed s/TELEPRESENCE_VERSION/$TELEPRESENCE_PLAIN_VERSION/ "${SCRIPT_DIR}/telepresence.wxs.in" > "${ZIPDIR}/telepresence.wxs"
-sed s/TELEPRESENCE_VERSION/$TELEPRESENCE_PLAIN_VERSION/ "${SCRIPT_DIR}/bundle.wxs.in" > "${ZIPDIR}/bundle.wxs"
+sed s/TELEPRESENCE_VERSION/"$TELEPRESENCE_PLAIN_VERSION"/ "${SCRIPT_DIR}/telepresence.wxs.in" > "${ZIPDIR}/telepresence.wxs"
+sed s/TELEPRESENCE_VERSION/"$TELEPRESENCE_PLAIN_VERSION"/ "${SCRIPT_DIR}/bundle.wxs.in" > "${ZIPDIR}/bundle.wxs"
 
 WIX_VERSION=4.0.4
 dotnet tool install --global wix --version $WIX_VERSION

--- a/pkg/authenticator/authenticator.go
+++ b/pkg/authenticator/authenticator.go
@@ -17,7 +17,7 @@ func NewService(
 	}
 }
 
-//go:generate go run github.com/golang/mock/mockgen -package=mock_authenticator -destination=mocks/credentialsresolver_mock.go . ExecCredentialsResolver
+//go:generate go run go.uber.org/mock/mockgen -package=mock_authenticator -destination=mocks/credentialsresolver_mock.go . ExecCredentialsResolver
 type ExecCredentialsResolver interface {
 	Resolve(
 		ctx context.Context,
@@ -25,7 +25,7 @@ type ExecCredentialsResolver interface {
 	) ([]byte, error)
 }
 
-//go:generate go run github.com/golang/mock/mockgen -package=mock_authenticator -destination=mocks/clientconfig_mock.go k8s.io/client-go/tools/clientcmd ClientConfig
+//go:generate go run go.uber.org/mock/mockgen -package=mock_authenticator -destination=mocks/clientconfig_mock.go k8s.io/client-go/tools/clientcmd ClientConfig
 type Service struct {
 	kubeClientConfig        clientcmd.ClientConfig
 	execCredentialsResolver ExecCredentialsResolver

--- a/pkg/client/rootd/in_process.go
+++ b/pkg/client/rootd/in_process.go
@@ -121,9 +121,10 @@ func NewInProcSession(
 	mi *rpc.OutboundInfo,
 	mc manager.ManagerClient,
 	ver semver.Version,
+	isPodDaemon bool,
 ) (*InProcSession, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	session, err := newSession(ctx, mi, &userdToManagerShortcut{mc}, ver)
+	session, err := newSession(ctx, mi, &userdToManagerShortcut{mc}, ver, isPodDaemon)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -193,6 +193,9 @@ type Session struct {
 	// done is closed when the session ends
 	done               chan struct{}
 	subnetViaWorkloads []*rpc.SubnetViaWorkload
+
+	// daemon runs as part of a pod-daemon setup.
+	podDaemon bool
 }
 
 type NewSessionFunc func(context.Context, *rpc.OutboundInfo) (context.Context, *Session, error)
@@ -323,7 +326,7 @@ func NewSession(c context.Context, mi *rpc.OutboundInfo) (context.Context, *Sess
 	if mc == nil || err != nil {
 		return c, nil, err
 	}
-	s, err := newSession(c, mi, mc, ver)
+	s, err := newSession(c, mi, mc, ver, false)
 	if err != nil {
 		return c, nil, err
 	}
@@ -335,7 +338,7 @@ func NewSession(c context.Context, mi *rpc.OutboundInfo) (context.Context, *Sess
 
 func nope() bool { return false }
 
-func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerProxyClient, ver semver.Version) (*Session, error) {
+func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerProxyClient, ver semver.Version, isPodDaemon bool) (*Session, error) {
 	cfg := client.GetDefaultConfig()
 	cliCfg, err := mc.GetClientConfig(c, &empty.Empty{})
 	if err != nil {
@@ -361,6 +364,7 @@ func newSession(c context.Context, mi *rpc.OutboundInfo, mc connector.ManagerPro
 		vifReady:           make(chan error, 2),
 		config:             cfg,
 		done:               make(chan struct{}),
+		podDaemon:          isPodDaemon,
 	}
 	s.alsoProxySubnets, err = validateSubnets("also-proxy", mi.AlsoProxySubnets, s.alsoProxyVia)
 	if err != nil {
@@ -650,6 +654,9 @@ func (s *Session) onFirstClusterInfo(ctx context.Context, mgrInfo *manager.Clust
 		}
 		close(s.vifReady)
 	}()
+	if s.podDaemon {
+		return nil
+	}
 	s.proxyClusterPods = s.checkPodConnectivity(ctx, mgrInfo)
 	s.proxyClusterSvcs = s.checkSvcConnectivity(ctx, mgrInfo)
 	if ctx.Err() != nil {
@@ -663,6 +670,9 @@ func (s *Session) onFirstClusterInfo(ctx context.Context, mgrInfo *manager.Clust
 }
 
 func (s *Session) onClusterInfo(ctx context.Context, mgrInfo *manager.ClusterInfo, span trace.Span) error {
+	if s.podDaemon {
+		return nil
+	}
 	dlog.Debugf(ctx, "WatchClusterInfo update")
 	if mgrInfo.Dns == nil {
 		// Older traffic-manager. Use deprecated mgrInfo fields for DNS
@@ -1000,14 +1010,16 @@ func (s *Session) Start(c context.Context, g *dgroup.Group) error {
 	cancelDNSLock := sync.Mutex{}
 	cancelDNS := func() {}
 
-	g.Go("network", func(ctx context.Context) error {
-		defer func() {
-			cancelDNSLock.Lock()
-			cancelDNS()
-			cancelDNSLock.Unlock()
-		}()
-		return s.watchClusterInfo(ctx)
-	})
+	if !s.podDaemon {
+		g.Go("network", func(ctx context.Context) error {
+			defer func() {
+				cancelDNSLock.Lock()
+				cancelDNS()
+				cancelDNSLock.Unlock()
+			}()
+			return s.watchClusterInfo(ctx)
+		})
+	}
 
 	if rmc, ok := s.managerClient.(interface{ RealManagerClient() manager.ManagerClient }); ok {
 		clusterCfg := client.GetConfig(c).Cluster()
@@ -1024,6 +1036,9 @@ func (s *Session) Start(c context.Context, g *dgroup.Group) error {
 				dlog.Infof(c, "Agent port-forwards are disabled. Client is not permitted to do port-forward to namespace %s", s.namespace)
 			}
 		}
+	}
+	if s.podDaemon {
+		return nil
 	}
 
 	if s.agentClients == nil && len(s.subnetViaWorkloads) > 0 {

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -110,6 +110,9 @@ func NewService(ctx context.Context, _ *dgroup.Group, cfg client.Config, srv *gr
 			return nil, err
 		}
 		common.RegisterTracingServer(srv, tracer)
+	} else {
+		s.rootSessionInProc = true
+		s.quit = func() {}
 	}
 	return s, nil
 }

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -241,7 +241,7 @@ func NewSession(
 		}
 	}
 
-	tmgr.rootDaemon, err = tmgr.connectRootDaemon(ctx, oi)
+	tmgr.rootDaemon, err = tmgr.connectRootDaemon(ctx, oi, cr.IsPodDaemon)
 	if err != nil {
 		tmgr.managerConn.Close()
 		return ctx, nil, connectError(rpc.ConnectInfo_DAEMON_FAILED, err)
@@ -1104,13 +1104,13 @@ func (s *session) getOutboundInfo(ctx context.Context) *rootdRpc.OutboundInfo {
 	return info
 }
 
-func (s *session) connectRootDaemon(ctx context.Context, oi *rootdRpc.OutboundInfo) (rd rootdRpc.DaemonClient, err error) {
+func (s *session) connectRootDaemon(ctx context.Context, oi *rootdRpc.OutboundInfo, isPodDaemon bool) (rd rootdRpc.DaemonClient, err error) {
 	// establish a connection to the root daemon gRPC grpcService
 	dlog.Info(ctx, "Connecting to root daemon...")
 	svc := userd.GetService(ctx)
 	if svc.RootSessionInProcess() {
 		// Just run the root session in-process.
-		rootSession, err := rootd.NewInProcSession(ctx, oi, s.managerClient, s.managerVersion)
+		rootSession, err := rootd.NewInProcSession(ctx, oi, s.managerClient, s.managerVersion, isPodDaemon)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If a `telepresence connect` was made at a time when the root daemon was
not running (an abnormal condition) and a subsequent intercept was then
made, a panic would occur when the port-forward to the agent was set up.
This is now fixed so that the initial `telepresence connect` is refused
unless the root daemon is running.