### PR TITLE
Fix DNS-problem when sending singleton names to the traffic-manager.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,13 @@ items:
           A shared informer was sometimes reused when namespaces were removed and then later added again, leading
           to errors like "handler ... was not added to shared informer because it has stopped already".
         docs: https://github.com/telepresenceio/telepresence/issues/3831
+      - type: bugfix
+        title: Single label name DNS lookups didn't work unless at least one traffic-agent was installed
+        body: >-
+          A problem with incorrect handling of single label names in the traffic-manager's DNS resolver was fixed. The
+          problem would cause lookups like `curl echo` to fail, even though telepresence was connected to a namespace
+          containing an "echo" service, unless at least one of the workloads in the connected namespace had a
+          traffic-agent.
   - version: 2.22.2
     date: 2025-03-28
     notes:

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -841,7 +841,7 @@ func (s *service) LookupDNS(ctx context.Context, request *rpc.DNSRequest) (respo
 			default:
 				result = rrs.String()
 			}
-			dlog.Debugf(ctx, "LookupDNS: %s %s -> %s", request.Name, qtn, result)
+			dlog.Debugf(ctx, "%s %s -> %s", request.Name, qtn, result)
 		}()
 	}
 
@@ -873,58 +873,64 @@ func (s *service) LookupDNS(ctx context.Context, request *rpc.DNSRequest) (respo
 			dlog.Errorf(ctx, "AgentsLookupDNS %s %s: %v", request.Name, qtn, err)
 		} else if rCode != state.RcodeNoAgents {
 			if len(rrs) == 0 {
-				dlog.Tracef(ctx, "LookupDNS on agents: %s %s -> %s", request.Name, qtn, dns2.RcodeToString[rCode])
+				dlog.Tracef(ctx, "agents: %s %s -> %s", request.Name, qtn, dns2.RcodeToString[rCode])
 			} else {
-				dlog.Tracef(ctx, "LookupDNS on agents: %s %s -> %s", request.Name, qtn, rrs)
+				dlog.Tracef(ctx, "agents: %s %s -> %s", request.Name, qtn, rrs)
 			}
 		}
 	}
 
 	if rCode == state.RcodeNoAgents {
-		client := s.state.GetClient(sessionID)
-		name := request.Name
-		restoreName := false
-		nDots := 0
-		if client != nil {
-			for _, c := range name {
-				if c == '.' {
-					nDots++
-				}
-			}
-			if nDots == 1 && client.Namespace != tmNamespace {
-				noSearchDomain = client.Namespace + "."
-				name += noSearchDomain
-				restoreName = true
-			}
-		}
-		dlog.Tracef(ctx, "LookupDNS on traffic-manager: %s", name)
-		rrs, rCode, err = dnsproxy.Lookup(ctx, qType, name, noSearchDomain)
-		if err != nil {
-			// Could still be x.y.<client namespace>, but let's avoid x.<cluster domain>.<client namespace> and x.<client-namespace>.<client namespace>
-			if client != nil && nDots > 1 && client.Namespace != tmNamespace && !strings.HasSuffix(name, s.dotClusterDomain) && !hasDomainSuffix(name, client.Namespace) {
-				name += client.Namespace + "."
-				restoreName = true
-				dlog.Debugf(ctx, "LookupDNS on traffic-manager: %s", name)
-				rrs, rCode, err = dnsproxy.Lookup(ctx, qType, name, noSearchDomain)
-			}
-			if err != nil {
-				dlog.Tracef(ctx, "LookupDNS on traffic-manager: %s %s -> %s %s", request.Name, qtn, dns2.RcodeToString[rCode], err)
-				return nil, err
-			}
-		}
-		if len(rrs) == 0 {
-			dlog.Tracef(ctx, "LookupDNS on traffic-manager: %s %s -> %s", request.Name, qtn, dns2.RcodeToString[rCode])
-		} else {
-			if restoreName {
-				dlog.Tracef(ctx, "LookupDNS on traffic-manager: restore %s to %s", name, request.Name)
-				for _, rr := range rrs {
-					rr.Header().Name = request.Name
-				}
-			}
-			dlog.Tracef(ctx, "LookupDNS on traffic-manager: %s %s -> %s", request.Name, qtn, rrs)
-		}
+		rrs, rCode = s.lookupFromManager(ctx, sessionID, qType, request.Name, noSearchDomain)
 	}
 	return dnsproxy.ToRPC(rrs, rCode)
