### PR TITLE
Make telepresence connect --docker work with Rancher Desktop

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -145,6 +145,19 @@ items:
           The clusterID was deprecated some time ago, and replaced by the ID of the namespace where the traffic-manager
           is installed.
       - type: bugfix
+        title: Make telepresence connect --docker work with Rancher Desktop
+        body: >-
+          Rancher Desktop will start a K3s control-plane and typically expose the
+          Kubernetes API server at `127.0.0.1:6443`. Telepresence can connect to
+          this cluster when running on the host, but the address is not available
+          when connecting in docker mode.
+  
+          The problem is solved by ensuring that the Kubernetes API server address used when
+          doing a `telepresence connect --docker` is swapped from 127.0.0.1 to the
+          internal address of the control-plane node. This works because that
+          address is available to other docker containers, and the Kubernetes API
+          server is configured with a certificate that accepts it.
+      - type: bugfix
         title: Rename charts/telepresence to charts/telepresence-oss.
         body: >-
           The Helm chart name "telepresence-oss" was inconsistent with its contained folder "telepresence". As a result,

--- a/charts/telepresence-oss/templates/agentInjectorWebhook.yaml
+++ b/charts/telepresence-oss/templates/agentInjectorWebhook.yaml
@@ -43,6 +43,8 @@ already managed by some other traffic-manager.
           {{- $rqMatch = not (has $val .values) }}
         {{- else if eq .operator "Exists" }}
           {{- $rqMatch = not (eq $val "") }}
