### PR TITLE
Adds http-filters and http-paths to the docker compose integration

### DIFF
--- a/docs/howtos/engage.md
+++ b/docs/howtos/engage.md
@@ -29,9 +29,11 @@ Telepresence offers three powerful ways to develop your services locally:
   - Intercepts requests destined for a specific service port (or ports) and reroutes them to the local workstation.
   - Makes the remote environment of the targeted container available to the local workstation.
   - Provides read-write access to the volumes mounted by the targeted container.
+  - Makes it possible to filter traffic using HTTP headers and paths.
 * **Impact:**
   - A Traffic Agent is injected into the pods of the targeted workload.
   - Intercepted traffic is rerouted to the local workstation and will no longer reach the remote service.
+  - Only traffic that matches the intercept filters will be rerouted.
   - All containers keep on running.
 * **Use-cases:**
   - Your main focus is the service API rather than the cluster's pods and containers.
@@ -43,6 +45,7 @@ Telepresence offers three powerful ways to develop your services locally:
   - Adds a wiretap on a specific service port (or ports) and sends the data to the local workstation.
   - Makes the remote environment of the targeted container available to the local workstation.
   - Provides read-only access to the volumes mounted by the targeted container.
+  - Makes it possible to filter traffic using HTTP headers and paths.
 * **Impact:**
   - A Traffic Agent is injected into the pods of the targeted workload.
   - All containers keep on running.
@@ -183,23 +186,27 @@ You can now:
 
 ## Intercept your application
 
-You can use the `telepresence intercept` command when you want to intercept the traffic for a specific service and route that
-traffic to your workstation. The `intercept` is less intrusive than the `replace`, because it allows the original receiver of the
-intercepted traffic to continue to run and deal with tasks that aren't directly related to that traffic.
+The `telepresence intercept` command allows you to redirect traffic for a specific service to your local workstation.
+Compared to the replace command, intercept is less invasive because it: a) enables precise filtering of intercepted
+traffic using HTTP headers or paths, and b) allows the original service to continue running, handling all other traffic
+and tasks not directly related to the intercepted traffic.
 
 1. Connect to your cluster with `telepresence connect`.
 
 2. Intercept all traffic going to the application's http port in your cluster and redirect to port 8080 on your workstation.
     ```console
-    $ telepresence intercept example-app --port 8080:http --env-file ~/example-app-intercept.env --mount /tmp/example-app-mounts
+    $ telepresence intercept example-app --http-header 'x-user=margret' --port 8080:http --env-file ~/example-app-intercept.env --mount /tmp/example-app-mounts
     Using Deployment example-app
     intercepted
       Intercept name: example-app
       State         : ACTIVE
       Workload kind : Deployment
       Destination   : 127.0.0.1:8080
-      Intercepting  : all TCP connections
+      Intercepting  : HTTP filters: header x-user=margret
     ```
+
+   * For `--http-header`: specify the HTTP header you want to filter on. You can specify multiple headers by repeating
+     the flag.
 
    * For `--port`: specify the port the local instance of your application is running on, and optionally the remote port
      that you want to intercept. Telepresence will select the remote port automatically when there's only one service
@@ -213,8 +220,8 @@ intercepted traffic to continue to run and deal with tasks that aren't directly 
 3. Start your local application using the environment variables retrieved and the volumes that were mounted in the previous step.
 
 You can now:
-- Make changes on the fly and see them reflected when interacting with your Kubernetes environment.
-- Query services only exposed in your cluster's network.
+- Make changes on the fly and see them reflected when interacting with your Kubernetes environment without affecting other users of the same service.
+- Query services that are only exposed in your cluster's network.
 - Set breakpoints in your IDE to investigate bugs.
 
 ## Wiretap your application

--- a/docs/reference/cli/telepresence_intercept.md
+++ b/docs/reference/cli/telepresence_intercept.md
@@ -25,10 +25,10 @@ Intercept a service
   -j, --env-json string                Also emit the remote environment to a file as a JSON blob.
       --env-syntax string              Syntax used for env-file. One of "docker", "compose", "sh", "csh", "cmd", "json", and "ps"; where "sh", "csh", and "ps" can be suffixed with ":export" (default "docker")
   -h, --help                           help for intercept
