### PR TITLE
Lift requirement of .Release.Name == traffic-manager

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -70,7 +70,7 @@ items:
           Telepresence will now use WebSockets instead of SPDY when creating port-forwards to the Kubernetes Cluster, and
           will fall back to SPDY when connecting to clusters that don't support SPDY. Use of the deprecated SPDY can be
           forced by setting `cluster.forceSPDY=true` in the `config.yml`.
-          
+
           See [Streaming Transitions from SPDY to WebSockets](https://kubernetes.io/blog/2024/08/20/websockets-transition/)
           for more information about this transition.
       - type: feature
@@ -84,6 +84,12 @@ items:
           The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>.
           By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>.
           When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.
+      - type: feature
+        title: Allow Helm chart to be included as a sub-chart
+        body: >-
+          The Helm chart previously had the unnecessary restriction that the .Release.Name under which telepresence is installed is literally
+          called "traffic-manager".  This restriction was preventing telepresence from being included as a sub-chart in a parent chart
+          called anything but "traffic-manager".  This restriction has been lifted.
   - version: 2.20.3
     date: 2024-11-18
     notes:

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -1,8 +1,3 @@
-{{- define "clientRbac-ruleExtras" -}}
-- apiGroups: ["getambassador.io"]
-  resources: ["ispecs"]
-  verbs: ["get"]
-{{- end }}
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -5,8 +5,12 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Traffic Manager deployment/service name - as of v2.20.3, must be "traffic-manager" to align with code base.
+*/}}
 {{- define "traffic-manager.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $name := default "traffic-manager" }}
+{{- print $name }}
 {{- end -}}
 
 {{- /*

--- a/charts/telepresence/templates/_helpers.tpl
+++ b/charts/telepresence/templates/_helpers.tpl
@@ -1,3 +1,8 @@
+{{- define "clientRbac-ruleExtras" -}}
+- apiGroups: ["getambassador.io"]
+  resources: ["ispecs"]
+  verbs: ["get"]
+{{- end }}
 {{/*
 Expand the name of the chart.
 */}}
@@ -6,15 +11,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{- define "traffic-manager.name" -}}
-{{- $name := default "traffic-manager" }}
-{{- if .Values.isCI }}
-{{- print $name }}
-{{- else }}
-{{- if ne $name .Release.Name }}
-{{- fail "The name of the release MUST BE traffic-manager" }}
-{{- end }}
-{{- printf "%s" .Release.Name }}
-{{- end -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
 {{- /*

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -36,6 +36,12 @@ The OSS code-base will no longer report usage data to the proprietary collector 
 The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>. By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>. When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Allow Helm chart to be included as a sub-chart</div></div>
+<div style="margin-left: 15px">
+
+The Helm chart previously had the unnecessary restriction that the .Release.Name under which telepresence is installed is literally called "traffic-manager".  This restriction was preventing telepresence from being included as a sub-chart in a parent chart called anything but "traffic-manager".  This restriction has been lifted.
+</div>
+
 ## Version 2.20.3 <span style="font-size: 16px;">(November 18)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Ensure that Telepresence works with GitHub Codespaces](https://github.com/telepresenceio/telepresence/issues/3722)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -32,6 +32,10 @@ See [Streaming Transitions from SPDY to WebSockets](https://kubernetes.io/blog/2
 	<Title type="feature">Add deployments, statefulSets, replicaSets to workloads Helm chart value</Title>
 	<Body>The Helm chart value <code>workloads</code> now supports the kinds <code>deployments.enabled</code>, <code>statefulSets.enabled</code>, and <code>replicaSets.enabled</code>. By default, all three are enabled, but can be disabled by setting the corresponding value to <code>false</code>. When disabled, the traffic-manager will ignore workloads of a corresponding kind, and Telepresence will not be able to intercept them.</Body>
 </Note>
+<Note>
+	<Title type="feature">Allow Helm chart to be included as a sub-chart</Title>
+	<Body>The Helm chart previously had the unnecessary restriction that the .Release.Name under which telepresence is installed is literally called "traffic-manager".  This restriction was preventing telepresence from being included as a sub-chart in a parent chart called anything but "traffic-manager".  This restriction has been lifted.</Body>
+</Note>
 ## Version 2.20.3 <span style={{fontSize:'16px'}}>(November 18)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/3722">Ensure that Telepresence works with GitHub Codespaces</Title>


### PR DESCRIPTION
## Description

Addresses https://github.com/telepresenceio/telepresence/issues/3731, which is an apparently unnecessary restriction that the .Release.Name under which telepresence is installed is called "traffic-manager".  This restriction was preventing telepresence from being included as a sub-chart in a parent chart called anything but "traffic-manager".

This change just does the same for "traffic-manager.name" that we already do [here](https://github.com/telepresenceio/telepresence/compare/release/v2...dansimone:telepresence:release/v2?expand=1#diff-4df592d4dba16f53e48009e7161d000c794bbdf00e385406a2e491fa8ac6b956L4) for "telepresence.name": it has a default value, but can otherwise be controlled by the `nameOverride` value.

The rest of the Helm chart is already not referring to the literal "Release.Name" in any meaningful way - everything meaningful is referring to the "traffic-manager.name".

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml`.
 - [x] I made sure to add any docs changes required for my change (including release notes).
 - [x] My change is adequately tested.
 - [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-dev in the datawire-oss slack so that the "ok to test" label can be applied.
