### PR TITLE
Allow a comma-separated list of daemons for the gather-logs command.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -50,6 +50,12 @@ items:
           client originate from the specified container. Additionally, if the
           `--replace` option is used, it ensures that this container is replaced.
         docs: https://telepresence.io/docs/reference/intercepts/container
+      - type: bugfix
+        title: Allow comma separated list of daemons for the gather-logs command.
+        body: ->
+          The name of the `telepresence gather-logs` flag `--daemons` suggests that the argument can contain more
+          than one daemon, but prior to this fix, it couldn't. It is now possible to use a comma separated
+          list, e.g. `telepresence gather-logs --daemons root,user`.
   - version: 2.20.0
     date: 2024-10-03
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@
 This commit introduces a `--container <name>` option to the intercept command. While this option doesn't influence the port selection, it guarantees that the environment variables and mounts propagated to the client originate from the specified container. Additionally, if the `--replace` option is used, it ensures that this container is replaced.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Allow comma separated list of daemons for the gather-logs command.</div></div>
+<div style="margin-left: 15px">
+
+-> The name of the `telepresence gather-logs` flag `--daemons` suggests that the argument can contain more than one daemon, but prior to this fix, it couldn't. It is now possible to use a comma separated list, e.g. `telepresence gather-logs --daemons root,user`.
+</div>
+
 ## Version 2.20.0 <span style="font-size: 16px;">(October  3)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Add timestamp to telepresence_logs.zip filename.</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -13,6 +13,10 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 	<Body>-> In certain scenarios, the container owning the intercepted port differs from the container the intercept targets. This port owner's sole purpose is to route traffic from the service to the intended container, often using a direct localhost connection.
 This commit introduces a `--container <name>` option to the intercept command. While this option doesn't influence the port selection, it guarantees that the environment variables and mounts propagated to the client originate from the specified container. Additionally, if the `--replace` option is used, it ensures that this container is replaced.</Body>
 </Note>
+<Note>
+	<Title type="bugfix">Allow comma separated list of daemons for the gather-logs command.</Title>
+	<Body>-> The name of the `telepresence gather-logs` flag `--daemons` suggests that the argument can contain more than one daemon, but prior to this fix, it couldn't. It is now possible to use a comma separated list, e.g. `telepresence gather-logs --daemons root,user`.</Body>
+</Note>
 ## Version 2.20.0 <span style={{fontSize:'16px'}}>(October  3)</span>
 <Note>
 	<Title type="feature">Add timestamp to telepresence_logs.zip filename.</Title>

--- a/pkg/client/cli/cmd/gather_logs_test.go
+++ b/pkg/client/cli/cmd/gather_logs_test.go
@@ -191,6 +191,12 @@ func Test_gatherLogsNoK8s(t *testing.T) {
 			errMsg:     "",
 		},
 		{
+			name:       "successfulZipConnectorAndDaemonLogs",
+			outputFile: "",
+			daemons:    "user,root",
+			errMsg:     "",
+		},
+		{
 			name:       "successfulZipNoDaemonLogs",
 			outputFile: "",
 			daemons:    "None",
@@ -261,6 +267,8 @@ func Test_gatherLogsNoK8s(t *testing.T) {
 					regexStr = "daemon"
 				case "user":
 					regexStr = "connector"
+				case "user,root":
+					regexStr = "connector|daemon"
 				case "None":
 					regexStr = "a^" // impossible to match
 				default:


### PR DESCRIPTION
The name of the `telepresence gather-logs` flag `--daemons` suggests that the argument can contain more than one daemon, but prior to this fix, it couldn't. It is now possible to use a comma separated list, e.g. `telepresence gather-logs --daemons root,user`.