### PR TITLE
Fix traffic manager helm chart for agent security context

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -56,6 +56,10 @@ items:
           A new Helm chart value <code>schedulerName</code> has been added. With this feature, we are
           able to define some particular schedulers from Kubernetes to apply some different strategies to allocate telepresence resources,
           including the Traffic Manager and hooks pods.
+      - type: bugfix
+        title: Fix configuring custom agent security context
+        body: ->
+          The traffic-manager helm chart will now correctly use a custom agent security context if one is provided.
   - version: 2.19.0
     date: "2024-06-15"
     notes:

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -169,13 +169,13 @@ spec:
           {{- end }}
           - name: AGENT_IMAGE_PULL_POLICY
             value: {{ .agent.image.pullPolicy }}
-          {{- if .prometheus.port }}  # 0 is false
           {{- /* to allow running with no security context, must check against nil - this allows specifying an empty dict for the value */}}
           {{- if not (eq .agent.securityContext nil) }}
           - name: AGENT_SECURITY_CONTEXT
             value: '{{ toJson .agent.securityContext }}'
           {{- end }}
       {{- end }}
+          {{- if .prometheus.port }}  # 0 is false
           - name: PROMETHEUS_PORT
             value: "{{ .prometheus.port }}"
           {{- end }}


### PR DESCRIPTION
## Description

During a later commit, the `AGENT_SECURITY_CONTEXT` variable was inadvertently moved inside the `prometheus.port` section.

Fixes #3627

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [X] I made sure to update `./CHANGELOG.yml`.
 - [X] I made sure to add any docs changes required for my change (including release notes).
 - [X] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] I updated `TELEMETRY.md` if I added, changed, or removed a metric name.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
