### PR TITLE
Backward and forward compatibility testing

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -6,21 +6,28 @@ on:
 
 env:
   TELEPRESENCE_REGISTRY: ghcr.io/telepresenceio
-  DTEST_REGISTRY: ghcr.io/telepresenceio
 
 jobs:
   build_images:
-    if: github.event.label.name == 'ok to test'
+    if: github.event.label.name == 'ok to test' || github.event.label.name == 'compatibility test'
     runs-on: ubuntu-latest
     outputs:
       telepresenceVersion: ${{ steps.version.outputs.version }}
       telepresenceSemver: ${{ steps.version.outputs.semver }}
     steps:
-      - name: Remove label
+      - name: Remove ok to test label
+        if: github.event.label.name == 'ok to test'
         uses: buildsville/add-remove-label@v2.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: ok to test
+          type: remove
+      - name: Remove compatibility test label
+        if: github.event.label.name == 'compatibility test'
+        uses: buildsville/add-remove-label@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: compatibility test
           type: remove
       - uses: actions/checkout@v4
         with:
@@ -55,7 +62,7 @@ jobs:
         run: docker logout
 
   run_tests:
-    if: github.event.label.name == 'ok to test'
+    if: github.event.label.name == 'ok to test' || github.event.label.name == 'compatibility test'
     strategy:
       fail-fast: false
       matrix:
@@ -81,8 +88,7 @@ jobs:
       - name: Build client
         run: make build
       - name: Run integration tests
-        env:
-          SCOUT_DISABLE: "1"
+        if: github.event.label.name == 'ok to test'
         uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
@@ -93,13 +99,43 @@ jobs:
             if [[ ${RUNNER_OS} == "Windows" ]]; then
               export PATH="$PATH:/C/Program Files/SSHFS-Win/bin:$HOME/kubectl-plugins"
             fi
-            DEV_TELEPRESENCE_VERSION=${TELEPRESENCE_VERSION} DTEST_KUBECONFIG="${HOME}/.kube/config" make check-integration
+            make check-integration
+      - name: Compatibility with older manager and agent
+        if: github.event.label.name == 'compatibility test'
+        env:
+          DEV_MANAGER_VERSION: "2.21.3"
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 3
+          shell: bash
+          timeout_minutes: 90
+          command: |
+            set -ex
+            if [[ ${RUNNER_OS} == "Windows" ]]; then
+              export PATH="$PATH:/C/Program Files/SSHFS-Win/bin:$HOME/kubectl-plugins"
+            fi
+            make check-integration
+      - name: Compatibility with older client
+        if: github.event.label.name == 'compatibility test'
+        env:
+          DEV_CLIENT_VERSION: "2.21.3"
+        uses: nick-fields/retry/@v3
+        with:
+          max_attempts: 3
+          shell: bash
+          timeout_minutes: 90
+          command: |
+            set -ex
+            if [[ ${RUNNER_OS} == "Windows" ]]; then
+              export PATH="$PATH:/C/Program Files/SSHFS-Win/bin:$HOME/kubectl-plugins"
+            fi
+            make check-integration
       - uses: ./.github/actions/upload-logs
         env:
           LOG_SUFFIX: "${{ runner.os }}-${{ runner.arch }}-${{ matrix.clusters.distribution }}-${{ matrix.clusters.version }}"
         if: always()
   purge_images:
-    if: github.event.label.name == 'ok to test'
+    if: github.event.label.name == 'ok to test' || github.event.label.name == 'compatibility test'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,66 @@
-# Developing Telepresence 2
+# Developing Telepresence
 
-## Set up your environment
+## Development environment
 
-### Development environment
+### Building
 
- - `TELEPRESENCE_REGISTRY` (required) is the Docker registry that
-   `make push-images` pushes the `tel2` and `telepresence` image to.
-   For most developers, the easiest thing is to set it to
-   `docker.io/USERNAME`.
+The Open Source version of Telepresence consists of three artifacts.
+- The `telepresence` binary. This is the binary that runs on the client.
+  The same binary is used for the command line interface, the user daemon,
+  and the root daemon.
+- The `telepresence` docker image. Used by the container acting as both the
+  user and root daemon when using `telepresence connect --docker`.
+- The `tel2` docker image. Used by the traffic-manager and traffic-agent
+  container.
 
- - `TELEPRESENCE_VERSION` (optional) is the "vSEMVER" string to
-   compile-in to the binary and Docker image, if set.  Otherwise,
-   `make` will automatically set this based on the current Git commit
-   and the current time.
+- `TELEPRESENCE_REGISTRY` (required) is the Docker registry that `make push-images`
+  pushes the `tel2` and `telepresence` image to. For most developers, the easiest 
+  thing is to set it to `local` when using a docker-based Kubernetes, or
+  `ghcr.io/telepersenceio` when using the release registry.
 
- - `DTEST_KUBECONFIG` (optional) is the cluster that is used by tests,
-   if set.  Otherwise the tests will automatically use a K3s cluster
-   running locally in Docker.  It is not normally necessary to set
-   this, but it is useful to set it in order to test against different
-   Kubernetes versions/configurations than what
-   https://github.com/datawire/dtest uses.
+- `TELEPRESENCE_VERSION` (optional) is the "vSEMVER" string to
+  compile-in to the telepresence binary and the telepresence and tel2
+  Docker images, if set.  Otherwise, `make` will automatically set
+  this based on the version found in the CHANGELOG.yml and a hash
+  computed for the source.
 
- - `DTEST_REGISTRY` (optional) is the Docker registry that images are
-   pushed to by the tests, if set.  Otherwise, the tests will
-   automatically use a registry running locally in Docker
-   ("localhost:5000").  The tests will push images named `tel2` with
-   various version tags.  It is not necessary to set this unless you
-   have set `DTEST_KUBECONFIG`.
+The output of `make help` has a bit more information.
 
-   If `DTEST_KUBECONFIG` is pointing to a pre-existing cluster, and you
-   would like the `DTEST_REGISTRY` to point to a private registry that is
-   hosted in that cluster, then you can use `make private-registry`. It
-   will deploy a registry and set it up so that it is reachable at
-   `localhost:5000`, both from the cluster and from the local workstation.
+### Run Telepresence in a local cluster
 
- - `DEV_TELEPRESENCE_VERSION` (optional) if set to a version such as
-   `v2.12.1-alpha.0`, the integration tests will assume that this version
-   is pre-built and available, both as a CLI client (accessible from the
-   current runtime path), and also pre-pushed into a pre-existing cluster
-   accessible from `DTEST_KUBECONFIG`. In other words, if this is set, no
-   no binaries will be built or pushed so the development + test cycle
-   can be quit rapid.
+Using the Kubernetes bundled with Docker Desktop is a quick and easy way to
+develop Telepresence, because, when using this setup, there's no need to push
+images to a registry. Kubernetes will find them in Docker's local cache
+after they have been built.
 
- - `DEV_CLIENT_IMAGE` (optional) can be set to the fully qualified name of
-   an alternative image to use for the docker image used for the containerized
-   daemon when running in docker mode.
+Example building everything, install traffic-manager (with log-level debug),
+and connect to it.
+```bash
+export TELEPRESENCE_VERSION=v2.22.0-alpha.0
+export TELEPRESENCE_REGISTRY=local
+make build client-image tel2-image
+alias tel=./build-output/bin/telepresence
+tel helm install --set logLevel=debug,image.pullPolicy=Never,agent.image.pullPolicy=Never
+tel connect
+```
 
- - `DEV_MANAGER_IMAGE` (optional) can be set to the fully qualified name of
-   an alternative image to use for the traffic manager.
+### Environment Variables for Integration Testing
 
