### PR TITLE
Don't include k8s-defs.json to chart package

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -82,6 +82,12 @@ items:
           nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a
           bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still
           used in the Helm chart so this change is backwards compatible.
+      - type: bugfix
+        title: Don't include k8s-defs.json to chart package
+        body: >-
+          The k8s-defs.json was unnecessarily included to the Helm chart package and this increased the Helm release
+          secret size so much that it could prevent installation of the Helm chart depending on k8s settings. To fix
+          this k8s-defs.json is not included to the Helm chart anymore.
   - version: 2.22.4
     date: 2025-04-26
     notes:

--- a/charts/chart.go
+++ b/charts/chart.go
@@ -178,6 +178,8 @@ func WriteChart(helmChartDir DirType, out io.Writer, chartName, version string, 
 			if err = addFile(tarWriter, baseDir, filename, content); err != nil {
 				return err
 			}
+		case fmt.Sprintf("%s/k8s-defs.json", chartName):
+			// Don't include k8s-defs.json to the chart package
 		default:
 			content, err := fs.ReadFile(baseDir, filename)
 			if err != nil {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -51,6 +51,12 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Don't include k8s-defs.json to chart package</div></div>
+<div style="margin-left: 15px">
+
+The k8s-defs.json was unnecessarily included to the Helm chart package and this increased the Helm release secret size so much that it could prevent installation of the Helm chart depending on k8s settings. To fix this k8s-defs.json is not included to the Helm chart anymore.
+</div>
+
 ## Version 2.22.4 <span style="font-size: 16px;">(April 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Don't require internet access when installing the traffic-manager using Helm</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -57,6 +57,12 @@ command.
 The Helm chart schema for the `nodeSelector` value was incorrect. Kubernetes defines different types for nodeSelector (inside PodSpec objects) and NodeSelector (inside NodeAffinity, VolumeNodeAffinity and a bunch of other places). The schema was changed to use the correct type. The name `nodeSelector` is still used in the Helm chart so this change is backwards compatible.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Don't include k8s-defs.json to chart package</Title>
+	<Body>
+The k8s-defs.json was unnecessarily included to the Helm chart package and this increased the Helm release secret size so much that it could prevent installation of the Helm chart depending on k8s settings. To fix this k8s-defs.json is not included to the Helm chart anymore.
+  </Body>
+</Note>
 ## Version 2.22.4 <span style={{fontSize:'16px'}}>(April 26)</span>
 <Note>
 	<Title type="bugfix">Don't require internet access when installing the traffic-manager using Helm</Title>


### PR DESCRIPTION
## Description

This PR fixes #3860 by changing chart build so that it won't include the k8s-defs.json to chart package.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.