### PR TITLE
Introducing Telepresence Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [<img src="https://raw.githubusercontent.com/telepresenceio/telepresence.io/master/src/assets/images/telepresence-edgy.svg" width="80"/>](https://raw.githubusercontent.com/telepresenceio/telepresence.io/master/src/assets/images/telepresence-edgy.svg)
 
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/telepresence-oss)](https://artifacthub.io/packages/search?repo=telepresence-oss)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/telepresence-oss)](https://artifacthub.io/packages/search?repo=telepresence-oss) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Telepresence%20Guru-006BFF)](https://gurubase.io/g/telepresence)
 
 Telepresence gives developers infinite scale development environments for Kubernetes.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Telepresence Guru](https://gurubase.io/g/telepresence) to Gurubase. Telepresence Guru uses the data from this repo and data from the [docs](https://www.telepresence.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Telepresence Guru", which highlights that Telepresence now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Telepresence Guru in Gurubase, just let me know that's totally fine.
