### PR TITLE
Telepresence breaks if config.yml exists but is empty

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,12 @@ items:
         body: >-
           The new `telepresence helm version` command prints the version of the helm client that is embedded in the
           telepresence binary.
+      - type: bugfix
+        title: Telepresence breaks if config.yml exists but is empty
+        body: >-
+          Telepresence would refuse to connect with a misleading error if the `config.yml` file containing the client's
+          configuration parameters existed but was empty.
+        docs: https://github.com/telepresenceio/telepresence/issues/3887
   - version: 2.23.0
     date: 2025-06-17
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 The new `telepresence helm version` command prints the version of the helm client that is embedded in the telepresence binary.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Telepresence breaks if config.yml exists but is empty](https://github.com/telepresenceio/telepresence/issues/3887)</div></div>
+<div style="margin-left: 15px">
+
+Telepresence would refuse to connect with a misleading error if the `config.yml` file containing the client's configuration parameters existed but was empty.
+</div>
+
 ## Version 2.23.0 <span style="font-size: 16px;">(June 17)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">New telepresence wiretap command</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 The new `telepresence helm version` command prints the version of the helm client that is embedded in the telepresence binary.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/3887">Telepresence breaks if config.yml exists but is empty</Title>
+	<Body>
+Telepresence would refuse to connect with a misleading error if the `config.yml` file containing the client's configuration parameters existed but was empty.
+  </Body>
+</Note>
 ## Version 2.23.0 <span style={{fontSize:'16px'}}>(June 17)</span>
 <Note>
 	<Title type="feature">New telepresence wiretap command</Title>

--- a/integration_test/config_test.go
+++ b/integration_test/config_test.go
@@ -1,0 +1,20 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/filelocation"
+)
+
+func (s *notConnectedSuite) Test_EmptyConfigFile() {
+	ctx := s.Context()
+	cfgDir := itest.TempDir(ctx)
+	ctx = filelocation.WithAppUserConfigDir(ctx, cfgDir)
+	f, err := os.Create(filepath.Join(cfgDir, "config.json"))
+	s.Require().NoError(err)
+	f.Close()
+	s.TelepresenceConnect(ctx)
+	itest.TelepresenceQuitOk(ctx)
+}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -219,6 +220,10 @@ func UnmarshalJSONConfig(data []byte, rejectUnknown bool) (Config, error) {
 }
 
 func ParseConfigYAML(ctx context.Context, path string, data []byte) (Config, error) {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return GetDefaultConfig(), nil
+	}
 	data, err := yaml.YAMLToJSON(data)
 	if err != nil {
 		return nil, err

--- a/pkg/client/k8s_config.go
+++ b/pkg/client/k8s_config.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"net"
@@ -541,12 +542,16 @@ func newKubeconfig(
 func WithKubeExtension(ctx context.Context, cluster *api.Cluster, managerNamespace string) (context.Context, error) {
 	cfg := GetConfig(ctx)
 	var keCfg Config
+	var data []byte
 	if ext, ok := cluster.Extensions[configExtension].(*runtime.Unknown); ok {
-		if kc, err := UnmarshalJSONConfig(ext.Raw, true); err != nil {
+		data = bytes.TrimSpace(ext.Raw)
+	}
+	if len(data) > 0 {
+		if kc, err := UnmarshalJSONConfig(data, true); err != nil {
 			// Try with legacy kubeconfigExtension
 			dlog.Debug(ctx, "unable to unmarshal extension as client config, trying legacy format")
 			ke := kubeconfigExtension{}
-			if keErr := json.Unmarshal(ext.Raw, &ke); keErr != nil {
+			if keErr := json.Unmarshal(data, &ke); keErr != nil {
 				return ctx, errcat.Config.Newf("unable to parse extension %s in kubeconfig: %w", configExtension, err)
 			}
 			dlog.Debug(ctx, "legacy format was successfully parsed")


### PR DESCRIPTION
Telepresence would refuse to connect with a misleading error if the `config.yml` file containing the client's configuration parameters existed but was empty.
