### PR TITLE
Ensure that build-deps are built prior to linting.

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -20,6 +20,8 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - name: install dependencies
         uses: ./.github/actions/install-dependencies
+      - name: install build dependencies
+        run: make build-deps
       - name: Lint
         if: ${{ runner.os != 'Windows' }}
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
New linter checks embed statements, so fuseftp-bits must be in the right place before linting is started.
