### PR TITLE
Allow telepresence to run root daemon inside of a docker container

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -84,6 +84,10 @@ items:
           The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>.
           By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>.
           When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.
+      - type: bugfix
+        title: Allow root daemon to run inside docker container when not in docker mode
+        body: >-
+          Previously the root daemon would not be run when running docker inside a container such as github codespaces since it would assume that the root daemon was already running.
   - version: 2.20.2
     date: 2024-10-21
     notes:

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -333,7 +333,7 @@ func newUserDaemon(ctx context.Context, conn *grpc.ClientConn, daemonID *daemon.
 
 func EnsureUserDaemon(ctx context.Context, required bool) (rc context.Context, err error) {
 	defer func() {
-		if err == nil && required && !daemon.GetUserClient(rc).Containerized() {
+		if err == nil && required &&  !(os.Getuid() == 0 && daemon.GetUserClient(rc).Containerized()) {
 			// The RootDaemon must be started if the UserDaemon was started
 			err = ensureRootDaemonRunning(ctx)
 		}


### PR DESCRIPTION
## Description

Fix #3722 

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [ ] My change is adequately tested.
 - [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
