### PR TITLE
Use ghcr.io for images and a Minikube or Colima cluster.

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -6,8 +6,6 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: stable
-    - uses: azure/setup-kubectl@v3
-      id: kubectl
     - if: runner.os == 'Linux'
       name: install Linux dependencies
       shell: bash

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -50,7 +50,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-arm64
           - macos-latest # this runner uses arm64
-          - windows-2019
+          - windows-latest
         clusters:
           - distribution: Kubeception
             version: "1.29"

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -5,18 +5,16 @@ on:
       - labeled
 
 env:
-  KUBECONFIG: ${{ github.workspace }}/kubeconfig.yaml
-  DTEST_KUBECONFIG: ${{ github.workspace }}/kubeconfig.yaml
-  TELEPRESENCE_REGISTRY: localhost:5000
-  DTEST_REGISTRY: localhost:5000
-  SCOUT_DISABLE: "1"
+  TELEPRESENCE_REGISTRY: ghcr.io/telepresenceio
+  DTEST_REGISTRY: ghcr.io/telepresenceio
 
 jobs:
-  build_image:
-    if: ${{ github.event.label.name == 'ok to test' }}
+  build_images:
+    if: github.event.label.name == 'ok to test'
     runs-on: ubuntu-latest
     outputs:
-      telepresenceVersion: ${{ steps.build.outputs.version }}
+      telepresenceVersion: ${{ steps.version.outputs.version }}
+      telepresenceSemver: ${{ steps.version.outputs.semver }}
     steps:
       - name: Remove label
         uses: buildsville/add-remove-label@v2.0.1
@@ -26,95 +24,64 @@ jobs:
           type: remove
       - uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 0
-          show-progress: false
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: Build dev image
-        id: build
+          ref: "${{ github.event.pull_request.head.sha }}"
+      - name: Get Telepresence Version
+        id: version
         run: |
-          make save-tel2-image
-          echo "version=$(cat build-output/version.txt)" >> $GITHUB_OUTPUT
-      - name: Upload image
-        uses: actions/upload-artifact@v3
+          v=$(go run build-aux/genversion/main.go ${{github.run_id}})
+          echo "TELEPRESENCE_VERSION=$v" >> "$GITHUB_ENV"
+          echo "version=$v" >> $GITHUB_OUTPUT
+          echo "semver=${v#v}" >> $GITHUB_OUTPUT
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          name: image
-          path: build-output/tel2-image.tar
+          platforms: linux/amd64,linux/arm64
+      - name: Build cluster images
+        run: |
+          make push-images-x
   run_tests:
+    if: github.event.label.name == 'ok to test'
     strategy:
       fail-fast: false
       matrix:
         runners:
           - ubuntu-latest
-          - ubuntu-arm64
-          - macos-latest # this runner uses arm64
-          - windows-latest
-        clusters:
-          - distribution: Kubeception
-            version: "1.29"
+          - macos-13 # use macos-latest once that runner (which is arm64) supports virtualization.
+          # Re-enable when virtualization is available so that WSL2 can be used and docker has a linux container daemon.
+          # - windows-latest
     runs-on: ${{ matrix.runners }}
