### PR TITLE
Ensure that environment variable values are expanded correctly.

### DIFF
--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -1700,6 +1700,10 @@ func TestTrafficAgentInjector(t *testing.T) {
 									Name:  "SECRET_NAME",
 									Value: "default-secret-name",
 								},
+								{
+									Name:  "BOTH_NAMES",
+									Value: "$(TOKEN_VOLUME) and $(SECRET_NAME)",
+								},
 							},
 							Ports: []core.ContainerPort{
 								{
@@ -1735,6 +1739,8 @@ func TestTrafficAgentInjector(t *testing.T) {
       value: default-token-vol
     - name: _TEL_APP_A_SECRET_NAME
       value: default-secret-name
+    - name: _TEL_APP_A_BOTH_NAMES
+      value: $(_TEL_APP_A_TOKEN_VOLUME) and $(_TEL_APP_A_SECRET_NAME)
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -3,6 +3,7 @@ package agentconfig
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -434,9 +435,14 @@ func prefixInterpolated(str, pfx string) string {
 	return bd.String()
 }
 
+var envRxReplace = regexp.MustCompile(`\$\(([^)]+)\)`)
+
 func appendAppContainerEnv(app *core.Container, cc *Container, es []core.EnvVar) []core.EnvVar {
+	pfx := EnvPrefixApp + cc.EnvPrefix
+	pfxReplace := "$(" + pfx + "$1)"
 	for _, e := range app.Env {
-		e.Name = EnvPrefixApp + cc.EnvPrefix + e.Name
+		e.Name = pfx + e.Name
+		e.Value = envRxReplace.ReplaceAllString(e.Value, pfxReplace)
 		es = append(es, e)
 	}
 	return es


### PR DESCRIPTION
An environment looking like this for the application container:
```yaml
  - env:
    - name: HOST
      value: example.com
    - name: URL
      value: http://$(HOST):1234
```
would get this prefixed equivalent in the traffic-agent:
```yaml
  - env:
    - name: _TEL_APP_A_HOST
      value: example.com
    - name: _TEL_APP_A_URL
      value: http://$(HOST):1234
```
which then resulted in an invalid value for `TEL_APP_A_URL` because the `$(HOST)` was never prefixed.

This commit changes so that the last line of the traffic-agent env is:
```yaml
      value: http://$(_TEL_APP_A_HOST):1234
```

Closes #3680