-      --http-header strings            HTTP header filters for HTTP Intercepts. Only requests with matching headers will be intercepted. Supports both formats: --http-header "X-User-ID=dev123" or --http-header "X-User-ID: dev123" (curl -H compatible). Multiple headers use AND logic.
-      --http-path-equal strings        HTTP path filters for HTTP Intercepts. Only requests with matching paths will be intercepted. Exact path matching.
-      --http-path-prefix strings       HTTP path prefix filters for HTTP Intercepts. Only requests with matching path prefixes will be intercepted.
-      --http-path-regex strings        HTTP path regex filters for HTTP Intercepts. Only requests with paths matching the regex will be intercepted.
+      --http-header strings            HTTP header filters. Only requests with matching headers will be intercepted. Supports both formats: --http-header "X-User-ID=dev123" or --http-header "X-User-ID: dev123" (curl -H compatible). Multiple headers use AND logic.
+      --http-path-equal strings        HTTP path filters. Only requests with matching paths will be intercepted. Exact path matching.
+      --http-path-prefix strings       HTTP path prefix filters. Only requests with matching path prefixes will be intercepted.
+      --http-path-regex strings        HTTP path regex filters. Only requests with paths matching the regex will be intercepted.
       --local-mount-port uint16        Do not mount remote directories. Instead, expose this port on localhost to an external mounter
       --mechanism mechanism            Which extension mechanism to use (default "tcp")
       --mount string                   The absolute path for the root directory where volumes will be mounted, $TELEPRESENCE_ROOT. Use "true" to have Telepresence pick a random mount point (default). Use "false" to disable filesystem mounting entirely. Append ":ro" to mount everything read-only. (default "true")

--- a/docs/reference/cli/telepresence_wiretap.md
+++ b/docs/reference/cli/telepresence_wiretap.md
@@ -25,10 +25,10 @@ Wiretap a Service
   -j, --env-json string                Also emit the remote environment to a file as a JSON blob.
       --env-syntax string              Syntax used for env-file. One of "docker", "compose", "sh", "csh", "cmd", "json", and "ps"; where "sh", "csh", and "ps" can be suffixed with ":export" (default "docker")
   -h, --help                           help for wiretap
-      --http-header strings            HTTP header filters for HTTP Intercepts. Only requests with matching headers will be intercepted. Supports both formats: --http-header "X-User-ID=dev123" or --http-header "X-User-ID: dev123" (curl -H compatible). Multiple headers use AND logic.
-      --http-path-equal strings        HTTP path filters for HTTP Intercepts. Only requests with matching paths will be intercepted. Exact path matching.
-      --http-path-prefix strings       HTTP path prefix filters for HTTP Intercepts. Only requests with matching path prefixes will be intercepted.
-      --http-path-regex strings        HTTP path regex filters for HTTP Intercepts. Only requests with paths matching the regex will be intercepted.
+      --http-header strings            HTTP header filters. Only requests with matching headers will be wiretapped. Supports both formats: --http-header "X-User-ID=dev123" or --http-header "X-User-ID: dev123" (curl -H compatible). Multiple headers use AND logic.
+      --http-path-equal strings        HTTP path filters. Only requests with matching paths will be wiretapped. Exact path matching.
+      --http-path-prefix strings       HTTP path prefix filters. Only requests with matching path prefixes will be wiretapped.
+      --http-path-regex strings        HTTP path regex filters. Only requests with paths matching the regex will be wiretapped.
       --local-mount-port uint16        Do not mount remote directories. Instead, expose this port on localhost to an external mounter
       --mechanism mechanism            Which extension mechanism to use (default "tcp")
       --mount string                   The absolute path for the root directory where volumes will be mounted, $TELEPRESENCE_ROOT. Use "true" to have Telepresence pick a random mount point (default). Use "false" to disable filesystem mounting entirely. Append ":ro" to mount everything read-only. (default "true")

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -123,14 +123,18 @@ The `container` field is required when more than one container is declared in th
 
 The `intercept` ensures that the docker compose service receives traffic from, and shares the environment and volumes of, a remote container in the cluster. The extension can have the following fields set:
 