+}
+
+func (s *service) lookupFromManager(ctx context.Context, sessionID tunnel.SessionID, qType uint16, qName, noSearchDomain string) (dnsproxy.RRs, int) {
+	name := qName
+	client := s.state.GetClient(sessionID)
+	tmNamespace := managerutil.GetEnv(ctx).ManagerNamespace
+	restoreName := false
+	nDots := 0
+	if client != nil {
+		for _, c := range name {
+			if c == '.' {
+				nDots++
+			}
+		}
+		if nDots == 1 && client.Namespace != tmNamespace {
+			name += client.Namespace + "."
+			restoreName = true
+		}
+	}
+	dlog.Tracef(ctx, "traffic-manager: %s", name)
+	qtn := dns2.TypeToString[qType]
+	rrs, rCode, err := dnsproxy.Lookup(ctx, qType, name, noSearchDomain)
+	if err == nil && rCode == dns2.RcodeNameError {
+		// Could still be x.y.<client namespace>, but let's avoid x.<cluster domain>.<client namespace> and x.<client-namespace>.<client namespace>
+		if client != nil && nDots > 1 && client.Namespace != tmNamespace && !strings.HasSuffix(name, s.dotClusterDomain) && !hasDomainSuffix(name, client.Namespace) {
+			name += client.Namespace + "."
+			restoreName = true
+			dlog.Debugf(ctx, "traffic-manager: %s", name)
+			rrs, rCode, err = dnsproxy.Lookup(ctx, qType, name, noSearchDomain)
+		}
+	}
+	if err != nil {
+		dlog.Errorf(ctx, "traffic-manager: %s %s -> %s %s", qName, qtn, dns2.RcodeToString[rCode], err)
+		return nil, dns2.RcodeServerFailure
+	}
+	if len(rrs) == 0 {
+		dlog.Tracef(ctx, "traffic-manager: %s %s -> %s", qName, qtn, dns2.RcodeToString[rCode])
+	} else {
+		if restoreName {
+			dlog.Tracef(ctx, "traffic-manager: restore %s to %s", name, qName)
+			for _, rr := range rrs {
+				rr.Header().Name = qName
+			}
+		}
+		dlog.Tracef(ctx, "traffic-manager: %s %s -> %s", qName, qtn, rrs)
+	}
+	return rrs, rCode
 }
 
 func (s *service) AgentLookupDNSResponse(ctx context.Context, response *rpc.DNSAgentResponse) (*empty.Empty, error) {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 A shared informer was sometimes reused when namespaces were removed and then later added again, leading to errors like "handler ... was not added to shared informer because it has stopped already".
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Single label name DNS lookups didn't work unless at least one traffic-agent was installed</div></div>
+<div style="margin-left: 15px">
+
+A problem with incorrect handling of single label names in the traffic-manager's DNS resolver was fixed. The problem would cause lookups like `curl echo` to fail, even though telepresence was connected to a namespace containing an "echo" service, unless at least one of the workloads in the connected namespace had a traffic-agent.
+</div>
+
 ## Version 2.22.2 <span style="font-size: 16px;">(March 28)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Panic when using telepresence replace in a IPv6-only cluster](https://github.com/telepresenceio/telepresence/issues/3828)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 A shared informer was sometimes reused when namespaces were removed and then later added again, leading to errors like "handler ... was not added to shared informer because it has stopped already".
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Single label name DNS lookups didn't work unless at least one traffic-agent was installed</Title>
+	<Body>
+A problem with incorrect handling of single label names in the traffic-manager's DNS resolver was fixed. The problem would cause lookups like `curl echo` to fail, even though telepresence was connected to a namespace containing an "echo" service, unless at least one of the workloads in the connected namespace had a traffic-agent.
+  </Body>
+</Note>
 ## Version 2.22.2 <span style={{fontSize:'16px'}}>(March 28)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/3828">Panic when using telepresence replace in a IPv6-only cluster</Title>

--- a/integration_test/docker_daemon_test.go
+++ b/integration_test/docker_daemon_test.go
@@ -118,6 +118,19 @@ func (s *dockerDaemonSuite) Test_DockerDaemon_daemonHostNotConflict() {
 	s.TelepresenceConnect(ctx)
 }
 
+func (s *dockerDaemonSuite) Test_DockerDaemon_singleNameLookup() {
+	ctx := s.Context()
+	const svc = "echo-easy"
+	s.ApplyApp(ctx, svc, "deploy/"+svc)
+	defer s.DeleteSvcAndWorkload(ctx, "deploy", svc)
+	out := s.TelepresenceConnect(ctx, "--docker", "--", itest.GetExecutable(ctx), "curl", "--silent", "--max-time", "1", svc)
+	s.Contains(out, "Request served by "+svc)
+	so, err := itest.TelepresenceStatus(ctx)
+	s.NoError(err)
+	s.Nil(so.ContainerizedDaemon)
+	s.False(so.UserDaemon.Running)
+}
+
 func (s *dockerDaemonSuite) Test_DockerDaemon_cacheFiles() {
 	ctx := s.Context()
 	rq := s.Require()


### PR DESCRIPTION
Allow the use of a DNS search-path when performing `<name.namespace>` lookups from the traffic-manager.