### PR TITLE
Dont validate namespace in CI

### DIFF
--- a/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence/templates/trafficManagerRbac/namespace-scope.yaml
@@ -7,7 +7,7 @@ require less permissions in clientRbac.yaml
 */}}
 {{- if .Values.managerRbac.namespaced }}
 
-{{- if not (has (include "traffic-manager.namespace" .) .Values.managerRbac.namespaces) }}
+{{- if and (not (has (include "traffic-manager.namespace" .) .Values.managerRbac.namespaces)) (not .Values.isCI) }}
 {{- fail (printf "Namespace %s must be included in managerRbac.namespaces (managerRbac.namespaces contains: %s)" (include "traffic-manager.namespace" .) (join "," .Values.managerRbac.namespaces)) }}
 {{- end }}
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

Currently there exists a deadlock in the following situation:
- you are rendering the helm chart without a release name (as is common in CI tests)
- you are using managerRbac.namespaces


First, lets acknowledge that if isCI is set, we assume we dont have a release name/namespace. Therefore the chart skips the validation that release name is traffic-manager, which makes sense. The chart then defaults the traffic manager namespace to be ambassador. However this will throw if ambassador is not included in the list of namespaces.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `./CHANGELOG.yml`.
 - [ ] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