-| Name       | Description                                                                   | Type    | Default Value               |
-|------------|-------------------------------------------------------------------------------|---------|-----------------------------|
-| connection | The name of a connection declared in the top-level `x-tele` extension         | string  | empty                       |
-| name       | Name of the intercept engagement                                              | string  | name of the compose service |
-| workload   | Name of the remote workload (typically the deployment)                        | string  | name of the engagement      |
-| ports      | Service &lt;local port&gt;:&lt;service port&gt; to intercept                  | strings | empty                       |
-| service    | Name of the remote service                                                    | string  | empty                       |
-| to-pod     | Ports to forward from the local compose service to the remote pod's localhost | strings | empty                       |
+| Name             | Description                                                                                    | Type    | Default Value               |
+|------------------|------------------------------------------------------------------------------------------------|---------|-----------------------------|
+| connection       | The name of a connection declared in the top-level `x-tele` extension                          | string  | empty                       |
+| name             | Name of the intercept engagement                                                               | string  | name of the compose service |
+| httpFilters      | HTTP header filters. Only requests with matching headers will be intercepted                   | object  | empty                       |
+| httpPaths        | HTTP path filters. Only requests with matching paths will be intercepted. Exact path matching. | strings | empty                       |
+| httpPathPrefixes | HTTP path prefix filters. Only requests with matching path prefixes will be intercepted.       | strings | empty                       |
+| httpPathRegexps  | HTTP path regexp filters. Only requests with paths matching the regexp will be intercepted.    | strings | empty                       |
+| workload         | Name of the remote workload (typically the deployment)                                         | string  | name of the engagement      |
+| ports            | Service &lt;local port&gt;:&lt;service port&gt; to intercept                                   | strings | empty                       |
+| service          | Name of the remote service                                                                     | string  | empty                       |
+| to-pod           | Ports to forward from the local compose service to the remote pod's localhost                  | strings | empty                       |
 
 
 The `service` field is optional as long as the given `ports` are unique.
@@ -153,12 +157,16 @@ The `replace` ensures that the docker compose service receives traffic from, and
 
 The `wiretap` ensures that the docker compose service receives wiretapped traffic from a remote service, and shares the environment and volumes (read-only) of, a remote container. The extension can have the following fields set:
 
-| Name       | Description                                                                   | Type    | Default Value               |
-|------------|-------------------------------------------------------------------------------|---------|-----------------------------|
-| connection | The name of a connection declared in the top-level `x-tele` extension         | string  | empty                       |
-| name       | Name of the wiretapped workload  (typically the deployment)                   | string  | name of the compose service |
-| ports      | Service &lt;local port&gt;:&lt;service port&gt; to wiretap                    | strings | empty                       |
-| service    | Name of the remote service                                                    | string  | empty                       |
-| to-pod     | Ports to forward from the local compose service to the remote pod's localhost | strings | empty                       |
+| Name             | Description                                                                                   | Type    | Default Value               |
+|------------------|-----------------------------------------------------------------------------------------------|---------|-----------------------------|
+| connection       | The name of a connection declared in the top-level `x-tele` extension                         | string  | empty                       |
+| name             | Name of the wiretapped workload  (typically the deployment)                                   | string  | name of the compose service |
+| httpFilters      | HTTP header filters. Only requests with matching headers will be wiretapped                   | object  | empty                       |
+| httpPaths        | HTTP path filters. Only requests with matching paths will be wiretapped. Exact path matching. | strings | empty                       |
+| httpPathPrefixes | HTTP path prefix filters. Only requests with matching path prefixes will be wiretapped.       | strings | empty                       |
+| httpPathRegexps  | HTTP path regexp filters. Only requests with paths matching the regexp will be wiretapped.    | strings | empty                       |
+| ports            | Service &lt;local port&gt;:&lt;service port&gt; to wiretap                                    | strings | empty                       |
+| service          | Name of the remote service                                                                    | string  | empty                       |
+| to-pod           | Ports to forward from the local compose service to the remote pod's localhost                 | strings | empty                       |
 
 The `service` field is optional as long as the given `service ports` are unique.

