### PR TITLE
Add --create-namespace flag (default true) to telepresence helm install

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -34,6 +34,12 @@ items:
     date: (TBD)
     notes:
       - type: feature
+        title: Add --create-namespace flag to the telepresence helm install command.
+        body: >-
+          A <code>--create-namespace</code> (default <code>true</code>) flag was added to the <code>telepresence helm
+          install</code> command. No attempt will be made to create a namespace for the traffic-manager if it is explicitly
+          set to <code>false</code>. The command will then fail if the namespace is missing.
+      - type: feature
         title: Introduce DNS fallback on Windows.
         body: >-
           A <code>network.defaultDNSWithFallback</code> config option has been introduced on Windows. It will cause the

--- a/pkg/client/cli/cmd/helm.go
+++ b/pkg/client/cli/cmd/helm.go
@@ -54,6 +54,7 @@ func helmInstall() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&ha.NoHooks, "no-hooks", "", false, "prevent hooks from running during install")
 	flags.BoolVarP(&upgrade, "upgrade", "u", false, "replace the traffic manager if it already exists")
+	flags.BoolVar(&ha.CreateNamespace, "create-namespace", true, "create a namespace for the traffic-manager if not present")
 	ha.addValueSettingFlags(flags)
 	ha.addCRDsFlags(flags)
 	uf := flags.Lookup("upgrade")
@@ -83,6 +84,7 @@ func helmUpgrade() *cobra.Command {
 	flags.BoolVarP(&ha.ResetValues, "reset-values", "", false, "when upgrading, reset the values to the ones built into the chart")
 	flags.BoolVarP(&ha.ReuseValues, "reuse-values", "", false,
 		"when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f")
+	flags.BoolVarP(&ha.CreateNamespace, "create-namespace", "", true, "create the release namespace if not present")
 	ha.rq = daemon.InitRequest(cmd)
 	return cmd
 }

--- a/pkg/client/cli/helm/install.go
+++ b/pkg/client/cli/helm/install.go
@@ -46,12 +46,13 @@ const (
 
 type Request struct {
 	values.Options
-	Type        RequestType
-	ValuesJson  []byte
-	ReuseValues bool
-	ResetValues bool
-	Crds        bool
-	NoHooks     bool
+	Type            RequestType
+	ValuesJson      []byte
+	ReuseValues     bool
+	ResetValues     bool
+	CreateNamespace bool
+	Crds            bool
+	NoHooks         bool
 }
 
 func (hr *Request) Run(ctx context.Context, cr *connector.ConnectRequest) error {
@@ -219,7 +220,7 @@ func installNew(
 	install.ReleaseName = releaseName
 	install.Namespace = namespace
 	install.Atomic = true
-	install.CreateNamespace = true
+	install.CreateNamespace = req.CreateNamespace
 	install.DisableHooks = req.NoHooks
 	return timedRun(ctx, func(timeout time.Duration) error {
 		install.Timeout = timeout


### PR DESCRIPTION
A `--create-namespace` (default `true`) flag was added to the `telepresence helm install` command. No attempt will be made to create a namespace for the traffic-manager if it is explicitly set to `false`. The command will then fail if the namespace is missing.