### PR TITLE
Fix: Argument-list-to-long when connecting to cluster with lots of namespaces

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -82,6 +82,20 @@ items:
           nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a
           bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still
           used in the Helm chart so this change is backwards compatible.
+      - type: bugfix
+        title: Telepresence fails to connect with many namespaces due to DBus message size limit
+        body: >-
+          On Ubuntu-based Linux machines, Telepresence failed to connect when the user had access to a large number of Kubernetes
+          namespaces. This was caused by exceeding the system's DBus message size limit, which resulted in misleading errors like
+          "unable to determine the traffic-manager namespace" or "User Daemon: Not running, Root Daemon: Not running". The root cause
+          was an excessively long argument list generated when querying all namespaces, overwhelming DBus and leading to truncated or
+          unclear error messages.
+
+          A workaround using `--mapped-namespaces` was possible, but it degraded stability and usability by requiring frequent manual
+          reconnections and maintenance of namespace lists. This fix ensures that Telepresence can handle environments with many
+          namespaces gracefully by chunking queries or managing requests internally to stay within DBus limits.
+
+          This issue affected only Linux environments (Ubuntu 22.04 and 24.04) and was not reproducible on macOS.
   - version: 2.22.4
     date: 2025-04-26
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -51,6 +51,14 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Telepresence fails to connect with many namespaces due to DBus message size limit</div></div>
+<div style="margin-left: 15px">
+
+On Ubuntu-based Linux machines, Telepresence failed to connect when the user had access to a large number of Kubernetes namespaces. This was caused by exceeding the system's DBus message size limit, which resulted in misleading errors like "unable to determine the traffic-manager namespace" or "User Daemon: Not running, Root Daemon: Not running". The root cause was an excessively long argument list generated when querying all namespaces, overwhelming DBus and leading to truncated or unclear error messages.
+A workaround using `--mapped-namespaces` was possible, but it degraded stability and usability by requiring frequent manual reconnections and maintenance of namespace lists. This fix ensures that Telepresence can handle environments with many namespaces gracefully by chunking queries or managing requests internally to stay within DBus limits.
+This issue affected only Linux environments (Ubuntu 22.04 and 24.04) and was not reproducible on macOS.
+</div>
+
 ## Version 2.22.4 <span style="font-size: 16px;">(April 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Don't require internet access when installing the traffic-manager using Helm</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -57,6 +57,14 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Telepresence fails to connect with many namespaces due to DBus message size limit</Title>
+	<Body>
+On Ubuntu-based Linux machines, Telepresence failed to connect when the user had access to a large number of Kubernetes namespaces. This was caused by exceeding the system's DBus message size limit, which resulted in misleading errors like "unable to determine the traffic-manager namespace" or "User Daemon: Not running, Root Daemon: Not running". The root cause was an excessively long argument list generated when querying all namespaces, overwhelming DBus and leading to truncated or unclear error messages.
+A workaround using `--mapped-namespaces` was possible, but it degraded stability and usability by requiring frequent manual reconnections and maintenance of namespace lists. This fix ensures that Telepresence can handle environments with many namespaces gracefully by chunking queries or managing requests internally to stay within DBus limits.
+This issue affected only Linux environments (Ubuntu 22.04 and 24.04) and was not reproducible on macOS.
+  </Body>
+</Note>
 ## Version 2.22.4 <span style={{fontSize:'16px'}}>(April 26)</span>
 <Note>
 	<Title type="bugfix">Don't require internet access when installing the traffic-manager using Helm</Title>

--- a/pkg/client/rootd/dbus/resolved.go
+++ b/pkg/client/rootd/dbus/resolved.go
@@ -80,6 +80,9 @@ func SetLinkDNS(c context.Context, networkIndex int, ips ...net.IP) error {
 	})
 }
 
+// Set at an arbitrary value.
+const maxDomainsPerBatch = 100
+
 func SetLinkDomains(c context.Context, networkIndex int, domains ...string) error {
 	return withDBus(c, func(conn *dbus.Conn) error {
 		dds := make([]resolvedDomain, 0, len(domains))
@@ -94,8 +97,20 @@ func SetLinkDomains(c context.Context, networkIndex int, domains ...string) erro
 			}
 			dds = append(dds, resolvedDomain{Name: domain, RoutingOnly: routing})
 		}
-		return conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").CallWithContext(
-			c, "org.freedesktop.resolve1.Manager.SetLinkDomains", 0, int32(networkIndex), dds).Err
+		for i := 0; i < len(dds); i += maxDomainsPerBatch {
+			end := i + maxDomainsPerBatch
+			if end > len(dds) {
+				end = len(dds)
+			}
+			if err := conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1").CallWithContext(
+				c, "org.freedesktop.resolve1.Manager.SetLinkDomains", 0, int32(networkIndex), dds[i:end]).Err; err != nil {
+				return fmt.Errorf(
+					"SetLinkDomains failed for network index %d, batch %d-%d (count=%d): %w",
+					networkIndex, i, end, end-i, err,
+				)
+			}
+		}
+		return nil
 	})
 }
 


### PR DESCRIPTION
## Description

PR to fix this [issue](https://github.com/telepresenceio/telepresence/issues/3863). 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.