--- a/docs/reference/engagements/cli.md
+++ b/docs/reference/engagements/cli.md
@@ -25,57 +25,56 @@ laptop. This includes traffic coming through your ingress controller, so use thi
 carefully as to not disrupt production environments.
 
 ```shell
-telepresence intercept <deployment name> --port=<TCP port>
+telepresence intercept <deployment name> --http-header x-user=susan --port=<TCP port>
 ```
 
-Run `telepresence status` to see the list of active intercepts.
+Run `telepresence list` to see the list of active intercepts.
+
+```console
+$ telepresence list
+deployment dataprocessingnodeservice: intercepted
+   Intercept name: echo-one
+   State         : ACTIVE
+   Workload kind : Deployment
+   Intercepting  : 10.244.0.13 -> 127.0.0.1
+       8080 -> 8080 TCP
+   Intercepting  : HTTP filters: header x-user=susan
+```
+
+When intercepting a service that has [multiple ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services), the name of the
+service port that has been intercepted is also listed.
 
 ```console
 $ telepresence status
 OSS User Daemon: Running
-  Version           : v2.18.0
+  Version           : $version$
   Executable        : /usr/local/bin/telepresence
-  Install ID        : 4b1658f3-7ff8-4af3-66693-f521bc1da32f
+  Install ID        : 0e711768-a69b-4c36-9eea-fe2d3d964e3c
   Status            : Connected
-  Kubernetes server : https://cluster public IP>
-  Kubernetes context: default
+  Kubernetes server : https://<cluster public IP>
+  Kubernetes context: kind-dev
   Namespace         : default
   Manager namespace : ambassador
+  Mapped namespaces : [ambassador default kube-public]
   Intercepts        : 1 total
-    dataprocessingnodeservice: <laptop username>@<laptop name>
+    echo-one: <laptop username>@<laptop name>
 OSS Root Daemon: Running
-  Version: v2.18.0
+  Version: $version$
   DNS    : 
-    Remote IP       : 127.0.0.1
+    Local addresses : [127.0.0.1:51943]
+    VIF Address     : 10.244.0.10:53
     Exclude suffixes: [.com .io .net .org .ru]
     Include suffixes: []
-    Timeout         : 8s
+    Timeout         : 4s
   Subnets: (2 subnets)
     - 10.96.0.0/16
     - 10.244.0.0/24
 OSS Traffic Manager: Connected
-  Version      : v2.19.0
-  Traffic Agent: docker.io/datawire/tel2:2.18.0
+  Version      : v$version$
+  Traffic Agent: ghcr.io/telepresenceio/tel2:$version$
 ```
 
 Finally, run `telepresence leave <name of intercept>` to stop the intercept.
-
-[kube-multi-port-services]: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
-
-```console
-$ telepresence intercept <base name of intercept> --port=<local TCP port>:<servicePortIdentifier>
-Using Deployment <name of deployment>
-intercepted
-    Intercept name         : <full name of intercept>
-    State                  : ACTIVE
-    Workload kind          : Deployment
-    Destination            : 127.0.0.1:<local TCP port>
-    Service Port Identifier: <servicePortIdentifier>
-    Intercepting           : all TCP connections
-```
-
-When intercepting a service that has multiple ports, the name of the
-service port that has been intercepted is also listed.
 
 If you want to change which port has been intercepted, you can create
 a new intercept the same way you did above, and it will change which

--- a/pkg/client/cli/docker/compose/extension.go
+++ b/pkg/client/cli/docker/compose/extension.go
@@ -148,6 +148,10 @@ func (e *extension) connection() *connection {
 	return e.conn
 }
 
+func (e *extension) engaged() (*engagement, error) {
+	return createEngagement(daemon.MustGetUserClient(e.conn), e, 0)
+}
+
 func (e *extension) needsVolumes() bool {
 	return false
 }
@@ -178,10 +182,6 @@ func (e *proxyExtension) init(c *config, et types.EngagementType, composeService
 }
 
 func (e *proxyExtension) activate(*transformer) (*engagement, error) {
-	return createEngagement(daemon.MustGetUserClient(e.conn), e, 0)
-}
-
-func (e *extension) engaged() (*engagement, error) {
 	return createEngagement(daemon.MustGetUserClient(e.conn), e, 0)
 }
 
