### PR TITLE
Add deployments, statefulSets, replicaSets to workloads Helm chart values

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -78,6 +78,12 @@ items:
         body: >-
           The OSS code-base will no longer report usage data to the proprietary collector at Ambassador Labs. The actual calls
           to the collector remain, but will be no-ops unless a proper collector client is installed using an extension point.
+      - type: feature
+        title: Add deployments, statefulSets, replicaSets to workloads Helm chart value
+        body: >-
+          The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>.
+          By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>.
+          When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.
   - version: 2.20.2
     date: 2024-10-21
     notes:

--- a/charts/telepresence/README.md
+++ b/charts/telepresence/README.md
@@ -102,6 +102,9 @@ The following tables lists the configurable parameters of the Telepresence chart
 | client.routing.allowConflictingSubnets               | Allow the specified subnets to be routed even if they conflict with other routes on the local machine.                      | `[]`                                                                        |
 | client.dns.excludeSuffixes                           | Suffixes for which the client DNS resolver will always fail (or fallback in case of the overriding resolver)                | `[".com", ".io", ".net", ".org", ".ru"]`                                    |
 | client.dns.includeSuffixes                           | Suffixes for which the client DNS resolver will always attempt to do a lookup. Includes have higher priority than excludes. | `[]`                                                                        |
+| workloads.deployments.enabled                        | Enable/Disable the support for Deployments.                                                                                 | `true`                                                                      |
+| workloads.replicaSets.enabled                        | Enable/Disable the support for ReplicaSets.                                                                                 | `true`                                                                      |
+| workloads.statefulSets.enabled                       | Enable/Disable the support for StatefulSets.                                                                                | `true`                                                                      |
 | workloads.argoRollouts.enabled                       | Enable/Disable the argo-rollouts integration.                                                                               | `false`                                                                     |
 
 ### RBAC

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -88,7 +88,7 @@ RBAC rules required to create an intercept in a namespace; excludes any rules th
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets", "statefulsets"]
   verbs: ["get", "watch", "list"]
-{{- if .Values.workloads.argoRollouts.enabled }}
+{{- if and .Values.workloads .Values.workloads.argoRollouts .Values.workloads.argoRollouts.enabled }}
 - apiGroups: ["argoproj.io"]
   resources: ["rollouts"]
   verbs: ["get", "watch", "list"]

--- a/charts/telepresence/templates/deployment.yaml
+++ b/charts/telepresence/templates/deployment.yaml
@@ -81,9 +81,26 @@ spec:
             value: {{ .grpc.maxReceiveSize }}
           {{- end }}
           {{- end }}
