### PR TITLE
Prefer route with gateway when adding static route.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	github.com/telepresenceio/go-fuseftp/rpc v0.5.0
-	github.com/telepresenceio/telepresence/rpc/v2 v2.21.3-test.4
+	github.com/telepresenceio/telepresence/rpc/v2 v2.21.3-test.5
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884
 	golang.org/x/net v0.32.0

--- a/pkg/vif/router.go
+++ b/pkg/vif/router.go
@@ -191,12 +191,22 @@ func (rt *Router) addStaticOverrides(ctx context.Context, neverProxy, neverProxy
 			if err != nil {
 				return err
 			}
-			pr = &routing.Route{
-				Interface: ifd,
+			for _, addr := range addrs {
+				pfx, err := netip.ParsePrefix(addr.String())
+				if err != nil {
+					return err
+				}
+				pr, err = routing.GetRoute(ctx, pfx)
+				if err != nil {
+					return err
+				}
+				if pr.Gateway.IsValid() {
+					break
+				}
 			}
-			if len(addrs) > 0 {
-				if pfx, err := netip.ParsePrefix(addrs[0].String()); err == nil {
-					pr.LocalIP = pfx.Addr()
+			if pr == nil {
+				pr = &routing.Route{
+					Interface: ifd,
 				}
 			}
 		}

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.21.3-test.4 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.21.3-test.5 // indirect
 	github.com/vishvananda/netlink v1.3.0 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect


### PR DESCRIPTION
Lookup the proper route for the interface when adding a static route instead of just creating a route without a gateway.