### PR TITLE
Creation of individual pods was blocked by the agent-injector webhook.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,15 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.18.3
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Creation of individual pods was blocked by the agent-injector webhook.
+        body: >-
+          An attempt to create a pod was blocked unless it was provided by a workload. Hence, commands like
+          <code>kubectl run -i busybox --rm --image=curlimages/curl --restart=Never -- curl echo-easy.default</code>
+          would be blocked from executing.
   - version: 2.18.2
     date: (TBD)
     notes:

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -150,12 +150,12 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 			uwkError := k8sapi.UnsupportedWorkloadKindError("")
 			switch {
 			case k8sErrors.IsNotFound(err):
-				dlog.Warnf(ctx, "No workload owner found for pod %s.%s", pod.Name, pod.Namespace)
+				dlog.Debugf(ctx, "No workload owner found for pod %s.%s", pod.Name, pod.Namespace)
 			case errors.As(err, &uwkError):
 				dlog.Debugf(ctx, "Workload owner with %s found for pod %s.%s", uwkError.Error(), pod.Name, pod.Namespace)
-				err = nil
 			}
-			return nil, err
+			// Not an error. It just means that the pod is not eligible for intercepts.
+			return nil, nil
 		}
 		scx, err = a.agentConfigs.Get(ctx, wl.GetName(), wl.GetNamespace())
 		if err != nil {

--- a/integration_test/not_connected_test.go
+++ b/integration_test/not_connected_test.go
@@ -1,9 +1,11 @@
 package integration_test
 
 import (
+	"bufio"
 	"fmt"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
@@ -112,4 +114,18 @@ func (s *notConnectedSuite) Test_ReportsNotConnected() {
 	s.Regexp(fmt.Sprintf(`Root Daemon\s*: %s`, rxVer), stdout)
 	s.Regexp(fmt.Sprintf(`User Daemon\s*: %s`, rxVer), stdout)
 	s.Regexp(`Traffic Manager\s*: not connected`, stdout)
+}
+
+// Test_CreateAndRunIndividualPod tess that pods can be created without a workload.
+func (s *notConnectedSuite) Test_CreateAndRunIndividualPod() {
+	out := s.KubectlOk(s.Context(), "run", "-i", "busybox", "--rm", "--image", "curlimages/curl", "--restart", "Never", "--", "ls", "/etc")
+	lines := bufio.NewScanner(strings.NewReader(out))
+	hostsFound := false
+	for lines.Scan() {
+		if lines.Text() == "hosts" {
+			hostsFound = true
+			break
+		}
+	}
+	s.True(hostsFound, "remote ls command did not find /etc/hosts")
 }


### PR DESCRIPTION
An attempt to create a pod was blocked unless it was provided by a workload. Hence, commands like:

    kubectl run -i busybox --rm --image=curlimages/curl --restart=Never -- curl echo-easy.default

would be blocked from executing.
