### PR TITLE
Fix goroutine leak in dialer.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -43,6 +43,11 @@ items:
           when creating its port-forward to the agent. The implementation could handle one such requests but not
           several, resulting in a panic in situations where multiple simultaneous requests were made to the same client
           during a very short time period,
+      - type: bugfix
+        title: Fix goroutine leak in dialer.
+        body: >-
+          The context passed to the `Tunnel` call that creates a stream for a dialer, was not cancelled when the dialer
+          was finished, so the stream was never properly closed, leading to one dormant goroutine for each stream.
   - version: 2.21.1
     date: 2024-12-17
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 A race could occur where several requests where made to `agentpf.client.Tunnel` on a client that had errored when creating its port-forward to the agent. The implementation could handle one such requests but not several, resulting in a panic in situations where multiple simultaneous requests were made to the same client during a very short time period,
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Fix goroutine leak in dialer.</div></div>
+<div style="margin-left: 15px">
+
+The context passed to the `Tunnel` call that creates a stream for a dialer, was not cancelled when the dialer was finished, so the stream was never properly closed, leading to one dormant goroutine for each stream.
+</div>
+
 ## Version 2.21.1 <span style="font-size: 16px;">(December 17)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Allow ingest of serverless deployments without specifying an inject-container-ports annotation](https://github.com/telepresenceio/telepresence/issues/3741)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -12,6 +12,10 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 	<Title type="bugfix">Fix panic when agentpf.client creates a Tunnel</Title>
 	<Body>A race could occur where several requests where made to `agentpf.client.Tunnel` on a client that had errored when creating its port-forward to the agent. The implementation could handle one such requests but not several, resulting in a panic in situations where multiple simultaneous requests were made to the same client during a very short time period,</Body>
 </Note>
+<Note>
+	<Title type="bugfix">Fix goroutine leak in dialer.</Title>
+	<Body>The context passed to the `Tunnel` call that creates a stream for a dialer, was not cancelled when the dialer was finished, so the stream was never properly closed, leading to one dormant goroutine for each stream.</Body>
+</Note>
 ## Version 2.21.1 <span style={{fontSize:'16px'}}>(December 17)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/3741">Allow ingest of serverless deployments without specifying an inject-container-ports annotation</Title>

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -347,12 +347,13 @@ func DialWaitLoop(
 
 func dialRespond(ctx context.Context, tunnelProvider Provider, dr *rpc.DialRequest, sessionID string) {
 	id := ConnID(dr.ConnId)
+	ctx, cancel := context.WithCancel(ctx)
 	mt, err := tunnelProvider.Tunnel(ctx)
 	if err != nil {
 		dlog.Errorf(ctx, "!! CONN %s, call to manager Tunnel failed: %v", id, err)
+		cancel()
 		return
 	}
-	ctx, cancel := context.WithCancel(ctx)
 	s, err := NewClientStream(ctx, mt, id, sessionID, time.Duration(dr.RoundtripLatency), time.Duration(dr.DialTimeout))
 	if err != nil {
 		dlog.Error(ctx, err)


### PR DESCRIPTION
The context passed to the `Tunnel` call that creates a stream for a dialer, was not cancelled when the dialer was finished, so the stream was never properly closed, leading to one dormant goroutine for each stream.