### PR TITLE
Use ghcr.io instead of docker.io for test images.

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -453,6 +453,11 @@ push-image: push-tel2-image
 
 .PHONY: push-test-images
 push-test-images:
-	docker buildx build --platform=linux/amd64,linux/arm64 --push --tag docker.io/telepredocker buildx build --platform=linux/amd64,linux/arm64 --push --tag docker.io/telepresenceio/echo-server:latest --tag docker.io/telepresenceio/echo-server:0.1.0 .
-	docker buildx build --platform=linux/amd64,linux/arm64 --push --tag docker.io/telepredocker buildx build --platform=linux/amd64,linux/arm64 --push --tag docker.io/telepresenceio/udp-echo:latest --tag docker.io/telepresenceio/udp-echo:0.1.0 .
-
+	(cd integration_test/testdata/echo-server && \
+ 		docker buildx build --platform=linux/amd64,linux/arm64 --push \
+ 		 --tag ghcr.io/telepresenceio/echo-server:latest \
+ 		 --tag ghcr.io/telepresenceio/echo-server:0.1.0 .)
+	(cd integration_test/testdata/udp-echo && \
+		docker buildx build --platform=linux/amd64,linux/arm64 --push \
+		 --tag ghcr.io/telepresenceio/udp-echo:latest \
+		 --tag ghcr.io/telepresenceio/udp-echo:0.1.0 .)

--- a/integration_test/testdata/k8s/echo-double-one-unnamed.yaml
+++ b/integration_test/testdata/k8s/echo-double-one-unnamed.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: echo-server
-          image: docker.io/telepresenceio/echo-server:latest
+          image: ghcr.io/telepresenceio/echo-server:latest
           ports:
             - containerPort: 8080
             - containerPort: 8081

--- a/integration_test/testdata/k8s/echo-extra-udp.yaml
+++ b/integration_test/testdata/k8s/echo-extra-udp.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: echo-udp-server
-          image: docker.io/telepresenceio/udp-echo:latest
+          image: ghcr.io/telepresenceio/udp-echo:latest
           env:
             - name: PORT
               value: "8080"
@@ -39,7 +39,7 @@ spec:
               cpu: 50m
               memory: 8Mi
         - name: echo-server
-          image: docker.io/telepresenceio/echo-server:latest
+          image: ghcr.io/telepresenceio/echo-server:latest
           ports:
             - name: http
               containerPort: 8080

--- a/integration_test/testdata/k8s/echo-no-containerport.yaml
+++ b/integration_test/testdata/k8s/echo-no-containerport.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: echo-server
-          image: docker.io/telepresenceio/echo-server:latest
+          image: ghcr.io/telepresenceio/echo-server:latest
           env:
             - name: PORTS
               value: "8080,8081"

--- a/integration_test/testdata/k8s/echo-no-vols.yaml
+++ b/integration_test/testdata/k8s/echo-no-vols.yaml
@@ -31,7 +31,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: echo-server
-          image: docker.io/telepresenceio/echo-server:latest
+          image: ghcr.io/telepresenceio/echo-server:latest
           ports:
             - name: http
               containerPort: 8080

--- a/integration_test/testdata/k8s/echo-udp-tcp-unnamed.yaml
+++ b/integration_test/testdata/k8s/echo-udp-tcp-unnamed.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: echo-udp-server
-          image: docker.io/telepresenceio/udp-echo:latest
+          image: ghcr.io/telepresenceio/udp-echo:latest
           ports:
             - containerPort: 8080
               protocol: UDP
@@ -29,7 +29,7 @@ spec:
               cpu: 50m
               memory: 8Mi
         - name: echo-server
-          image: docker.io/telepresenceio/echo-server:latest
+          image: ghcr.io/telepresenceio/echo-server:latest
           ports:
             - containerPort: 8080
           env:

--- a/integration_test/udp_test.go
+++ b/integration_test/udp_test.go
@@ -12,7 +12,7 @@ func (s *connectedSuite) TestUDPEcho() {
 	ctx := s.Context()
 	require := s.Require()
 	svc := "udp-echo"
-	tag := "docker.io/telepresenceio/udp-echo:latest"
+	tag := "ghcr.io/telepresenceio/udp-echo:latest"
 
 	require.NoError(s.Kubectl(ctx, "create", "deploy", svc, "--image", tag))
 	require.NoError(s.Kubectl(ctx, "expose", "deploy", svc, "--port", "80", "--protocol", "UDP", "--target-port", "8080"))


### PR DESCRIPTION
The `docker.io/telepresenceio` is a personal account. This commit will replace all reference to this namespace with `ghcr.io/telepresenceio`, which is writable by all telepresence maintainers.
