### PR TITLE
Include "svc" as a top-level domain in the DNS resolver.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,14 @@ items:
   - version: 2.19.0
     date: (TBD)
     notes:
+      - type: bugfix
+        title: Include svc as a top-level domain in the DNS resolver.
+        body: ->
+          It's not uncommon that use-cases involving Kafka or other middleware use FQNs that end with
+          &quot;svc&quot;. The core-DNS resolver in Kubernetes can resolve such names. With this bugfix,
+          the Telepresence DNS resolver will also be able to resolve them, and thereby remove the need
+          to add &quot;.svc&quot; to the include-suffix list.
+        docs: https://github.com/telepresenceio/telepresence/issues/2814
       - type: feature
         title: Add ability to mount a webhook secret.
         body: >-

--- a/integration_test/svcdomain_test.go
+++ b/integration_test/svcdomain_test.go
@@ -1,0 +1,25 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/datawire/dlib/dlog"
+)
+
+func (s *connectedSuite) Test_SvcDomain() {
+	c := s.Context()
+	s.ApplyEchoService(c, "echo", 8080)
+	defer s.DeleteSvcAndWorkload(c, "deploy", "echo")
+
+	host := fmt.Sprintf("echo.%s.svc", s.AppNamespace())
+	s.Eventually(func() bool {
+		c, cancel := context.WithTimeout(c, 1800*time.Millisecond)
+		defer cancel()
+		dlog.Info(c, "LookupHost("+host+")")
+		_, err := net.DefaultResolver.LookupHost(c, host)
+		return s.NoErrorf(err, "%s did not resolve", host)
+	}, 10*time.Second, 2*time.Second)
+}

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -308,6 +308,10 @@ func (s *Server) isExcluded(name string) bool {
 	return false
 }
 
+func (s *Server) isDomainExcluded(name string) bool {
+	return slices.Contains(s.excludeSuffixes, "."+name)
+}
+
 func (s *Server) resolveInCluster(c context.Context, q *dns.Question) (result dnsproxy.RRs, rCode int, err error) {
 	query := q.Name
 	if query == "localhost." {
@@ -515,9 +519,12 @@ func (s *Server) processSearchPaths(g *dgroup.Group, processor func(context.Cont
 
 				routes := make(map[string]struct{}, len(das.domains))
 				for _, domain := range das.domains {
-					if domain != "" {
+					if domain != "" && !s.isDomainExcluded(domain) {
 						routes[domain] = struct{}{}
 					}
+				}
+				if !s.isDomainExcluded("svc") {
+					routes["svc"] = struct{}{}
 				}
 				s.Lock()
 				s.routes = routes


### PR DESCRIPTION
It's not uncommon that use-cases involving Kafka or other middleware use FQNs that end with "svc". The core-DNS resolver in Kubernetes can resolve such names. With this bugfix, the Telepresence DNS resolver will also be able to resolve them, and thereby remove the need to add ".svc" to the include-suffix list

Closes #2814