### PR TITLE
Improve how the traffic-manager resolves DNS when no agent is installed.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,12 @@ items:
   - version: 2.19.0
     date: (TBD)
     notes:
+      - type: bugfix
+        title: Improve how the traffic-manager resolves DNS when no agent is installed.
+        body: >-
+         The traffic-manager is typically installed into a namespace different from the one that clients are
+         connected to. It's therefore important that the traffic-manager adds the client's namespace when
+         resolving single label names in situations where there are any agents to dispatch the DNS query to.
       - type: change
         title: Removal of ability import legacy artifact into Helm.
         body: >-

--- a/cmd/traffic/cmd/manager/cluster/info.go
+++ b/cmd/traffic/cmd/manager/cluster/info.go
@@ -43,6 +43,8 @@ type Info interface {
 	// SetAdditionalAlsoProxy assigns a slice that will be added to the Routing.AlsoProxySubnets slice
 	// when notifications are sent.
 	SetAdditionalAlsoProxy(ctx context.Context, subnets []*rpc.IPNet)
+
+	ClusterDomain() string
 }
 
 type subnetRetriever interface {
@@ -353,6 +355,10 @@ func (oi *info) ID() string {
 
 func (oi *info) ClusterID() string {
 	return oi.clusterID
+}
+
+func (oi *info) ClusterDomain() string {
+	return oi.Dns.ClusterDomain
 }
 
 func (oi *info) clusterInfo() *rpc.ClusterInfo {


### PR DESCRIPTION
The traffic-manager is typically installed into a namespace different from the one that clients are connected to. It's therefore important that the traffic-manager adds the client's namespace when resolving single label names in situations where there are any agents to dispatch the DNS query to.
