### PR TITLE
Use nftables instead of iptables-legacy

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -53,6 +53,12 @@ items:
           All OSS telepresence images are now published at the public registry ghcr.io/telepresenceio
           and all references from the client and traffic-manager has been updated to use this registry
           instead of the one at docker.io/datawire.
+      - title: Use nftables instead of iptables-legacy
+        type: change
+        body: >-
+          Some time ago, we introduced iptables-legacy because users had problems using Telepresence with Fly.io where nftables
+          wasn't supported by the kernel. Fly.io has since fixed this, so Telepresence will now use nftables again. This in turn,
+          ensures that modern systems that lack support iptables-legacy will work.
       - type: bugfix
         title: Root daemon wouldn't start when sudo timeout was zero.
         body: >-

--- a/build-aux/docker/images/Dockerfile.client
+++ b/build-aux/docker/images/Dockerfile.client
@@ -41,9 +41,7 @@ RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/telepresence
 # The telepresence target is the one that gets published. It aims to be a small as possible.
 FROM alpine as telepresence
 
-RUN apk add --no-cache ca-certificates iptables iptables-legacy bash
-RUN rm /sbin/iptables && ln -s /sbin/iptables-legacy /sbin/iptables
-RUN rm /sbin/ip6tables && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+RUN apk add --no-cache ca-certificates iptables bash
 
 # the telepresence binary
 COPY --from=telepresence-build /usr/local/bin/telepresence /usr/local/bin

--- a/build-aux/docker/images/Dockerfile.traffic
+++ b/build-aux/docker/images/Dockerfile.traffic
@@ -40,11 +40,7 @@ RUN setcap 'cap_net_bind_service+ep' /usr/local/bin/traffic
 # The tel2 target is the one that gets published. It aims to be a small as possible.
 FROM alpine as tel2
 
-# some cluster providers don't support nftables, so we gotta use iptables-legacy
-# This ticket contains some good info: https://github.com/tailscale/tailscale/issues/10540
-RUN apk add --no-cache ca-certificates iptables iptables-legacy
-RUN rm /sbin/iptables && ln -s /sbin/iptables-legacy /sbin/iptables
-RUN rm /sbin/ip6tables && ln -s /sbin/ip6tables-legacy /sbin/ip6tables
+RUN apk add --no-cache ca-certificates iptables
 
 # the traffic binary
 COPY --from=tel2-build /usr/local/bin/traffic /usr/local/bin


### PR DESCRIPTION
Some time ago, we introduced iptables-legacy because users had problems using Telepresence with Fly.io where nftables wasn't supported by the kernel. Fly.io has since fixed this, so Telepresence will now use nftables again. This in turn, ensures that modern systems that lack support for iptables-legacy will work.

Closes #3542