### PR TITLE
Fix backward incompatibility regression.

### DIFF
--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -441,7 +441,15 @@ func connectMgr(
 
 	knownWorkloadKinds, err := mClient.GetKnownWorkloadKinds(ctx, si)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get known workload kinds: %w", err)
+		if status.Code(err) != codes.Unimplemented {
+			return nil, fmt.Errorf("failed to get known workload kinds: %w", err)
+		}
+		// Talking to an older traffic-manager, use legacy default types
+		knownWorkloadKinds = &manager.KnownWorkloadKinds{Kinds: []manager.WorkloadInfo_Kind{
+			manager.WorkloadInfo_DEPLOYMENT,
+			manager.WorkloadInfo_REPLICASET,
+			manager.WorkloadInfo_STATEFULSET,
+		}}
 	}
 
 	sess := &session{


### PR DESCRIPTION
The introduction of argo-rollouts introduced a call to the new traffic-manager function `GetKnownWorkloadKinds` from the user client, and a client connecting to older traffic-managers that don't have this method would therefore fail with an error.

This commit checks if the returned error has code `Unimplemented`, and if so, assumes the default set of workload kinds.
