### PR TITLE
Change traffic-agent's target port to podIP instead of localhost.

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -441,11 +441,17 @@ save-image: save-tel2-image
 push-image: push-tel2-image
 
 .PHONY: push-test-images
-push-test-images:
+push-test-images: push-echo-server push-udp-echo
+
+.PHONY: push-echo-server
+push-echo-server:
 	(cd integration_test/testdata/echo-server && \
  		docker buildx build --platform=linux/amd64,linux/arm64 --push \
  		 --tag ghcr.io/telepresenceio/echo-server:latest \
- 		 --tag ghcr.io/telepresenceio/echo-server:0.1.0 .)
+ 		 --tag ghcr.io/telepresenceio/echo-server:0.2.0 .)
+
+.PHONY: push-udp-echo
+push-udp-echo:
 	(cd integration_test/testdata/udp-echo && \
 		docker buildx build --platform=linux/amd64,linux/arm64 --push \
 		 --tag ghcr.io/telepresenceio/udp-echo:latest \

--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -1398,6 +1398,7 @@ func TestTrafficAgentInjector(t *testing.T) {
   - args:
     - agent-init
     env:
+    - name: LOG_LEVEL
     - name: POD_IP
       valueFrom:
         fieldRef:
@@ -1505,6 +1506,7 @@ func TestTrafficAgentInjector(t *testing.T) {
     args:
     - agent-init
     env:
+    - name: LOG_LEVEL
     - name: POD_IP
       valueFrom:
         fieldRef:

--- a/integration_test/bind_to_podip_test.go
+++ b/integration_test/bind_to_podip_test.go
@@ -1,0 +1,73 @@
+package integration_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	core "k8s.io/api/core/v1"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+)
+
+func (s *connectedSuite) Test_BindToPodIP() {
+	const svcPfx = "echo-server"
+	tplPath := filepath.Join("testdata", "k8s", "generic.goyaml")
+
+	for i, targetPort := range []string{"8080", "http"} {
+		s.Run("TargetPort:"+targetPort, func() {
+			ctx := s.Context()
+			svc := fmt.Sprintf("%s-%d", svcPfx, i)
+			svcPort, cancel := itest.StartLocalHttpEchoServer(ctx, svc)
+			defer cancel()
+			tpl := &itest.Generic{
+				Name:       svc,
+				TargetPort: targetPort,
+				Registry:   "ghcr.io/telepresenceio",
+				Image:      "echo-server:latest",
+				Environment: []core.EnvVar{
+					{
+						Name:  "PORTS",
+						Value: "8080",
+					},
+					{
+						Name: "LISTEN_ADDRESS",
+						ValueFrom: &core.EnvVarSource{
+							FieldRef: &core.ObjectFieldSelector{
+								FieldPath: "status.podIP",
+							},
+						},
+					},
+				},
+				Annotations: map[string]string{
+					agentconfig.InjectAnnotation: "enabled",
+				},
+			}
+			s.ApplyTemplate(ctx, tplPath, tpl)
+			rq := s.Require()
+			rq.NoError(s.RolloutStatusWait(ctx, "deploy/"+svc))
+
+			defer s.DeleteTemplate(ctx, tplPath, tpl)
+
+			stdout := itest.TelepresenceOk(ctx, "intercept", "--mount", "false", svc, "--port", strconv.Itoa(svcPort))
+			rq.Contains(stdout, "Using Deployment "+svc)
+
+			itest.PingInterceptedEchoServer(ctx, svc, "80")
+			itest.TelepresenceOk(ctx, "leave", svc)
+
+			// Ensure that we now reach the original app again.
+			s.Eventually(func() bool {
+				out, err := itest.Output(ctx, "curl", "--verbose", "--max-time", "0.5", svc)
+				dlog.Infof(ctx, "Received %s", out)
+				if err != nil {
+					dlog.Errorf(ctx, "curl error %v", err)
+					return false
+				}
+				return true
+			}, 30*time.Second, 2*time.Second, "Pod app is not reachable after ending the intercept")
+		})
+	}
+}

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -621,6 +621,11 @@ func (s *cluster) GetValuesForHelm(ctx context.Context, values map[string]string
 	if !release {
 		settings = append(settings, fmt.Sprintf("image.registry=%s", s.self.Registry()))
 	}
+	if reg == "local" {
+		settings = append(settings, "agent.image.pullPolicy=Never")
+	} else if !s.isCI {
+		settings = append(settings, "agent.image.pullPolicy=Always")
+	}
 
 	for k, v := range values {
 		settings = append(settings, k+"="+v)
@@ -750,6 +755,13 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 			pp = "Never"
 		}
 		vx.Image.PullPolicy = pp
+		if vx.Agent == nil {
+			vx.Agent = &xAgent{}
+		}
+		if vx.Agent.Image == nil {
+			vx.Agent.Image = &Image{}
+		}
+		vx.Agent.Image.PullPolicy = pp
 	}
 
 	ss, err := sigsYaml.Marshal(&vx)

--- a/integration_test/itest/template.go
+++ b/integration_test/itest/template.go
@@ -17,6 +17,8 @@ type Generic struct {
 	Name           string
 	Annotations    map[string]string
 	Environment    []core.EnvVar
+	TargetPort     string
+	ContainerPort  int
 	Image          string
 	Registry       string
 	ServiceAccount string

--- a/integration_test/testdata/k8s/generic.goyaml
+++ b/integration_test/testdata/k8s/generic.goyaml
@@ -11,7 +11,7 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: http
+      targetPort: {{ .TargetPort | default "http" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -38,7 +38,7 @@ spec:
           image: "{{ .Registry }}/{{ .Image }}"
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .ContainerPort | default 8080 }}
 {{- with .Environment }}
           env:
   {{- toYaml . | nindent 12 }}

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -205,6 +205,10 @@ func InitContainer(config *Sidecar) *core.Container {
 		Args:  []string{"agent-init"},
 		Env: []core.EnvVar{
 			{
+				Name:  "LOG_LEVEL",
+				Value: config.LogLevel,
+			},
+			{
 				Name: "POD_IP",
 				ValueFrom: &core.EnvVarSource{
 					FieldRef: &core.ObjectFieldSelector{

--- a/pkg/agentconfig/util.go
+++ b/pkg/agentconfig/util.go
@@ -42,3 +42,16 @@ func PortUniqueIntercepts(cn *Container) []*Intercept {
 	}
 	return ics
 }
+
+// ProxyPort returns a port that can be used as a proxy for container port for the given Intercept.
+// The proxy port will be the intercept's agentPort + the maximum number of possible intercepts for the sidecar.
+func (s *Sidecar) ProxyPort(ic *Intercept) uint16 {
+	return ic.AgentPort + 11 + uint16(s.numberOfPossibleIntercepts())
+}
+
+func (s *Sidecar) numberOfPossibleIntercepts() (count int) {
+	for _, c := range s.Containers {
+		count += len(c.Intercepts)
+	}
+	return
+}


### PR DESCRIPTION
Using the IP of the pod means that an application now has a choice to
either bind to that IP or to localhost. Internally, it also meant that
we could implement a safer routing from the traffic-agent to the app-
container when numeric ports were used.

In detail, there's a huge difference between requests that the traffic-
agent performs on behalf of a client that wants to connect to the app,
and the forwarding it does to the app during times when no intercepts
are active. The former must be routed back to the agent, so that
potential intercepts are served correctly, whereas the latter must not
be routed back, because that would result in an endless loop.