### PR TITLE
Race in traffic-agent injector when using inject annotation

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -70,6 +70,12 @@ items:
           able to define some particular schedulers from Kubernetes to apply some different strategies to allocate telepresence resources,
           including the Traffic Manager and hooks pods.
       - type: bugfix
+        title: Race in traffic-agent injector when using inject annotation
+        body: >-
+          Applying multiple deployments that used the <code>telepresence.getambassador.io/inject-traffic-agent: enabled</code> would cause
+          a race condition, resulting in a large number of created pods that eventually had to be deleted, or sometimes in
+          pods that didn't contain a traffic agent.
+      - type: bugfix
         title: Fix configuring custom agent security context
         body: ->
           The traffic-manager helm chart will now correctly use a custom agent security context if one is provided.

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -144,18 +144,14 @@ func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Wor
 	if !ok {
 		return
 	}
-	if oldWl != nil {
-		diff := cmp.Diff(oldWl.GetPodTemplate(), tpl,
-			cmpopts.IgnoreFields(meta.ObjectMeta{}, "Namespace", "UID", "ResourceVersion", "CreationTimestamp", "DeletionTimestamp"),
-			cmpopts.IgnoreMapEntries(func(k, _ string) bool {
-				return k == AnnRestartedAt
-			}),
-		)
-		if diff == "" {
-			return
-		}
-		dlog.Debugf(ctx, "Diff: %s", diff)
+	if oldWl != nil && cmp.Equal(oldWl.GetPodTemplate(), tpl,
+		cmpopts.IgnoreFields(meta.ObjectMeta{}, "Namespace", "UID", "ResourceVersion", "CreationTimestamp", "DeletionTimestamp"),
+		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
+			return k == AnnRestartedAt
+		})) {
+		return
 	}
+
 	switch ia {
 	case "enabled":
 		img := managerutil.GetAgentImage(ctx)

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -470,8 +470,8 @@ func (s *session) Remain(ctx context.Context) error {
 	defer cancel()
 	_, err := self.ManagerClient().Remain(ctx, self.NewRemainRequest())
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			// Session has expired. We need to cancel the owner session and reconnect
+		if status.Code(err) == codes.NotFound || status.Code(err) == codes.Unavailable {
+			// The session has expired. We need to cancel the owner session and reconnect.
 			return ErrSessionExpired
 		}
 		dlog.Errorf(ctx, "error calling Remain: %v", client.CheckTimeout(ctx, err))

--- a/pkg/dnet/kpfconn.go
+++ b/pkg/dnet/kpfconn.go
@@ -88,14 +88,14 @@ func (pf *k8sPortForwardDialer) Dial(ctx context.Context, addr string) (conn net
 			return conn, nil
 		}
 	}
-	dlog.Errorf(pf.logCtx, "Error with k8sPortForwardDialer dial: %s", err)
+	dlog.Errorf(pf.logCtx, "Error with k8sPortForwardDialer dial %s: %s", addr, err)
 	return nil, err
 }
 
 func (pf *k8sPortForwardDialer) DialPod(ctx context.Context, name, namespace string, podPortNumber uint16) (net.Conn, error) {
 	conn, err := pf.dial(ctx, &podAddress{name: name, namespace: namespace, port: podPortNumber})
 	if err != nil {
-		dlog.Errorf(pf.logCtx, "Error with k8sPortForwardDialer dial: %s", err)
+		dlog.Errorf(pf.logCtx, "Error with k8sPortForwardDialer dial %s.%s:%d: %s", name, namespace, podPortNumber, err)
 	}
 	return conn, err
 }


### PR DESCRIPTION
Applying multiple deployments that used the `telepresence.getambassador.io/inject-traffic-agent: enabled` would cause a race condition, resulting in a large number of created pods that
eventually had to be deleted, or sometimes in pods that didn't contain a traffic agent.