### PR TITLE
Ensure the kubeconfig data is used when creating minimized kubeconfig

### DIFF
--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -181,7 +181,7 @@ func DiscoverDaemon(ctx context.Context, match *regexp.Regexp, daemonID *daemon.
 func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required bool) (context.Context, *daemon.UserClient, error) {
 	cr := daemon.GetRequest(ctx)
 	cliInContainer := proc.RunningInContainer()
-	daemonID, err := daemon.IdentifierFromFlags(cr.Name, cr.KubeFlags, cr.Docker || cliInContainer)
+	daemonID, err := daemon.IdentifierFromFlags(ctx, cr.Name, cr.KubeFlags, cr.KubeconfigData, cr.Docker || cliInContainer)
 	if err != nil {
 		return ctx, nil, err
 	}

--- a/pkg/client/cli/daemon/identifier.go
+++ b/pkg/client/cli/daemon/identifier.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
@@ -51,11 +52,11 @@ func (id *Identifier) ContainerName() string {
 
 // IdentifierFromFlags returns a unique name created from the name of the current context
 // and the active namespace denoted by the given flagMap.
-func IdentifierFromFlags(name string, flagMap map[string]string, containerized bool) (*Identifier, error) {
+func IdentifierFromFlags(ctx context.Context, name string, flagMap map[string]string, kubeConfigData []byte, containerized bool) (*Identifier, error) {
 	cc := flagMap["context"]
 	ns := flagMap["namespace"]
 	if cc == "" || ns == "" {
-		cld, err := client.ConfigLoader(flagMap)
+		cld, err := client.ConfigLoader(ctx, flagMap, kubeConfigData)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -217,7 +217,11 @@ func enableK8SAuthenticator(ctx context.Context, daemonID *daemon.Identifier) er
 		// Been there, done that
 		return nil
 	}
-	config, err := patcher.CreateExternalKubeConfig(ctx, cr.KubeFlags,
+	loader, err := client.ConfigLoader(ctx, cr.KubeFlags, cr.KubeconfigData)
+	if err != nil {
+		return err
+	}
+	config, err := patcher.CreateExternalKubeConfig(ctx, loader, cr.KubeFlags["context"],
 		func(configFiles []string) (string, string, error) {
 			port, err := ensureAuthenticatorService(ctx, cr.KubeFlags, configFiles)
 			if err != nil {

--- a/pkg/client/k8s_config.go
+++ b/pkg/client/k8s_config.go
@@ -175,17 +175,17 @@ func ConfigFlags(flagMap map[string]string) (*genericclioptions.ConfigFlags, err
 }
 
 // ConfigLoader returns the name of the current Kubernetes context, and the context itself.
-func ConfigLoader(flagMap map[string]string) (clientcmd.ClientConfig, error) {
+func ConfigLoader(ctx context.Context, flagMap map[string]string, kubeConfigData []byte) (clientcmd.ClientConfig, error) {
 	configFlags, err := ConfigFlags(flagMap)
 	if err != nil {
 		return nil, err
 	}
-	return configFlags.ToRawKubeConfigLoader(), nil
+	return NewClientConfig(ctx, configFlags, kubeConfigData)
 }
 
 // CurrentContext returns the name of the current Kubernetes context, the active namespace, and the context itself.
-func CurrentContext(flagMap map[string]string) (string, string, *api.Context, error) {
-	cld, err := ConfigLoader(flagMap)
+func CurrentContext(ctx context.Context, flagMap map[string]string, configBytes []byte) (string, string, *api.Context, error) {
+	cld, err := ConfigLoader(ctx, flagMap, configBytes)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -227,7 +227,7 @@ func NewSession(
 		if client.GetConfig(ctx).Cluster().ConnectFromRootDaemon {
 			// Root daemon needs this to authenticate with the cluster. Potential exec configurations in the kubeconfig
 			// must be executed by the user, not by root.
-			konfig, err := patcher.CreateExternalKubeConfig(ctx, cluster.EffectiveFlagMap, func([]string) (string, string, error) {
+			konfig, err := patcher.CreateExternalKubeConfig(ctx, config.ClientConfig, cluster.Context, func([]string) (string, string, error) {
 				s := userd.GetService(ctx)
 				if _, ok := s.Server().GetServiceInfo()[authenticator.Authenticator_ServiceDesc.ServiceName]; !ok {
 					authGrpc.RegisterAuthenticatorServer(s.Server(), config.ClientConfig)


### PR DESCRIPTION
Fix glitch causing normal kubeconfig loading to interfere with kubeconfig provided on stdin.