@@ -252,11 +252,37 @@ func (e *engageExtension) desiredRemoteMounts(remoteMounts types.MountPolicies) 
 	return desiredMounts, volumes
 }
 
-type interceptExtension struct {
+type httpFilterExtension struct {
 	engageExtension
+	HttpFilters  map[string]string   `json:"httpFilters,omitempty"`
+	Ports        []types.PortMapping `json:"ports,omitempty"`
+	Paths        []string            `json:"httpPaths,omitempty"`
+	PathPrefixes []string            `json:"httpPathPrefixes,omitempty"`
+	PathRegexps  []string            `json:"httpPathRegexps,omitempty"`
+}
+
+func (e *httpFilterExtension) amendInterceptSpec(spec *manager.InterceptSpec) error {
+	ports := e.servicePorts()
+	if len(ports) == 0 {
+		return fmt.Errorf("a %s requires at least one port", e.engagementType())
+	}
+	err := addPortsSpec(spec, ports)
+	if err != nil {
+		return err
+	}
+	spec.HeaderFilters = e.HttpFilters
+	spec.PathFilters = intercept.BuildPathFilters(e.Paths, e.PathPrefixes, e.PathRegexps)
+	return nil
+}
+
+func (e *httpFilterExtension) servicePorts() []types.PortMapping {
+	return e.Ports
+}
+
+type interceptExtension struct {
+	httpFilterExtension
 	Workload string               `json:"workload,omitempty"`
 	Service  string               `json:"service,omitempty"`
-	Ports    []types.PortMapping  `json:"ports,omitempty"`
 	ToPod    []types.PortAndProto `json:"toPod,omitempty"`
 }
 
@@ -288,10 +314,6 @@ func (e *interceptExtension) service() string {
 	return e.Service
 }
 
-func (e *interceptExtension) servicePorts() []types.PortMapping {
-	return e.Ports
-}
-
 func (e *interceptExtension) toPod() []types.PortAndProto {
 	return e.ToPod
 }
@@ -303,11 +325,7 @@ func (e *interceptExtension) createInterceptRequest(localMountPort uint16) (*con
 	for _, toPod := range e.toPod() {
 		spec.LocalPorts = append(spec.LocalPorts, toPod.String())
 	}
-	ports := e.servicePorts()
-	if len(ports) == 0 {
-		return nil, fmt.Errorf("a %s requires at least one port", e.engagementType())
-	}
-	err := addPortsSpec(spec, ports)
+	err := e.amendInterceptSpec(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -434,13 +452,10 @@ func (e *replaceExtension) toPod() []types.PortAndProto {
 }
 
 type wiretapExtension struct {
-	engageExtension
+	httpFilterExtension
 
 	// Service is the Kubernetes service that Telepresence will engage with.
 	Service string `json:"service,omitempty"`
-
-	// Ports maps service ports to local ports.
-	Ports []types.PortMapping `json:"ports,omitempty"`
 }
 
 func (e *wiretapExtension) activate(t *transformer) (*engagement, error) {
@@ -459,23 +474,13 @@ func (e *wiretapExtension) service() string {
 	return e.Service
 }
 
-// ServicePorts to intercept mapped to local ports.
-func (e *wiretapExtension) servicePorts() []types.PortMapping {
-	return e.Ports
-}
-
 func (e *wiretapExtension) createInterceptRequest(localMountPort uint16) (*connector.CreateInterceptRequest, error) {
 	ir := createInterceptRequest(e, localMountPort)
 	spec := ir.Spec
 	spec.ServiceName = e.service()
 	spec.Wiretap = true
 	ir.MountReadOnly = true
-
-	ports := e.servicePorts()
-	if len(ports) == 0 {
-		return nil, fmt.Errorf("a %s requires at least one port", e.engagementType())
-	}
-	err := addPortsSpec(spec, ports)
+	err := e.amendInterceptSpec(spec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/cli/intercept/command.go
+++ b/pkg/client/cli/intercept/command.go
@@ -162,19 +162,19 @@ func (c *Command) AddInterceptFlags(cmd *cobra.Command) {
 
 	// HTTP Intercepts flags
 	flagSet.StringSliceVar(&c.HTTPHeaderFilters, "http-header", nil,
-		`HTTP header filters for HTTP Intercepts. Only requests with matching headers will be intercepted. `+
+		fmt.Sprintf(`HTTP header filters. Only requests with matching headers will be %s. `+
 			`Supports both formats: --http-header "X-User-ID=dev123" or --http-header "X-User-ID: dev123" (curl -H compatible). `+
-			`Multiple headers use AND logic.`)
+			`Multiple headers use AND logic.`, how))
 
 	flagSet.StringSliceVar(&c.HTTPPathEqualFilters, "http-path-equal", nil,
-		`HTTP path filters for HTTP Intercepts. Only requests with matching paths will be intercepted. `+
-			`Exact path matching.`)
+		fmt.Sprintf(`HTTP path filters. Only requests with matching paths will be %s. `+
+			`Exact path matching.`, how))
 
 	flagSet.StringSliceVar(&c.HTTPPathPrefixFilters, "http-path-prefix", nil,
-		`HTTP path prefix filters for HTTP Intercepts. Only requests with matching path prefixes will be intercepted.`)
+		fmt.Sprintf(`HTTP path prefix filters. Only requests with matching path prefixes will be %s.`, how))
 
 	flagSet.StringSliceVar(&c.HTTPPathRegexFilters, "http-path-regex", nil,
-		`HTTP path regex filters for HTTP Intercepts. Only requests with paths matching the regex will be intercepted.`)
+		fmt.Sprintf(`HTTP path regex filters. Only requests with paths matching the regex will be %s.`, how))
 
 	_ = cmd.RegisterFlagCompletionFunc("container", ingest.AutocompleteContainer)
 	_ = cmd.RegisterFlagCompletionFunc("service", autocompleteService)
@@ -412,4 +412,34 @@ func ValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 	// There probably exists a number that would be a good cutoff limit.
 
 	return list, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+// BuildPathFilters builds a list of path filters from the given arguments.
+// The filters are of the form:
+//   - :path-equal:<path>
+//   - :path-prefix:<path>
+//   - :path-regex:<path>
+func BuildPathFilters(equals, prefixes, regexps []string) []string {
+	// Combine all path filters with their type prefixes
+	allFilters := make([]string, len(equals)+len(prefixes)+len(regexps))
+
+	// Add exact match filters
+	i := 0
+	for _, path := range equals {
+		allFilters[i] = ":path-equal:" + path
+		i++
+	}
+
+	// Add prefix match filters
+	for _, path := range prefixes {
+		allFilters[i] = ":path-prefix:" + path
+		i++
+	}
+
+	// Add regex match filters
+	for _, path := range regexps {
+		allFilters[i] = ":path-regex:" + path
+		i++
+	}
+	return allFilters
 }

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -95,25 +95,7 @@ func (s *state) CreateRequest(ctx context.Context) (*connector.CreateInterceptRe
 			// so we can safely ignore them here
 		}
 	}
-	// Combine all path filters with their type prefixes
-	var allPathFilters []string
-
-	// Add exact match filters
-	for _, path := range s.HTTPPathEqualFilters {
-		allPathFilters = append(allPathFilters, ":path-equal:"+path)
-	}
-
-	// Add prefix match filters
-	for _, path := range s.HTTPPathPrefixFilters {
-		allPathFilters = append(allPathFilters, ":path-prefix:"+path)
-	}
-
-	// Add regex match filters
-	for _, path := range s.HTTPPathRegexFilters {
-		allPathFilters = append(allPathFilters, ":path-regex:"+path)
-	}
-
-	spec.PathFilters = allPathFilters
+	spec.PathFilters = BuildPathFilters(s.HTTPPathEqualFilters, s.HTTPPathPrefixFilters, s.HTTPPathRegexFilters)
 
 	for _, toPod := range s.ToPod {
 		pp, err := types.ParsePortAndProto(toPod)


### PR DESCRIPTION
Also adds some more documentation related to the http-filters, and fixes help output for the wiretap command so that it mentions "wiretapped" instead of "intercepted".