### PR TITLE
Update installation documentation links in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,7 +126,7 @@ jobs:
           tag: ${{ github.ref_name }}
           body: |
             ## Draft Release
-            For more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start/).
+            For more information, visit our [installation docs](https://www.telepresence.io/docs/latest/quick-start).
       - name: Create release
         if: ${{ steps.semver_check.outputs.draft == 'false' }}
         uses: ncipollo/release-action@v1
@@ -151,7 +151,7 @@ jobs:
             ### Helm Chart
                - 📦 [Telepresence Helm Chart](https://artifacthub.io/packages/helm/telepresence-oss/telepresence-oss/${{ steps.semver_check.outputs.semver }})
 
-            For more information, visit our [installation docs](https://www.telepresence.io/docs/quick-start/).
+            For more information, visit our [installation docs](https://www.telepresence.io/docs/quick-start).
       - uses: actions/checkout@v4
         if: ${{ steps.semver_check.outputs.make_latest == 'true' }}
       - name: Update Homebrew


### PR DESCRIPTION
Fix broken architecture link from quick-start page
Problem
The architecture link from the quick-start page breaks when accessed from URLs with trailing slashes, resulting in 404 errors.
Root Cause
Relative links behave differently depending on whether the current URL has a trailing slash - the browser resolves them relative to different base paths.
Solution
Update the relative link path to ensure consistent resolution behavior regardless of trailing slashes.
Impact
Fixes broken navigation from quick-start to architecture documentation
Ensures the link works reliably for all users
Improves overall documentation UX