### PR TITLE
Let the list-context command output indicate the current context.

### DIFF
--- a/pkg/client/cli/cmd/list_contexts.go
+++ b/pkg/client/cli/cmd/list_contexts.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 )
 
 type listContextsCommand struct {
@@ -26,6 +26,11 @@ func listContexts() *cobra.Command {
 	return cmd
 }
 
+type kubeCtx struct {
+	*api.Context `yaml:",inline"`
+	Current      bool `json:"current,omitempty"`
+}
+
 func (lcc *listContextsCommand) run(cmd *cobra.Command, _ []string) error {
 	config, err := lcc.rq.GetConfig(cmd)
 	if err != nil {
@@ -33,13 +38,20 @@ func (lcc *listContextsCommand) run(cmd *cobra.Command, _ []string) error {
 	}
 
 	ctx := cmd.Context()
-	kcmap := config.Contexts
+	cm := make(map[string]kubeCtx, len(config.Contexts))
+	for n, c := range config.Contexts {
+		cm[n] = kubeCtx{Context: c, Current: n == config.CurrentContext}
+	}
 
 	if output.WantsFormatted(cmd) {
-		output.Object(ctx, kcmap, false)
+		output.Object(ctx, cm, false)
 	} else {
-		for name, kc := range kcmap {
-			fmt.Fprintf(output.Out(ctx), "- name: %s\n  default namespace: %s\n", name, kc.Namespace)
+		for n, c := range cm {
+			pfx := '-'
+			if c.Current {
+				pfx = '*'
+			}
+			ioutil.Printf(output.Out(ctx), "%c name: %s\n  default namespace: %s\n", pfx, n, c.Namespace)
 		}
 	}
 	return nil


### PR DESCRIPTION
Replaces the '-' prefix with '*' for the current context in text output and adds a boolean `current` to structured output.
