### PR TITLE
Limit intercepts based on container port number and protocol, not pod.

### DIFF
--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -139,7 +139,7 @@ func Main(ctx context.Context, _ ...string) error {
 		EnableSignalHandling: true,
 	})
 
-	s := NewSimpleState(config)
+	s := NewState(config)
 	info, err := StartServices(ctx, g, config, s)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func Main(ctx context.Context, _ ...string) error {
 	return g.Wait()
 }
 
-func sidecar(ctx context.Context, s SimpleState, info *rpc.AgentInfo) error {
+func sidecar(ctx context.Context, s State, info *rpc.AgentInfo) error {
 	// Manage the forwarders
 	ac := s.AgentConfig()
 	for _, cn := range ac.Containers {

--- a/cmd/traffic/cmd/agent/state_test.go
+++ b/cmd/traffic/cmd/agent/state_test.go
@@ -40,7 +40,7 @@ func makeFS(t *testing.T, ctx context.Context) (forwarder.Interceptor, agent.Sta
 
 	c, err := agent.LoadConfig(ctx)
 	require.NoError(t, err)
-	s := agent.NewSimpleState(c)
+	s := agent.NewState(c)
 	cn := c.AgentConfig().Containers[0]
 	cnMountPoint := filepath.Join(agentconfig.ExportsMountPoint, filepath.Base(cn.MountPoint))
 	s.AddInterceptState(s.NewInterceptState(f, agent.NewInterceptTarget(cn.Intercepts), cnMountPoint, map[string]string{}))

--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -795,6 +795,8 @@ func TestTrafficAgentConfigGenerator(t *testing.T) {
 
 	for _, test := range tests {
 		test := test // pin it
+		pod := test.request
+		cw.Blacklist(pod.Name, pod.Namespace) // prevent rollout
 		agentmap.GeneratorConfigFunc = env.GeneratorConfig
 		t.Run(test.name, func(t *testing.T) {
 			runFunc(t, ctx, &test)
@@ -1840,6 +1842,7 @@ func TestTrafficAgentInjector(t *testing.T) {
 			cw := NewWatcher("")
 			cw.Start(ctx)
 			require.NoError(t, cw.StartWatchers(ctx))
+			cw.Blacklist(test.pod.Name, test.pod.Namespace)
 
 			var actualPatch PatchOps
 			var actualErr error

--- a/integration_test/testdata/k8s/echo-two.yaml
+++ b/integration_test/testdata/k8s/echo-two.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-one
+spec:
+  type: ClusterIP
+  selector:
+    app: echo-both
+  ports:
+    - name: one
+      port: 80
+      targetPort: echo-one
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-two
+spec:
+  type: ClusterIP
+  selector:
+    app: echo-both
+  ports:
+    - name: two
+      port: 80
+      targetPort:  echo-two
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-both
+  labels:
+    app: echo-both
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-both
+  template:
+    metadata:
+      labels:
+        app: echo-both
+    spec:
+      containers:
+        - name: echo-one
+          image: jmalloc/echo-server
+          ports:
+            - name: echo-one
+              containerPort: 8080
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+        - name: echo-two
+          image: jmalloc/echo-server
+          ports:
+            - name: echo-two
+              containerPort: 8081
+          env:
+            - name: PORT
+              value: "8081"
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi


### PR DESCRIPTION
This commit gets rid of an unnecessary limitation in the traffic-agent
that prohibits more than one simultaneous intercept per pod. Instead,
an intercept is now limited to the unique combination of `<protocol>`
and `<port>`, where `<protocol>` is UDP or TCP and `<port>` is a
container port.