-    needs: build_image
+    needs: build_images
+    env:
+      TELEPRESENCE_VERSION: ${{ needs.build_images.outputs.telepresenceVersion }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: "${{ github.event.pull_request.head.sha }}"
       - name: install dependencies
         uses: ./.github/actions/install-dependencies
-      - name: install dependencies for arm64
-        if: runner.os == 'Linux' && runner.arch == 'arm64'
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get update -y
-          sudo apt-get install -y socat gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu make jq uidmap
-      - name: install docker for arm64
-        if: runner.os == 'Linux' && runner.arch == 'arm64'
-        run: |
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sudo sh get-docker.sh
-          dockerd-rootless-setuptool.sh install
-      - name: Build client
-        env:
-          TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
-        run: make build
-      - name: Build client image
+      - name: Start minikube
         if: runner.os == 'Linux'
-        env:
-          TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
-        run: make client-image
-      - name: Create cluster
-        uses: datawire/infra-actions/provision-cluster@v0.2.7
-        with:
-          kubeconfig: ${{ env.KUBECONFIG }}
-          kubeceptionToken: ${{ secrets.DEV_TELEPRESENCE_KUBECEPTION_TOKEN }}
-          kubeceptionProfile: small
-          lifespan: 7200
-          distribution: ${{ matrix.clusters.distribution }}
-          version: ${{ matrix.clusters.version }}
-          gkeCredentials: '{"project_id": "foo"}' # See https://github.com/datawire/infra-actions/issues/66
-      - name: Download prebuilt docker image
-        uses: actions/download-artifact@v3
-        with:
-          name: image
+        uses: medyagh/setup-minikube@latest
+      - name: Start colima
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          brew install kubectl docker colima
+          # the macos-13 runner has 4 cpus, 14 GiB memory, and 14 GiB disk
+          colima start --kubernetes --cpu 2 --memory 6 --disk 10
       - name: Install Argo Rollouts
         shell: bash
         run: |
           kubectl create namespace argo-rollouts
           kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
-      - name: Upload docker image to cluster
-        shell: bash
-        run: |
-          kubectl apply -f build-aux/image-importer.yaml
-          kubectl rollout status -w deployment/image-importer
-          POD_NAME=$(kubectl get pod -ojsonpath='{.items[0].metadata.name}' -l app=image-importer)
-          kubectl cp tel2-image.tar "$POD_NAME:/tmp/image.tar"
-          kubectl exec $POD_NAME -- //hostbin/ctr images import //tmp/image.tar
+      - name: Build client
+        run: make build
       - name: Run integration tests
         env:
-          DEV_TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
-          TELEPRESENCE_VERSION: ${{needs.build_image.outputs.telepresenceVersion}}
+          SCOUT_DISABLE: "1"
         uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
@@ -125,8 +92,47 @@ jobs:
             if [[ ${RUNNER_OS} == "Windows" ]]; then
               export PATH="$PATH:/C/Program Files/SSHFS-Win/bin:$HOME/kubectl-plugins"
             fi
-            make check-integration
+            DEV_TELEPRESENCE_VERSION=${TELEPRESENCE_VERSION} DTEST_KUBECONFIG="${HOME}/.kube/config" make check-integration
       - uses: ./.github/actions/upload-logs
         env:
           LOG_SUFFIX: "${{ runner.os }}-${{ runner.arch }}-${{ matrix.clusters.distribution }}-${{ matrix.clusters.version }}"
         if: always()
+  purge_images:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - build_images
+      - run_tests
+    steps:
+      - name: Delete tel2 image
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        continue-on-error: true
+        with:
+          owner: telepresenceio
+          name: tel2
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.build_images.outputs.telepresenceSemver }}
+          untagged-keep-latest: 6
+      - name: Delete telepresence image
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        continue-on-error: true
+        with:
+          owner: telepresenceio
+          name: telepresence
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.build_images.outputs.telepresenceSemver }}
+          untagged-keep-latest: 6
+      - name: Delete tel2 untagged images
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: telepresenceio
+          name: tel2
+          token: ${{ secrets.GITHUB_TOKEN }}
+          untagged-keep-latest: 6
+      - name: Delete telepresence untagged images
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: telepresenceio
+          name: telepresence
+          token: ${{ secrets.GITHUB_TOKEN }}
+          untagged-keep-latest: 6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         runners:
           - ubuntu-latest
-          - ubuntu-arm64
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.runners }}
@@ -48,20 +47,31 @@ jobs:
           name: binaries
           path: build-output/release
           retention-days: 1
-      - if: runner.os == 'Linux' && runner.arch == 'X64'
-        uses: docker/setup-buildx-action@v3
+      - name: generate binaries linux-arm64 # ubuntu-latest is amd64, so we need an extra arm64 build
+        if: runner.os == 'Linux'
+        env:
+          GOARCH: arm64
+        run: make clean release-binary
+      - name: Upload binaries linux-arm64
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
         with:
-          platforms: linux/amd64,linux/arm64
-      - if: runner.os == 'Linux' && runner.arch == 'X64'
-        name: Upload Docker image
-        run: |
-          docker login -u="${{ secrets.DOCKERHUB_USERNAME }}" -p="${{ secrets.DOCKERHUB_PASSWORD }}"
-          make push-images-x
+          name: binaries
+          path: build-output/release
+          retention-days: 1
 
   publish-release:
     runs-on: ubuntu-latest
     needs: build-release
     steps:
+      - name: Setup docker builx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+      - name: Upload Docker image
+        run: |
+          docker login -u="${{ secrets.DOCKERHUB_USERNAME }}" -p="${{ secrets.DOCKERHUB_PASSWORD }}"
+          make push-images-x
       - name: Download artifacts
         uses: actions/download-artifact@v3
       - name: Determine if version is RC, TEST, or GA

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-arm64
           - macos-latest
-          - windows-2019
+          - windows-latest
     runs-on: ${{ matrix.runners }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         runners:
           - ubuntu-latest
-          - ubuntu-arm64
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.runners }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-arm64
           - macos-latest
