### PR TITLE
Prevent all updates to telepresence-agents configmap from the injector.

### DIFF
--- a/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/cluster-scope.yaml
@@ -71,21 +71,12 @@ rules:
   - "apps"
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - watch
-{{- if .Values.agentInjector.enabled }}
-  - patch
-{{- end }}
-- apiGroups:
-  - "apps"
-  resources:
   - replicasets
   - statefulsets
   verbs:
   - get
   - list
+  - watch
 {{- if .Values.agentInjector.enabled }}
   - patch
 {{- end }}

--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -71,21 +71,12 @@ rules:
   - "apps"
   resources:
   - deployments
-  verbs:
-  - get
-  - list
-  - watch
-{{- if $interceptEnabled }}
-  - patch
-{{- end }}
-- apiGroups:
-  - "apps"
-  resources:
   - replicasets
   - statefulsets
   verbs:
   - get
   - list
+  - watch
 {{- if $interceptEnabled }}
   - patch
 {{- end }}

--- a/cmd/traffic/cmd/manager/mutator/configmap_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/configmap_watcher.go
@@ -1,0 +1,132 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	informerCore "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+)
+
+func tpAgentsInformer(ctx context.Context, ns string) informerCore.ConfigMapInformer {
+	f := informer.GetFactory(ctx, ns)
+	cV1 := informerCore.New(f, ns, func(options *meta.ListOptions) {
+		options.FieldSelector = "metadata.name=" + agentconfig.ConfigMap
+	})
+	cms := cV1.ConfigMaps()
+	return cms
+}
+
+func tpAgentsConfigMap(ctx context.Context, ns string) (*core.ConfigMap, error) {
+	cm, err := tpAgentsInformer(ctx, ns).Lister().ConfigMaps(ns).Get(agentconfig.ConfigMap)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to get ConfigMap %s: %w", agentconfig.ConfigMap, err)
+		}
+		cm = nil
+	}
+	return cm, nil
+}
+
+func (c *configWatcher) startConfigMap(ctx context.Context, ns string) cache.SharedIndexInformer {
+	ix := tpAgentsInformer(ctx, ns).Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		// Strip of the parts of the service that we don't care about
+		if cm, ok := o.(*core.ConfigMap); ok {
+			cm.ManagedFields = nil
+			cm.Finalizers = nil
+			cm.OwnerReferences = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		dlog.Errorf(ctx, "watcher for ConfigMap %s %s: %v", agentconfig.ConfigMap, whereWeWatch(ns), err)
+	})
+	return ix
+}
+
+func (c *configWatcher) watchConfigMap(ctx context.Context, ix cache.SharedIndexInformer) error {
+	_, err := ix.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				if cm, ok := obj.(*core.ConfigMap); ok {
+					dlog.Debugf(ctx, "ADDED %s.%s", cm.Name, cm.Namespace)
+					c.getNamespaceLock(cm.Namespace)
+					c.handleAdd(ctx, cm)
+				}
+			},
+			DeleteFunc: func(obj any) {
+				cm, ok := obj.(*core.ConfigMap)
+				if !ok {
+					if dfu, isDfu := obj.(*cache.DeletedFinalStateUnknown); isDfu {
+						cm, ok = dfu.Obj.(*core.ConfigMap)
+					}
+				}
+				if ok {
+					dlog.Debugf(ctx, "DELETED %s.%s", cm.Name, cm.Namespace)
+					c.getNamespaceLock(cm.Namespace)
+					c.handleDelete(ctx, cm)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				if cm, ok := newObj.(*core.ConfigMap); ok {
+					dlog.Debugf(ctx, "UPDATED %s.%s", cm.Name, cm.Namespace)
+					c.handleUpdate(ctx, oldObj.(*core.ConfigMap), cm)
+				}
+			},
+		})
+	return err
+}
+
+func (c *configWatcher) handleAdd(ctx context.Context, cm *core.ConfigMap) {
+	ns := cm.Namespace
+	for n, yml := range cm.Data {
+		c.handleAddOrUpdateEntry(ctx, entry{
+			name:      n,
+			namespace: ns,
+			value:     yml,
+		})
+	}
+}
+
+func (c *configWatcher) handleDelete(ctx context.Context, cm *core.ConfigMap) {
+	ns := cm.Namespace
+	for n, yml := range cm.Data {
+		c.handleDeleteEntry(ctx, entry{
+			name:      n,
+			namespace: ns,
+			value:     yml,
+		})
+	}
+}
+
+func (c *configWatcher) handleUpdate(ctx context.Context, oldCm, newCm *core.ConfigMap) {
+	ns := newCm.Namespace
+	for n, newYml := range newCm.Data {
+		e := entry{
+			name:      n,
+			namespace: ns,
+			value:     newYml,
+		}
+		if oldYml, ok := oldCm.Data[n]; ok {
+			e.oldValue = oldYml
+		}
+		c.handleAddOrUpdateEntry(ctx, e)
+	}
+	for n, oldYml := range oldCm.Data {
+		if _, ok := newCm.Data[n]; !ok {
+			c.handleDeleteEntry(ctx, entry{
+				name:      n,
+				namespace: ns,
+				value:     oldYml,
+			})
+		}
+	}
+}

