### PR TITLE
Fix endless recursion when a workload uses the same name as its owner.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,12 @@ items:
     date: (TBD)
     notes:
       - type: bugfix
+        title: Fix bug in workload cache, causing endless recursion when a workload uses the same name as its owner.
+        body: >-
+          The workload cache was keyed by name and namespace, but not by kind, so a workload named the same as its
+          owner workload would be found using the same key. This led to the workload finding itself when looking up
+          its owner, which in turn resulted in an endless recursion when searching for the topmost owner.
+      - type: bugfix
         title: FailedScheduling events mentioning node availability considered fatal when waiting for agent to arrive.
         body: >-
           The traffic-manager considers some events as fatal when waiting for a traffic-agent to arrive after an injection

--- a/pkg/agentmap/workload_cache.go
+++ b/pkg/agentmap/workload_cache.go
@@ -13,6 +13,7 @@ import (
 type workloadKey struct {
 	name      string
 	namespace string
+	kind      string
 }
 
 type workloadValue struct {
@@ -71,7 +72,7 @@ func (w workloadCache) gc(ctx context.Context) {
 
 func (w workloadCache) GetWorkload(c context.Context, name, namespace, workloadKind string) (k8sapi.Workload, error) {
 	dlog.Debugf(c, "GetWorkload(%s,%s,%s)", name, namespace, workloadKind)
-	wv, _ := w.Compute(workloadKey{name: name, namespace: namespace}, func(wv workloadValue, loaded bool) (workloadValue, bool) {
+	wv, _ := w.Compute(workloadKey{name: name, namespace: namespace, kind: workloadKind}, func(wv workloadValue, loaded bool) (workloadValue, bool) {
 		now := time.Now().UnixNano()
 		if loaded && wv.cTime >= now-int64(w.maxAge) {
 			return wv, false


### PR DESCRIPTION
The workload cache was keyed by name and namespace, but not by kind, so a workload named the same as its owner workload would be found using the same key. This led to the workload finding itself when looking up its owner, which in turn resulted in an endless recursion when searching for the topmost owner.