- - `DEV_AGENT_IMAGE` (optional) can be set to the fully qualified name of
-   an alternative image to use for the traffic agent.
-
- - `DEV_USERD_PROFILING_PORT` and `DEV_ROOTD_PROFILING_PORT` (optional) if
-   set, will cause the `telepresence connect` calls in the integration tests
-   to start daemons where pprof is enabled (see
-   [Profiling the daemons](#profiling_the_daemons) below).
+| Environment Name           | Description                                   | Default                   |
+|----------------------------|-----------------------------------------------|---------------------------|
+| `DEV_KUBECONFIG`           | Cluster configuration used by the tests       | Kubernetes default        |
+| `DEV_CLIENT_REGISTRY`      | Docker registry for the client image          | ${TELEPRESENCE_REGISTRY}  |
+| `DEV_MANAGER_REGISTRY`     | Docker registry for the traffic-manager image | ${TELEPRESENCE_REGISTRY}  |
+| `DEV_AGENT_REGISTRY`       | Docker registry for the traffic-agent image   | Traffic-manager registry  |
+| `DEV_CLIENT_IMAGE`         | Name of the client image                      | "telepresence"            |
+| `DEV_MANAGER_IMAGE`        | Name of the traffic-manager image             | "tel2"                    |
+| `DEV_AGENT_IMAGE`          | Name of the traffic-agent image               | Traffic-manager image     |
+| `DEV_CLIENT_VERSION`       | Client version                                | ${TELEPRESENCE_VERSION#v} |
+| `DEV_MANAGER_VERSION`      | Traffic-manager version                       | ${TELEPRESENCE_VERSION#v} |
+| `DEV_AGENT_VERSION`        | Traffic-agent image version                   | Traffic-manager version   |
+| `DEV_USERD_PROFILING_PORT` | start user daemon with pprof is enabled       |                           |
+| `DEV_ROOTD_PROFILING_PORT` | start root daemon with pprof is enabled       |                           |
+| `TEST_SUITE`               | Regexp matching test suite name(s)            |                           |
 
 The above environment can optionally be provided in a `itest.yml` file
 that is placed adjacent to the normal `config.yml` file used to configure
@@ -64,181 +69,48 @@ Telepresence. The `itest.yml` currently has only one single entry, the
 
 ```yaml
 Env:
-  DEV_TELEPRESENCE_VERSION: v2.12.1-alpha.0
-  DTEST_KUBECONFIG: /home/thhal/.kube/testconfig
+  DEV_CLIENT_VERSION: v2.22.0-alpha.0
+  DEV_KUBECONFIG: /home/thhal/.kube/testconfig
 ```
 
-The output of `make help` has a bit more information.
+## Running integration tests
 
-### Running integration tests
+Integration tests can be run using `go test ./integration_test/...`. For individual tests, use the
+`-m.testify=<pattern>` flag. Verbose output using the `-v` flag is also recommended, because the
+tests are built with human-readable output in mind and timestamps can be compared to timestamps
+found in the telepresence logs.
 
-Integration tests can be run using `go test ./integration_test/...`. For
-individual tests, use the `-m.testify=<pattern>` flag. Verbose output using
-the `-v` flag is also recommended, because the tests are built with human
-readable output in mind and timestamps can be compared to timestamps found
-in the telepresence logs.
+### Using Docker Desktop with Kubernetes enabled
 
-Example of running one test with existing cluster and registry:
-```
-make private-registry
-export DTEST_KUBECONFIG=<your kubeconfig>
-export DTEST_REGISTRY=localhost:5000
+Using the Kubernetes embedded with Docker is a quick and easy way to run
+integration tests, because, when using this setup, there's no need to push
+images to a registry. Kubernetes will find them in Docker's local cache
+after they have been built.
+
+The integration tests will automatically use `pullPolicy=Never` when the DEV_CLIENT_REGISTRY` is set to
+"local", and hence instruct Kubernetes to either find the images in the local cache or fail.
+See [local cluster](#run-telepresence-in-a-local-cluster) above.
+
+```bash
+export TELEPRESENCE_VERSION=v2.22.0-alpha.0
+export TELEPRESENCE_REGISTRY=local
+make build client-image tel2-image
 go test ./integration_test/... -v -testify.m=Test_InterceptDetailedOutput
 ```
 
-The user running the integration tests needs to be in the docker group.
-
-If you run these tests on a Mac, localhost won't work. Please use the docker hub, or this value for the registry:
-
-```cli
-export DTEST_REGISTRY=host.docker.internal:5000
-```
-
-You must also set this in your docker engine settings: 
-
-```json
-{
-   "insecure-registries": [
-     "host.docker.internal:5000"
-   ]
-}
-```
-
-The test takes about a minute to complete when using an existing cluster
-and a private registry created by `make private-registry`. During that time
-it:
-- builds the traffic-manager image
-- pushes the image to the registry
-- builds the client binary
-- creates two namespaces for the test
-- performs a helm install of a namespace scoped traffic-manager
-- runs the test
-- uninstalls the traffic-manager
-- deletes the namespaces
-
-The first two can be omitted (and are omitted when the tests run
-from CI) by building the binary using `make build`.
-Example of running test with existing client and traffic-mananager:
-
-```
-make private-registry
-export TELEPRESENCE_VERSION=v2.12.1-alpha.0
-export TELEPRESENCE_REGISTRY=localhost:5000
-make build
-make push-images
-export DTEST_KUBECONFIG=<your kubeconfig>
-export DTEST_REGISTRY=$TELEPRESENCE_REGISTRY
-export DEV_TELEPRESENCE_VERSION=$TELEPRESENCE_VERSION
-
-# Run any number of indivitual test with this setup
+### Run an individual test:
+```bash
 go test ./integration_test/... -v -testify.m=Test_InterceptDetailedOutput
 ```
 
-The `DEV_TELEPRESENCE_VERSION` tells the integration test that a client and
-a traffic-manager of that version has been prebuilt and pushed. This usually
-shortens the time for the test with about 20 seconds.
-
-### Runtime environment
-
- - The main thing is that in your `~/.config/telepresence/config.yml`
-   (`~/Library/Application Support/telepresence/config.yml` on macOS)
-   file you set `images.registry` to match the `TELEPRESENCE_REGISTRY`
-   environment variable. See https://www.telepresence.io/docs/reference/config
-   for more information.
-
- - `TELEPRESENCE_VERSION` is is the "vSEMVER" string used by the
-   `telepresence` binary *if* one was not compiled in (for example, if
-   you're running it with `go run ./cmd/telepresence` rather than
-   having built it with `make build`).
-
- - `TELEPRESENCE_AGENT_IMAGE` is is the "name:vSEMVER" string used when
-   the telepresence auto-installs the traffic-manager unless the config.yml
-   overrides it by defining `images.agentImage`.
-
- - You will need have a `~/.kube/config` file (or set `KUBECONFIG` to
-   point to a different file) file in order to connect to a cluster;
-   same as any other Kubernetes tool.
-
- - You will need to have [mockgen](https://github.com/golang/mock) installed
-   to generate new or updated testing mocks for interfaces.
-
- - You will need to have [argo-rollouts](https://github.com/argoproj/argo-rollouts) (including kubectl-argo-rollouts) installed
-   if you interact with functionality that relies on it.
-
-## Build the binary, push the image
-
-The easiest thing to do to get going:
-
-```console
-$ TELEPRESENCE_REGISTRY=docker.io/thhal make build push-images # use .\build-aux\winmake.bat build on windows
-[make] TELEPRESENCE_VERSION=v2.12.1-19-g37085c2d7-1655891839
-... # Lots of output
-2.12.1-19-g37085c2d7-1655891839: digest: sha256:40fe852f8d8026a89f196293f37ae8c462c765c85572150d26263d78c43cdd4b size: 1157
+### Run an integration test suite:
+```bash
+TEST_SUITE='^WorkloadConfiguration$' go test ./integration_test... -v
 ```
-
-This has 3 primary outputs:
- 1. The `./build-output/bin/telepresence` executable binary
- 2. The `${TELEPRESENCE_REGISTRY}/tel2` Docker image
- 3. The `${TELEPRESENCE_REGISTRY}/telepresence` Docker image
-
-It essentially does 4 separate tasks:
- 1. `make build` to build the `./build-output/bin/telepresence`
-    executable binary
- 2. `make tel2-image` to build the `${TELEPRESENCE_REGISTRY}/tel2` Docker
-    image.
- 3. `make client-image` to build the `${TELEPRESENCE_REGISTRY}/telepresence` Docker
-   image.
- 4. `make push-images` to push the `${TELEPRESENCE_REGISTRY}/tel2` and `${TELEPRESENCE_REGISTRY}/telepresence`
-    Docker images.
-
-You can run any of those tasks separately, but be warned: The
-`TELEPRESENCE_VERSION` for all 4 needs to agree, and `make` includes a
-timestamp in the default `TELEPRESENCE_VERSION`; if you run the tasks
-separately you will need to explicitly set the `TELEPRESENCE_VERSION`
-environment variable so that they all agree.
-
-When working on just the command-line binary, it is often useful to
-run it simply using `go run ./cmd/telepresence` rather than compiling
-it first; but be warned: When run this way it won't know its own
-version number (`telepresence version` will report "v0.0.0-devel")
-unless you set the `TELEPRESENCE_VERSION` environment variable, you
-will want to set it to the version of a previously-pushed Docker
-image.
-
-You may think that the initial suggestion of running `make build
-push-images` all the time (so that every build gets new matching
-version numbers) would be terribly slow.  However, This is not as slow
-as you might think; both `go` and `docker` are very good about reusing
-existing builds and avoiding unnecessary work.
-
-## Run the tests
-
-Running the tests does *not* require having previously built or pushed
-anything.
-
-The tests make use of `sudo`; it is useful to get in the habit of
-running a no-op `sudo` command to pre-emptively prompt for your
-password to avoid having to notice when the prompt appears in the test
-output.
-
-```console
-$ sudo id
-[sudo] password for lukeshu:
-uid=0(root) gid=0(root) groups=0(root)
-
-$ make check-unit
-[make] TELEPRESENCE_VERSION=v2.6.7-20-g9de10e316-1655892249
-...
-```
-
-The first time you run the tests, you should use `make check`, to get
-`make` to automatically create the requisite `heml` tool
-binaries.  However, after that initial run, you can instead use
-`gotestsum` or `go test` if you prefer.
 
 ### Test metric collection
 
-**When running in CI,** `make check-unit` and `make check-integration` this `test-report` tool will
+**When running in CI,** `make check-unit` and `make check-integration` the `test-report` tool will
 visually modify test output; this happens even running locally, since the json output to go test
 is piped to the tool anyway:
 
@@ -265,25 +137,25 @@ you would pass to make. `winmake.bat` will run `make` from inside a Docker conta
 
 ### Log output
 
-There are two logs:
- - the `connector.log` log file which contains output from the
-   background-daemon parts of Telepresence that run as your regular
-   user: the interaction with the traffic-manager and the cluster
-   (traffic-manager and traffic-agent installs, intercepts, port
-   forwards, etc.), and
- - the `daemon.log` log file which contains output from the parts of
-   telepresence that run as the "root" administrator user: the
-   networking changes and services that happen on your workstation.
+There are three logs:
+- the `connector.log` log file which contains output from the
+  background-daemon parts of Telepresence that run as your regular
+  user: the interaction with the traffic-manager and the cluster
+  (traffic-manager and traffic-agent installs, intercepts, port
+  forwards, etc.), and
+- the `daemon.log` log file which contains output from the parts of
+  telepresence that run as the "root" administrator user: the
+  networking changes and services that happen on your workstation.
+- the `cli.log` log file which contains output from the command line
+  interface.
 
 The location of both logs is:
 
- - on macOS: `~/Library/Logs/telepresence/`
- - on GNU/Linux: `~/.cache/telepresence/logs/`
- - on Windows `"%USERPROFILE%\AppData\Local\logs"`
+- on macOS: `~/Library/Logs/telepresence/`
+- on GNU/Linux: `~/.cache/telepresence/logs/`
+- on Windows `"%USERPROFILE%\AppData\Local\logs"`
 
-The logs are rotating and a new log is created every time Telepresence
-creates a new connection to the cluster, e.g. on `telepresence
-connect` after a `telepresence quit` that terminated the last session.
+The logs are rotating daily.
 
 #### Watching the logs
 
@@ -358,21 +230,3 @@ This creates a ServiceAccount, ClusterRole, and ClusterRoleBinding
 which can be used with kubectl (`kubectl config use-context
 telepresence-test-developer`) to work in a RBAC-restricted
 environment.
-
-### Errors from `make generate`
-
-#### Missing go.sum entries
-If you get an error like this:
-
-```
-cd tools/src/go-mkopensource && GOOS= GOARCH= go build -o /home/andres/source/production/telepresence/tools/bin/go-mkopensource $(sed -En 's,^import "(.*)".*,\1,p' pin.go)
-missing go.sum entry for module providing package github.com/datawire/go-mkopensource; to add:
-	go mod download github.com/datawire/go-mkopensource
-```
-
-Add the missing entries by going to the folder that caused the failure (in this case it's
-/home/andres/source/production/telepresence/tools/bin/go-mkopensource) and run the command provided by go:
-
-```
-go mod download github.com/datawire/go-mkopensource
-```

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -449,7 +449,8 @@ endif
 	# is only used for extensions. Therefore, we want to validate that our tests, and
 	# telepresence, run without requiring any outside dependencies.
 	set -o pipefail
-	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 CGO_ENABLED=$(CGO_ENABLED) go test $(BUILD_TAGS) -failfast -json -timeout=80m ./integration_test/... | $(tools/test-report)
+	TELEPRESENCE_MAX_LOGFILES=300 TELEPRESENCE_LOGIN_DOMAIN=127.0.0.1 CGO_ENABLED=$(CGO_ENABLED) go test $(BUILD_TAGS) \
+ 		-count=1 -failfast -json -timeout=80m ./integration_test/... | $(tools/test-report)
 
 .PHONY: _login
 _login:

--- a/integration_test/argo_rollouts_test.go
+++ b/integration_test/argo_rollouts_test.go
@@ -34,9 +34,7 @@ func (s *argoRolloutsSuite) SetupSuite() {
 	s.Suite.SetupSuite()
 	ctx := s.Context()
 	rq := s.Require()
-	if itest.Kubectl(ctx, "", "get", "namespaces", "argo-rollouts") != nil {
-		itest.CreateNamespaces(ctx, "argo-rollouts")
-	}
+	itest.CreateNamespaces(ctx, "argo-rollouts")
 	arExe := filepath.Join(itest.BuildOutput(ctx), "bin", "kubectl-argo-rollouts")
 	if runtime.GOOS == "windows" {
 		arExe += ".exe"
@@ -49,6 +47,10 @@ func (s *argoRolloutsSuite) SetupSuite() {
 	rq.NoError(err)
 	dlog.Info(ctx, out)
 	rq.NoError(itest.Kubectl(ctx, "argo-rollouts", "apply", "-f", "https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml"))
+}
+
+func (s *argoRolloutsSuite) TearDownSuite() {
+	itest.DeleteNamespaces(s.Context(), "argo-rollouts")
 }
 
 func downloadKubectlArgoRollouts(ctx context.Context, arExe string) error {
@@ -105,6 +107,13 @@ func (s *argoRolloutsSuite) Test_SuccessfullyInterceptsArgoRollout() {
 	itest.TelepresenceOk(ctx, "leave", svc)
 	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
 	require.NotContains(stdout, svc+": intercepted")
+
+	if !s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x") {
+		// An <2.22.0 client will not be able to uninstall an agent when the traffic-manager is >=2.22.0
+		// because the client will attempt to remove the entry in the telepresence-agents configmap. It
+		// is no longer present in versions >=2.22.0
+		return
+	}
 	itest.TelepresenceOk(ctx, "uninstall", svc)
 
 	require.Eventually(

--- a/integration_test/argo_rollouts_test.go
+++ b/integration_test/argo_rollouts_test.go
@@ -114,6 +114,7 @@ func (s *argoRolloutsSuite) Test_SuccessfullyInterceptsArgoRollout() {
 		// is no longer present in versions >=2.22.0
 		return
 	}
+	time.Sleep(3 * time.Second)
 	itest.TelepresenceOk(ctx, "uninstall", svc)
 
 	require.Eventually(

--- a/integration_test/cli_test.go
+++ b/integration_test/cli_test.go
@@ -32,7 +32,7 @@ func (s *cliSuite) Test_Version() {
 		s.Require().NoError(err)
 	}
 	s.Empty(stderr)
-	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
+	s.Regexp(fmt.Sprintf(`Client\s*: v%s`, regexp.QuoteMeta(s.ClientVersion().String())), stdout)
 }
 
 func (s *cliSuite) Test_VersionWithInvalidKubeContext() {
@@ -43,7 +43,7 @@ func (s *cliSuite) Test_VersionWithInvalidKubeContext() {
 		s.Require().NoError(err)
 	}
 
-	s.Regexp(fmt.Sprintf(`Client\s*: %s`, regexp.QuoteMeta(s.TelepresenceVersion())), stdout)
+	s.Regexp(fmt.Sprintf(`Client\s*: v%s`, regexp.QuoteMeta(s.ClientVersion().String())), stdout)
 }
 
 func (s *cliSuite) Test_Help() {

--- a/integration_test/connected_test.go
+++ b/integration_test/connected_test.go
@@ -30,11 +30,12 @@ func (s *connectedSuite) Test_ListExcludesTM() {
 
 func (s *connectedSuite) Test_ReportsAllVersions() {
 	stdout := itest.TelepresenceOk(s.Context(), "version")
-	rxVer := regexp.QuoteMeta(s.TelepresenceVersion())
-	s.Regexp(fmt.Sprintf(`Client\s*: %s`, rxVer), stdout)
-	s.Regexp(fmt.Sprintf(`Root Daemon\s*: %s`, rxVer), stdout)
-	s.Regexp(fmt.Sprintf(`User Daemon\s*: %s`, rxVer), stdout)
-	s.Regexp(fmt.Sprintf(`Traffic Manager\s*: %s`, rxVer), stdout)
+	rxVer := regexp.QuoteMeta(s.ClientVersion().String())
+	s.Regexp(fmt.Sprintf(`Client\s*: v%s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`Root Daemon\s*: v%s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`User Daemon\s*: v%s`, rxVer), stdout)
+	mgrVer := regexp.QuoteMeta(s.ManagerVersion().String())
+	s.Regexp(fmt.Sprintf(`Traffic Manager\s*: v%s`, mgrVer), stdout)
 }
 
 func (s *connectedSuite) Test_Status() {

--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -69,9 +69,13 @@ func (s *helmSuite) Test_HelmWebhookInjectsInManagedNamespace() {
 	s.ApplyApp(ctx, "echo-auto-inject", "deploy/echo-auto-inject")
 	defer s.DeleteSvcAndWorkload(ctx, "deploy", "echo-auto-inject")
 
+	verb := "engage"
+	if !s.ClientIsVersion(">2.21.x") {
+		verb = "intercept"
+	}
 	s.Eventually(func() bool {
 		stdout, _, err := itest.Telepresence(ctx, "list", "--agents")
-		return err == nil && strings.Contains(stdout, "echo-auto-inject: ready to engage (traffic-agent already installed)")
+		return err == nil && strings.Contains(stdout, fmt.Sprintf("echo-auto-inject: ready to %s (traffic-agent already installed)", verb))
 	},
 		20*time.Second, // waitFor
 		2*time.Second,  // polling interval
@@ -83,9 +87,13 @@ func (s *helmSuite) Test_HelmWebhookDoesntInjectInUnmanagedNamespace() {
 	itest.ApplyApp(ctx, "echo-auto-inject", s.appSpace2, "deploy/echo-auto-inject")
 	defer itest.DeleteSvcAndWorkload(ctx, "deploy", "echo-auto-inject", s.appSpace2)
 
+	verb := "engage"
+	if !s.ClientIsVersion(">2.21.x") {
+		verb = "intercept"
+	}
 	s.Never(func() bool {
 		stdout, _, err := itest.Telepresence(ctx, "list", "--namespace", s.appSpace2, "--agents")
-		return err == nil && strings.Contains(stdout, "echo-auto-inject: ready to engage (traffic-agent already installed)")
+		return err == nil && strings.Contains(stdout, fmt.Sprintf("echo-auto-inject: ready to %s (traffic-agent already installed)", verb))
 	},
 		10*time.Second, // waitFor
 		2*time.Second,  // polling interval

--- a/integration_test/ingest_test.go
+++ b/integration_test/ingest_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ingest"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 type ingestSuite struct {
@@ -210,6 +211,9 @@ func (s *ingestSuite) Test_IngestRepeat() {
 }
 
 func (s *ingestSuite) Test_IngestFTP() {
+	if !s.ClientVersion().EQ(version.Structured) {
+		s.T().Skip(`Not part of compatibility tests. DoWithSession assumes compiled executable`)
+	}
 	mountPoint := filepath.Join(s.T().TempDir(), "mnt")
 	rq := s.Require()
 	rq.NoError(os.Mkdir(mountPoint, 0o755))

--- a/integration_test/injector_test.go
+++ b/integration_test/injector_test.go
@@ -18,6 +18,9 @@ import (
 // injection of a traffic-agent.
 // See ticket https://github.com/telepresenceio/telepresence/issues/3441 for more info.
 func (s *singleServiceSuite) Test_InterceptOperationRestoredAfterFailingInject() {
+	if !s.ClientIsVersion(">2.21.x") {
+		s.T().Skip("Not part of compatibility tests.")
+	}
 	ctx := s.Context()
 	rq := s.Require()
 
@@ -49,9 +52,7 @@ func (s *singleServiceSuite) Test_InterceptOperationRestoredAfterFailingInject()
 		}
 	}()
 
-	// Uninstall the agent. This will remove it from the telepresence-agents configmap. It must also
-	// uninstall from the agent, even though the webhook is muted, because there will be a rollout and
-	// without the webhook, the default is that the pod has no agent.
+	// Uninstall the agent.
 	itest.TelepresenceOk(ctx, "uninstall", s.ServiceName())
 
 	oneContainer := func() bool {

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -26,20 +26,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
-	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	sigsYaml "sigs.k8s.io/yaml"
 
 	"github.com/datawire/dlib/dexec"
 	"github.com/datawire/dlib/dlog"
 	"github.com/datawire/dlib/dtime"
 	"github.com/datawire/dtest"
-	telcharts "github.com/telepresenceio/telepresence/v2/charts"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
-	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/socket"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/userd/k8s"
@@ -47,7 +43,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-	"github.com/telepresenceio/telepresence/v2/pkg/labels"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
@@ -582,262 +577,6 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 	case file := <-ready:
 		return file
 	}
-}
-
-func (s *cluster) PackageHelmChart(ctx context.Context) (string, error) {
-	filename := filepath.Join(getT(ctx).TempDir(), "telepresence-chart.tgz")
-	fh, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o666)
-	if err != nil {
-		return "", err
-	}
-	if err := telcharts.WriteChart(telcharts.DirTypeTelepresence, fh, "telepresence", s.self.TelepresenceVersion()[1:]); err != nil {
-		_ = fh.Close()
-		return "", err
-	}
-	if err := fh.Close(); err != nil {
-		return "", err
-	}
-	return filename, nil
-}
-
-func (s *cluster) GetSetArgsForHelm(ctx context.Context, values map[string]any, release bool) []string {
-	settings := s.GetValuesForHelm(ctx, values, release)
-	args := make([]string, len(settings)*2)
-	n := 0
-	for _, s := range settings {
-		args[n] = "--set-json"
-		n++
-		args[n] = s
-		n++
-	}
-	return args
-}
-
-func (s *cluster) GetValuesForHelm(ctx context.Context, values map[string]any, release bool) []string {
-	nss := GetNamespaces(ctx)
-	settings := []string{
-		`logLevel="debug"`,
-	}
-	reg := s.self.Registry()
-	if reg == "local" {
-		settings = append(settings, `image.pullPolicy="Never"`)
-	} else if !s.isCI {
-		settings = append(settings, `image.pullPolicy="Always"`)
-	}
-	if nss != nil && nss.Selector != nil {
-		j, err := json.Marshal(nss.Selector)
-		if err != nil {
-			dlog.Errorf(ctx, "unable to marshal selector '%v': %v", nss.Selector, err)
-		} else {
-			settings = append(settings, `namespaceSelector=`+string(j))
-		}
-	}
-	agentImage := GetAgentImage(ctx)
-	if agentImage != nil {
-		settings = append(settings,
-			fmt.Sprintf(`agent.image.name=%q`, agentImage.Name), // Prevent attempts to retrieve image from SystemA
-			fmt.Sprintf(`agent.image.tag=%q`, agentImage.Tag),
-			fmt.Sprintf(`agent.image.registry=%q`, agentImage.Registry))
-	}
-	if !release {
-		settings = append(settings, fmt.Sprintf(`image.registry=%q`, s.self.Registry()))
-	}
-	if reg == "local" {
-		settings = append(settings, `agent.image.pullPolicy="Never"`)
-	} else if !s.isCI {
-		settings = append(settings, `agent.image.pullPolicy="Always"`)
-	}
-
-	for k, v := range values {
-		j, err := json.Marshal(v)
-		if err != nil {
-			dlog.Errorf(ctx, "unable to marshal value %v: %v", v, err)
-		} else {
-			settings = append(settings, k+"="+string(j))
-		}
-	}
-	return settings
-}
-
-func (s *cluster) InstallTrafficManager(ctx context.Context, values map[string]any) error {
-	chartFilename, err := s.self.PackageHelmChart(ctx)
-	if err != nil {
-		return err
-	}
-	return s.installChart(ctx, false, chartFilename, values)
-}
-
-// InstallTrafficManagerVersion performs a helm install of a specific version of the traffic-manager using
-// the helm registry at https://app.getambassador.io. It is assumed that the image to use for the traffic-manager
-// can be pulled from the standard registry at ghcr.io/telepresenceio, and that the traffic-manager image is
-// configured using DEV_AGENT_IMAGE.
-//
-// The intent is to simulate connection to an older cluster from the current client.
-func (s *cluster) InstallTrafficManagerVersion(ctx context.Context, version string, values map[string]any) error {
-	chartFilename, err := s.pullHelmChart(ctx, version)
-	if err != nil {
-		return err
-	}
-	return s.installChart(ctx, true, chartFilename, values)
-}
-
-func (s *cluster) installChart(ctx context.Context, release bool, chartFilename string, values map[string]any) error {
-	settings := s.self.GetSetArgsForHelm(ctx, values, release)
-
-	ctx = WithWorkingDir(ctx, GetOSSRoot(ctx))
-	nss := GetNamespaces(ctx)
-	args := []string{"install", "-n", nss.Namespace, "--wait"}
-	args = append(args, settings...)
-	args = append(args, "traffic-manager", chartFilename)
-
-	err := Run(ctx, "helm", args...)
-	if err == nil {
-		err = RolloutStatusWait(ctx, nss.Namespace, "deploy/traffic-manager")
-		if err == nil {
-			s.self.CapturePodLogs(ctx, "traffic-manager", "", nss.Namespace)
-		}
-	}
-	return err
-}
-
-func (s *cluster) TelepresenceHelmInstallOK(ctx context.Context, upgrade bool, settings ...string) string {
-	logFile, err := s.self.TelepresenceHelmInstall(ctx, upgrade, settings...)
-	require.NoError(getT(ctx), err)
-	return logFile
-}
-
-func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, settings ...string) (string, error) {
-	nss := GetNamespaces(ctx)
-	subjectNames := []string{TestUser}
-	subjects := make([]rbac.Subject, len(subjectNames))
-	for i, s := range subjectNames {
-		subjects[i] = rbac.Subject{
-			Kind:      "ServiceAccount",
-			Name:      s,
-			Namespace: nss.Namespace,
-		}
-	}
-
-	type xRbac struct {
-		Create     bool           `json:"create"`
-		Namespaced bool           `json:"namespaced"`
-		Subjects   []rbac.Subject `json:"subjects,omitempty"`
-		Namespaces []string       `json:"namespaces,omitempty"`
-	}
-	type xAgent struct {
-		Image *Image `json:"image,omitempty"`
-	}
-	var agent *xAgent
-	if agentImage := GetAgentImage(ctx); agentImage != nil {
-		agent = &xAgent{Image: agentImage}
-	}
-	type xClient struct {
-		Routing map[string][]string `json:"routing"`
-	}
-	type xTimeouts struct {
-		AgentArrival string `json:"agentArrival,omitempty"`
-	}
-	vx := struct {
-		LogLevel          string           `json:"logLevel"`
-		Image             Image            `json:"image,omitempty"`
-		Agent             *xAgent          `json:"agent,omitempty"`
-		ClientRbac        xRbac            `json:"clientRbac"`
-		ManagerRbac       xRbac            `json:"managerRbac"`
-		Client            xClient          `json:"client"`
-		Timeouts          xTimeouts        `json:"timeouts,omitempty"`
-		Namespaces        []string         `json:"namespaces,omitempty"`
-		NamespaceSelector *labels.Selector `json:"namespaceSelector,omitempty"`
-	}{
-		LogLevel: "debug",
-		Agent:    agent,
-		ClientRbac: xRbac{
-			Create:   true,
-			Subjects: subjects,
-		},
-		ManagerRbac: xRbac{
-			Create: true,
-		},
-		Client: xClient{
-			Routing: map[string][]string{},
-		},
-		Timeouts: xTimeouts{AgentArrival: "60s"},
-	}
-	if managedNamespaces := nss.Selector.StaticNames(); len(managedNamespaces) > 0 {
-		vx.Namespaces = managedNamespaces
-	} else {
-		vx.NamespaceSelector = nss.Selector
-	}
-
-	image := GetImage(ctx)
-	if image != nil {
-		vx.Image = *image
-	}
-	if !s.isCI {
-		pp := "Always"
-		if s.Registry() == "local" {
-			// Using minikube with local images.
-			// They are automatically present and must not be pulled.
-			pp = "Never"
-		}
-		vx.Image.PullPolicy = pp
-		if vx.Agent == nil {
-			vx.Agent = &xAgent{}
-		}
-		if vx.Agent.Image == nil {
-			vx.Agent.Image = &Image{}
-		}
-		vx.Agent.Image.PullPolicy = pp
-	}
-
-	ss, err := sigsYaml.Marshal(&vx)
-	if err != nil {
-		return "", err
-	}
-	valuesFile := filepath.Join(getT(ctx).TempDir(), "values.yaml")
-	if err := os.WriteFile(valuesFile, ss, 0o644); err != nil {
-		return "", err
-	}
-
-	verb := "install"
-	if upgrade {
-		verb = "upgrade"
-	}
-	args := []string{"helm", verb, "-n", nss.Namespace, "-f", valuesFile}
-	args = append(args, settings...)
-
-	if _, _, err = Telepresence(WithUser(ctx, "default"), args...); err != nil {
-		return "", err
-	}
-	if err = RolloutStatusWait(ctx, nss.Namespace, "deploy/"+agentmap.ManagerAppName); err != nil {
-		return "", err
-	}
-	logFileName := s.self.CapturePodLogs(ctx, agentmap.ManagerAppName, "", nss.Namespace)
-	return logFileName, nil
-}
-
-func (s *cluster) pullHelmChart(ctx context.Context, version string) (string, error) {
-	if err := Run(ctx, "helm", "repo", "add", "datawire", "https://app.getambassador.io"); err != nil {
-		return "", err
-	}
-	if err := Run(ctx, "helm", "repo", "update"); err != nil {
-		return "", err
-	}
-	dir := getT(ctx).TempDir()
-	if err := Run(WithWorkingDir(ctx, dir), "helm", "pull", "datawire/telepresence", "--version", version); err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("telepresence-%s.tgz", version)), nil
-}
-
-func (s *cluster) UninstallTrafficManager(ctx context.Context, managerNamespace string, args ...string) {
-	t := getT(ctx)
-	ctx = WithUser(ctx, "default")
-	TelepresenceOk(ctx, append([]string{"helm", "uninstall", "--manager-namespace", managerNamespace}, args...)...)
-
-	// Helm uninstall does deletions asynchronously, so let's wait until the deployment is gone
-	assert.Eventually(t, func() bool { return len(RunningPodNames(ctx, agentmap.ManagerAppName, managerNamespace)) == 0 },
-		60*time.Second, 4*time.Second, "traffic-manager deployment was not removed")
-	TelepresenceQuitOk(ctx)
 }
 
 func (s *cluster) GetK8SCluster(ctx context.Context, context, managerNamespace string) (context.Context, *k8s.Cluster, error) {

--- a/integration_test/itest/context.go
+++ b/integration_test/itest/context.go
@@ -199,3 +199,16 @@ func GetGlobalHarness(ctx context.Context) Cluster {
 	}
 	panic("No globalHarness in context")
 }
+
+type exeContextKey struct{}
+
+func WithExecutable(ctx context.Context, exe string) context.Context {
+	return context.WithValue(ctx, exeContextKey{}, exe)
+}
+
+func GetExecutable(ctx context.Context) string {
+	if user, ok := ctx.Value(exeContextKey{}).(string); ok {
+		return user
+	}
+	panic("No executable in context")
+}

--- a/integration_test/itest/helm.go
+++ b/integration_test/itest/helm.go
@@ -1,0 +1,276 @@
+package itest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-json-experiment/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbac "k8s.io/api/rbac/v1"
+	sigsYaml "sigs.k8s.io/yaml"
+
+	"github.com/datawire/dlib/dlog"
+	telcharts "github.com/telepresenceio/telepresence/v2/charts"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/labels"
+)
+
+func (s *cluster) PackageHelmChart(ctx context.Context) (string, error) {
+	filename := filepath.Join(getT(ctx).TempDir(), "telepresence-chart.tgz")
+	fh, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o666)
+	if err != nil {
+		return "", err
+	}
+	if err := telcharts.WriteChart(telcharts.DirTypeTelepresence, fh, "telepresence", s.self.TelepresenceVersion()[1:]); err != nil {
+		_ = fh.Close()
+		return "", err
+	}
+	if err := fh.Close(); err != nil {
+		return "", err
+	}
+	return filename, nil
+}
+
+func (s *cluster) GetSetArgsForHelm(ctx context.Context, values map[string]any, release bool) []string {
+	settings := s.GetValuesForHelm(ctx, values, release)
+	args := make([]string, len(settings)*2)
+	n := 0
+	for _, s := range settings {
+		args[n] = "--set-json"
+		n++
+		args[n] = s
+		n++
+	}
+	return args
+}
+
+func (s *cluster) GetValuesForHelm(ctx context.Context, values map[string]any, release bool) []string {
+	nss := GetNamespaces(ctx)
+	settings := []string{
+		`logLevel="debug"`,
+	}
+	reg := s.self.Registry()
+	if reg == "local" {
+		settings = append(settings, `image.pullPolicy="Never"`)
+	} else if !s.isCI {
+		settings = append(settings, `image.pullPolicy="Always"`)
+	}
+	if nss != nil && nss.Selector != nil {
+		j, err := json.Marshal(nss.Selector)
+		if err != nil {
+			dlog.Errorf(ctx, "unable to marshal selector '%v': %v", nss.Selector, err)
+		} else {
+			settings = append(settings, `namespaceSelector=`+string(j))
+		}
+	}
+	agentImage := GetAgentImage(ctx)
+	if agentImage != nil {
+		settings = append(settings,
+			fmt.Sprintf(`agent.image.name=%q`, agentImage.Name), // Prevent attempts to retrieve image from SystemA
+			fmt.Sprintf(`agent.image.tag=%q`, agentImage.Tag),
+			fmt.Sprintf(`agent.image.registry=%q`, agentImage.Registry))
+	}
+	if !release {
+		settings = append(settings, fmt.Sprintf(`image.registry=%q`, s.self.Registry()))
+	}
+	if reg == "local" {
+		settings = append(settings, `agent.image.pullPolicy="Never"`)
+	} else if !s.isCI {
+		settings = append(settings, `agent.image.pullPolicy="Always"`)
+	}
+
+	for k, v := range values {
+		j, err := json.Marshal(v)
+		if err != nil {
+			dlog.Errorf(ctx, "unable to marshal value %v: %v", v, err)
+		} else {
+			settings = append(settings, k+"="+string(j))
+		}
+	}
+	return settings
+}
+
+func (s *cluster) InstallTrafficManager(ctx context.Context, values map[string]any) error {
+	chartFilename, err := s.self.PackageHelmChart(ctx)
+	if err != nil {
+		return err
+	}
+	return s.installChart(ctx, false, chartFilename, values)
+}
+
+// InstallTrafficManagerVersion performs a helm install of a specific version of the traffic-manager using
+// the helm registry at https://app.getambassador.io. It is assumed that the image to use for the traffic-manager
+// can be pulled from the standard registry at ghcr.io/telepresenceio, and that the traffic-manager image is
+// configured using DEV_AGENT_IMAGE.
+//
+// The intent is to simulate connection to an older cluster from the current client.
+func (s *cluster) InstallTrafficManagerVersion(ctx context.Context, version string, values map[string]any) error {
+	chartFilename, err := s.pullHelmChart(ctx, version)
+	if err != nil {
+		return err
+	}
+	return s.installChart(ctx, true, chartFilename, values)
+}
+
+func (s *cluster) installChart(ctx context.Context, release bool, chartFilename string, values map[string]any) error {
+	settings := s.self.GetSetArgsForHelm(ctx, values, release)
+
+	ctx = WithWorkingDir(ctx, GetOSSRoot(ctx))
+	nss := GetNamespaces(ctx)
+	args := []string{"install", "-n", nss.Namespace, "--wait"}
+	args = append(args, settings...)
+	args = append(args, "traffic-manager", chartFilename)
+
+	err := Run(ctx, "helm", args...)
+	if err == nil {
+		err = RolloutStatusWait(ctx, nss.Namespace, "deploy/traffic-manager")
+		if err == nil {
+			s.self.CapturePodLogs(ctx, "traffic-manager", "", nss.Namespace)
+		}
+	}
+	return err
+}
+
+func (s *cluster) TelepresenceHelmInstallOK(ctx context.Context, upgrade bool, settings ...string) string {
+	logFile, err := s.self.TelepresenceHelmInstall(ctx, upgrade, settings...)
+	require.NoError(getT(ctx), err)
+	return logFile
+}
+
+func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, settings ...string) (string, error) {
+	nss := GetNamespaces(ctx)
+	subjectNames := []string{TestUser}
+	subjects := make([]rbac.Subject, len(subjectNames))
+	for i, s := range subjectNames {
+		subjects[i] = rbac.Subject{
+			Kind:      "ServiceAccount",
+			Name:      s,
+			Namespace: nss.Namespace,
+		}
+	}
+
+	type xRbac struct {
+		Create     bool           `json:"create"`
+		Namespaced bool           `json:"namespaced"`
+		Subjects   []rbac.Subject `json:"subjects,omitempty"`
+		Namespaces []string       `json:"namespaces,omitempty"`
+	}
+	type xAgent struct {
+		Image *Image `json:"image,omitempty"`
+	}
+	var agent *xAgent
+	if agentImage := GetAgentImage(ctx); agentImage != nil {
+		agent = &xAgent{Image: agentImage}
+	}
+	type xClient struct {
+		Routing map[string][]string `json:"routing"`
+	}
+	type xTimeouts struct {
+		AgentArrival string `json:"agentArrival,omitempty"`
+	}
+	vx := struct {
+		LogLevel          string           `json:"logLevel"`
+		Image             Image            `json:"image,omitempty"`
+		Agent             *xAgent          `json:"agent,omitempty"`
+		ClientRbac        xRbac            `json:"clientRbac"`
+		ManagerRbac       xRbac            `json:"managerRbac"`
+		Client            xClient          `json:"client"`
+		Timeouts          xTimeouts        `json:"timeouts,omitempty"`
+		Namespaces        []string         `json:"namespaces,omitempty"`
+		NamespaceSelector *labels.Selector `json:"namespaceSelector,omitempty"`
+	}{
+		LogLevel: "debug",
+		Agent:    agent,
+		ClientRbac: xRbac{
+			Create:   true,
+			Subjects: subjects,
+		},
+		ManagerRbac: xRbac{
+			Create: true,
+		},
+		Client: xClient{
+			Routing: map[string][]string{},
+		},
+		Timeouts: xTimeouts{AgentArrival: "60s"},
+	}
+	if managedNamespaces := nss.Selector.StaticNames(); len(managedNamespaces) > 0 {
+		vx.Namespaces = managedNamespaces
+	} else {
+		vx.NamespaceSelector = nss.Selector
+	}
+
+	image := GetImage(ctx)
+	if image != nil {
+		vx.Image = *image
+	}
+	if !s.isCI {
+		pp := "Always"
+		if s.Registry() == "local" {
+			// Using minikube with local images.
+			// They are automatically present and must not be pulled.
+			pp = "Never"
+		}
+		vx.Image.PullPolicy = pp
+		if vx.Agent == nil {
+			vx.Agent = &xAgent{}
+		}
+		if vx.Agent.Image == nil {
+			vx.Agent.Image = &Image{}
+		}
+		vx.Agent.Image.PullPolicy = pp
+	}
+
+	ss, err := sigsYaml.Marshal(&vx)
+	if err != nil {
+		return "", err
+	}
+	valuesFile := filepath.Join(getT(ctx).TempDir(), "values.yaml")
+	if err := os.WriteFile(valuesFile, ss, 0o644); err != nil {
+		return "", err
+	}
+
+	verb := "install"
+	if upgrade {
+		verb = "upgrade"
+	}
+	args := []string{"helm", verb, "-n", nss.Namespace, "-f", valuesFile}
+	args = append(args, settings...)
+
+	if _, _, err = Telepresence(WithUser(ctx, "default"), args...); err != nil {
+		return "", err
+	}
+	if err = RolloutStatusWait(ctx, nss.Namespace, "deploy/"+agentmap.ManagerAppName); err != nil {
+		return "", err
+	}
+	logFileName := s.self.CapturePodLogs(ctx, agentmap.ManagerAppName, "", nss.Namespace)
+	return logFileName, nil
+}
+
+func (s *cluster) pullHelmChart(ctx context.Context, version string) (string, error) {
+	if err := Run(ctx, "helm", "repo", "add", "datawire", "https://app.getambassador.io"); err != nil {
+		return "", err
+	}
+	if err := Run(ctx, "helm", "repo", "update"); err != nil {
+		return "", err
+	}
+	dir := getT(ctx).TempDir()
+	if err := Run(WithWorkingDir(ctx, dir), "helm", "pull", "datawire/telepresence", "--version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("telepresence-%s.tgz", version)), nil
+}
+
+func (s *cluster) UninstallTrafficManager(ctx context.Context, managerNamespace string, args ...string) {
+	t := getT(ctx)
+	ctx = WithUser(ctx, "default")
+	TelepresenceOk(ctx, append([]string{"helm", "uninstall", "--manager-namespace", managerNamespace}, args...)...)
+
+	// Helm uninstall does deletions asynchronously, so let's wait until the deployment is gone
+	assert.Eventually(t, func() bool { return len(RunningPodNames(ctx, agentmap.ManagerAppName, managerNamespace)) == 0 },
+		60*time.Second, 4*time.Second, "traffic-manager deployment was not removed")
+	TelepresenceQuitOk(ctx)
+}

--- a/integration_test/itest/helm.go
+++ b/integration_test/itest/helm.go
@@ -1,22 +1,28 @@
 package itest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-json-experiment/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbac "k8s.io/api/rbac/v1"
-	sigsYaml "sigs.k8s.io/yaml"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/datawire/dlib/dlog"
 	telcharts "github.com/telepresenceio/telepresence/v2/charts"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/labels"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 func (s *cluster) PackageHelmChart(ctx context.Context) (string, error) {
@@ -25,7 +31,7 @@ func (s *cluster) PackageHelmChart(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := telcharts.WriteChart(telcharts.DirTypeTelepresence, fh, "telepresence", s.self.TelepresenceVersion()[1:]); err != nil {
+	if err := telcharts.WriteChart(telcharts.DirTypeTelepresence, fh, "telepresence", s.self.ManagerVersion().String()); err != nil {
 		_ = fh.Close()
 		return "", err
 	}
@@ -53,11 +59,16 @@ func (s *cluster) GetValuesForHelm(ctx context.Context, values map[string]any, r
 	settings := []string{
 		`logLevel="debug"`,
 	}
-	reg := s.self.Registry()
-	if reg == "local" {
-		settings = append(settings, `image.pullPolicy="Never"`)
-	} else if !s.isCI {
-		settings = append(settings, `image.pullPolicy="Always"`)
+
+	if s.ManagerVersion().EQ(version.Structured) {
+		reg := s.self.ManagerRegistry()
+		if reg == "local" {
+			settings = append(settings, `image.pullPolicy="Never"`)
+			settings = append(settings, `agent.image.pullPolicy="Never"`)
+		} else if !s.isCI {
+			settings = append(settings, `image.pullPolicy="Always"`)
+			settings = append(settings, `agent.image.pullPolicy="Always"`)
+		}
 	}
 	if nss != nil && nss.Selector != nil {
 		j, err := json.Marshal(nss.Selector)
@@ -75,12 +86,7 @@ func (s *cluster) GetValuesForHelm(ctx context.Context, values map[string]any, r
 			fmt.Sprintf(`agent.image.registry=%q`, agentImage.Registry))
 	}
 	if !release {
-		settings = append(settings, fmt.Sprintf(`image.registry=%q`, s.self.Registry()))
-	}
-	if reg == "local" {
-		settings = append(settings, `agent.image.pullPolicy="Never"`)
-	} else if !s.isCI {
-		settings = append(settings, `agent.image.pullPolicy="Always"`)
+		settings = append(settings, fmt.Sprintf(`image.registry=%q`, s.self.ManagerRegistry()))
 	}
 
 	for k, v := range values {
@@ -121,69 +127,151 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 	type xAgent struct {
 		Image *Image `json:"image,omitempty"`
 	}
-	var agent *xAgent
-	if agentImage := GetAgentImage(ctx); agentImage != nil {
-		agent = &xAgent{Image: agentImage}
-	}
+	agentImage := GetAgentImage(ctx)
+	agent := &xAgent{Image: agentImage}
 	type xClient struct {
 		Routing map[string][]string `json:"routing"`
 	}
 	type xTimeouts struct {
 		AgentArrival string `json:"agentArrival,omitempty"`
 	}
+	managerRbac := xRbac{
+		Create: true,
+	}
+	clientRbac := xRbac{
+		Create:   true,
+		Subjects: subjects,
+	}
 	vx := struct {
 		LogLevel          string           `json:"logLevel"`
-		Image             Image            `json:"image,omitempty"`
+		Image             *Image           `json:"image,omitempty"`
 		Agent             *xAgent          `json:"agent,omitempty"`
-		ClientRbac        xRbac            `json:"clientRbac"`
-		ManagerRbac       xRbac            `json:"managerRbac"`
+		ClientRbac        *xRbac           `json:"clientRbac"`
+		ManagerRbac       *xRbac           `json:"managerRbac"`
 		Client            xClient          `json:"client"`
 		Timeouts          xTimeouts        `json:"timeouts,omitempty"`
 		Namespaces        []string         `json:"namespaces,omitempty"`
 		NamespaceSelector *labels.Selector `json:"namespaceSelector,omitempty"`
 	}{
-		LogLevel: "debug",
-		Agent:    agent,
-		ClientRbac: xRbac{
-			Create:   true,
-			Subjects: subjects,
-		},
-		ManagerRbac: xRbac{
-			Create: true,
-		},
+		LogLevel:    "debug",
+		Agent:       agent,
+		ClientRbac:  &clientRbac,
+		ManagerRbac: &managerRbac,
 		Client: xClient{
 			Routing: map[string][]string{},
 		},
 		Timeouts: xTimeouts{AgentArrival: "60s"},
 	}
 	if managedNamespaces := nss.Selector.StaticNames(); len(managedNamespaces) > 0 {
-		vx.Namespaces = managedNamespaces
+		if s.ManagerIsVersion(">2.21.x") {
+			vx.Namespaces = managedNamespaces
+		} else {
+			if !slices.Contains(managedNamespaces, nss.Namespace) {
+				managedNamespaces = append(managedNamespaces, nss.Namespace)
+			}
+			svcAccArg := "--serviceaccount=" + nss.Namespace + ":" + TestUser
+
+			if !s.ManagerIsVersion(">2.21.x") {
+				clientRbac.Namespaced = true
+				clientRbac.Namespaces = managedNamespaces
+				managerRbac.Namespaced = true
+				managerRbac.Namespaces = managedNamespaces
+				role := "tele-update-config"
+
+				// Agent is removed by removing its entry in the telepresence-agents configmap
+				for _, ns := range managedNamespaces {
+					err := Kubectl(ctx, ns, "create", "role", role, "--verb=update", "--resource=configmaps", "--resource-name=telepresence-agents")
+					if err != nil && !strings.Contains(err.Error(), "already exists") {
+						return "", err
+					}
+					err = Kubectl(ctx, ns, "create", "rolebinding", role, "--role", role, svcAccArg)
+					if err != nil && !strings.Contains(err.Error(), "already exists") {
+						return "", err
+					}
+				}
+			}
+		}
+
+		if !s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x") {
+			// Clients older than 2.22.0 need several additional permissions.
+			role := "tele-client"
+			for _, ns := range managedNamespaces {
+				r := rbac.Role{
+					TypeMeta: meta.TypeMeta{
+						APIVersion: "rbac.authorization.k8s.io/v1",
+						Kind:       "Role",
+					},
+					ObjectMeta: meta.ObjectMeta{
+						Name:      role,
+						Namespace: ns,
+					},
+					Rules: []rbac.PolicyRule{
+						{
+							Verbs:     []string{"get", "list", "watch"},
+							APIGroups: []string{"apps"},
+							Resources: []string{"deployments", "replicasets", "statefulsets"},
+						},
+						{
+							Verbs:     []string{"get", "list", "watch"},
+							APIGroups: []string{"argoproj.io"},
+							Resources: []string{"rollouts"},
+						},
+						{
+							Verbs:     []string{"get", "list", "watch"},
+							APIGroups: []string{""},
+							Resources: []string{"services"},
+						},
+					},
+				}
+				rj, err := yaml.Marshal(&r)
+				if err != nil {
+					return "", err
+				}
+				rb := rbac.RoleBinding{
+					TypeMeta: meta.TypeMeta{
+						APIVersion: "rbac.authorization.k8s.io/v1",
+						Kind:       "RoleBinding",
+					},
+					ObjectMeta: meta.ObjectMeta{
+						Name:      role,
+						Namespace: ns,
+					},
+					Subjects: subjects,
+					RoleRef: rbac.RoleRef{
+						APIGroup: "rbac.authorization.k8s.io",
+						Kind:     "Role",
+						Name:     role,
+					},
+				}
+				rbj, err := yaml.Marshal(&rb)
+				if err != nil {
+					return "", err
+				}
+				rj = append(rj, []byte("\n---\n")...)
+				rj = append(rj, rbj...)
+				err = Kubectl(dos.WithStdin(ctx, bytes.NewReader(rj)), ns, "apply", "-f", "-")
+				if err != nil {
+					return "", err
+				}
+			}
+		}
 	} else {
 		vx.NamespaceSelector = nss.Selector
 	}
 
-	image := GetImage(ctx)
-	if image != nil {
-		vx.Image = *image
-	}
-	if !s.isCI {
+	vx.Image = GetImage(ctx)
+	if !s.isCI && s.ManagerVersion().EQ(s.ClientVersion()) {
 		pp := "Always"
-		if s.Registry() == "local" {
+		if s.ManagerRegistry() == "local" {
 			// Using minikube with local images.
 			// They are automatically present and must not be pulled.
 			pp = "Never"
 		}
 		vx.Image.PullPolicy = pp
-		if vx.Agent == nil {
-			vx.Agent = &xAgent{}
-		}
-		if vx.Agent.Image == nil {
-			vx.Agent.Image = &Image{}
-		}
 		vx.Agent.Image.PullPolicy = pp
 	}
 
-	ss, err := sigsYaml.Marshal(&vx)
+	ss, err := yaml.Marshal(&vx)
 	if err != nil {
 		return "", err
 	}
@@ -197,6 +285,17 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 		verb = "upgrade"
 	}
 	args := []string{"helm", verb, "-n", nss.Namespace, "-f", valuesFile}
+	if !s.ManagerVersion().EQ(s.ClientVersion()) {
+		if !s.ClientIsVersion(">2.21.x") {
+			// Need to use the built executable because the client version doesn't handle the --version flag.
+			ctx = WithExecutable(ctx, s.executable)
+			if !s.ManagerVersion().EQ(version.Structured) {
+				args = append(args, "--version", s.ManagerVersion().String())
+			}
+		} else {
+			args = append(args, "--version", s.ManagerVersion().String())
+		}
+	}
 	args = append(args, settings...)
 
 	if _, _, err = Telepresence(WithUser(ctx, "default"), args...); err != nil {
@@ -206,6 +305,11 @@ func (s *cluster) TelepresenceHelmInstall(ctx context.Context, upgrade bool, set
 		return "", err
 	}
 	logFileName := s.self.CapturePodLogs(ctx, agentmap.ManagerAppName, "", nss.Namespace)
+
+	if !s.ManagerIsVersion(">2.21.x") {
+		// Give the manager time to perform rollouts, listen to telepresence-agents configmap, etc.
+		time.Sleep(2 * time.Second)
+	}
 	return logFileName, nil
 }
 

--- a/integration_test/itest/traffic_manager.go
+++ b/integration_test/itest/traffic_manager.go
@@ -111,7 +111,7 @@ func (th *trafficManager) DoWithTrafficManager(ctx context.Context, f func(conte
 		Namespace: th.AppNamespace(),
 		InstallId: "xxx",
 		Product:   "telepresence",
-		Version:   th.TelepresenceVersion(),
+		Version:   th.ClientVersion().String(),
 	})
 	if err != nil {
 		return err

--- a/integration_test/large_files_test.go
+++ b/integration_test/large_files_test.go
@@ -66,6 +66,9 @@ func (s *largeFilesSuite) ServiceCount() int {
 }
 
 func (s *largeFilesSuite) SetupSuite() {
+	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
+		s.T().Skip("Not part of compatibility tests. Not enough transfer stability in versions < 2.22.0")
+	}
 	s.Suite.SetupSuite()
 	ctx := s.Context()
 	wg := sync.WaitGroup{}

--- a/integration_test/manual_agent_test.go
+++ b/integration_test/manual_agent_test.go
@@ -113,7 +113,7 @@ func testManualAgent(s *itest.Suite, nsp itest.NamespacePair) {
 	defer itest.TelepresenceQuitOk(ctx)
 
 	stdout = itest.TelepresenceOk(ctx, "list")
-	require.Regexp(regexp.MustCompile(`.*`+ac.WorkloadName+`\s*:\s*ready to engage|intercept \(traffic-agent already installed\).*`), stdout)
+	require.Regexp(regexp.MustCompile(`.*`+ac.WorkloadName+`\s*:\s*ready to (engage|intercept) \(traffic-agent already installed\).*`), stdout)
 
 	svcPort, svcCancel := itest.StartLocalHttpEchoServer(ctx, ac.WorkloadName)
 	defer svcCancel()

--- a/integration_test/multiple_port_intercept_test.go
+++ b/integration_test/multiple_port_intercept_test.go
@@ -37,6 +37,9 @@ func init() {
 }
 
 func (s *multiportInterceptSuite) SetupSuite() {
+	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
+		s.T().Skip("Not part of compatibility tests. Support for multiport intercept was introduced in 2.22")
+	}
 	s.Suite.SetupSuite()
 	ctx := s.Context()
 	for i := 0; i < 4; i++ {

--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -33,6 +33,9 @@ func init() {
 }
 
 func (s *multipleServicesSuite) Test_LargeRequest() {
+	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
+		s.T().Skip("Not part of compatibility tests. TUN-device isn't stable enough versions <2.22.0")
+	}
 	// This particular cannot run with recursion detection, because it will trigger on the very high concurrency.
 	ctx := s.Context()
 	itest.TelepresenceQuitOk(ctx)
@@ -116,7 +119,7 @@ func (s *multipleServicesSuite) Test_LargeRequest() {
 func (s *multipleServicesSuite) Test_List() {
 	stdout := itest.TelepresenceOk(s.Context(), "-n", s.AppNamespace(), "list")
 	for i := 0; i < s.ServiceCount(); i++ {
-		s.Regexp(fmt.Sprintf(`%s-%d\s*: ready to engage`, s.Name(), i), stdout)
+		s.Regexp(fmt.Sprintf(`%s-%d\s*: ready to engage|intercept`, s.Name(), i), stdout)
 	}
 }
 

--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -119,7 +119,7 @@ func (s *multipleServicesSuite) Test_LargeRequest() {
 func (s *multipleServicesSuite) Test_List() {
 	stdout := itest.TelepresenceOk(s.Context(), "-n", s.AppNamespace(), "list")
 	for i := 0; i < s.ServiceCount(); i++ {
-		s.Regexp(fmt.Sprintf(`%s-%d\s*: ready to engage|intercept`, s.Name(), i), stdout)
+		s.Regexp(fmt.Sprintf(`%s-%d\s*: ready to (engage|intercept)`, s.Name(), i), stdout)
 	}
 }
 

--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -34,7 +34,7 @@ func init() {
 
 func (s *multipleServicesSuite) Test_LargeRequest() {
 	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
-		s.T().Skip("Not part of compatibility tests. TUN-device isn't stable enough versions <2.22.0")
+		s.T().Skip("Not part of compatibility tests. TUN-device isn't stable enough in versions <2.22.0")
 	}
 	// This particular cannot run with recursion detection, because it will trigger on the very high concurrency.
 	ctx := s.Context()

--- a/integration_test/multiport_test.go
+++ b/integration_test/multiport_test.go
@@ -15,6 +15,9 @@ import (
 // unnamed ports targets different container ports in the same workload and the same
 // container.
 func (s *connectedSuite) Test_MultipleUnnamedServicePorts() {
+	if !s.ManagerIsVersion(">2.21.x") {
+		s.T().Skip(`Not part of compatibility tests. No support for port annotation "all" in Versions < 2.22.0`)
+	}
 	ctx := s.Context()
 	dep := "echo-double-one-unnamed"
 	s.ApplyApp(ctx, dep, "deploy/"+dep)

--- a/integration_test/namespaces_test.go
+++ b/integration_test/namespaces_test.go
@@ -45,6 +45,9 @@ type namespaceData struct {
 }
 
 func (s *nsSuite) SetupSuite() {
+	if !(s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x")) {
+		s.T().Skip("Not part of compatibility tests. Namespace selector was introduced in 2.22.0")
+	}
 	s.nss = []namespaceData{
 		{
 			"manager",

--- a/integration_test/namespaces_test.go
+++ b/integration_test/namespaces_test.go
@@ -33,9 +33,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Name}}
-{{- with .Labels }}
   labels:
     purpose: tp-cli-testing
+{{- with .Labels }}
 {{ toYaml . | nindent 4 }}
 {{- end }}`
 

--- a/integration_test/not_connected_test.go
+++ b/integration_test/not_connected_test.go
@@ -111,10 +111,10 @@ func (s *notConnectedSuite) Test_ReportsNotConnected() {
 	s.TelepresenceConnect(ctx)
 	itest.TelepresenceDisconnectOk(ctx)
 	stdout := itest.TelepresenceOk(ctx, "version")
-	rxVer := regexp.QuoteMeta(s.TelepresenceVersion())
-	s.Regexp(fmt.Sprintf(`Client\s*: %s`, rxVer), stdout)
-	s.Regexp(fmt.Sprintf(`Root Daemon\s*: %s`, rxVer), stdout)
-	s.Regexp(fmt.Sprintf(`User Daemon\s*: %s`, rxVer), stdout)
+	rxVer := regexp.QuoteMeta(s.ClientVersion().String())
+	s.Regexp(fmt.Sprintf(`Client\s*: v%s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`Root Daemon\s*: v%s`, rxVer), stdout)
+	s.Regexp(fmt.Sprintf(`User Daemon\s*: v%s`, rxVer), stdout)
 	s.Regexp(`Traffic Manager\s*: not connected`, stdout)
 }
 

--- a/integration_test/podscaling_test.go
+++ b/integration_test/podscaling_test.go
@@ -64,11 +64,15 @@ func (s *interceptMountSuite) Test_RestartInterceptedPod() {
 	assert.Eventually(func() bool {
 		stdout, _, err := itest.Telepresence(ctx, "list")
 		if err != nil {
+			dlog.Errorf(ctx, "%s: %v", stdout, err)
 			return false
 		}
 		if match := rx.FindStringSubmatch(stdout); match != nil {
-			return match[1] == "ACTIVE"
+			if match[1] == "ACTIVE" {
+				return true
+			}
 		}
+		dlog.Info(ctx, stdout)
 		return false
 	}, 30*time.Second, 3*time.Second)
 

--- a/integration_test/reconnect_session_test.go
+++ b/integration_test/reconnect_session_test.go
@@ -35,6 +35,9 @@ func init() {
 }
 
 func (s *reconnectSuite) SetupSuite() {
+	if !s.ClientIsVersion(">2.21.x") {
+		s.T().Skip(`Not part of compatibility tests. Reconnect doesn't work well in Versions < 2.22.0`)
+	}
 	s.Suite.SetupSuite()
 
 	// Add our iptables table, disable tests if we're unable to.

--- a/integration_test/replace_test.go
+++ b/integration_test/replace_test.go
@@ -31,6 +31,9 @@ func init() {
 }
 
 func (s *replaceSuite) SetupSuite() {
+	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
+		s.T().Skip("Not part of compatibility tests. The replace command was introduced in 2.22")
+	}
 	s.Suite.SetupSuite()
 	s.tplPath = filepath.Join("testdata", "k8s", "generic.goyaml")
 	s.tpl = &itest.Generic{

--- a/integration_test/uninstall_test.go
+++ b/integration_test/uninstall_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -33,9 +34,13 @@ func (s *notConnectedSuite) Test_Uninstall() {
 	s.ApplyApp(ctx, jobname, deployname)
 	defer s.DeleteSvcAndWorkload(ctx, "deploy", jobname)
 
+	verb := "engage"
+	if !s.ClientIsVersion(">2.21.x") {
+		verb = "intercept"
+	}
 	s.Eventually(func() bool {
 		stdout, _, err = itest.Telepresence(ctx, "list", "--agents")
-		return err == nil && strings.Contains(stdout, jobname+": ready to engage (traffic-agent already installed)")
+		return err == nil && strings.Contains(stdout, fmt.Sprintf("%s: ready to %s (traffic-agent already installed)", jobname, verb))
 	}, 30*time.Second, 3*time.Second)
 
 	stdout = itest.TelepresenceOk(ctx, "helm", "uninstall", "-n", s.ManagerNamespace())

--- a/k8s/echo-sc.yaml
+++ b/k8s/echo-sc.yaml
@@ -33,7 +33,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: echo-sc
-          image: jmalloc/echo-server
+          image: ghcr.io/telepresenceio/echo-server:latest
           ports:
             - containerPort: 8080
               name: http

--- a/pkg/client/cli/cmd/helm.go
+++ b/pkg/client/cli/cmd/helm.go
@@ -56,6 +56,7 @@ func helmInstall() *cobra.Command {
 	flags.BoolVarP(&ha.NoHooks, "no-hooks", "", false, "prevent hooks from running during install")
 	flags.BoolVarP(&upgrade, "upgrade", "u", false, "replace the traffic manager if it already exists")
 	flags.BoolVar(&ha.CreateNamespace, "create-namespace", true, "create a namespace for the traffic-manager if not present")
+	flags.StringVar(&ha.Version, "version", "", "the telepresence version if different from the client's version. May be a range (e.g. ^2.21.0)")
 	ha.addValueSettingFlags(flags)
 	ha.addCRDsFlags(flags)
 	uf := flags.Lookup("upgrade")
@@ -86,6 +87,7 @@ func helmUpgrade() *cobra.Command {
 	flags.BoolVarP(&ha.ReuseValues, "reuse-values", "", false,
 		"when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f")
 	flags.BoolVarP(&ha.CreateNamespace, "create-namespace", "", true, "create the release namespace if not present")
+	flags.StringVar(&ha.Version, "version", "", "the telepresence version if different from the client's version. May be a range (e.g. ^2.21.0)")
 	ha.rq = daemon.InitRequest(cmd)
 	return cmd
 }

--- a/pkg/client/cli/helm/chart.go
+++ b/pkg/client/cli/helm/chart.go
@@ -2,10 +2,18 @@ package helm
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
 
+	"github.com/datawire/dlib/dlog"
 	telcharts "github.com/telepresenceio/telepresence/v2/charts"
 )
 
@@ -15,6 +23,47 @@ func loadCoreChart(version string) (*chart.Chart, error) {
 		return nil, err
 	}
 	return loader.LoadArchive(&buf)
+}
+
+func newDefaultRegistryClient(ctx context.Context) (*registry.Client, error) {
+	return registry.NewClient(
+		registry.ClientOptDebug(dlog.MaxLogLevel(ctx) >= dlog.LogLevelDebug),
+		registry.ClientOptEnableCache(true),
+		registry.ClientOptWriter(dlog.StdLogger(ctx, dlog.LogLevelDebug).Writer()),
+	)
+}
+
+func pullCoreChart(ctx context.Context, helmConfig *action.Configuration, ref, version string) (*chart.Chart, error) {
+	client, err := newDefaultRegistryClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "helm-")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = os.RemoveAll(dir)
+		if err != nil {
+			dlog.Error(ctx, err)
+		}
+	}()
+	pull := action.NewPullWithOpts(action.WithConfig(helmConfig))
+	pull.Version = version
+	pull.DestDir = dir
+	pull.Settings = cli.New()
+	pull.SetRegistryClient(client)
+	out, err := pull.Run(ref)
+	dlog.Info(ctx, out)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(filepath.Join(dir, fmt.Sprintf("telepresence-oss-%s.tgz", version)))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return loader.LoadArchive(f)
 }
 
 func loadCRDChart(version string) (*chart.Chart, error) {

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -469,7 +469,7 @@ func (s *session) CanIntercept(c context.Context, ir *rpc.CreateInterceptRequest
 		return nil, nil
 	}
 
-	if len(spec.PodPorts) > 0 && s.compareFinalizedManagerVersion(2, 22, 0) < 0 {
+	if (spec.PortIdentifier == "all" || len(spec.PodPorts) > 0) && s.compareFinalizedManagerVersion(2, 22, 0) < 0 {
 		return nil, InterceptError(common.InterceptError_TRAFFIC_MANAGER_ERROR, errcat.User.Newf(
 			"traffic-manager version %s has no support for multi-port intercepts", s.managerVersion))
 	}


### PR DESCRIPTION
This PR enables the integration tests to run with an traffic-manager/traffic-agent pair of a different version than the binary being tested, so that compatibility tests can be added for release candidates.