### PR TITLE
fix [charts]: remove extra whitespace in charts/configmap

### DIFF
--- a/charts/telepresence-oss/templates/trafficManager-configmap.yaml
+++ b/charts/telepresence-oss/templates/trafficManager-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "traffic-manager.name" $ }}
-  namespace:  {{ include "traffic-manager.namespace" $ }}
+  namespace: {{ include "traffic-manager.namespace" $ }}
   labels:
     {{- include "telepresence.labels" $ | nindent 4 }}
 data:


### PR DESCRIPTION
## Description

remove extra whitespace in charts/configmap