### PR TITLE
Rollout workload when disruption budget prevents pod eviction

### DIFF
--- a/charts/telepresence-oss/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence-oss/templates/trafficManagerRbac/cluster-scope.yaml
@@ -56,6 +56,9 @@ rules:
   - get
   - list
   - watch
+{{- if .agentInjector.enabled }}
+  - patch
+{{- end }}
 {{- if .workloads.argoRollouts.enabled }}
 - apiGroups:
   - "argoproj.io"
@@ -65,6 +68,9 @@ rules:
   - get
   - list
   - watch
+{{- if .agentInjector.enabled }}
+  - patch
+{{- end }}
 {{- end }}
 - apiGroups:
     - "events.k8s.io"

--- a/charts/telepresence-oss/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence-oss/templates/trafficManagerRbac/namespace-scope.yaml
@@ -73,6 +73,9 @@ rules:
   - get
   - list
   - watch
+{{- if $interceptEnabled }}
+  - patch
+{{- end }}
 {{- if $argoRolloutsEnabled }}
 - apiGroups:
   - "argoproj.io"

--- a/cmd/traffic/cmd/manager/cluster/podwatcher.go
+++ b/cmd/traffic/cmd/manager/cluster/podwatcher.go
@@ -19,14 +19,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/subnet"
 )
 