+        {{- else if eq .operator "DoesNotExist" }}
+          {{- $rqMatch = eq $val "" }}
         {{- else }}
           {{- fail printf "unsupported labelSelectorOperator %s" .operator}}
         {{- end }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -126,6 +126,13 @@ The traffic-agent configuration was moved into a pod-annotation. This avoids syn
 The clusterID was deprecated some time ago, and replaced by the ID of the namespace where the traffic-manager is installed.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Make telepresence connect --docker work with Rancher Desktop</div></div>
+<div style="margin-left: 15px">
+
+Rancher Desktop will start a K3s control-plane and typically expose the Kubernetes API server at `127.0.0.1:6443`. Telepresence can connect to this cluster when running on the host, but the address is not available when connecting in docker mode.
+The problem is solved by ensuring that the Kubernetes API server address used when doing a `telepresence connect --docker` is swapped from 127.0.0.1 to the internal address of the control-plane node. This works because that address is available to other docker containers, and the Kubernetes API server is configured with a certificate that accepts it.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Rename charts/telepresence to charts/telepresence-oss.</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -133,6 +133,13 @@ The clusterID was deprecated some time ago, and replaced by the ID of the namesp
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Make telepresence connect --docker work with Rancher Desktop</Title>
+	<Body>
+Rancher Desktop will start a K3s control-plane and typically expose the Kubernetes API server at `127.0.0.1:6443`. Telepresence can connect to this cluster when running on the host, but the address is not available when connecting in docker mode.
+The problem is solved by ensuring that the Kubernetes API server address used when doing a `telepresence connect --docker` is swapped from 127.0.0.1 to the internal address of the control-plane node. This works because that address is available to other docker containers, and the Kubernetes API server is configured with a certificate that accepts it.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix">Rename charts/telepresence to charts/telepresence-oss.</Title>
 	<Body>
 The Helm chart name "telepresence-oss" was inconsistent with its contained folder "telepresence". As a result, attempts to install the chart using an argo ApplicationSet failed. The contained folder was renamed to match the chart name.

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/common"
@@ -34,6 +35,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
 
@@ -252,7 +254,20 @@ func launchConnectorDaemon(ctx context.Context, connectorDaemon string, required
 			_ = fh.Close()
 		}
 		ctx = docker.EnableClient(ctx)
-		conn, err = docker.LaunchDaemon(ctx, daemonID)
+
+		// An initialized kubernetes interface is required by LaunchDaemon, because it is necessary
+		// when checking if the containerized daemon is connecting to a k3s control plane node.
+		var kc *client.Kubeconfig
+		ctx, kc, err = client.NewKubeconfig(ctx, cr.KubeFlags, cr.ManagerNamespace)
+		if err != nil {
+			return ctx, err
+		}
+		var ki *kubernetes.Clientset
+		ki, err = kubernetes.NewForConfig(kc.RestConfig)
+		if err != nil {
+			return ctx, err
+		}
+		conn, err = docker.LaunchDaemon(k8sapi.WithK8sInterface(ctx, ki), daemonID)
 	} else {
 		args := []string{connectorDaemon, "connector-foreground"}
 		if cr.UserDaemonProfilingPort > 0 {

--- a/pkg/client/docker/daemon.go
+++ b/pkg/client/docker/daemon.go
@@ -22,7 +22,10 @@ import (
 	"github.com/go-json-experiment/json"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	runtime2 "k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/datawire/dlib/dlog"
@@ -34,6 +37,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/routing"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
@@ -277,7 +281,7 @@ func handleLocalK8s(ctx context.Context, daemonID *daemon.Identifier, config *ap
 		return nil
 	}
 	isMinikube := false
-	if ex, ok := cl.Extensions["cluster_info"].(*runtime2.Unknown); ok {
+	if ex, ok := cl.Extensions["cluster_info"].(*runtime.Unknown); ok {
 		var data map[string]any
 		isMinikube = json.Unmarshal(ex.Raw, &data) == nil && data["provider"] == "minikube.sigs.k8s.io"
 	}
@@ -304,7 +308,12 @@ func handleLocalK8s(ctx context.Context, daemonID *daemon.Identifier, config *ap
 	if isMinikube {
 		hostPort, network = detectMinikube(ctx, cjs, addrPort, cc.Cluster)
 	} else {
-		hostPort, network = detectKind(ctx, cjs, addrPort)
+		addr = detectK3sControlPlaneNode(ctx)
+		if addr.IsValid() {
+			hostPort = netip.AddrPortFrom(addr, uint16(port))
+		} else {
+			hostPort, network = detectKind(ctx, cjs, addrPort)
+		}
 	}
 	if hostPort.IsValid() {
 		dlog.Debugf(ctx, "hostPort %s, network %s", hostPort, network)
@@ -366,7 +375,7 @@ func LaunchDaemon(ctx context.Context, daemonID *daemon.Identifier) (conn *grpc.
 			// This may happen if the daemon has died (and hence, we never discovered it), but
 			// the container still hasn't died. Let's sleep for a short while and retry.
 			if i < 6 {
-				dtime.SleepWithContext(ctx, time.Duration(i)*200*time.Millisecond)
+				dtime.SleepWithContext(ctx, time.Duration(i)*500*time.Millisecond)
 				continue
 			}
 			if stopAttempted {
@@ -484,6 +493,38 @@ func useMinikubeNetwork(ctx context.Context, addr netip.Addr) bool {
 		}
 	}
 	return false
+}
+
+// detectK3sControlPlaneNode returns the internal IP of the k3s control-plane node, if
+// such a node is found, or an invalid address otherwise.
+func detectK3sControlPlaneNode(ctx context.Context) (addr netip.Addr) {
+	ki := k8sapi.GetK8sInterface(ctx)
+	le := labels.SelectorFromSet(map[string]string{
+		"node-role.kubernetes.io/control-plane": "true",
+		"node-role.kubernetes.io/master":        "true",
+		"node.kubernetes.io/instance-type":      "k3s",
+	})
+	ns, err := ki.CoreV1().Nodes().List(ctx, meta.ListOptions{LabelSelector: le.String()})
+	if err != nil {
+		dlog.Errorf(ctx, "failed to list nodes: %v", err)
+		return addr
+	}
+	nis := ns.Items
+	for i := range nis {
+		n := &nis[i]
+		for _, a := range n.Status.Addresses {
+			if a.Type == core.NodeInternalIP {
+				addr, err = netip.ParseAddr(a.Address)
+				if err != nil {
+					dlog.Errorf(ctx, "failed to parse address %s: %v", a.Address, err)
+				} else {
+					dlog.Debugf(ctx, "Found k3s control plane %s with internal IP %s", n.Name, addr)
+				}
+				break
+			}
+		}
+	}
+	return addr
 }
 
 // detectMinikube returns the container IP:port for the given hostAddrPort for a container where the

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -19,9 +19,10 @@ type Operator string
 // NOTE! The lowercase variants in the k8s.io/apimachinery/pkg/selection are intended for
 // the selector string representation only. They are invalid in a YAML/JSON manifest!
 const (
-	OperatorIn     Operator = "In"
-	OperatorNotIn  Operator = "NotIn"
-	OperatorExists Operator = "Exists"
+	OperatorIn        Operator = "In"
+	OperatorNotIn     Operator = "NotIn"
+	OperatorExists    Operator = "Exists"
+	OperatorNotExists Operator = "DoesNotExist"
 )
 
 func (op Operator) String() string {


### PR DESCRIPTION
Rancher Desktop will start a K3s control-plane and typically expose the Kubernetes API server at `127.0.0.1:6443`. Telepresence can connect to this cluster when running on the host, but the address is not available when connecting in docker mode.

The problem is solved by ensuring that the Kubernetes API server address used when doing a `telepresence connect --docker` is swapped from 127.0.0.1 to the internal address of the control-plane node. This works because that address is available to other docker containers, and the Kubernetes API server is configured with a certificate that accepts it.