### PR TITLE
Change the help text for the engagement sub-commands

### DIFF
--- a/pkg/client/cli/cmd/ingest.go
+++ b/pkg/client/cli/cmd/ingest.go
@@ -11,7 +11,7 @@ import (
 func ingestCmd() *cobra.Command {
 	ic := &ingest.Command{}
 	cmd := &cobra.Command{
-		Use:   "ingest [flags] <workload> [-- <command with arguments...>]",
+		Use:   "ingest [flags] <name> [-- [[docker run flags] <image name>] OR [<command>]] args...]",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Ingest a container",
 		Annotations: map[string]string{

--- a/pkg/client/cli/cmd/intercept.go
+++ b/pkg/client/cli/cmd/intercept.go
@@ -10,7 +10,7 @@ import (
 func interceptCmd() *cobra.Command {
 	ic := &intercept.Command{}
 	cmd := &cobra.Command{
-		Use:   "intercept [flags] <intercept_base_name> [-- <command with arguments...>]",
+		Use:   "intercept [flags] <name> [-- [[docker run flags] <image name>] OR [<command>]] args...]",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Intercept a service",
 		Annotations: map[string]string{

--- a/pkg/client/cli/cmd/replace.go
+++ b/pkg/client/cli/cmd/replace.go
@@ -10,7 +10,7 @@ import (
 func replaceCmd() *cobra.Command {
 	ic := &intercept.Command{}
 	cmd := &cobra.Command{
-		Use:   "replace [flags] <replace_base_name> [-- <command with arguments...>]",
+		Use:   "replace [flags] <name> [-- [[docker run flags] <image name>] OR [<command>]] args...]",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Replace a container",
 		Annotations: map[string]string{


### PR DESCRIPTION
The new help text clarifies what is expected after the stand-alone double dash, so that the user understands that options to docker run must come before the name of the image to run.