### PR TITLE
Move brew-tap for telepresence-oss to telepresenceio

### DIFF
--- a/docs/install/client.md
+++ b/docs/install/client.md
@@ -14,22 +14,31 @@ Install the Telepresence client on your workstation by running the commands belo
 <Platform.TabGroup>
 <Platform.MacOSTab>
 
+## Install with brew:
 ```shell
-# Intel Macs
+brew install telepresenceio/telepresence/telepresence-oss
+```
 
-# 1. Download the latest binary (~105 MB):
+## OR download the binary for your platform
+
+### Intel Macs
+
+```shell
+# 1. Download the binary.
 sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
 
 # 2. Make the binary executable:
 sudo chmod a+x /usr/local/bin/telepresence
+```
 
-# Apple silicon Macs
+### Apple silicon Macs
 
+```shell
 # 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
-#    and just updating it in place will not work.
-sudo rm -f /usr/local/bin/telepresence
+# and just updating it in place will not work.
+sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
 
-# 2. Download the latest binary (~101 MB):
+# 2. Download the binary.
 sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-arm64 -o /usr/local/bin/telepresence
 
 # 3. Make the binary executable:

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -16,27 +16,36 @@ if your current version is less than 2.8.0).
 <Platform.TabGroup>
 <Platform.MacOSTab>
 
+## Upgrade with brew:
 ```shell
-# Intel Macs
+brew upgrade telepresenceio/telepresence/telepresence-oss
+```
 
-# 1. Download the latest binary (~105 MB):
+## OR upgrade by downloading the binary for your platform
+
+### Intel Macs
+
+```shell
+# 1. Download the binary.
 sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
 
 # 2. Make the binary executable:
 sudo chmod a+x /usr/local/bin/telepresence
+```
 
-# Apple silicon Macs
+### Apple silicon Macs
 
-# 1. Remove the old binary. This is very important on Silicon macs, because they keep track of the binary signature
-sudo rm /usr/local/bin/telepresence
+```shell
+# 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
+# and just updating it in place will not work.
+sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
 