-// PodLister helps list Pods.
-// All objects returned here must be treated as read-only.
-type PodLister interface {
-	// List lists all Pods in the indexer.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*corev1.Pod, err error)
-}
-
 type podWatcher struct {
 	ipsMap    map[netip.Addr]struct{}
 	timer     *time.Timer

--- a/cmd/traffic/cmd/manager/mutator/eviction.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction.go
@@ -1,0 +1,335 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	core "k8s.io/api/core/v1"
+	v1 "k8s.io/api/policy/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/datawire/dlib/derror"
+	"github.com/datawire/dlib/dlog"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+)
+
+type wlPods struct {
+	wl   k8sapi.Workload
+	pods []*core.Pod
+}
+
+type wlPodMap map[workloadKey]*wlPods
+
+func (em wlPodMap) add(wl k8sapi.Workload, pod *core.Pod) {
+	k := workloadKey{kind: wl.GetKind(), name: wl.GetName(), namespace: wl.GetNamespace()}
+	if v, ok := em[k]; ok {
+		v.pods = append(v.pods, pod)
+	} else {
+		em[k] = &wlPods{wl: wl, pods: []*core.Pod{pod}}
+	}
+}
+
+func (c *configWatcher) EvictPodsWithAgentConfigMismatch(ctx context.Context, wl k8sapi.Workload, scx agentconfig.SidecarExt) error {
+	cfgJSON, err := agentconfig.MarshalTight(scx)
+	if err != nil {
+		return err
+	}
+	pods, err := workloadPods(ctx, wl)
+	if err != nil {
+		return err
+	}
+	return c.evictPodsWithAgentConfigMismatch(ctx, wl, pods, cfgJSON)
+}
+
+func (c *configWatcher) EvictPodsWithAgentConfig(ctx context.Context, wl k8sapi.Workload) error {
+	pods, err := workloadPods(ctx, wl)
+	if err != nil {
+		return err
+	}
+	return c.evictPodsWithAgentConfigMismatch(ctx, wl, pods, "")
+}
+
+func (c *configWatcher) EvictAllPodsWithAgentConfig(ctx context.Context, namespace string) error {
+	c.agentConfigs.Delete(namespace)
+	evictMap, err := podList(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	var errs derror.MultiError
+	for _, wp := range evictMap {
+		err = c.evictPodsWithAgentConfigMismatch(ctx, wp.wl, wp.pods, "")
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		return errs
+	}
+}
+
+func (c *configWatcher) evictPodsWithAgentConfigMismatch(ctx context.Context, wl k8sapi.Workload, pods []*core.Pod, cfgJSON string) error {
+	pods = slices.DeleteFunc(pods, func(pod *core.Pod) bool {
+		if pod.Annotations[agentconfig.ConfigAnnotation] == cfgJSON {
+			dlog.Tracef(ctx, "Keeping pod %s because its config is still valid", pod.Name)
+			return true
+		}
+		return false
+	})
+	return c.evictPods(ctx, wl, pods)
+}
+
+func (c *configWatcher) evictPods(ctx context.Context, wl k8sapi.Workload, pods []*core.Pod) (err error) {
+	didRollout := false
+	counter := 0
+	for _, pod := range pods {
+		podID := pod.UID
+		if c.isEvicted(podID) {
+			dlog.Debugf(ctx, "Skipping pod %s because it is already deleted", pod.Name)
+			continue
+		}
+		a := pod.ObjectMeta.Annotations
+		if v, ok := a[agentconfig.ManualInjectAnnotation]; ok && v == "true" {
+			dlog.Tracef(ctx, "Skipping pod %s because it is managed manually", pod.Name)
+			continue
+		}
+		c.inactivePods.Compute(podID, func(v inactivation, loaded bool) (inactivation, bool) {
+			if loaded && v.deleted {
+				return v, false
+			}
+			if !didRollout {
+				didRollout, err = evictOrRollout(ctx, wl, pod, counter)
+				if err != nil {
+					return v, false
+				}
+				counter++
+			}
+			return inactivation{Time: time.Now(), deleted: true}, false
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func evictOrRollout(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, counter int) (didRollout bool, err error) {
+	err = evictPod(ctx, pod)
+	if err == nil {
+		return false, nil
+	}
+	if wl == nil || !strings.Contains(err.Error(), "disruption budget") {
+		return false, fmt.Errorf("failed to evict pod %s: %v", pod.Name, err)
+	}
+	dlog.Debugf(ctx, "Unable to evict pod %s because it would violate the pod's disruption budget", pod.Name)
+	if counter > 0 {
+		// Other pod siblings were evicted successfully, which means that an engagement will be able to
+		// proceed, Wait for the previous eviction(s) to trigger pod recreation, so the disruption budget
+		// can be satisfied even though this pod is evicted.
+		go func() {
+			evictCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), managerutil.GetEnv(ctx).AgentArrivalTimeout)
+			defer cancel()
+			if err := retryEvictPod(evictCtx, wl, pod, wl.Replicas()); err != nil {
+				dlog.Errorf(ctx, "unable to evict pod %s: %v", pod.Name, err)
+			}
+		}()
+		return false, nil
+	}
+	switch wl.GetKind() {
+	case k8sapi.StatefulSetKind, k8sapi.ReplicaSetKind:
+		return false, triggerScalingEviction(ctx, wl, pod)
+	default:
+		dlog.Debugf(ctx, "Patching %s to trigger pod recreation", wl)
+		restartAnnotation := generateRestartAnnotationPatch(wl.GetPodTemplate().Annotations)
+		if err = wl.Patch(ctx, types.JSONPatchType, []byte(restartAnnotation)); err != nil {
+			return false, fmt.Errorf("unable to patch %s: %v", wl, err)
+		}
+		dlog.Debugf(ctx, "Successfully patched %s", wl)
+	}
+	// Rollout applies to all pods for the workload, so we're done here
+	return true, nil
+}
+
+func retryEvictPod(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, replicas int) error {
+	err := waitForReplicaCount(ctx, wl, replicas)
+	if err != nil {
+		return err
+	}
+	for {
+		err = evictPod(ctx, pod)
+		if err == nil || !strings.Contains(err.Error(), "disruption budget") {
+			return err
+		}
+		delay := 2 * time.Second
+		dlog.Debugf(ctx, "Unable to evict pod %s. Will retry in %s", pod.Name, delay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// generateRestartAnnotationPatch generates a JSON patch that adds or updates the annotation
+// We need to use this particular patch type because argo-rollouts do not support strategic merge patches.
+func generateRestartAnnotationPatch(annotations map[string]string) string {
+	basePointer := "/spec/template/metadata/annotations"
+	pointer := fmt.Sprintf(
+		basePointer+"/%s",
+		strings.ReplaceAll(agentconfig.RestartedAtAnnotation, "/", "~1"),
+	)
+
+	if _, ok := annotations[agentconfig.RestartedAtAnnotation]; ok {
+		return fmt.Sprintf(
+			`[{"op": "replace", "path": "%s", "value": "%s"}]`, pointer, time.Now().Format(time.RFC3339),
+		)
+	}
+
+	if len(annotations) == 0 {
+		return fmt.Sprintf(
+			`[{"op": "add", "path": "%s", "value": {}}, {"op": "add", "path": "%s", "value": "%s"}]`, basePointer, pointer, time.Now().Format(time.RFC3339),
+		)
+	}
+
+	return fmt.Sprintf(
+		`[{"op": "add", "path": "%s", "value": "%s"}]`, pointer, time.Now().Format(time.RFC3339),
+	)
+}
+
+func waitForReplicaCount(ctx context.Context, wl k8sapi.Workload, count int) error {
+	for {
+		pods, err := workloadPods(ctx, wl)
+		if err != nil {
+			return err
+		}
+		if len(pods) == count && !slices.ContainsFunc(pods, func(pod *core.Pod) bool { return pod.Status.Phase != core.PodRunning }) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s never scaled to %d", wl, count)
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+}
+
+func scaleIt(ctx context.Context, wl k8sapi.Workload, replicas int) error {
+	dlog.Debugf(ctx, "Scaling %s to %d replicas", wl, replicas)
+	patch := fmt.Sprintf(`{"spec": {"replicas": %d}}`, replicas)
+	err := wl.Patch(ctx, types.StrategicMergePatchType, []byte(patch))
+	if err != nil {
+		err = fmt.Errorf("unable to scale %s to %d: %v", wl, replicas, err)
+	}
+	return err
+}
+
+func triggerScalingEviction(ctx context.Context, wl k8sapi.Workload, pod *core.Pod) error {
+	// Rollout of a replicatset/statefulset will not recreate the pods. In order for that to happen, the
+	// set must be scaled down to zero replicas and then up again.
+	replicas := wl.Replicas()
+	if err := scaleIt(ctx, wl, replicas+1); err != nil {
+		return err
+	}
+	defer func() {
+		// Ensure that the original replica count is restored. Don't wait for it though
+		go func() {
+			if err := scaleIt(context.WithoutCancel(ctx), wl, replicas); err != nil {
+				dlog.Error(ctx, err)
+			}
+		}()
+	}()
+	return retryEvictPod(ctx, wl, pod, replicas+1)
+}
+
+func evictPod(ctx context.Context, pod *core.Pod) error {
+	err := k8sapi.GetK8sInterface(ctx).CoreV1().Pods(pod.Namespace).EvictV1(ctx, &v1.Eviction{
+		ObjectMeta: meta.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+	})
+	if err == nil {
+		store := informer.GetK8sFactory(ctx, pod.Namespace).Core().V1().Pods().Informer().GetStore()
+		_ = store.Delete(pod)
+		dlog.Debugf(ctx, "Successfully evicted pod %s", pod.Name)
+	}
+	return err
+}
+
+func podIsPendingOrRunning(pod *core.Pod) bool {
+	switch pod.Status.Phase {
+	case core.PodPending, core.PodRunning:
+		return true
+	default:
+		return false
+	}
+}
+
+type podLister interface {
+	List(selector labels.Selector) (ret []*core.Pod, err error)
+}
+
+func getPodLister(ctx context.Context, namespace string) (lister podLister) {
+	api := informer.GetK8sFactory(ctx, namespace).Core().V1().Pods().Lister()
+	if namespace == "" {
+		lister = api
+	} else {
+		lister = api.Pods(namespace)
+	}
+	return lister
+}
+
+func podList(ctx context.Context, namespace string) (wlPodMap, error) {
+	lister := getPodLister(ctx, namespace)
+	pods, err := lister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods %s: %v", whereWeWatch(namespace), err)
+	}
+	enabledWorkloads := managerutil.GetEnv(ctx).EnabledWorkloadKinds
+	podMap := make(wlPodMap)
+	for _, pod := range pods {
+		if !podIsPendingOrRunning(pod) {
+			continue
+		}
+		var wl k8sapi.Workload
+		if podKind, ok := pod.Labels[agentconfig.WorkloadKindLabel]; ok && !enabledWorkloads.Contains(k8sapi.Kind(podKind)) {
+			// Pod's label indicates a workload kind that has been disabled. As such, it will not be present in the
+			// shared informer cache.
+			wl, err = k8sapi.GetWorkload(ctx, pod.Labels[agentconfig.WorkloadNameLabel], pod.Namespace, k8sapi.Kind(podKind))
+		} else {
+			wl, err = agentmap.FindOwnerWorkload(ctx, k8sapi.Pod(pod), enabledWorkloads)
+		}
+		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		podMap.add(wl, pod)
+	}
+	return podMap, nil
+}
+
+func workloadPods(ctx context.Context, wl k8sapi.Workload) ([]*core.Pod, error) {
+	lister := getPodLister(ctx, wl.GetNamespace())
+	selector, err := wl.Selector()
+	if err != nil {
+		return nil, err
+	}
+	pods, err := lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(slices.Clone(pods), func(pod *core.Pod) bool { return !podIsPendingOrRunning(pod) }), nil
+}

--- a/cmd/traffic/cmd/manager/mutator/service_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/service_watcher.go
@@ -129,7 +129,7 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustU
 			}
 			if err != nil {
 				if errors.IsNotFound(err) {
-					dlog.Debugf(ctx, "Deleting config entry for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
+					dlog.Debugf(ctx, "Deleting config entry for %s", wl)
 					c.Delete(ac.AgentName, ac.Namespace)
 				} else {
 					dlog.Error(ctx, err)
@@ -137,7 +137,7 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustU
 				continue
 			}
 		}
-		dlog.Debugf(ctx, "Regenerating config entry for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
+		dlog.Debugf(ctx, "Regenerating config entry for %s", wl)
 		acn, err := cfg.Generate(ctx, wl, ac)
 		if err != nil {
 			if strings.Contains(err.Error(), "unable to find") {
@@ -147,10 +147,9 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustU
 			}
 			continue
 		}
-		ac = acn.AgentConfig()
 		c.Store(acn)
-		dlog.Debugf(ctx, "deleting pods with config mismatch for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
-		err = c.EvictPodsWithAgentConfigMismatch(ctx, acn)
+		dlog.Debugf(ctx, "deleting pods with config mismatch for %s", wl)
+		err = c.EvictPodsWithAgentConfigMismatch(ctx, wl, acn)
 		if err != nil {
 			dlog.Error(ctx, err)
 		}

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -85,7 +85,7 @@ func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Wor
 		if scx == nil {
 			action = "Regenerating"
 		}
-		dlog.Debugf(ctx, "%s config entry for %s %s.%s", action, wl.GetKind(), wl.GetName(), wl.GetNamespace())
+		dlog.Debugf(ctx, "%s config entry for %s", action, wl)
 
 		scx, err = cfg.Generate(ctx, wl, scx)
 		if err != nil {
@@ -98,9 +98,8 @@ func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Wor
 		}
 
 		c.Store(scx)
-		ac := scx.AgentConfig()
-		dlog.Debugf(ctx, "deleting pods with config mismatch for %s %s.%s", ac.WorkloadKind, ac.WorkloadName, ac.Namespace)
-		err = c.EvictPodsWithAgentConfigMismatch(ctx, scx)
+		dlog.Debugf(ctx, "deleting pods with config mismatch for %s", wl)
+		err = c.EvictPodsWithAgentConfigMismatch(ctx, wl, scx)
 		if err != nil {
 			dlog.Error(ctx, err)
 		}

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -212,7 +212,7 @@ func (wf *workloadInfoWatcher) handleWorkloadsSnapshot(ctx context.Context, wes 
 		if w, ok := wf.workloadEvents[wl.GetName()]; ok {
 			if we.Type == workload.EventTypeDelete && w.Type != rpc.WorkloadEvent_DELETED {
 				w.Type = rpc.WorkloadEvent_DELETED
-				dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s.%s %s", we.Type, wl.GetKind(), wl.GetName(), wl.GetNamespace(), workload.GetWorkloadState(wl))
+				dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s", we.Type, wl, workload.GetWorkloadState(wl))
 				wf.resetTicker()
 			}
 		} else {
@@ -236,7 +236,7 @@ func (wf *workloadInfoWatcher) handleWorkloadsSnapshot(ctx context.Context, wes 
 					break
 				}
 			}
-			dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s.%s %s %s", we.Type, wl.GetKind(), wl.GetName(), wl.GetNamespace(), as, workload.GetWorkloadState(wl))
+			dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s %s", we.Type, wl, as, workload.GetWorkloadState(wl))
 			wf.addEvent(we.Type, wl, as, iClients)
 		}
 	}
@@ -320,7 +320,7 @@ func (wf *workloadInfoWatcher) handleInterceptSnapshot(ctx context.Context, iis 
 					wf.resetTicker()
 				}
 			} else if wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, ""); err == nil {
-				dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", wl.GetName(), wl.GetNamespace(), as, workload.GetWorkloadState(wl))
+				dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", wl, as, workload.GetWorkloadState(wl))
 				wf.addEvent(workload.EventTypeUpdate, wl, as, nil)
 			}
 		}
@@ -346,7 +346,7 @@ func (wf *workloadInfoWatcher) handleInterceptSnapshot(ctx context.Context, iis 
 				wf.resetTicker()
 			}
 		} else if wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, ""); err == nil {
-			dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", wl.GetName(), wl.GetNamespace(), as, workload.GetWorkloadState(wl))
+			dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", wl, as, workload.GetWorkloadState(wl))
 			wf.addEvent(workload.EventTypeUpdate, wl, as, iClients)
 		}
 	}

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -169,7 +169,7 @@ func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
 			ras := itest.RunningPodsWithAgents(ctx, "quote-", is.AppNamespace())
 			dlog.Infof(ctx, "pod with agent count %d, expected 0", len(ras))
 			return len(ras) == 0
-		}, 120*time.Second, 5*time.Second)
+		}, 60*time.Second, 5*time.Second)
 	}()
 
 	// And check that all pods receive a traffic-agent
