### PR TITLE
Docker aliases deprecation caused failure to detect Kind cluster.

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -49,9 +49,8 @@ jobs:
         runners:
           - ubuntu-latest
           - ubuntu-arm64
-          - macos-latest
+          - macos-latest # this runner uses arm64
           - windows-2019
-          - macOS-arm64
         clusters:
           - distribution: Kubeception
             version: "1.27"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-arm64
           - macos-latest
-          - macOS-arm64
           - windows-2019
     runs-on: ${{ matrix.runners }}
     steps:
@@ -32,6 +31,18 @@ jobs:
       - name: generate binaries
         run: make release-binary
       - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: build-output/release
+          retention-days: 1
+      - name: generate binaries darwin-amd64 # macos-latest is arm64, so we need an extra amd64 build
+        if: runner.os == 'macOS'
+        env:
+          GOARCH: amd64
+        run: make clean release-binary
+      - name: Upload binaries darwin-amd64
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -4,29 +4,26 @@ on:
 env:
   HOMEBREW_NO_INSTALL_FROM_API:
 jobs:
-  macos:
-    runs-on: macos-latest
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        runners:
+          - ubuntu-latest
+          - ubuntu-arm64
+          - macos-latest
+          - windows-2019
+    runs-on: ${{ matrix.runners }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: "${{ github.event.pull_request.head.sha }}"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: "Install dependencies"
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: ""
-        run: |
-          brew untap homebrew/core || true
-          brew untap homebrew/cask || true
-          brew update
-          brew install --cask macfuse
+      - name: install dependencies
+        uses: ./.github/actions/install-dependencies
       - name: Lint
         run: make lint
-      - name: "Test arm64 build"
-        run: GOARCH=arm64 make build
-      - name: "Test amd64 build"
+      - name: Build
         run: make build
       - name: Run tests
         uses: nick-fields/retry/@v3
@@ -34,104 +31,3 @@ jobs:
           max_attempts: 3
           timeout_minutes: 12
           command: make check-unit
-
-  windows:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: "${{ github.event.pull_request.head.sha }}"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: "Download winfsp"
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 5
-          timeout_minutes: 1
-          shell: bash
-          command: make winfsp.msi
-      - name: "Download wintun"
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 5
-          timeout_minutes: 1
-          shell: bash
-          command: make wintun.dll
-      - name: install make
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 5
-          timeout_minutes: 1
-          command: choco install make
-      - name: "Install winfsp"
-        shell: powershell
-        run: |
-          Start-Process msiexec -Wait -verb runAs -Args "/i build-output\\winfsp.msi /passive /qn /L*V winfsp-install.log"
-          [Environment]::SetEnvironmentVariable("Path", "C:\\Program Files (x86)\\WinFsp\\inc\\fuse;$ENV:Path", "Machine")
-      - name: Build
-        run: make build
-      - name: Lint
-        run: make lint
-      - name: Run tests
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 12
-          command: |
-            $ENV:DTEST_KUBECONFIG = "${{ steps.kluster.outputs.kubeconfig }}"
-            $ENV:DTEST_REGISTRY = "docker.io/datawire"
-            make check-unit
-
-  linux-amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: "${{ github.event.pull_request.head.sha }}"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get update
-          sudo apt-get install -y socat make jq
-      - name: Lint
-        run: make lint
-      - name: "Test amd64 build"
-        run: make build
-      - name: Run tests
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 10
-          command: |
-            make check-unit
-
-  linux-arm64:
-    runs-on: ubuntu-arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: "${{ github.event.pull_request.head.sha }}"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get update
-          sudo apt-get install -y socat gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu make jq
-      - name: Lint
-        run: make lint
-      - name: "Test arm64 build"
-        run: GOARCH=arm64 CC=aarch64-linux-gnu-gcc make build
-      - name: Run tests
-        uses: nick-fields/retry/@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 10
-          command: |
-            make check-unit

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,16 @@ docDescription: >-
   environments, access to instantaneous feedback loops, and highly
   customizable development environments.
 items:
+  - version: 2.18.4
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Docker aliases deprecation caused failure to detect Kind cluster.
+        body: >-
+          The logic for detecting if a cluster is a local Kind cluster, and therefore needs some special attention when
+          using <code>telepresence connect --docker</code>, relied on the presence of <code>Aliases</code> in the Docker
+          network that a Kind cluster sets up. In Docker versions from 26 and up, this value is no longer used, but the
+          corresponding info can instead be found in the new <code>DNSNames</code> field.
   - version: 2.18.3
     date: (TBD)
     notes:

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -61,6 +61,10 @@ $(BUILDDIR)/go1%.src.tar.gz:
 	mkdir -p $(BUILDDIR)
 	curl -o $@ --fail -L https://dl.google.com/go/$(@F)
 
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)
+
 .PHONY: protoc-clean
 protoc-clean:
 	find ./rpc -name '*.go' -delete


### PR DESCRIPTION
The logic for detecting if a cluster is a local Kind cluster, and
therefore needs some special attention when using `telepresence connect
--docker`, relied on the presence of `Aliases` in the Docker network
that a Kind cluster sets up. In Docker versions from 26 and up, this
value is no longer used, but the corresponding info can instead be found
in the new `DNSNames` field.