-# 2. Download the latest binary (~101 MB):
+# 2. Download the binary.
 sudo curl -fL https://app.getambassador.io/download/tel2oss/releases/download/$dlVersion$/telepresence-darwin-arm64 -o /usr/local/bin/telepresence
 
 # 3. Make the binary executable:
 sudo chmod a+x /usr/local/bin/telepresence
 ```
-
 </Platform.MacOSTab>
 <Platform.GNULinuxTab>
 

--- a/packaging/homebrew-formula.rb
+++ b/packaging/homebrew-formula.rb
@@ -13,7 +13,7 @@ class __FORMULA_NAME__ < Formula
     #depends_on "macfuse"
 
     if Hardware::CPU.arm?
-      url "https://app.getambassador.io/download/tel2/darwin/arm64/__NEW_VERSION__/telepresence"
+      url "https://app.getambassador.io/download/tel2/darwin/arm64/v__NEW_VERSION__/telepresence"
       sha256 "__TARBALL_HASH_DARWIN_ARM64__"
 
       def install
@@ -34,7 +34,7 @@ class __FORMULA_NAME__ < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://app.getambassador.io/download/tel2/darwin/amd64/__NEW_VERSION__/telepresence"
+      url "https://app.getambassador.io/download/tel2/darwin/amd64/v__NEW_VERSION__/telepresence"
       sha256 "__TARBALL_HASH_DARWIN_AMD64__"
 
       def install
@@ -58,7 +58,7 @@ class __FORMULA_NAME__ < Formula
 
   on_linux do
     # if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    #   url "https://app.getambassador.io/download/tel2/linux/arm64/__NEW_VERSION__/telepresence"
+    #   url "https://app.getambassador.io/download/tel2/linux/arm64/v__NEW_VERSION__/telepresence"
     #   sha256 "__TARBALL_HASH_LINUX_ARM64__"
 
     #   def install
@@ -78,7 +78,7 @@ class __FORMULA_NAME__ < Formula
     #   end
     # end
     if Hardware::CPU.intel?
-      url "https://app.getambassador.io/download/tel2/linux/amd64/__NEW_VERSION__/telepresence"
+      url "https://app.getambassador.io/download/tel2/linux/amd64/v__NEW_VERSION__/telepresence"
       sha256 "__TARBALL_HASH_LINUX_AMD64__"
 
       def install

--- a/packaging/homebrew-oss-formula.rb
+++ b/packaging/homebrew-oss-formula.rb
@@ -10,7 +10,7 @@ class __FORMULA_NAME__ < Formula
   OPERATING_SYSTEM = OS.mac? ? "darwin" : "linux"
   PACKAGE_NAME = "telepresence-#{OPERATING_SYSTEM}-#{ARCH}"
 
-  url "#{BASE_URL}/#{version}/#{PACKAGE_NAME}"
+  url "#{BASE_URL}/v#{version}/#{PACKAGE_NAME}"
 
   sha256 "__TARBALL_HASH_DARWIN_AMD64__" if OS.mac? && Hardware::CPU.intel?
   sha256 "__TARBALL_HASH_DARWIN_ARM64__" if OS.mac? && Hardware::CPU.arm?

--- a/packaging/homebrew-package.sh
+++ b/packaging/homebrew-package.sh
@@ -18,13 +18,13 @@ echo "Working in ${WORK_DIR}"
 
 BUILD_HOMEBREW_DIR=${WORK_DIR}/homebrew
 if [ "${PACKAGE_NAME}" == 'tel2' ]; then
-    FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence.rb"
     FORMULA_NAME="Telepresence"
     FORMULA_FILE="packaging/homebrew-formula.rb"
+    FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence.rb"
 elif [ "${PACKAGE_NAME}" == 'tel2oss' ]; then
-    FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence-oss.rb"
-    FORMULA_NAME="Telepresence OSS"
+    FORMULA_NAME="TelepresenceOss"
     FORMULA_FILE="packaging/homebrew-oss-formula.rb"
+    FORMULA="${BUILD_HOMEBREW_DIR}/Formula/telepresence-oss.rb"
 fi
 
 for this_os in "${OS[@]}"; do
@@ -38,7 +38,7 @@ for this_os in "${OS[@]}"; do
         # We should only be updating homebrew with a version of telepresence that
         # already exists, so let's download it
         if [ "${PACKAGE_NAME}" == 'tel2' ]; then
-            DOWNLOAD_PATH="/download/${PACKAGE_NAME}/${this_os}/${this_arch}/${VERSION}/telepresence"
+            DOWNLOAD_PATH="/download/${PACKAGE_NAME}/${this_os}/${this_arch}/v${VERSION}/telepresence"
         elif [ "${PACKAGE_NAME}" == 'tel2oss' ]; then
             DOWNLOAD_PATH="/download/${PACKAGE_NAME}/releases/download/v${VERSION}/telepresence-${this_os}-${this_arch}"
         fi
@@ -79,11 +79,12 @@ if [ "${HASH_ERRORS}" -gt 0 ]; then
     exit 1
 fi
 
-# Clone blackbird-homebrew:
+# Clone telepresenceio-homebrew:
 echo "Cloning into ${BUILD_HOMEBREW_DIR}..."
-git clone https://github.com/datawire/homebrew-blackbird.git "${BUILD_HOMEBREW_DIR}"
+git clone https://github.com/telepresenceio/homebrew-telepresence.git "${BUILD_HOMEBREW_DIR}"
 
 # Update recipe
+mkdir -p "$(dirname "${FORMULA}")"
 cp "${FORMULA_FILE}" "${FORMULA}"
 
 sed -i'' -e "s/__FORMULA_NAME__/${FORMULA_NAME}/g" "${FORMULA}"
@@ -104,10 +105,6 @@ done
 chmod 644 "${FORMULA}"
 cd "${BUILD_HOMEBREW_DIR}"
 
-# Use the correct machine user for committing
-git config user.email "services@datawire.io"
-git config user.name "d6e automaton"
-
 git add "${FORMULA}"
 git commit -m "Release ${VERSION}"
 
@@ -116,7 +113,7 @@ git commit -m "Release ${VERSION}"
 # the change. Once we know the automation is working, we can
 # remove it.
 cat "${FORMULA}"
-git push origin master
+git push origin main
 
 # Clean up the working directory
 rm -rf "${WORK_DIR}"


### PR DESCRIPTION
The brew-tap at datawire/blackbird is not writeable to all maintainers of Telepresence, and the name isn't suitable either, given the new Blackbird product from Ambassador Labs. This commit moves the brew tap for telepresence-oss to telepresenceio/homebrew-telepresence.