@@ -177,7 +177,7 @@ func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
 		ras := itest.RunningPodsWithAgents(ctx, "quote-", is.AppNamespace())
 		dlog.Infof(ctx, "pod with agent count %d, expected %d", len(ras), svcCount)
 		return len(ras) == svcCount
-	}, 120*time.Second, 5*time.Second)
+	}, 60*time.Second, 5*time.Second)
 }
 
 func (is *installSuite) Test_MultiOnDemandInjectOnApply() {

--- a/integration_test/itest/template.go
+++ b/integration_test/itest/template.go
@@ -48,6 +48,12 @@ type PersistentVolume struct {
 	MountDirectory string
 }
 
+type DisruptionBudget struct {
+	Name           string
+	MinAvailable   int
+	MaxUnavailable int
+}
+
 func OpenTemplate(ctx context.Context, name string, data any) (io.Reader, error) {
 	b, err := ReadTemplate(ctx, name, data)
 	if err != nil {

--- a/integration_test/testdata/k8s/disruption-budget.goyaml
+++ b/integration_test/testdata/k8s/disruption-budget.goyaml
@@ -1,0 +1,15 @@
+{{- /*gotype: github.com/telepresenceio/telepresence/v2/integration_test/itest.DisruptionBudget*/ -}}---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{.Name}}
+spec:
+{{- if gt .MinAvailable 0 }}
+  minAvailable: {{ .MinAvailable }}
+{{- end }}
+{{- if gt .MaxUnavailable 0 }}
+	maxUnavailable: {{ .MaxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      budget: {{.Name}}

--- a/integration_test/testdata/k8s/echo-min.yaml
+++ b/integration_test/testdata/k8s/echo-min.yaml
@@ -2,44 +2,49 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: echo-no-vols
+  name: "echo"
 spec:
   type: ClusterIP
   selector:
-    app: echo-no-vols
+    app: echo
   ports:
-    - name: http
+    - name: proxied
       port: 80
       targetPort: http
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: echo
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: echo
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: echo-no-vols
+  name: "echo"
   labels:
-    app: echo-no-vols
+    app: echo
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: echo-no-vols
+      app: echo
   template:
     metadata:
       labels:
-        app: echo-no-vols
-        budget: telepresence-test
+        app: echo
     spec:
-      automountServiceAccountToken: false
       containers:
-        - name: echo-server
+        - name: echo
           image: ghcr.io/telepresenceio/echo-server:latest
           ports:
-            - name: http
-              containerPort: 8080
-          env:
-            - name: PORT
-              value: "8080"
+            - containerPort: 8080
+              name: http
           resources:
             limits:
               cpu: 50m
-              memory: 8Mi
+              memory: 128Mi

--- a/integration_test/testdata/k8s/echo-no-svc-ann.yaml
+++ b/integration_test/testdata/k8s/echo-no-svc-ann.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: echo-no-svc-ann
+        budget: telepresence-test
       annotations:
         telepresence.getambassador.io/inject-container-ports: http
     spec:

--- a/integration_test/testdata/k8s/rs-echo.yaml
+++ b/integration_test/testdata/k8s/rs-echo.yaml
@@ -27,6 +27,7 @@ spec:
     metadata:
       labels:
         app: rs-echo
+        budget: telepresence-test
     spec:
       containers:
         - name: rs-echo

--- a/integration_test/testdata/k8s/ss-echo.yaml
+++ b/integration_test/testdata/k8s/ss-echo.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       labels:
         app: ss-echo
+        budget: telepresence-test
     spec:
       containers:
         - name: ss-echo

--- a/integration_test/testdata/k8s/with-probes.yaml
+++ b/integration_test/testdata/k8s/with-probes.yaml
@@ -15,6 +15,7 @@ spec:
         sidecar.istio.io/inject: 'false'
       labels:
         app: with-probes
+        budget: telepresence-test
     spec:
       containers:
         - name: sample-app

--- a/integration_test/workloads_test.go
+++ b/integration_test/workloads_test.go
@@ -1,18 +1,62 @@
 package integration_test
 
 import (
+	"bytes"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 )
+
+func (s *connectedSuite) uninstall(wl string) {
+	ctx := s.Context()
+
+	itest.TelepresenceOk(ctx, "uninstall", wl)
+	s.Require().Eventually(
+		func() bool {
+			stdout, _, err := itest.Telepresence(ctx, "list", "--agents")
+			return err == nil && !strings.Contains(stdout, wl)
+		},
+		180*time.Second, // waitFor
+		6*time.Second,   // polling interval
+	)
+}
 
 func (s *connectedSuite) successfulIntercept(tp, wl, port string) {
 	ctx := s.Context()
 	s.ApplyApp(ctx, wl, strings.ToLower(tp)+"/"+wl)
 	defer s.DeleteSvcAndWorkload(ctx, tp, wl)
 
+	s.doIntercept(tp, wl, port)
+	if !s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x") {
+		// An <2.22.0 client will not be able to uninstall an agent when the traffic-manager is >=2.22.0
+		// because the client will attempt to remove the entry in the telepresence-agents configmap. It
+		// is no longer present in versions >=2.22.0
+		return
+	}
+	s.uninstall(wl)
+	tpl := itest.DisruptionBudget{
+		Name:         "telepresence-test",
+		MinAvailable: 1,
+	}
+
+	// Do the intercept again, this time with a disruption budget with minAvailable=1 in place.
+	rq := s.Require()
+	db, err := itest.ReadTemplate(ctx, filepath.Join("testdata", "k8s", "disruption-budget.goyaml"), &tpl)
+	rq.NoError(err)
+	rq.NoError(s.Kubectl(dos.WithStdin(ctx, bytes.NewReader(db)), "apply", "-f", "-"))
+	defer func() {
+		_ = s.Kubectl(dos.WithStdin(ctx, bytes.NewReader(db)), "delete", "-f", "-")
+	}()
+	s.doIntercept(tp, wl, port)
+}
+
+func (s *connectedSuite) doIntercept(tp, wl, port string) {
+	ctx := s.Context()
 	require := s.Require()
 
 	require.Eventually(
@@ -24,31 +68,26 @@ func (s *connectedSuite) successfulIntercept(tp, wl, port string) {
 		2*time.Second, // polling interval
 	)
 
+	out, err := s.KubectlOut(ctx, "get", strings.ToLower(tp), wl, "-o", "jsonpath={.spec.replicas}")
+	require.NoError(err)
+	replicas, err := strconv.Atoi(out)
+	require.NoError(err)
+
 	stdout := itest.TelepresenceOk(ctx, "intercept", "--mount", "false", "--port", port, wl)
 	require.Contains(stdout, "Using "+tp+" "+wl)
 	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
 	require.Contains(stdout, wl+": intercepted")
 	require.NotContains(stdout, "Volume Mount Point")
+	s.Eventually(func() bool {
+		ras := itest.RunningPodsWithAgents(ctx, wl, s.AppNamespace())
+		dlog.Infof(ctx, "pod with agent count %d, expected %d", len(ras), replicas)
+		return len(ras) == replicas
+	}, 60*time.Second, 5*time.Second)
 	s.CapturePodLogs(ctx, wl, "traffic-agent", s.AppNamespace())
+	time.Sleep(10 * time.Second)
 	itest.TelepresenceOk(ctx, "leave", wl)
 	stdout = itest.TelepresenceOk(ctx, "list", "--intercepts")
 	require.NotContains(stdout, wl+": intercepted")
-
-	if !s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x") {
-		// An <2.22.0 client will not be able to uninstall an agent when the traffic-manager is >=2.22.0
-		// because the client will attempt to remove the entry in the telepresence-agents configmap. It
-		// is no longer present in versions >=2.22.0
-		return
-	}
-	itest.TelepresenceOk(ctx, "uninstall", wl)
-	require.Eventually(
-		func() bool {
-			stdout, _, err := itest.Telepresence(ctx, "list", "--agents")
-			return err == nil && !strings.Contains(stdout, wl)
-		},
-		180*time.Second, // waitFor
-		6*time.Second,   // polling interval
-	)
 }
 
 func (s *connectedSuite) successfulIngest(tp, wl string) {
@@ -76,31 +115,13 @@ func (s *connectedSuite) successfulIngest(tp, wl string) {
 	itest.TelepresenceOk(ctx, "leave", wl)
 	stdout = itest.TelepresenceOk(ctx, "list", "--ingests")
 	require.NotContains(stdout, wl+": ingested")
-
 	if !s.ClientIsVersion(">2.21.x") && s.ManagerIsVersion(">2.21.x") {
 		// An <2.22.0 client will not be able to uninstall an agent when the traffic-manager is >=2.22.0
 		// because the client will attempt to remove the entry in the telepresence-agents configmap. It
 		// is no longer present in versions >=2.22.0
 		return
 	}
-
-	itest.TelepresenceOk(ctx, "uninstall", wl)
-	require.Eventually(
-		func() bool {
-			stdout, _, err := itest.Telepresence(ctx, "list", "--agents")
-			if err != nil {
-				dlog.Error(ctx, err)
-				return false
-			}
-			if strings.Contains(stdout, wl) {
-				dlog.Errorf(ctx, "Expected %q to not contain %q", stdout, wl)
-				return false
-			}
-			return true
-		},
-		60*time.Second, // waitFor
-		6*time.Second,  // polling interval
-	)
+	s.uninstall(wl)
 }
 
 func (s *connectedSuite) Test_SuccessfullyInterceptsDeploymentWithProbes() {

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -98,7 +98,7 @@ func portsFromAnnotationValue(wl k8sapi.Workload, annotation, value string) (por
 	for i, cp := range cps {
 		pi := agentconfig.PortIdentifier(cp)
 		if err = pi.Validate(); err != nil {
-			return nil, fmt.Errorf("unable to parse annotation %s of workload %s.%s: %w", annotation, wl.GetName(), wl.GetNamespace(), err)
+			return nil, fmt.Errorf("unable to parse annotation %s of %s: %w", annotation, wl, err)
 		}
 		ports[i] = pi
 	}
@@ -111,7 +111,7 @@ func (cfg *BasicGeneratorConfig) Generate(
 	existingConfig agentconfig.SidecarExt,
 ) (sc agentconfig.SidecarExt, err error) {
 	if TrafficManagerSelector.Matches(labels.Set(wl.GetLabels())) {
-		return nil, fmt.Errorf("deployment %s.%s is the Telepresence Traffic Manager. It can not have a traffic-agent", wl.GetName(), wl.GetNamespace())
+		return nil, fmt.Errorf("%s is the Telepresence Traffic Manager. It can not have a traffic-agent", wl)
 	}
 
 	pod := wl.GetPodTemplate()

--- a/pkg/k8sapi/object.go
+++ b/pkg/k8sapi/object.go
@@ -145,6 +145,10 @@ func (o *service) Selector() (labels.Selector, error) {
 	return labels.SelectorFromSet(o.Spec.Selector), nil
 }
 
+func (o *service) String() string {
+	return String(o)
+}
+
 func (o *service) Update(c context.Context) error {
 	d, err := o.ki(c).Update(c, o.Service, meta.UpdateOptions{})
 	if err == nil {
@@ -198,6 +202,10 @@ func (o *pod) Refresh(c context.Context) error {
 
 func (o *pod) Selector() (labels.Selector, error) {
 	return nil, nil
+}
+
+func (o *pod) String() string {
+	return String(o)
 }
 
 func (o *pod) Update(c context.Context) error {

--- a/pkg/k8sapi/workload.go
+++ b/pkg/k8sapi/workload.go
@@ -232,6 +232,10 @@ func StatefulSetImpl(o Object) (*apps.StatefulSet, bool) {
 	return nil, false
 }
 
+func String(o Object) string {
+	return fmt.Sprintf("%s %s.%s", o.GetKind(), o.GetName(), o.GetNamespace())
+}
+
 type deployment struct {
 	*apps.Deployment
 }
@@ -285,6 +289,10 @@ func (o *deployment) Replicas() int {
 
 func (o *deployment) Selector() (labels.Selector, error) {
 	return meta.LabelSelectorAsSelector(o.Spec.Selector)
+}
+
+func (o *deployment) String() string {
+	return String(o)
 }
 
 func (o *deployment) Update(c context.Context) error {
@@ -363,6 +371,10 @@ func (o *rollout) Selector() (labels.Selector, error) {
 	return meta.LabelSelectorAsSelector(o.Spec.Selector)
 }
 
+func (o *rollout) String() string {
+	return String(o)
+}
+
 func (o *rollout) Update(c context.Context) error {
 	d, err := o.ki(c).Update(c, o.Rollout, meta.UpdateOptions{})
 	if err == nil {
@@ -435,6 +447,10 @@ func (o *replicaSet) Selector() (labels.Selector, error) {
 	return meta.LabelSelectorAsSelector(o.Spec.Selector)
 }
 
+func (o *replicaSet) String() string {
+	return String(o)
+}
+
 func (o *replicaSet) Update(c context.Context) error {
 	d, err := o.ki(c).Update(c, o.ReplicaSet, meta.UpdateOptions{})
 	if err == nil {
@@ -505,6 +521,10 @@ func (o *statefulSet) Replicas() int {
 
 func (o *statefulSet) Selector() (labels.Selector, error) {
 	return meta.LabelSelectorAsSelector(o.Spec.Selector)
+}
+
+func (o *statefulSet) String() string {
+	return String(o)
 }
 
 func (o *statefulSet) Update(c context.Context) error {


### PR DESCRIPTION
Eviction might be prevented when a disruption budget is in place because Kubernetes will not start a new pod until after the eviction. This commit introduces three ways to mitigate this problem.

1. When multiple evictions are made, and some of those evictions have succeeded, then a good strategy is to just wait until the evicted pods are recreated, and then continue to evict others.
2. For a deployment or argo-rollout, applying a patch with a restart annotation causes all pods to be redeployed in a manner that doesn't disrupt the budget.
3. For replicasets and statefulsets, the approach is to scale up above the budget threshold, evict the pod, and then scale back down again.
