### PR TITLE
Don't dispatch DNS discovery queries to the cluster.

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -30,7 +30,7 @@ jobs:
           severity: "CRITICAL,HIGH"
           hide-progress: false
       - name: Upload Scan to GitHub Security Tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
   pass:

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -41,6 +41,11 @@ items:
         body: >-
           The clusterID was deprecated some time ago, and replaced by the ID of the namespace where the traffic-manager
           is installed.
+      - type: bugfix
+        title: Don't dispatch DNS discovery queries to the cluster.
+        body: >-
+          macOS based systems will often PTR queries using nameslike `b._dns-sd._udp`, lb._dns-sd._udp, or
+          `db-dns-sd._udp`. Those queries are no longer dispatched to the cluster.
   - version: 2.21.1
     date: 2024-12-17
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 The clusterID was deprecated some time ago, and replaced by the ID of the namespace where the traffic-manager is installed.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Don't dispatch DNS discovery queries to the cluster.</div></div>
+<div style="margin-left: 15px">
+
+macOS based systems will often PTR queries using nameslike `b._dns-sd._udp`, lb._dns-sd._udp, or `db-dns-sd._udp`. Those queries are no longer dispatched to the cluster.
+</div>
+
 ## Version 2.21.1 <span style="font-size: 16px;">(December 17)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Allow ingest of serverless deployments without specifying an inject-container-ports annotation](https://github.com/telepresenceio/telepresence/issues/3741)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -12,6 +12,10 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 	<Title type="change">Drop deprecated current-cluster-id command.</Title>
 	<Body>The clusterID was deprecated some time ago, and replaced by the ID of the namespace where the traffic-manager is installed.</Body>
 </Note>
+<Note>
+	<Title type="bugfix">Don't dispatch DNS discovery queries to the cluster.</Title>
+	<Body>macOS based systems will often PTR queries using nameslike `b._dns-sd._udp`, lb._dns-sd._udp, or `db-dns-sd._udp`. Those queries are no longer dispatched to the cluster.</Body>
+</Note>
 ## Version 2.21.1 <span style={{fontSize:'16px'}}>(December 17)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/3741">Allow ingest of serverless deployments without specifying an inject-container-ports annotation</Title>

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -187,7 +187,17 @@ const (
 	tel2SubDomainDot = tel2SubDomain + "."
 )
 
-var excludePrefixes = []string{"wpad.", "_grpc_config."} //nolint:gochecknoglobals // constant
+// excludePrefixes are prefixes for name queries that we just want to respond NXNAME to
+// without dispatching them to the cluster.
+//
+//nolint:gochecknoglobals // constant
+var excludePrefixes = []string{
+	"wpad.",
+	"_grpc_config.",
+	"lb._dns-sd.",
+	"db._dns-sd.",
+	"b._dns-sd.",
+}
 
 var (
 	localhostIPv4 = net.IP{127, 0, 0, 1}                                   //nolint:gochecknoglobals // constant


### PR DESCRIPTION
macOS based systems will often PTR queries using nameslike `b._dns-sd._udp`, lb._dns-sd._udp, or `db-dns-sd._udp`. This commit prevents that those queries are dispatched to the cluster.