-          {{- if .workloads.argoRollouts }}
-          - name: ARGO_ROLLOUTS_ENABLED
-            value: {{ .workloads.argoRollouts.enabled | quote }}
+          {{- if .workloads }}
+          {{- with .workloads }}
+          - name: ENABLED_WORKLOAD_KINDS
+            value: >-
+              {{- if or (not .deployments) .deployments.enabled }}
+              Deployment
+              {{- end }}
+              {{- if or (not .statefulSets) .statefulSets.enabled }}
+              StatefulSet
+              {{- end }}
+              {{- if or (not .replicaSets) .replicaSets.enabled }}
+              ReplicaSet
+              {{- end }}
+              {{- if and .argoRollouts .argoRollouts.enabled }}
+              Rollout
+              {{- end }}
+          {{- end }}
+          {{- else }}
+          - name: ENABLED_WORKLOAD_KINDS
+            value: Deployment StatefulSet ReplicaSet
           {{- end }}
       {{- if .agentInjector.enabled }}
         {{- /*

--- a/charts/telepresence/values.yaml
+++ b/charts/telepresence/values.yaml
@@ -347,6 +347,12 @@ client:
 
 # Controls which workload kinds are recognized by Telepresence
 workloads:
+  deployments:
+    enabled: true
+  replicaSets:
+    enabled: true
+  statefulSets:
+    enabled: true
   argoRollouts:
     enabled: false
 

--- a/cmd/traffic/cmd/manager/cluster/info.go
+++ b/cmd/traffic/cmd/manager/cluster/info.go
@@ -129,6 +129,8 @@ func NewInfo(ctx context.Context) Info {
 		}
 	}
 
+	dlog.Infof(ctx, "Enabled support for the following workload kinds: %v", env.EnabledWorkloadKinds)
+
 	// make an attempt to create a service with ClusterIP that is out of range and then
 	// check the error message for the correct range as suggested tin the second answer here:
 	//   https://stackoverflow.com/questions/44190607/how-do-you-find-the-cluster-service-cidr-of-a-kubernetes-cluster

--- a/cmd/traffic/cmd/manager/managerutil/argorollouts.go
+++ b/cmd/traffic/cmd/manager/managerutil/argorollouts.go
@@ -1,9 +1,0 @@
-package managerutil
-
-import (
-	"context"
-)
-
-func ArgoRolloutsEnabled(ctx context.Context) bool {
-	return GetEnv(ctx).ArgoRolloutsEnabled
-}

--- a/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/datawire/k8sapi/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/workload"
 )
 
 func TestEnvconfig(t *testing.T) {
@@ -53,6 +54,7 @@ func TestEnvconfig(t *testing.T) {
 		PodCIDRStrategy:          "auto",
 		PodIP:                    netip.AddrFrom4([4]byte{203, 0, 113, 18}),
 		ServerPort:               8081,
+		EnabledWorkloadKinds:     []workload.WorkloadKind{workload.DeploymentWorkloadKind, workload.StatefulSetWorkloadKind, workload.ReplicaSetWorkloadKind},
 	}
 
 	testcases := map[string]struct {
@@ -65,12 +67,10 @@ func TestEnvconfig(t *testing.T) {
 		},
 		"simple": {
 			Input: map[string]string{
-				"AGENT_REGISTRY":        "ghcr.io/telepresenceio",
-				"ARGO_ROLLOUTS_ENABLED": "true",
+				"AGENT_REGISTRY": "ghcr.io/telepresenceio",
 			},
 			Output: func(e *managerutil.Env) {
 				e.AgentRegistry = "ghcr.io/telepresenceio"
-				e.ArgoRolloutsEnabled = true
 			},
 		},
 		"complex": {

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -495,7 +495,7 @@ func (s *state) WatchWorkloads(ctx context.Context, sessionID string) (ch <-chan
 	}
 	ns := client.Namespace
 	ww, _ := s.workloadWatchers.LoadOrCompute(ns, func() (ww workload.Watcher) {
-		ww, err = workload.NewWatcher(s.backgroundCtx, ns, managerutil.ArgoRolloutsEnabled(ctx))
+		ww, err = workload.NewWatcher(s.backgroundCtx, ns, managerutil.GetEnv(ctx).EnabledWorkloadKinds)
 		return ww
 	})
 	if err != nil {

--- a/docs/reference/intercepts/sidecar.md
+++ b/docs/reference/intercepts/sidecar.md
@@ -9,7 +9,7 @@ The injection is triggered by a Kubernetes Mutating Webhook and will
 only happen once. The Traffic Agent is responsible for redirecting
 intercepted traffic to the developer's workstation.
 
-The intercept will intercept all`tcp` and/or `udp` traffic to the
+The intercept will intercept all `tcp` and/or `udp` traffic to the
 intercepted service and send all of that traffic down to the developer's
 workstation. This means that an intercept will affect all users of
 the intercepted service.
@@ -20,6 +20,17 @@ Kubernetes has various
 [workloads](https://kubernetes.io/docs/concepts/workloads/).
 Currently, Telepresence supports intercepting (installing a
 traffic-agent on) `Deployments`, `ReplicaSets`, `StatefulSets`, and `ArgoRollouts`.
+
+### Disable workloads
+
+By default, traffic-manager will observe `Deployments`, `ReplicaSets` and `StatefulSets`.
+Each workload used today adds certain overhead. If you are not intercepting a specific workload type, you can disable it to reduce that overhead.
+That can be achieved by setting the Helm chart values `workloads.<workloadType>.enabled=false` when installing the traffic-manager.
+The following are the Helm chart values to disable the workload types:
+
+- `workloads.deployments.enabled=false` for `Deployments`,
+- `workloads.replicaSets.enabled=false` for `ReplicaSets`,
+- `workloads.statefulSets.enabled=false` for `StatefulSets`.
 
 ### Enable ArgoRollouts
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,12 @@ See [Streaming Transitions from SPDY to WebSockets](https://kubernetes.io/blog/2
 The OSS code-base will no longer report usage data to the proprietary collector at Ambassador Labs. The actual calls to the collector remain, but will be no-ops unless a proper collector client is installed using an extension point.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Add deployments, statefulSets, replicaSets to workloads Helm chart value</div></div>
+<div style="margin-left: 15px">
+
+The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>. By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>. When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.
+</div>
+
 ## Version 2.20.2 <span style="font-size: 16px;">(October 21)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Crash in traffic-manager configured with agentInjector.enabled=false</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -28,6 +28,10 @@ See [Streaming Transitions from SPDY to WebSockets](https://kubernetes.io/blog/2
 	<Title type="feature">Make usage data collection configurable using an extension point, and default to no-ops</Title>
 	<Body>The OSS code-base will no longer report usage data to the proprietary collector at Ambassador Labs. The actual calls to the collector remain, but will be no-ops unless a proper collector client is installed using an extension point.</Body>
 </Note>
+<Note>
+	<Title type="feature">Add deployments, statefulSets, replicaSets to workloads Helm chart value</Title>
+	<Body>The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>. By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>. When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.</Body>
+</Note>
 ## Version 2.20.2 <span style={{fontSize:'16px'}}>(October 21)</span>
 <Note>
 	<Title type="bugfix">Crash in traffic-manager configured with agentInjector.enabled=false</Title>

--- a/integration_test/workload_configuration_test.go
+++ b/integration_test/workload_configuration_test.go
@@ -1,0 +1,135 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+type workloadConfigurationSuite struct {
+	itest.Suite
+	itest.NamespacePair
+}
+
+func (s *workloadConfigurationSuite) SuiteName() string {
+	return "WorkloadConfiguration"
+}
+
+func init() {
+	itest.AddTrafficManagerSuite("-workload-configuration", func(h itest.NamespacePair) itest.TestingSuite {
+		return &workloadConfigurationSuite{Suite: itest.Suite{Harness: h}, NamespacePair: h}
+	})
+}
+
+func (s *workloadConfigurationSuite) disabledWorkloadKind(tp, wl string) {
+	ctx := s.Context()
+	require := s.Require()
+
+	s.ApplyApp(ctx, wl, strings.ToLower(tp)+"/"+wl)
+	defer s.DeleteSvcAndWorkload(ctx, strings.ToLower(tp), wl)
+
+	defer s.uninstallAgents(ctx, wl)
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceDisconnectOk(ctx)
+
+	// give it time for the workload to be detected (if it was going to be)
+	time.Sleep(6 * time.Second)
+
+	list := itest.TelepresenceOk(ctx, "list")
+	require.Equal("No Workloads (Deployments, StatefulSets, ReplicaSets, or Rollouts)", list)
+
+	_, stderr, err := itest.Telepresence(ctx, "intercept", wl)
+	require.Error(err)
+	require.Contains(stderr, fmt.Sprintf("connector.CreateIntercept: workload \"%s.%s\" not found", wl, s.NamespacePair.AppNamespace()))
+}
+
+func (s *workloadConfigurationSuite) uninstallAgents(ctx context.Context, wl string) {
+	dfltCtx := itest.WithUser(ctx, "default")
+	itest.TelepresenceOk(dfltCtx, "connect", "--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace())
+	itest.TelepresenceOk(dfltCtx, "uninstall", "--agent", wl)
+	itest.TelepresenceDisconnectOk(dfltCtx)
+}
+
+func (s *workloadConfigurationSuite) Test_DisabledReplicaSet() {
+	s.TelepresenceHelmInstallOK(s.Context(), true, "--set", "workloads.replicaSets.enabled=false")
+	defer s.TelepresenceHelmInstallOK(s.Context(), true, "--set", "workloads.replicaSets.enabled=true")
+	s.disabledWorkloadKind("ReplicaSet", "rs-echo")
+}
+
+func (s *workloadConfigurationSuite) Test_DisabledStatefulSet() {
+	s.TelepresenceHelmInstallOK(s.Context(), true, "--set", "workloads.statefulSets.enabled=false")
+	defer s.TelepresenceHelmInstallOK(s.Context(), true, "--set", "workloads.statefulSets.enabled=true")
+	s.disabledWorkloadKind("StatefulSet", "ss-echo")
+}
+
+func (s *workloadConfigurationSuite) Test_InterceptsDeploymentWithDisabledReplicaSets() {
+	ctx := s.Context()
+	require := s.Require()
+
+	wl, tp := "echo-one", "Deployment"
+	s.ApplyApp(ctx, wl, strings.ToLower(tp)+"/"+wl)
+	defer s.DeleteSvcAndWorkload(ctx, strings.ToLower(tp), wl)
+
+	s.TelepresenceHelmInstallOK(ctx, true, "--set", "workloads.replicaSets.enabled=false")
+	defer s.TelepresenceHelmInstallOK(ctx, true, "--set", "workloads.replicaSets.enabled=true")
+
+	defer s.uninstallAgents(ctx, wl)
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceDisconnectOk(ctx)
+
+	require.Eventually(
+		func() bool {
+			stdout, _, err := itest.Telepresence(ctx, "list")
+			return err == nil && strings.Contains(stdout, fmt.Sprintf("%s: ready to intercept", wl))
+		},
+		6*time.Second, // waitFor
+		2*time.Second, // polling interval
+	)
+
+	stdout := itest.TelepresenceOk(ctx, "intercept", wl)
+	require.Contains(stdout, fmt.Sprintf("Using %s %s", tp, wl))
+
+	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
+	require.Contains(stdout, fmt.Sprintf("%s: intercepted", wl))
+	itest.TelepresenceOk(ctx, "leave", wl)
+}
+
+func (s *workloadConfigurationSuite) Test_InterceptsReplicaSetWithDisabledDeployments() {
+	ctx := s.Context()
+	require := s.Require()
+
+	wl, tp := "echo-one", "Deployment"
+	s.ApplyApp(ctx, wl, strings.ToLower(tp)+"/"+wl)
+	defer s.DeleteSvcAndWorkload(ctx, strings.ToLower(tp), wl)
+
+	interceptableWl := s.KubectlOk(ctx, "get", "replicasets", "-l", fmt.Sprintf("app=%s", wl), "-o", "jsonpath={.items[*].metadata.name}")
+
+	s.TelepresenceHelmInstallOK(ctx, true, "--set", "workloads.deployments.enabled=false")
+	defer s.TelepresenceHelmInstallOK(ctx, true, "--set", "workloads.deployments.enabled=true")
+
+	defer s.uninstallAgents(ctx, interceptableWl)
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceDisconnectOk(ctx)
+
+	require.Eventually(
+		func() bool {
+			stdout, _, err := itest.Telepresence(ctx, "list")
+			return err == nil && strings.Contains(stdout, fmt.Sprintf("%s: ready to intercept", interceptableWl))
+		},
+		6*time.Second, // waitFor
+		2*time.Second, // polling interval
+	)
+
+	stdout := itest.TelepresenceOk(ctx, "intercept", interceptableWl)
+	require.Contains(stdout, fmt.Sprintf("Using %s %s", "ReplicaSet", interceptableWl))
+
+	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
+	require.Contains(stdout, fmt.Sprintf("%s: intercepted", interceptableWl))
+	itest.TelepresenceOk(ctx, "leave", interceptableWl)
+}

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -779,8 +779,8 @@ service Manager {
   rpc ReviewIntercept(ReviewInterceptRequest) returns (google.protobuf.Empty);
 
   // GetKnownWorkloadKinds returns the known workload kinds
-  // that the manager can handle. This base set should always include Deployment, StatefulSet, and ReplicaSet,
-  // and it may include Rollout (Argo Rollouts) if the support for it is enabled.
+  // that the manager can handle. This set may include Deployment, StatefulSet, ReplicaSet, Rollout (Argo Rollouts)
+  // as configured in the manager's Helm values.
   rpc GetKnownWorkloadKinds(SessionInfo) returns (KnownWorkloadKinds);
 
   // LookupDNS performs a DNS lookup in the cluster. If the caller has intercepts

--- a/rpc/manager/manager_grpc.pb.go
+++ b/rpc/manager/manager_grpc.pb.go
@@ -142,8 +142,8 @@ type ManagerClient interface {
 	// error, and setting a human-readable status message.
 	ReviewIntercept(ctx context.Context, in *ReviewInterceptRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// GetKnownWorkloadKinds returns the known workload kinds
-	// that the manager can handle. This base set should always include Deployment, StatefulSet, and ReplicaSet,
-	// and it may include Rollout (Argo Rollouts) if the support for it is enabled.
+	// that the manager can handle. This set may include Deployment, StatefulSet, ReplicaSet, Rollout (Argo Rollouts)
+	// as configured in the manager's Helm values.
 	GetKnownWorkloadKinds(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (*KnownWorkloadKinds, error)
 	// LookupDNS performs a DNS lookup in the cluster. If the caller has intercepts
 	// active, the lookup will be performed from the intercepted pods.
@@ -834,8 +834,8 @@ type ManagerServer interface {
 	// error, and setting a human-readable status message.
 	ReviewIntercept(context.Context, *ReviewInterceptRequest) (*emptypb.Empty, error)
 	// GetKnownWorkloadKinds returns the known workload kinds
-	// that the manager can handle. This base set should always include Deployment, StatefulSet, and ReplicaSet,
-	// and it may include Rollout (Argo Rollouts) if the support for it is enabled.
+	// that the manager can handle. This set may include Deployment, StatefulSet, ReplicaSet, Rollout (Argo Rollouts)
+	// as configured in the manager's Helm values.
 	GetKnownWorkloadKinds(context.Context, *SessionInfo) (*KnownWorkloadKinds, error)
 	// LookupDNS performs a DNS lookup in the cluster. If the caller has intercepts
 	// active, the lookup will be performed from the intercepted pods.


### PR DESCRIPTION

## Description

This PR adds the remaining workload kinds Telepresence is able to intercept to the `workloads` option in Helm chart. This based on the initial suggestion made by @thallgren in 
https://github.com/telepresenceio/telepresence/pull/3651#discussion_r1689392081.
To retain backwards compatibility all existing workload kinds that is Deployment, StatefulSet and ReplicaSet are enabled by default unless configured otherwise.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
