### PR TITLE
ensures duplicate container port names don't cause intercept to fail.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -82,6 +82,11 @@ items:
           nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a
           bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still
           used in the Helm chart so this change is backwards compatible.
+      - type: bugfix
+        title: Pods with container ports named the same caused intercept to fail
+        body: >-
+          Intercept container ports now have numbers appended to them if there are multiple
+          ports from multiple containers with the same name.
   - version: 2.22.4
     date: 2025-04-26
     notes:

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -86,7 +86,8 @@ items:
         title: Pods with container ports named the same caused intercept to fail
         body: >-
           Intercept container ports now have numbers appended to them if there are multiple
-          ports from multiple containers with the same name.
+          ports from multiple containers with the same name. This bugfix works around an issue
+          where Kubernetes allows multiple port definitions in a pod spec to have the same name.
   - version: 2.22.4
     date: 2025-04-26
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -51,6 +51,12 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Pods with container ports named the same caused intercept to fail</div></div>
+<div style="margin-left: 15px">
+
+Intercept container ports now have numbers appended to them if there are multiple ports from multiple containers with the same name. This bugfix works around an issue where Kubernetes allows multiple port definitions in a pod spec to have the same name.
+</div>
+
 ## Version 2.22.4 <span style="font-size: 16px;">(April 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Don't require internet access when installing the traffic-manager using Helm</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -57,6 +57,12 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Pods with container ports named the same caused intercept to fail</Title>
+	<Body>
+Intercept container ports now have numbers appended to them if there are multiple ports from multiple containers with the same name. This bugfix works around an issue where Kubernetes allows multiple port definitions in a pod spec to have the same name.
+  </Body>
+</Note>
 ## Version 2.22.4 <span style={{fontSize:'16px'}}>(April 26)</span>
 <Note>
 	<Title type="bugfix">Don't require internet access when installing the traffic-manager using Helm</Title>

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -36,7 +36,9 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 			for _, ic := range PortUniqueIntercepts(cc) {
 				name := ic.ContainerPortName
 
-				if _, ok := names[name]; ok {
+				// We don't want to apply duplication logic to empty strings
+				// as - is not a valid starting character for port names.
+				if _, ok := names[name]; ok && ic.ContainerPortName != "" {
 					// if name already exists, append a number to it
 					names[ic.ContainerPortName]++
 					// convert number to string
@@ -48,9 +50,11 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 					} else {
 						name = ic.ContainerPortName + number
 					}
-				} else {
+				} else if ic.ContainerPortName != "" {
 					name = ic.ContainerPortName
 					names[ic.ContainerPortName] = 1
+				} else {
+					name = ic.ContainerPortName
 				}
 
 				ports = append(ports, core.ContainerPort{

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -26,6 +26,7 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 	ports := make([]core.ContainerPort, 0, 5)
 	confCns := a.configuredContainers(ctx)
 
+	names := make(map[string]int)
 	a.eachConfiguredContainer(confCns, func(app *core.Container, cc *Container) {
 		switch cc.Replace {
 		case ReplacePolicyContainer:
@@ -33,8 +34,27 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 			ports = append(ports, app.Ports...)
 		case ReplacePolicyIntercept:
 			for _, ic := range PortUniqueIntercepts(cc) {
+				name := ic.ContainerPortName
+
+				if _, ok := names[name]; ok {
+					// if name already exists, append a number to it
+					names[ic.ContainerPortName]++
+					// convert number to string
+					number := "-" + strconv.Itoa(names[ic.ContainerPortName])
+					// if string length of name plus number is greater than 15
+					if len(ic.ContainerPortName)+len(number) > 15 {
+						// truncate name to 15 characters
+						name = ic.ContainerPortName[:15-len(number)] + number
+					} else {
+						name = ic.ContainerPortName + number
+					}
+				} else {
+					name = ic.ContainerPortName
+					names[ic.ContainerPortName] = 1
+				}
+
 				ports = append(ports, core.ContainerPort{
-					Name:          ic.ContainerPortName,
+					Name:          name,
 					ContainerPort: int32(ic.AgentPort),
 					Protocol:      ic.Protocol,
 				})

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -39,21 +39,23 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 				// We don't want to apply duplication logic to empty strings
 				// as - is not a valid starting character for port names.
 				if name != "" {
-					if _, ok := names[name]; ok {
+					if n, ok := names[name]; ok {
 						// if name already exists, append a number to it
-						names[ic.ContainerPortName]++
-						// convert number to string
-						number := "-" + strconv.Itoa(names[ic.ContainerPortName])
+
+						n++
+						names[name] = n
+
+						// convert to numeric name suffix
+						suffix := "-" + strconv.Itoa(n)
 						// if string length of name plus number is greater than 15
-						if len(ic.ContainerPortName)+len(number) > 15 {
+						if len(name) + len(suffix) > 15 {
 							// truncate name to 15 characters
-							name = ic.ContainerPortName[:15-len(number)] + number
-						} else {
-							name = ic.ContainerPortName + number
+							name = name[:15-len(suffix)]
 						}
+
+						name += suffix
 					} else {
-						name = ic.ContainerPortName
-						names[ic.ContainerPortName] = 1
+						names[name] = 1
 					}
 				}
 

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -38,23 +38,23 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 
 				// We don't want to apply duplication logic to empty strings
 				// as - is not a valid starting character for port names.
-				if _, ok := names[name]; ok && ic.ContainerPortName != "" {
-					// if name already exists, append a number to it
-					names[ic.ContainerPortName]++
-					// convert number to string
-					number := "-" + strconv.Itoa(names[ic.ContainerPortName])
-					// if string length of name plus number is greater than 15
-					if len(ic.ContainerPortName)+len(number) > 15 {
-						// truncate name to 15 characters
-						name = ic.ContainerPortName[:15-len(number)] + number
+				if name != "" {
+					if _, ok := names[name]; ok {
+						// if name already exists, append a number to it
+						names[ic.ContainerPortName]++
+						// convert number to string
+						number := "-" + strconv.Itoa(names[ic.ContainerPortName])
+						// if string length of name plus number is greater than 15
+						if len(ic.ContainerPortName)+len(number) > 15 {
+							// truncate name to 15 characters
+							name = ic.ContainerPortName[:15-len(number)] + number
+						} else {
+							name = ic.ContainerPortName + number
+						}
 					} else {
-						name = ic.ContainerPortName + number
+						name = ic.ContainerPortName
+						names[ic.ContainerPortName] = 1
 					}
-				} else if ic.ContainerPortName != "" {
-					name = ic.ContainerPortName
-					names[ic.ContainerPortName] = 1
-				} else {
-					name = ic.ContainerPortName
 				}
 
 				ports = append(ports, core.ContainerPort{

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -48,7 +48,7 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 						// convert to numeric name suffix
 						suffix := "-" + strconv.Itoa(n)
 						// if string length of name plus number is greater than 15
-						if len(name) + len(suffix) > 15 {
+						if len(name)+len(suffix) > 15 {
 							// truncate name to 15 characters
 							name = name[:15-len(suffix)]
 						}


### PR DESCRIPTION
## Description

This PR fixes #3858 by ensuring duplicate names have a `-{num}` appended to them. This prevents the "Duplicate value" I encountered.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change. **none needed AFAIK**
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.