### PR TITLE
Remove option WithNoProxy from grpc clients using context dialer.

### DIFF
--- a/pkg/client/k8sclient/connect.go
+++ b/pkg/client/k8sclient/connect.go
@@ -62,7 +62,6 @@ func dialClusterGRPC(ctx context.Context, address string, grpcDialer dnet.Dialer
 	return grpc.NewClient(dnet.K8sPFScheme+":///"+address, grpc.WithContextDialer(grpcDialer),
 		grpc.WithResolvers(dnet.NewResolver(ctx)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithNoProxy(),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 }
 

--- a/pkg/client/userd/trafficmgr/tracing.go
+++ b/pkg/client/userd/trafficmgr/tracing.go
@@ -135,7 +135,6 @@ func (c *traceCollector) trafficManagerTraces(ctx context.Context, sess *session
 		grpc.WithContextDialer(sess.pfDialer.Dial),
 		grpc.WithResolvers(dnet.NewResolver(ctx)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithNoProxy(),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 
@@ -157,7 +156,6 @@ func (c *traceCollector) agentTraces(ctx context.Context, sess *session, tCh cha
 		opts := []grpc.DialOption{
 			grpc.WithContextDialer(sess.pfDialer.Dial),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithNoProxy(),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		}
 


### PR DESCRIPTION
The `grpc.WithNoProxy()` is ignored when used together with `grpc.WithContextDialer()`.