-          - windows-2019
+          - windows-latest
     runs-on: ${{ matrix.runners }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -40,10 +40,18 @@ items:
           The behavior is controlled by `workloads.argoRollouts.enabled` Helm chart value.
           It is recommended to set the following annotation <code>telepresence.getambassador.io/inject-traffic-agent: enabled</code>
           to avoid creation of unwanted revisions.
+      - type: bugfix
+        title: Detect minikube network when connecting with --docker
+        body: >-
+          A <code>telepresence connect --docker</code> failed when attempting to connect to a minikube that
+          uses a docker driver because the containerized daemon did not have access to the <code>minikube</code>
+          docker network. Telepresence will now detect an attempt to connect to that network and attach it to
+          the daemon container as needed.
   - version: 2.19.1
-    date: (TBD)
+    date: "2024-07-12"
     notes:
-      - title: Add brew support for the OSS version of Telepresence.
+      - type: feature
+        title: Add brew support for the OSS version of Telepresence.
         body: >-
           The Open-Source Software version of Telepresence can now be installed using the brew formula
           via <code>brew install datawire/blackbird/telepresence-oss</code>.

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -18,8 +18,6 @@
 # clever should probably be factored into a separate file.
 
 # All build artifacts that are files end up in $(BUILDDIR).
-$(VERBOSE).SILENT:
-
 BUILDDIR=build-output
 
 BINDIR=$(BUILDDIR)/bin

--- a/build-aux/prelude.mk
+++ b/build-aux/prelude.mk
@@ -35,6 +35,9 @@ MAKEFLAGS += --no-builtin-rules
 # target, mark that target as .PRECIOUS.
 .DELETE_ON_ERROR:
 
+# Be silent
+$(VERBOSE).SILENT:
+
 # Add a rule to generate `make help` output from comments in the
 # Makefiles.
 .PHONY: help

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -135,7 +136,12 @@ func (is *installSuite) applyOrDeleteMultipleServices(svcCount int, applyOrDelet
 }
 
 func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
-	const svcCount = 25
+	svcCount := 25
+	if runtime.GOOS != "linux" {
+		// The GitHub runner is probably using Colima for Kubernetes and running with limited
+		// resources.
+		svcCount = 10
+	}
 	ctx := is.Context()
 
 	// First create the pods with inject annotation
@@ -160,7 +166,12 @@ func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
 }
 
 func (is *installSuite) Test_MultiOnDemandInjectOnApply() {
-	const svcCount = 25
+	svcCount := 25
+	if runtime.GOOS != "linux" {
+		// The GitHub runner is probably using Colima for Kubernetes and running with limited
+		// resources.
+		svcCount = 10
+	}
 	ctx := is.Context()
 
 	// First install the traffic-manager

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -461,11 +461,39 @@ func localAddr(ctx context.Context, cnID, nwID string, isIPv6 bool) (addr netip.
 	return addr, err
 }
 
+// useMinikubeNetwork returns true if the given hostAddrPort points to a network named "minikube".
+func useMinikubeNetwork(ctx context.Context, addr netip.Addr) bool {
+	cli, err := GetClient(ctx)
+	if err != nil {
+		return false
+	}
+	nw, err := cli.NetworkInspect(ctx, "minikube", network.InspectOptions{})
+	if err != nil {
+		return false
+	}
+	for _, c := range nw.Containers {
+		if addr.Is4() {
+			if a, err := netip.ParsePrefix(c.IPv4Address); err == nil && a.Addr() == addr {
+				return true
+			}
+		}
+		if addr.Is6() {
+			if a, err := netip.ParsePrefix(c.IPv6Address); err == nil && a.Addr() == addr {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // detectMinikube returns the container IP:port for the given hostAddrPort for a container where the
 // "name.minikube.sigs.k8s.io" label is equal to the given cluster name.
 // Returns the internal IP:port for the given hostAddrPort and the name of a network that makes the
 // IP available.
 func detectMinikube(ctx context.Context, cns []types.ContainerJSON, hostAddrPort netip.AddrPort, clusterName string) (netip.AddrPort, string) {
+	if useMinikubeNetwork(ctx, hostAddrPort.Addr()) {
+		return hostAddrPort, "minikube"
+	}
 	for _, cn := range cns {
 		if cfg, ns := cn.Config, cn.NetworkSettings; cfg != nil && ns != nil && cfg.Labels["name.minikube.sigs.k8s.io"] == clusterName {
 			if port, isIPv6 := containerPort(hostAddrPort, ns); port != 0 {


### PR DESCRIPTION
This PR uses a Minikube or Colima cluster instead of kubeception. This
removes the need for a special proprietary kubeception token when
running the integration tests, and also opens up for running tests that
require Docker on all platforms.

The PR also changes how images are built and used. Instead of pushing
them a registry in the cluster, the images are pushed to ghcr.io, and
then removed when the workflow ends.

Integration tests on windows are disabled because there's no way to run
a local cluster without nested virtualization. In essence:
 - WSL1 doesn't work because it doesn't provide systemd, and systemd
   requires a real kernel.
 - WSL2 is unable to run because virtualization is unavailable..](https://github.com/telepresenceio/telepresence/pull/3659/commits/942de91ee0a6ac15bed6c790b50d7483a8fab8fa) 

This PR uses a Minikube or Colima cluster instead of kubeception. This
removes the need for a special proprietary kubeception token when
running the integration tests, and also opens up for running tests that
require Docker on all platforms.

The PR also changes how images are built and used. Instead of pushing
them a registry in the cluster, the images are pushed to ghcr.io, and
then removed when the workflow ends.

Integration tests on windows are disabled because there's no way to run
a local cluster without nested virtualization. In essence:
 - WSL1 doesn't work because it doesn't provide systemd, and systemd
   requires a real kernel.
 - WSL2 is unable to run because virtualization is unavailable.