### PR TITLE
fix(Helm): Add Removed Value in config

### DIFF
--- a/charts/telepresence-oss/templates/trafficManager-configmap.yaml
+++ b/charts/telepresence-oss/templates/trafficManager-configmap.yaml
@@ -18,4 +18,5 @@ data:
 {{- end }}
   namespace-selector.yaml: |
     {{- toYaml (mustFromJson (include "traffic-manager.namespaceSelector" $)) | nindent 4 }}
-  agent-state.yaml:
+  agent-state.yaml: |
+    AgentStates: {}


### PR DESCRIPTION
## Description

This was removed in github.com/telepresenceio/telepresence/commit/54cfaa5306c75f266b83dfaf81ed04705b1c3f4c

This makes Problems when using this Helm chart from Argo CD.
Because it tries to sync a empty string and k8s deletes the empty string.