### PR TITLE
Docker aliases deprecation caused failure to detect Kind cluster.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,8 +34,16 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Docker aliases deprecation caused failure to detect Kind cluster.
+        body: >-
+          The logic for detecting if a cluster is a local Kind cluster, and therefore needs some special attention when
+          using <code>telepresence connect --docker</code>, relied on the presence of <code>Aliases</code> in the Docker
+          network that a Kind cluster sets up. In Docker versions from 26 and up, this value is no longer used, but the
+          corresponding info can instead be found in the new <code>DNSNames</code> field.
+        docs: https://docs.docker.com/engine/deprecated/#container-short-id-in-network-aliases-field
+      - type: bugfix
         title: Include svc as a top-level domain in the DNS resolver.
-        body: ->
+        body: >-
           It's not uncommon that use-cases involving Kafka or other middleware use FQNs that end with
           &quot;svc&quot;. The core-DNS resolver in Kubernetes can resolve such names. With this bugfix,
           the Telepresence DNS resolver will also be able to resolve them, and thereby remove the need

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -480,15 +480,29 @@ func detectKind(ctx context.Context, cns []types.ContainerJSON, hostAddrPort net
 		if cfg, ns := cn.Config, cn.NetworkSettings; cfg != nil && ns != nil && cfg.Labels["io.x-k8s.kind.role"] == "control-plane" {
 			if port, isIPv6 := containerPort(hostAddrPort, ns); port != 0 {
 				for n, nw := range ns.Networks {
-					for _, alias := range nw.Aliases {
-						if strings.HasSuffix(alias, "-control-plane") {
-							addr, err := localAddr(ctx, cn.ID, nw.NetworkID, isIPv6)
-							if err != nil {
-								dlog.Error(ctx, err)
+					found := false
+					for _, names := range nw.DNSNames {
+						if strings.HasSuffix(names, "-control-plane") {
+							found = true
+							break
+						}
+					}
+					if !found {
+						// Aliases got deprecated in favor of DNSNames in Docker versions 25+
+						for _, alias := range nw.Aliases {
+							if strings.HasSuffix(alias, "-control-plane") {
+								found = true
 								break
 							}
-							return netip.AddrPortFrom(addr, port), n
 						}
+					}
+					if found {
+						addr, err := localAddr(ctx, cn.ID, nw.NetworkID, isIPv6)
+						if err != nil {
+							dlog.Error(ctx, err)
+							break
+						}
+						return netip.AddrPortFrom(addr, port), n
 					}
 				}
 			}


### PR DESCRIPTION
The logic for detecting if a cluster is a local Kind cluster, and therefore needs some special attention when using `telepresence connect --docker`, relied on the presence of `Aliases` in the Docker network that a Kind cluster sets up. In Docker versions from 26 and up, this value is no longer used, but the corresponding info can instead be found in the new `DNSNames` field.