### PR TITLE
fix: work with custom go versions, like `go1.25.1 X:nodwarf5`

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -94,7 +94,7 @@ protoc: protoc-clean $(tools/protoc) $(tools/protoc-gen-go) $(tools/protoc-gen-g
 .PHONY: generate
 generate: ## (Generate) Update generated files that get checked in to Git
 generate: generate-clean
-generate: protoc $(tools/go-mkopensource) $(BUILDDIR)/$(shell go env GOVERSION).src.tar.gz
+generate: protoc $(tools/go-mkopensource) $(BUILDDIR)/$(shell go env GOVERSION | awk '{print $$1}').src.tar.gz
 	cd ./rpc && export GOFLAGS=-mod=mod && go mod tidy && go mod vendor && rm -rf vendor
 	cd ./pkg/vif/testdata/router && export GOFLAGS=-mod=mod && go mod tidy && go mod vendor && rm -rf vendor
 	cd ./tools/src/test-report && export GOFLAGS=-mod=mod && go mod tidy && go mod vendor && rm -rf vendor


### PR DESCRIPTION
Closes #3960

## Description

Only use the first column of the GOVERSION file to determine the Go version to use.
This allows to use custom go versions like `go1.25.1 X:nodwarf5`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

- [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
- [x] I made sure to add any documentation changes required for my change.
- [x] My change is adequately tested.
- [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
- [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
      [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.