--- a/cmd/traffic/cmd/manager/mutator/service_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/service_watcher.go
@@ -1,0 +1,165 @@
+package mutator
+
+import (
+	"context"
+	"strings"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+)
+
+type affectedConfig struct {
+	err error
+	wl  k8sapi.Workload // If a workload is retrieved, it will be cached here.
+	scx agentconfig.SidecarExt
+}
+
+func (c *configWatcher) configsAffectedBySvc(ctx context.Context, nsData map[string]string, svc *core.Service, trustUID bool) []affectedConfig {
+	references := func(ac *agentconfig.Sidecar) (k8sapi.Workload, error, bool) {
+		for _, cn := range ac.Containers {
+			for _, ic := range cn.Intercepts {
+				if ic.ServiceUID == svc.UID {
+					return nil, nil, true
+				}
+			}
+		}
+		if trustUID {
+			// A deleted service will only affect configs that matches its UID
+			return nil, nil, false
+		}
+
+		// The config will be affected if a service is added or modified so that it now selects the pod for the workload.
+		wl, err := agentmap.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
+		if err != nil {
+			return nil, err, false
+		}
+		return wl, nil, labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(wl.GetPodTemplate().Labels))
+	}
+
+	var affected []affectedConfig
+	for _, cfg := range nsData {
+		scx, err := agentconfig.UnmarshalYAML([]byte(cfg))
+		if err != nil {
+			dlog.Errorf(ctx, "failed to decode ConfigMap entry %q into an agent config", cfg)
+		} else if wl, err, ok := references(scx.AgentConfig()); ok {
+			affected = append(affected, affectedConfig{scx: scx, wl: wl, err: err})
+		}
+	}
+	return affected
+}
+
+func (c *configWatcher) affectedConfigs(ctx context.Context, svc *core.Service, trustUID bool) []affectedConfig {
+	ns := svc.Namespace
+	nsData, err := data(ctx, ns)
+	if err != nil {
+		return nil
+	}
+	if len(nsData) == 0 {
+		return nil
+	}
+	return c.configsAffectedBySvc(ctx, nsData, svc, trustUID)
+}
+
+func (c *configWatcher) startServices(ctx context.Context, ns string) cache.SharedIndexInformer {
+	f := informer.GetFactory(ctx, ns)
+	ix := f.Core().V1().Services().Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		// Strip of the parts of the service that we don't care about
+		if svc, ok := o.(*core.Service); ok {
+			svc.ManagedFields = nil
+			svc.Status = core.ServiceStatus{}
+			svc.Finalizers = nil
+			svc.OwnerReferences = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		dlog.Errorf(ctx, "watcher for Services %s: %v", whereWeWatch(ns), err)
+	})
+	return ix
+}
+
+func (c *configWatcher) watchServices(ctx context.Context, ix cache.SharedIndexInformer) error {
+	_, err := ix.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				if svc, ok := obj.(*core.Service); ok {
+					c.updateSvc(ctx, svc, false)
+				}
+			},
+			DeleteFunc: func(obj any) {
+				if svc, ok := obj.(*core.Service); ok {
+					c.updateSvc(ctx, svc, true)
+				} else if dfsu, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+					if svc, ok := dfsu.Obj.(*core.Service); ok {
+						c.updateSvc(ctx, svc, true)
+					}
+				}
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				if newSvc, ok := newObj.(*core.Service); ok {
+					c.updateSvc(ctx, newSvc, true)
+				}
+			},
+		})
+	return err
+}
+
+func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustUID bool) {
+	// Does the snapshot contain workloads that we didn't find using the service's Spec.Selector?
+	// If so, include them, or if workload for the config entry isn't found, delete that entry
+	img := managerutil.GetAgentImage(ctx)
+	if img == "" {
+		return
+	}
+	cfg, err := agentmap.GeneratorConfigFunc(img)
+	if err != nil {
+		dlog.Error(ctx, err)
+		return
+	}
+	for _, ax := range c.affectedConfigs(ctx, svc, trustUID) {
+		ac := ax.scx.AgentConfig()
+		wl := ax.wl
+		if wl == nil {
+			err = ax.err
+			if err == nil {
+				wl, err = agentmap.GetWorkload(ctx, ac.WorkloadName, ac.Namespace, ac.WorkloadKind)
+			}
+			if err != nil {
+				if errors.IsNotFound(err) {
+					dlog.Debugf(ctx, "Deleting config entry for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
+					if err = c.remove(ctx, ac.AgentName, ac.Namespace); err != nil {
+						dlog.Error(ctx, err)
+					}
+				} else {
+					dlog.Error(ctx, err)
+				}
+				continue
+			}
+		}
+		dlog.Debugf(ctx, "Regenerating config entry for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
+		acn, err := cfg.Generate(ctx, wl, ac)
+		if err != nil {
+			if strings.Contains(err.Error(), "unable to find") {
+				if err = c.remove(ctx, ac.AgentName, ac.Namespace); err != nil {
+					dlog.Error(ctx, err)
+				}
+			} else {
+				dlog.Error(ctx, err)
+			}
+			continue
+		}
+		if err = c.store(ctx, acn); err != nil {
+			dlog.Error(ctx, err)
+		}
+	}
+}

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -50,7 +50,7 @@ type Map interface {
 
 	RegenerateAgentMaps(ctx context.Context, s string) error
 
-	Delete(ctx context.Context, namespace string, name string) error
+	Delete(ctx context.Context, name, namespace string) error
 	Update(ctx context.Context, namespace string, updater func(cm *core.ConfigMap) (bool, error)) error
 }
 
@@ -397,7 +397,7 @@ func (c *configWatcher) IsBlacklisted(podName, namespace string) bool {
 	return ok
 }
 
-func (c *configWatcher) Delete(ctx context.Context, namespace string, name string) error {
+func (c *configWatcher) Delete(ctx context.Context, name, namespace string) error {
 	return c.remove(ctx, name, namespace)
 }
 

--- a/cmd/traffic/cmd/manager/mutator/workload_state.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_state.go
@@ -1,0 +1,63 @@
+package mutator
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+)
+
+type WorkloadState int
+
+const (
+	WorkloadStateUnknown WorkloadState = iota
+	WorkloadStateProgressing
+	WorkloadStateAvailable
+	WorkloadStateFailure
+)
+
+func deploymentState(d *appsv1.Deployment) WorkloadState {
+	for _, c := range d.Status.Conditions {
+		switch c.Type {
+		case appsv1.DeploymentProgressing:
+			if c.Status == core.ConditionTrue {
+				return WorkloadStateProgressing
+			}
+		case appsv1.DeploymentAvailable:
+			if c.Status == core.ConditionTrue {
+				return WorkloadStateAvailable
+			}
+		case appsv1.DeploymentReplicaFailure:
+			if c.Status == core.ConditionTrue {
+				return WorkloadStateFailure
+			}
+		}
+	}
+	return WorkloadStateUnknown
+}
+
+func replicaSetState(d *appsv1.ReplicaSet) WorkloadState {
+	for _, c := range d.Status.Conditions {
+		if c.Type == appsv1.ReplicaSetReplicaFailure && c.Status == core.ConditionTrue {
+			return WorkloadStateFailure
+		}
+	}
+	return WorkloadStateAvailable
+}
+
+func statefulSetState(d *appsv1.StatefulSet) WorkloadState {
+	return WorkloadStateAvailable
+}
+
+func workloadState(wl k8sapi.Workload) WorkloadState {
+	if d, ok := k8sapi.DeploymentImpl(wl); ok {
+		return deploymentState(d)
+	}
+	if r, ok := k8sapi.ReplicaSetImpl(wl); ok {
+		return replicaSetState(r)
+	}
+	if s, ok := k8sapi.StatefulSetImpl(wl); ok {
+		return statefulSetState(s)
+	}
+	return WorkloadStateUnknown
+}

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -134,11 +134,11 @@ func (c *configWatcher) watchWorkloads(ctx context.Context, ix cache.SharedIndex
 func (c *configWatcher) deleteWorkload(ctx context.Context, wl k8sapi.Workload) {
 	scx, err := c.Get(ctx, wl.GetName(), wl.GetNamespace())
 	if err != nil {
-		dlog.Error(ctx, "Failed to get sidecar config: %v", err)
+		dlog.Errorf(ctx, "Failed to get sidecar config: %v", err)
 	} else if scx != nil {
 		err = c.Delete(ctx, wl.GetName(), wl.GetNamespace())
 		if err != nil {
-			dlog.Error(ctx, "Failed to delete sidecar config: %v", err)
+			dlog.Errorf(ctx, "Failed to delete sidecar config: %v", err)
 		}
 	}
 }
@@ -179,7 +179,7 @@ func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Wor
 		if oldWl != nil {
 			scx, err = c.Get(ctx, wl.GetName(), wl.GetNamespace())
 			if err != nil {
-				dlog.Error(ctx, "Failed to get sidecar config: %v", err)
+				dlog.Errorf(ctx, "Failed to get sidecar config: %v", err)
 				return
 			}
 		}

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -1,0 +1,30 @@
+package mutator
+
+import (
+	"context"
+
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+)
+
+func (c *configWatcher) startDeployments(ctx context.Context, ns string) cache.SharedIndexInformer {
+	f := informer.GetFactory(ctx, ns)
+	ix := f.Apps().V1().Deployments().Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		// Strip of the parts of the deployment that we don't care about. Saves memory
+		if dep, ok := o.(*apps.Deployment); ok {
+			dep.ManagedFields = nil
+			dep.Status = apps.DeploymentStatus{}
+			dep.Finalizers = nil
+			dep.OwnerReferences = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		dlog.Errorf(ctx, "watcher for Deployments %s: %v", whereWeWatch(ns), err)
+	})
+	return ix
+}

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -2,11 +2,21 @@ package mutator
 
 import (
 	"context"
+	"strings"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/datawire/dlib/dlog"
+	"github.com/datawire/k8sapi/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 )
 
@@ -14,10 +24,13 @@ func (c *configWatcher) startDeployments(ctx context.Context, ns string) cache.S
 	f := informer.GetFactory(ctx, ns)
 	ix := f.Apps().V1().Deployments().Informer()
 	_ = ix.SetTransform(func(o any) (any, error) {
-		// Strip of the parts of the deployment that we don't care about. Saves memory
+		// Strip the parts of the deployment that we don't care about to save memory
 		if dep, ok := o.(*apps.Deployment); ok {
+			om := &dep.ObjectMeta
+			if an := om.Annotations; an != nil {
+				delete(an, core.LastAppliedConfigAnnotation)
+			}
 			dep.ManagedFields = nil
-			dep.Status = apps.DeploymentStatus{}
 			dep.Finalizers = nil
 			dep.OwnerReferences = nil
 		}
@@ -27,4 +40,169 @@ func (c *configWatcher) startDeployments(ctx context.Context, ns string) cache.S
 		dlog.Errorf(ctx, "watcher for Deployments %s: %v", whereWeWatch(ns), err)
 	})
 	return ix
+}
+
+func (c *configWatcher) startReplicaSets(ctx context.Context, ns string) cache.SharedIndexInformer {
+	f := informer.GetFactory(ctx, ns)
+	ix := f.Apps().V1().ReplicaSets().Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		// Strip the parts of the replicaset that we don't care about. Saves memory
+		if dep, ok := o.(*apps.ReplicaSet); ok {
+			om := &dep.ObjectMeta
+			if an := om.Annotations; an != nil {
+				delete(an, core.LastAppliedConfigAnnotation)
+			}
+			dep.ManagedFields = nil
+			dep.Finalizers = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		dlog.Errorf(ctx, "watcher for ReplicaSets %s: %v", whereWeWatch(ns), err)
+	})
+	return ix
+}
+
+func (c *configWatcher) startStatefulSets(ctx context.Context, ns string) cache.SharedIndexInformer {
+	f := informer.GetFactory(ctx, ns)
+	ix := f.Apps().V1().StatefulSets().Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		// Strip the parts of the stateful that we don't care about. Saves memory
+		if dep, ok := o.(*apps.StatefulSet); ok {
+			om := &dep.ObjectMeta
+			if an := om.Annotations; an != nil {
+				delete(an, core.LastAppliedConfigAnnotation)
+			}
+			dep.ManagedFields = nil
+			dep.Finalizers = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		dlog.Errorf(ctx, "watcher for StatefulSet %s: %v", whereWeWatch(ns), err)
+	})
+	return ix
+}
+
+func workloadFromAny(obj any) (k8sapi.Workload, bool) {
+	if ro, ok := obj.(runtime.Object); ok {
+		if wl, err := k8sapi.WrapWorkload(ro); err == nil {
+			return wl, true
+		}
+	}
+	return nil, false
+}
+
+func (c *configWatcher) watchWorkloads(ctx context.Context, ix cache.SharedIndexInformer) error {
+	_, err := ix.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				if wl, ok := workloadFromAny(obj); ok && len(wl.GetOwnerReferences()) == 0 {
+					c.updateWorkload(ctx, wl, nil, workloadState(wl))
+				}
+			},
+			DeleteFunc: func(obj any) {
+				if wl, ok := workloadFromAny(obj); ok {
+					if len(wl.GetOwnerReferences()) == 0 {
+						c.deleteWorkload(ctx, wl)
+					}
+				} else if dfsu, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
+					if wl, ok = workloadFromAny(dfsu.Obj); ok && len(wl.GetOwnerReferences()) == 0 {
+						c.deleteWorkload(ctx, wl)
+					}
+				}
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				if wl, ok := workloadFromAny(newObj); ok && len(wl.GetOwnerReferences()) == 0 {
+					if oldWl, ok := workloadFromAny(oldObj); ok {
+						c.updateWorkload(ctx, wl, oldWl, workloadState(wl))
+					}
+				}
+			},
+		})
+	if err == nil {
+		// Act on initial snapshot
+		for _, obj := range ix.GetStore().List() {
+			if wl, ok := workloadFromAny(obj); ok && len(wl.GetOwnerReferences()) == 0 {
+				c.updateWorkload(ctx, wl, nil, workloadState(wl))
+			}
+		}
+	}
+	return err
+}
+
+func (c *configWatcher) deleteWorkload(ctx context.Context, wl k8sapi.Workload) {
+	scx, err := c.Get(ctx, wl.GetName(), wl.GetNamespace())
+	if err != nil {
+		dlog.Error(ctx, "Failed to get sidecar config: %v", err)
+	} else if scx != nil {
+		err = c.Delete(ctx, wl.GetName(), wl.GetNamespace())
+		if err != nil {
+			dlog.Error(ctx, "Failed to delete sidecar config: %v", err)
+		}
+	}
+}
+
+func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Workload, state WorkloadState) {
+	if state == WorkloadStateFailure {
+		return
+	}
+	tpl := wl.GetPodTemplate()
+	ia, ok := tpl.Annotations[InjectAnnotation]
+	if !ok {
+		return
+	}
+	if oldWl != nil {
+		diff := cmp.Diff(oldWl.GetPodTemplate(), tpl,
+			cmpopts.IgnoreFields(meta.ObjectMeta{}, "Namespace", "UID", "ResourceVersion", "CreationTimestamp", "DeletionTimestamp"),
+			cmpopts.IgnoreMapEntries(func(k, _ string) bool {
+				return k == annRestartedAt
+			}),
+		)
+		if diff == "" {
+			return
+		}
+		dlog.Debugf(ctx, "Diff: %s", diff)
+	}
+	switch ia {
+	case "enabled":
+		img := managerutil.GetAgentImage(ctx)
+		if img == "" {
+			return
+		}
+		cfg, err := agentmap.GeneratorConfigFunc(img)
+		if err != nil {
+			dlog.Error(ctx, err)
+			return
+		}
+		var scx agentconfig.SidecarExt
+		if oldWl != nil {
+			scx, err = c.Get(ctx, wl.GetName(), wl.GetNamespace())
+			if err != nil {
+				dlog.Error(ctx, "Failed to get sidecar config: %v", err)
+				return
+			}
+		}
+		action := "Generating"
+		if scx == nil {
+			action = "Regenerating"
+		}
+		dlog.Debugf(ctx, "%s config entry for %s %s.%s", action, wl.GetKind(), wl.GetName(), wl.GetNamespace())
+
+		scx, err = cfg.Generate(ctx, wl, scx)
+		if err != nil {
+			if strings.Contains(err.Error(), "unable to find") {
+				if err = c.remove(ctx, wl.GetName(), wl.GetNamespace()); err != nil {
+					dlog.Error(ctx, err)
+				}
+			} else {
+				dlog.Error(ctx, err)
+			}
+		}
+		if err = c.store(ctx, scx); err != nil {
+			dlog.Error(ctx, err)
+		}
+	case "false", "disabled":
+		c.deleteWorkload(ctx, wl)
+	}
 }

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -167,7 +167,7 @@ func (s *state) dropAgentConfig(
 	ctx context.Context,
 	wl k8sapi.Workload,
 ) error {
-	return mutator.GetMap(ctx).Delete(ctx, wl.GetNamespace(), wl.GetName())
+	return mutator.GetMap(ctx).Delete(ctx, wl.GetName(), wl.GetNamespace())
 }
 
 func (s *state) RestoreAppContainer(ctx context.Context, ii *managerrpc.InterceptInfo) (err error) {

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -104,9 +104,11 @@ func (is *installSuite) TestInjectPolicy() {
 func (is *installSuite) applyMultipleServices(svcCount int) {
 	is.applyOrDeleteMultipleServices(svcCount, is.ApplyTemplate, true)
 }
+
 func (is *installSuite) deleteMultipleServices(svcCount int) {
 	is.applyOrDeleteMultipleServices(svcCount, is.DeleteTemplate, false)
 }
+
 func (is *installSuite) applyOrDeleteMultipleServices(svcCount int, applyOrDelete func(context.Context, string, any), wait bool) {
 	ctx := is.Context()
 	wg := sync.WaitGroup{}

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
@@ -98,4 +99,79 @@ func (is *installSuite) TestInjectPolicy() {
 			is.injectPolicyTest(is.Context(), policy)
 		})
 	}
+}
+
+func (is *installSuite) applyMultipleServices(svcCount int) {
+	is.applyOrDeleteMultipleServices(svcCount, is.ApplyTemplate, true)
+}
+func (is *installSuite) deleteMultipleServices(svcCount int) {
+	is.applyOrDeleteMultipleServices(svcCount, is.DeleteTemplate, false)
+}
+func (is *installSuite) applyOrDeleteMultipleServices(svcCount int, applyOrDelete func(context.Context, string, any), wait bool) {
+	ctx := is.Context()
+	wg := sync.WaitGroup{}
+	wg.Add(svcCount)
+	for i := range svcCount {
+		svc := fmt.Sprintf("quote-%d", i)
+		go func() {
+			defer wg.Done()
+			k8s := filepath.Join("testdata", "k8s")
+			applyOrDelete(ctx, filepath.Join(k8s, "generic.goyaml"), &itest.Generic{
+				Name:     svc,
+				Registry: "datawire",
+				Image:    "quote:0.5.0",
+				Annotations: map[string]string{
+					agentconfig.InjectAnnotation: "enabled",
+				},
+			})
+			if wait {
+				is.NoError(is.RolloutStatusWait(ctx, "deploy/"+svc))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
+	const svcCount = 25
+	ctx := is.Context()
+
+	// First create the pods with inject annotation
+	is.applyMultipleServices(svcCount)
+	defer is.deleteMultipleServices(svcCount)
+
+	// Then install the traffic-manager
+	is.TelepresenceHelmInstallOK(ctx, false)
+
+	// And check that all pods receive a traffic-agent
+	is.Eventually(func() bool {
+		ras := itest.RunningPodsWithAgents(ctx, "quote-", is.AppNamespace())
+		return len(ras) == svcCount
+	}, 60*time.Second, 5*time.Second)
+
+	// Uninstall the traffic-manager and check that all pods traffic-agent is removed
+	is.UninstallTrafficManager(ctx, is.ManagerNamespace())
+	is.Eventually(func() bool {
+		ras := itest.RunningPodsWithAgents(ctx, "quote-", is.AppNamespace())
+		return len(ras) == 0
+	}, 120*time.Second, 5*time.Second)
+}
+
+func (is *installSuite) Test_MultiOnDemandInjectOnApply() {
+	const svcCount = 25
+	ctx := is.Context()
+
+	// First install the traffic-manager
+	is.TelepresenceHelmInstallOK(ctx, false)
+	defer is.UninstallTrafficManager(ctx, is.ManagerNamespace())
+
+	// Then create the pods with inject annotation
+	is.applyMultipleServices(svcCount)
+	defer is.deleteMultipleServices(svcCount)
+
+	// And check that all pods receive a traffic-agent
+	is.Require().Eventually(func() bool {
+		ras := itest.RunningPodsWithAgents(ctx, "quote-", is.AppNamespace())
+		return len(ras) == svcCount
+	}, 60*time.Second, 5*time.Second)
 }

--- a/integration_test/itest/namespace.go
+++ b/integration_test/itest/namespace.go
@@ -189,8 +189,8 @@ func (s *nsPair) ApplyTemplate(ctx context.Context, path string, values any) {
 func (s *nsPair) DeleteTemplate(ctx context.Context, path string, values any) {
 	yml, err := ReadTemplate(ctx, path, values)
 	require.NoError(getT(ctx), err)
-	if err = s.Kubectl(dos.WithStdin(ctx, bytes.NewReader(yml)), "apply", "-f", "-"); err != nil {
-		dlog.Errorf(ctx, "unable to apply %q", string(yml))
+	if err = s.Kubectl(dos.WithStdin(ctx, bytes.NewReader(yml)), "delete", "-f", "-"); err != nil {
+		dlog.Errorf(ctx, "unable to delete %q", string(yml))
 		getT(ctx).Fatal(err)
 	}
 }

--- a/integration_test/itest/template.go
+++ b/integration_test/itest/template.go
@@ -9,8 +9,18 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
+
+type Generic struct {
+	Name           string
+	Annotations    map[string]string
+	Environment    []core.EnvVar
+	Image          string
+	Registry       string
+	ServiceAccount string
+}
 
 func OpenTemplate(ctx context.Context, name string, data any) (io.Reader, error) {
 	b, err := ReadTemplate(ctx, name, data)

--- a/integration_test/testdata/k8s/generic.goyaml
+++ b/integration_test/testdata/k8s/generic.goyaml
@@ -1,0 +1,46 @@
+{{- /*gotype: github.com/telepresenceio/telepresence/v2/integration_test/itest.Generic*/ -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Name }}
+  labels:
+    app: {{ .Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Name }}
+{{- with .Annotations }}
+      annotations:
+  {{- toYaml . | nindent 8 }}
+{{- end}}
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Registry }}/{{ .Image }}"
+          ports:
+            - name: http
+              containerPort: 8080
+{{- with .Environment }}
+          env:
+  {{- toYaml . | nindent 12 }}
+{{- end}}
+


### PR DESCRIPTION
Updates to the telepresence-agents configmap may well trigger a roll-out of the corresponding workload. That roll-out will trigger new calls to the injector. If the API is fast enough, this will result in a loop that is similar to a recursion. The result is a large number of created pods that eventually must be deleted.

This PR removes the update of the configmap from the injector so that this loop is prevented.

This PR also add the needed watchers and event handlers that take care of the special `telepresence.getambassador.io/inject-traffic-agent` annotation, and ensure that the traffic-agent is injected or removed in accordance with its setting.

Integration tests that uses 25 service/deployment combos with the annotation enabled was added to ensure correct behavior for the traffic-manager for the cases when the traffic-manager is installed before the deployments or installed/updated when they were already present.