### PR TITLE
feat(intercept): implement interceptSpecsConflict function and add tests

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -48,10 +48,31 @@ items:
         title: HTTP Intercepts with HTTP header and path filtering
         body: >-
           Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts.
-          Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http` flag
-          along with `--header` and `--path` filters. This allows multiple developers to work on the same service
-          simultaneously by intercepting only their specific traffic patterns, rather than intercepting all traffic
-          to a service. The feature maintains full backward compatibility with existing TCP intercepts.
+          Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http-header`,
+          `--http-path-prefix`, `--http-path-equal`, and `--http-path-regex` flags. This allows multiple developers
+          to work on the same service simultaneously by intercepting only their specific traffic patterns, rather than
+          intercepting all traffic to a service.
+
+
+          **Routing Precedence Model**: Header-based intercepts take priority over path-only intercepts. When multiple
+          intercepts are active on the same workload, requests are evaluated against header-based filters first, then
+          path-only filters. This enables different developers to use header-based personal intercepts (e.g.,
+          `x-user=alice`) while others use path-based intercepts (e.g., `/admin/*`) without conflicts.
+
+
+          **Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different
+          destinations. Key rules:
+
+          - Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
+
+          - Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
+
+          - Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+
+          - Path-only intercepts operate at a lower priority tier than header-based intercepts
+
+
+          The feature maintains full backward compatibility with existing TCP intercepts.
         docs: https://github.com/telepresenceio/telepresence/issues/3852
       - type: feature
         title: More efficient DNS handling in the traffic-manager

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -111,15 +112,16 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 	return pm.AgentProvider.CreateClientStream(ctx, tag, sessionID, id, roundTripLatency, dialTimeout)
 }
 
-// normalizeHeaderFilters returns a new map with all header keys normalized to lowercase.
-// HTTP headers are case-insensitive per RFC 7230.
+// normalizeHeaderFilters returns a new map with all header keys normalized to canonical MIME format.
+// HTTP headers are case-insensitive per RFC 7230, so we use the same canonicalization as net/http.
+// Examples: "x-user" -> "X-User", "content-type" -> "Content-Type"
 func normalizeHeaderFilters(headers map[string]string) map[string]string {
 	if len(headers) == 0 {
 		return headers
 	}
 	normalized := make(map[string]string, len(headers))
 	for key, value := range headers {
-		normalized[strings.ToLower(key)] = value
+		normalized[textproto.CanonicalMIMEHeaderKey(key)] = value
 	}
 	return normalized
 }
@@ -257,14 +259,14 @@ func isHeaderSubset(subset, superset map[string]string) bool {
 // priority tier than intercepts with only paths.
 //
 // Conflict Rules:
-// 1. Global intercepts (no headers, no paths) conflict with everything
-// 2. Headers vs Paths: One spec with headers, another with only paths → NO CONFLICT
-//    (different priority tiers - headers are checked first, then paths)
-// 3. Both have headers: Conflict if headers form a subset AND paths overlap
-//    - Within each intercept, filters use AND logic (must match ALL headers AND ALL paths)
-//    - Example: {x-user:adam} vs {x-user:adam, x-session:xyz} → CONFLICT (first is subset)
-//    - Example: {x-user:adam}+/api/* vs {x-user:adam}+/admin/* → NO CONFLICT (different paths)
-// 4. Both have only paths (no headers): Conflict if paths overlap
+//  1. Global intercepts (no headers, no paths) conflict with everything
+//  2. Headers vs Paths: One spec with headers, another with only paths → NO CONFLICT
+//     (different priority tiers - headers are checked first, then paths)
+//  3. Both have headers: Conflict if headers form a subset AND paths overlap
+//     - Within each intercept, filters use AND logic (must match ALL headers AND ALL paths)
+//     - Example: {x-user:adam} vs {x-user:adam, x-session:xyz} → CONFLICT (first is subset)
+//     - Example: {x-user:adam}+/api/* vs {x-user:adam}+/admin/* → NO CONFLICT (different paths)
+//  4. Both have only paths (no headers): Conflict if paths overlap
 func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 	hasHeaders1 := len(spec1.HeaderFilters) > 0
 	hasHeaders2 := len(spec2.HeaderFilters) > 0
@@ -282,11 +284,11 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 
 	// Rule 2: Headers take precedence - different priority tiers don't conflict
 	// If one spec has headers and the other has only paths, they operate at different tiers
-	if hasHeaders1 && !hasHeaders2 && !isGlobal2 {
+	if hasHeaders1 && !hasHeaders2 {
 		// spec1 has headers (high priority), spec2 has only paths (low priority)
 		return false
 	}
-	if hasHeaders2 && !hasHeaders1 && !isGlobal1 {
+	if hasHeaders2 && !hasHeaders1 {
 		// spec2 has headers (high priority), spec1 has only paths (low priority)
 		return false
 	}

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -96,46 +96,94 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 
 // interceptSpecsConflict determines if two intercept specs would conflict with each other.
 // Two specs conflict if they would route the same traffic to different destinations.
+//
+// Precedence Model:
+// Headers take precedence over paths. This means intercepts with headers operate at a higher
+// priority tier than intercepts with only paths.
+//
+// Conflict Rules:
+// 1. Global intercepts (no headers, no paths) conflict with everything
+// 2. Headers vs Paths: One spec with headers, another with only paths → NO CONFLICT
+//    (different priority tiers - headers are checked first, then paths)
+// 3. Both have headers: Conflict if headers form a subset AND paths overlap
+//    - Within each intercept, filters use AND logic (must match ALL headers AND ALL paths)
+//    - Example: {x-user:adam} vs {x-user:adam, x-session:xyz} → CONFLICT (first is subset)
+//    - Example: {x-user:adam}+/api/* vs {x-user:adam}+/admin/* → NO CONFLICT (different paths)
+// 4. Both have only paths (no headers): Conflict if paths overlap
 func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
-	// Fast path: For TCP intercepts (no filters), they always conflict on the same port
-	if len(spec1.HeaderFilters) == 0 && len(spec1.PathFilters) == 0 &&
-		len(spec2.HeaderFilters) == 0 && len(spec2.PathFilters) == 0 {
+	hasHeaders1 := len(spec1.HeaderFilters) > 0
+	hasHeaders2 := len(spec2.HeaderFilters) > 0
+	hasPaths1 := len(spec1.PathFilters) > 0
+	hasPaths2 := len(spec2.PathFilters) > 0
+
+	// Global intercept: no headers and no paths means it intercepts everything
+	isGlobal1 := !hasHeaders1 && !hasPaths1
+	isGlobal2 := !hasHeaders2 && !hasPaths2
+
+	// Rule 1: Global intercepts conflict with anything
+	if isGlobal1 || isGlobal2 {
 		return true
 	}
 
-	// For HTTP intercepts, check header filter conflicts
-	if len(spec1.HeaderFilters) > 0 && len(spec2.HeaderFilters) > 0 {
-		// Check if any header key has the same value in both specs
-		for key1, value1 := range spec1.HeaderFilters {
-			if value2, exists := spec2.HeaderFilters[key1]; exists && value1 == value2 {
-				// Same header key with same value = traffic would match both intercepts
-				return true
-			}
-		}
-		// All header keys either don't overlap or have different values = no conflict
+	// Rule 2: Headers take precedence - different priority tiers don't conflict
+	// If one spec has headers and the other has only paths, they operate at different tiers
+	if hasHeaders1 && !hasHeaders2 && !isGlobal2 {
+		// spec1 has headers (high priority), spec2 has only paths (low priority)
+		return false
+	}
+	if hasHeaders2 && !hasHeaders1 && !isGlobal1 {
+		// spec2 has headers (high priority), spec1 has only paths (low priority)
 		return false
 	}
 
-	// For HTTP intercepts, check path filter conflicts
-	if len(spec1.PathFilters) > 0 && len(spec2.PathFilters) > 0 {
-		// Check for overlapping path patterns
+	// Helper function to check if all headers in subset exist in superset with same values
+	isHeaderSubset := func(subset, superset map[string]string) bool {
+		for key, value := range subset {
+			if superValue, exists := superset[key]; !exists || superValue != value {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Rule 3: Both have headers - check for subset relationship AND path overlap
+	if hasHeaders1 && hasHeaders2 {
+		// Check if headers form a subset relationship
+		hasHeaderSubset := isHeaderSubset(spec1.HeaderFilters, spec2.HeaderFilters) ||
+			isHeaderSubset(spec2.HeaderFilters, spec1.HeaderFilters)
+
+		if !hasHeaderSubset {
+			// Headers don't form subset, no conflict
+			return false
+		}
+
+		// Headers form subset, now check paths
+		if !hasPaths1 || !hasPaths2 {
+			// At least one has no path restriction, so paths overlap
+			return true
+		}
+
+		// Both have paths: check for overlap
 		for _, path1 := range spec1.PathFilters {
 			if slices.Contains(spec2.PathFilters, path1) {
 				return true
 			}
 		}
-		// Disjoint path filters = no conflict
+		// Different paths, no conflict
 		return false
 	}
 
-	// If one has header filters and the other has path filters, they can coexist
-	// Each will only match traffic meeting their specific criteria
-	if (len(spec1.HeaderFilters) > 0 && len(spec2.PathFilters) > 0) ||
-		(len(spec1.PathFilters) > 0 && len(spec2.HeaderFilters) > 0) {
+	// Rule 4: Both have only paths (no headers) - check for path overlap
+	if hasPaths1 && hasPaths2 {
+		for _, path1 := range spec1.PathFilters {
+			if slices.Contains(spec2.PathFilters, path1) {
+				return true
+			}
+		}
 		return false
 	}
 
-	// Default: no conflict
+	// Should not reach here, but default to no conflict
 	return false
 }
 
@@ -229,8 +277,11 @@ func (fs *fwdState) processRegularIntercept(
 			MechanismArgsDesc: generateMechanismDescription(ii.Spec),
 		}
 	}
-	if !ii.Spec.Wiretap && *activeIntercept == nil {
-		// Set the first non-wiretap intercept as the active one for the forwarder
+	// Only set activeIntercept for global/TCP intercepts (no filters)
+	// HTTP intercepts with filters use the multiple-intercept mode instead
+	isGlobalIntercept := len(ii.Spec.HeaderFilters) == 0 && len(ii.Spec.PathFilters) == 0
+	if !ii.Spec.Wiretap && isGlobalIntercept && *activeIntercept == nil {
+		// Set the first global non-wiretap intercept as the active one for the forwarder
 		*activeIntercept = ii
 	}
 	dlog.Infof(ctx, "Allowing non-conflicting intercept %q to become active", ii.Id)
@@ -265,7 +316,9 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 	if fs.chosenInterceptId != "" {
 		for _, is := range active {
 			if fs.chosenInterceptId == is.Id {
-				if !is.Spec.Wiretap {
+				// Only track global/TCP intercepts as activeIntercept
+				isGlobalIntercept := len(is.Spec.HeaderFilters) == 0 && len(is.Spec.PathFilters) == 0
+				if !is.Spec.Wiretap && isGlobalIntercept {
 					activeIntercept = is
 				}
 				break
@@ -276,9 +329,10 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 	if activeIntercept == nil {
 		fs.chosenInterceptId = ""
 
-		// Attach to already ACTIVE intercept if there is one.
+		// Attach to already ACTIVE global/TCP intercept if there is one.
 		for _, is := range active {
-			if !is.Spec.Wiretap {
+			isGlobalIntercept := len(is.Spec.HeaderFilters) == 0 && len(is.Spec.PathFilters) == 0
+			if !is.Spec.Wiretap && isGlobalIntercept {
 				fs.chosenInterceptId = is.Id
 				activeIntercept = is
 				break
@@ -291,7 +345,26 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 		// Update forwarding.
 		fwd.SetStreamProvider(fs)
 	}
-	fwd.SetIntercepting(ctx, activeIntercept)
+
+	// Check if we have HTTP intercepts (any with HeaderFilters or PathFilters)
+	var httpIntercepts []*manager.InterceptInfo
+	for _, is := range active {
+		if !is.Spec.Wiretap {
+			spec := is.Spec
+			if len(spec.HeaderFilters) > 0 || len(spec.PathFilters) > 0 {
+				httpIntercepts = append(httpIntercepts, is)
+			}
+		}
+	}
+
+	if len(httpIntercepts) > 0 {
+		// We have HTTP intercepts - use multiple intercept mode
+		dlog.Debugf(ctx, "Setting %d HTTP intercepts on forwarder", len(httpIntercepts))
+		fwd.SetInterceptingMultiple(ctx, httpIntercepts)
+	} else {
+		// No HTTP filters - use single intercept mode for TCP
+		fwd.SetIntercepting(ctx, activeIntercept)
+	}
 
 	// Remove inactive wiretaps.
 	for _, id := range fwd.WiretapIDs() {

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -114,7 +114,7 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 
 // normalizeHeaderFilters returns a new map with all header keys normalized to canonical MIME format.
 // HTTP headers are case-insensitive per RFC 7230, so we use the same canonicalization as net/http.
-// Examples: "x-user" -> "X-User", "content-type" -> "Content-Type"
+// Examples: "x-user" -> "X-User", "content-type" -> "Content-Type".
 func normalizeHeaderFilters(headers map[string]string) map[string]string {
 	if len(headers) == 0 {
 		return headers

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -139,6 +139,107 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 	return false
 }
 
+// processWiretapIntercept handles wiretap intercepts which can always be active alongside others
+func (fs *fwdState) processWiretapIntercept(ii *manager.InterceptInfo) *manager.ReviewInterceptRequest {
+	container := ii.Spec.ContainerName
+	if container == "" {
+		container = fs.container
+	}
+	cs := fs.containerStates[container]
+	if cs == nil {
+		return &manager.ReviewInterceptRequest{
+			Id:                ii.Id,
+			Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
+			Message:           fmt.Sprintf("No match for container %q", container),
+			MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+		}
+	}
+	return &manager.ReviewInterceptRequest{
+		Id:                ii.Id,
+		Disposition:       manager.InterceptDispositionType_ACTIVE,
+		PodIp:             fs.PodIP().String(),
+		FtpPort:           int32(fs.FtpPort()),
+		SftpPort:          int32(fs.SftpPort()),
+		MountPoint:        cs.MountPoint(),
+		Mounts:            cs.Mounts().ToRPC(),
+		MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+		Environment:       cs.Env(),
+	}
+}
+
+// findConflictingIntercept checks if an intercept conflicts with any active or waiting intercepts
+func (fs *fwdState) findConflictingIntercept(ii *manager.InterceptInfo, index int, active []*manager.InterceptInfo, candidates []*manager.InterceptInfo) *manager.InterceptInfo {
+	// Check for conflicts with active intercepts
+	for _, activeII := range active {
+		if !activeII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, activeII.Spec) {
+			return activeII
+		}
+	}
+
+	// Check for conflicts with other waiting intercepts that would become active
+	// Only check intercepts that come before this one (first wins policy)
+	for j, otherII := range candidates {
+		if j < index && !otherII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, otherII.Spec) {
+			return otherII
+		}
+	}
+	return nil
+}
+
+// processRegularIntercept handles non-wiretap intercepts with conflict detection
+func (fs *fwdState) processRegularIntercept(ctx context.Context, ii *manager.InterceptInfo, index int, active []*manager.InterceptInfo, candidates []*manager.InterceptInfo, activeIntercept **manager.InterceptInfo) *manager.ReviewInterceptRequest {
+	conflictingIntercept := fs.findConflictingIntercept(ii, index, active, candidates)
+
+	if conflictingIntercept != nil {
+		// Reject due to actual conflict
+		chosenID := conflictingIntercept.Id
+		dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q", ii.Id, chosenID)
+		var msg string
+		if conflictingIntercept.Disposition == manager.InterceptDispositionType_ACTIVE {
+			msg = fmt.Sprintf("Conflicts with the currently-served intercept %q", chosenID)
+		} else {
+			msg = fmt.Sprintf("Conflicts with the currently-waiting-to-be-served intercept %q", chosenID)
+		}
+		return &manager.ReviewInterceptRequest{
+			Id:                ii.Id,
+			Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
+			Message:           msg,
+			MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+		}
+	}
+
+	// No conflict detected, allow this intercept to become active
+	container := ii.Spec.ContainerName
+	if container == "" {
+		container = fs.container
+	}
+	cs := fs.containerStates[container]
+	if cs == nil {
+		return &manager.ReviewInterceptRequest{
+			Id:                ii.Id,
+			Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
+			Message:           fmt.Sprintf("No match for container %q", container),
+			MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+		}
+	}
+	if !ii.Spec.Wiretap && *activeIntercept == nil {
+		// Set the first non-wiretap intercept as the active one for the forwarder
+		*activeIntercept = ii
+	}
+	dlog.Infof(ctx, "Allowing non-conflicting intercept %q to become active", ii.Id)
+	return &manager.ReviewInterceptRequest{
+		Id:                ii.Id,
+		Disposition:       manager.InterceptDispositionType_ACTIVE,
+		PodIp:             fs.PodIP().String(),
+		FtpPort:           int32(fs.FtpPort()),
+		SftpPort:          int32(fs.SftpPort()),
+		MountPoint:        cs.MountPoint(),
+		Mounts:            cs.Mounts().ToRPC(),
+		MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+		Environment:       cs.Env(),
+	}
+}
+
 func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptInfo) []*manager.ReviewInterceptRequest {
 	dlog.Debugf(ctx, "fwdState.HandlePort called with %d intercepts", len(cepts))
 
@@ -206,112 +307,18 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 	// Review waiting intercepts
 	reviews := make([]*manager.ReviewInterceptRequest, 0, len(waiting))
 
-	// Collect all intercepts that could potentially become active (excluding wiretaps and already processed)
-	var candidateIntercepts []*manager.InterceptInfo
-	for _, ii := range waiting {
-		candidateIntercepts = append(candidateIntercepts, ii)
-	}
+	// Collect all intercepts that could potentially become active
+	candidateIntercepts := slices.Clone(waiting)
 
 	for i, ii := range candidateIntercepts {
 		if ii.Spec.Wiretap {
-			// Wiretaps can always be active alongside other intercepts
-			container := ii.Spec.ContainerName
-			if container == "" {
-				container = fs.container
-			}
-			cs := fs.containerStates[container]
-			if cs == nil {
-				reviews = append(reviews, &manager.ReviewInterceptRequest{
-					Id:                ii.Id,
-					Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
-					Message:           fmt.Sprintf("No match for container %q", container),
-					MechanismArgsDesc: generateMechanismDescription(ii.Spec),
-				})
-				continue
-			}
-			reviews = append(reviews, &manager.ReviewInterceptRequest{
-				Id:                ii.Id,
-				Disposition:       manager.InterceptDispositionType_ACTIVE,
-				PodIp:             fs.PodIP().String(),
-				FtpPort:           int32(fs.FtpPort()),
-				SftpPort:          int32(fs.SftpPort()),
-				MountPoint:        cs.MountPoint(),
-				Mounts:            cs.Mounts().ToRPC(),
-				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
-				Environment:       cs.Env(),
-			})
+			reviews = append(reviews, fs.processWiretapIntercept(ii))
 			continue
 		}
 
-		// Check for conflicts with active intercepts
-		var conflictingIntercept *manager.InterceptInfo
-		for _, activeII := range active {
-			if !activeII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, activeII.Spec) {
-				conflictingIntercept = activeII
-				break
-			}
-		}
-
-		// Check for conflicts with other waiting intercepts that would become active
-		// Only check intercepts that come before this one (first wins policy)
-		if conflictingIntercept == nil {
-			for j, otherII := range candidateIntercepts {
-				if j < i && !otherII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, otherII.Spec) {
-					conflictingIntercept = otherII
-					break
-				}
-			}
-		}
-
-		if conflictingIntercept != nil {
-			// Reject due to actual conflict
-			chosenID := conflictingIntercept.Id
-			dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q", ii.Id, chosenID)
-			var msg string
-			if conflictingIntercept.Disposition == manager.InterceptDispositionType_ACTIVE {
-				msg = fmt.Sprintf("Conflicts with the currently-served intercept %q", chosenID)
-			} else {
-				msg = fmt.Sprintf("Conflicts with the currently-waiting-to-be-served intercept %q", chosenID)
-			}
-			reviews = append(reviews, &manager.ReviewInterceptRequest{
-				Id:                ii.Id,
-				Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
-				Message:           msg,
-				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
-			})
-		} else {
-			// No conflict detected, allow this intercept to become active
-			container := ii.Spec.ContainerName
-			if container == "" {
-				container = fs.container
-			}
-			cs := fs.containerStates[container]
-			if cs == nil {
-				reviews = append(reviews, &manager.ReviewInterceptRequest{
-					Id:                ii.Id,
-					Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
-					Message:           fmt.Sprintf("No match for container %q", container),
-					MechanismArgsDesc: generateMechanismDescription(ii.Spec),
-				})
-				continue
-			}
-			if !ii.Spec.Wiretap && activeIntercept == nil {
-				// Set the first non-wiretap intercept as the active one for the forwarder
-				activeIntercept = ii
-			}
-			dlog.Infof(ctx, "Allowing non-conflicting intercept %q to become active", ii.Id)
-			reviews = append(reviews, &manager.ReviewInterceptRequest{
-				Id:                ii.Id,
-				Disposition:       manager.InterceptDispositionType_ACTIVE,
-				PodIp:             fs.PodIP().String(),
-				FtpPort:           int32(fs.FtpPort()),
-				SftpPort:          int32(fs.SftpPort()),
-				MountPoint:        cs.MountPoint(),
-				Mounts:            cs.Mounts().ToRPC(),
-				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
-				Environment:       cs.Env(),
-			})
-		}
+		// Check for conflicts and process regular intercept
+		review := fs.processRegularIntercept(ctx, ii, i, active, candidateIntercepts, &activeIntercept)
+		reviews = append(reviews, review)
 	}
 	return reviews
 }

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -139,7 +139,7 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 	return false
 }
 
-// processWiretapIntercept handles wiretap intercepts which can always be active alongside others
+// processWiretapIntercept handles wiretap intercepts which can always be active alongside others.
 func (fs *fwdState) processWiretapIntercept(ii *manager.InterceptInfo) *manager.ReviewInterceptRequest {
 	container := ii.Spec.ContainerName
 	if container == "" {
@@ -167,7 +167,7 @@ func (fs *fwdState) processWiretapIntercept(ii *manager.InterceptInfo) *manager.
 	}
 }
 
-// findConflictingIntercept checks if an intercept conflicts with any active or waiting intercepts
+// findConflictingIntercept checks if an intercept conflicts with any active or waiting intercepts.
 func (fs *fwdState) findConflictingIntercept(ii *manager.InterceptInfo, index int, active []*manager.InterceptInfo, candidates []*manager.InterceptInfo) *manager.InterceptInfo {
 	// Check for conflicts with active intercepts
 	for _, activeII := range active {
@@ -186,8 +186,15 @@ func (fs *fwdState) findConflictingIntercept(ii *manager.InterceptInfo, index in
 	return nil
 }
 
-// processRegularIntercept handles non-wiretap intercepts with conflict detection
-func (fs *fwdState) processRegularIntercept(ctx context.Context, ii *manager.InterceptInfo, index int, active []*manager.InterceptInfo, candidates []*manager.InterceptInfo, activeIntercept **manager.InterceptInfo) *manager.ReviewInterceptRequest {
+// processRegularIntercept handles non-wiretap intercepts with conflict detection.
+func (fs *fwdState) processRegularIntercept(
+	ctx context.Context,
+	ii *manager.InterceptInfo,
+	index int,
+	active []*manager.InterceptInfo,
+	candidates []*manager.InterceptInfo,
+	activeIntercept **manager.InterceptInfo,
+) *manager.ReviewInterceptRequest {
 	conflictingIntercept := fs.findConflictingIntercept(ii, index, active, candidates)
 
 	if conflictingIntercept != nil {

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -34,14 +35,30 @@ func generateMechanismDescription(spec *manager.InterceptSpec) string {
 	// Build HTTP filter description
 	var filters []string
 
-	// Add header filters
-	for key, value := range spec.HeaderFilters {
-		filters = append(filters, fmt.Sprintf("header %s=%s", key, value))
+	// Add header filters (sorted for deterministic output)
+	headerKeys := make([]string, 0, len(spec.HeaderFilters))
+	for key := range spec.HeaderFilters {
+		headerKeys = append(headerKeys, key)
+	}
+	slices.Sort(headerKeys)
+	for _, key := range headerKeys {
+		filters = append(filters, fmt.Sprintf("header %s=%s", key, spec.HeaderFilters[key]))
 	}
 
-	// Add path filters
+	// Add path filters with type information (already in order from slice)
 	for _, path := range spec.PathFilters {
-		filters = append(filters, fmt.Sprintf("path %s", path))
+		filterType, pattern := parsePathFilter(path)
+		switch filterType {
+		case "equal":
+			filters = append(filters, fmt.Sprintf("path (equal) %s", pattern))
+		case "prefix":
+			filters = append(filters, fmt.Sprintf("path (prefix) %s", pattern))
+		case "regex":
+			filters = append(filters, fmt.Sprintf("path (regex) %s", pattern))
+		default:
+			// Fallback for unknown format
+			filters = append(filters, fmt.Sprintf("path %s", path))
+		}
 	}
 
 	if len(filters) > 0 {
@@ -94,6 +111,144 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 	return pm.AgentProvider.CreateClientStream(ctx, tag, sessionID, id, roundTripLatency, dialTimeout)
 }
 
+// normalizeHeaderFilters returns a new map with all header keys normalized to lowercase.
+// HTTP headers are case-insensitive per RFC 7230.
+func normalizeHeaderFilters(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return headers
+	}
+	normalized := make(map[string]string, len(headers))
+	for key, value := range headers {
+		normalized[strings.ToLower(key)] = value
+	}
+	return normalized
+}
+
+// headerValueMatches checks if a header value matches a pattern, supporting wildcard matching.
+// This matches the runtime behavior in pkg/forwarder/http.go.
+func headerValueMatches(value, pattern string) bool {
+	// Support wildcard matching with *
+	if strings.Contains(pattern, "*") {
+		matched, _ := filepath.Match(pattern, value)
+		return matched
+	}
+	// Exact match
+	return value == pattern
+}
+
+// pathFiltersOverlap checks if two sets of path filters can match the same request path.
+// This properly handles the three path filter types: :path-equal:, :path-prefix:, and :path-regex:.
+func pathFiltersOverlap(paths1, paths2 []string) bool {
+	for _, path1 := range paths1 {
+		for _, path2 := range paths2 {
+			if pathsCanMatch(path1, path2) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathsCanMatch determines if two path filters can match the same request path.
+func pathsCanMatch(filter1, filter2 string) bool {
+	type1, pattern1 := parsePathFilter(filter1)
+	type2, pattern2 := parsePathFilter(filter2)
+
+	switch {
+	case type1 == "equal" && type2 == "equal":
+		// Both exact matches - conflict only if same path
+		return pattern1 == pattern2
+
+	case type1 == "prefix" && type2 == "prefix":
+		// Both prefixes - conflict if one is prefix of the other
+		return strings.HasPrefix(pattern1, pattern2) || strings.HasPrefix(pattern2, pattern1)
+
+	case type1 == "prefix" && type2 == "equal":
+		// Prefix can match an exact path if the path starts with the prefix
+		return strings.HasPrefix(pattern2, pattern1)
+
+	case type1 == "equal" && type2 == "prefix":
+		// Exact path matches prefix if it starts with the prefix
+		return strings.HasPrefix(pattern1, pattern2)
+
+	case type1 == "regex" || type2 == "regex":
+		// Conservative: assume regexes can overlap
+		// Proper regex intersection is computationally expensive
+		return true
+
+	default:
+		// Unknown types - assume no conflict
+		return false
+	}
+}
+
+// parsePathFilter extracts the filter type and pattern from a path filter string.
+func parsePathFilter(filter string) (filterType, pattern string) {
+	switch {
+	case strings.HasPrefix(filter, ":path-equal:"):
+		return "equal", strings.TrimPrefix(filter, ":path-equal:")
+	case strings.HasPrefix(filter, ":path-prefix:"):
+		return "prefix", strings.TrimPrefix(filter, ":path-prefix:")
+	case strings.HasPrefix(filter, ":path-regex:"):
+		return "regex", strings.TrimPrefix(filter, ":path-regex:")
+	default:
+		// Unknown format - treat as exact match
+		return "equal", filter
+	}
+}
+
+// explainConflict generates a human-readable explanation of why two intercept specs conflict.
+func explainConflict(spec1, spec2 *manager.InterceptSpec) string {
+	hasHeaders1 := len(spec1.HeaderFilters) > 0
+	hasHeaders2 := len(spec2.HeaderFilters) > 0
+	hasPaths1 := len(spec1.PathFilters) > 0
+	hasPaths2 := len(spec2.PathFilters) > 0
+
+	isGlobal1 := !hasHeaders1 && !hasPaths1
+	isGlobal2 := !hasHeaders2 && !hasPaths2
+
+	if isGlobal1 || isGlobal2 {
+		return "one intercept has no filters (intercepts all traffic)"
+	}
+
+	// Normalize headers for comparison
+	headers1 := normalizeHeaderFilters(spec1.HeaderFilters)
+	headers2 := normalizeHeaderFilters(spec2.HeaderFilters)
+
+	if hasHeaders1 && hasHeaders2 {
+		// Check if headers form subset relationship
+		isSubset1of2 := isHeaderSubset(headers1, headers2)
+		isSubset2of1 := isHeaderSubset(headers2, headers1)
+
+		if isSubset1of2 || isSubset2of1 {
+			if !hasPaths1 || !hasPaths2 || pathFiltersOverlap(spec1.PathFilters, spec2.PathFilters) {
+				subsetDesc := "header filters form a subset"
+				if hasPaths1 && hasPaths2 {
+					subsetDesc += " and paths overlap"
+				}
+				return subsetDesc
+			}
+		}
+	}
+
+	if hasPaths1 && hasPaths2 && !hasHeaders1 && !hasHeaders2 {
+		return "path filters overlap"
+	}
+
+	return "filters would route the same traffic to different destinations"
+}
+
+// isHeaderSubset checks if all headers in subset exist in superset with matching values.
+// Uses wildcard matching for header values.
+func isHeaderSubset(subset, superset map[string]string) bool {
+	for key, value := range subset {
+		if superValue, exists := superset[key]; !exists || !headerValueMatches(value, superValue) {
+			return false
+		}
+	}
+	return true
+}
+
 // interceptSpecsConflict determines if two intercept specs would conflict with each other.
 // Two specs conflict if they would route the same traffic to different destinations.
 //
@@ -136,21 +291,15 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 		return false
 	}
 
-	// Helper function to check if all headers in subset exist in superset with same values
-	isHeaderSubset := func(subset, superset map[string]string) bool {
-		for key, value := range subset {
-			if superValue, exists := superset[key]; !exists || superValue != value {
-				return false
-			}
-		}
-		return true
-	}
+	// Normalize headers for case-insensitive comparison (HTTP headers per RFC 7230)
+	headers1 := normalizeHeaderFilters(spec1.HeaderFilters)
+	headers2 := normalizeHeaderFilters(spec2.HeaderFilters)
 
 	// Rule 3: Both have headers - check for subset relationship AND path overlap
 	if hasHeaders1 && hasHeaders2 {
 		// Check if headers form a subset relationship
-		hasHeaderSubset := isHeaderSubset(spec1.HeaderFilters, spec2.HeaderFilters) ||
-			isHeaderSubset(spec2.HeaderFilters, spec1.HeaderFilters)
+		hasHeaderSubset := isHeaderSubset(headers1, headers2) ||
+			isHeaderSubset(headers2, headers1)
 
 		if !hasHeaderSubset {
 			// Headers don't form subset, no conflict
@@ -163,24 +312,13 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 			return true
 		}
 
-		// Both have paths: check for overlap
-		for _, path1 := range spec1.PathFilters {
-			if slices.Contains(spec2.PathFilters, path1) {
-				return true
-			}
-		}
-		// Different paths, no conflict
-		return false
+		// Both have paths: check for overlap using proper path matching
+		return pathFiltersOverlap(spec1.PathFilters, spec2.PathFilters)
 	}
 
 	// Rule 4: Both have only paths (no headers) - check for path overlap
 	if hasPaths1 && hasPaths2 {
-		for _, path1 := range spec1.PathFilters {
-			if slices.Contains(spec2.PathFilters, path1) {
-				return true
-			}
-		}
-		return false
+		return pathFiltersOverlap(spec1.PathFilters, spec2.PathFilters)
 	}
 
 	// Should not reach here, but default to no conflict
@@ -248,12 +386,13 @@ func (fs *fwdState) processRegularIntercept(
 	if conflictingIntercept != nil {
 		// Reject due to actual conflict
 		chosenID := conflictingIntercept.Id
-		dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q", ii.Id, chosenID)
+		reason := explainConflict(ii.Spec, conflictingIntercept.Spec)
+		dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q: %s", ii.Id, chosenID, reason)
 		var msg string
 		if conflictingIntercept.Disposition == manager.InterceptDispositionType_ACTIVE {
-			msg = fmt.Sprintf("Conflicts with the currently-served intercept %q", chosenID)
+			msg = fmt.Sprintf("Conflicts with the currently-served intercept %q: %s", chosenID, reason)
 		} else {
-			msg = fmt.Sprintf("Conflicts with the currently-waiting-to-be-served intercept %q", chosenID)
+			msg = fmt.Sprintf("Conflicts with the currently-waiting-to-be-served intercept %q: %s", chosenID, reason)
 		}
 		return &manager.ReviewInterceptRequest{
 			Id:                ii.Id,

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -94,6 +94,51 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 	return pm.AgentProvider.CreateClientStream(ctx, tag, sessionID, id, roundTripLatency, dialTimeout)
 }
 
+// interceptSpecsConflict determines if two intercept specs would conflict with each other.
+// Two specs conflict if they would route the same traffic to different destinations.
+func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
+	// Fast path: For TCP intercepts (no filters), they always conflict on the same port
+	if len(spec1.HeaderFilters) == 0 && len(spec1.PathFilters) == 0 &&
+		len(spec2.HeaderFilters) == 0 && len(spec2.PathFilters) == 0 {
+		return true
+	}
+
+	// For HTTP intercepts, check header filter conflicts
+	if len(spec1.HeaderFilters) > 0 && len(spec2.HeaderFilters) > 0 {
+		// Check if any header key has the same value in both specs
+		for key1, value1 := range spec1.HeaderFilters {
+			if value2, exists := spec2.HeaderFilters[key1]; exists && value1 == value2 {
+				// Same header key with same value = traffic would match both intercepts
+				return true
+			}
+		}
+		// All header keys either don't overlap or have different values = no conflict
+		return false
+	}
+
+	// For HTTP intercepts, check path filter conflicts
+	if len(spec1.PathFilters) > 0 && len(spec2.PathFilters) > 0 {
+		// Check for overlapping path patterns
+		for _, path1 := range spec1.PathFilters {
+			if slices.Contains(spec2.PathFilters, path1) {
+				return true
+			}
+		}
+		// Disjoint path filters = no conflict
+		return false
+	}
+
+	// If one has header filters and the other has path filters, they can coexist
+	// Each will only match traffic meeting their specific criteria
+	if (len(spec1.HeaderFilters) > 0 && len(spec2.PathFilters) > 0) ||
+		(len(spec1.PathFilters) > 0 && len(spec2.HeaderFilters) > 0) {
+		return false
+	}
+
+	// Default: no conflict
+	return false
+}
+
 func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptInfo) []*manager.ReviewInterceptRequest {
 	dlog.Debugf(ctx, "fwdState.HandlePort called with %d intercepts", len(cepts))
 
@@ -160,10 +205,16 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 
 	// Review waiting intercepts
 	reviews := make([]*manager.ReviewInterceptRequest, 0, len(waiting))
+
+	// Collect all intercepts that could potentially become active (excluding wiretaps and already processed)
+	var candidateIntercepts []*manager.InterceptInfo
 	for _, ii := range waiting {
-		switch {
-		case activeIntercept == nil || ii.Spec.Wiretap:
-			// This intercept is ready to be active
+		candidateIntercepts = append(candidateIntercepts, ii)
+	}
+
+	for i, ii := range candidateIntercepts {
+		if ii.Spec.Wiretap {
+			// Wiretaps can always be active alongside other intercepts
 			container := ii.Spec.ContainerName
 			if container == "" {
 				container = fs.container
@@ -178,10 +229,6 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 				})
 				continue
 			}
-			if !ii.Spec.Wiretap {
-				// We can only have one active intercept that isn't a wiretap
-				activeIntercept = ii
-			}
 			reviews = append(reviews, &manager.ReviewInterceptRequest{
 				Id:                ii.Id,
 				Disposition:       manager.InterceptDispositionType_ACTIVE,
@@ -193,12 +240,35 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
 				Environment:       cs.Env(),
 			})
-		default:
-			// We already have an intercept in play, so reject this one.
-			chosenID := activeIntercept.Id
-			dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q as the current chosen-to-be-ACTIVE intercept", ii.Id, chosenID)
+			continue
+		}
+
+		// Check for conflicts with active intercepts
+		var conflictingIntercept *manager.InterceptInfo
+		for _, activeII := range active {
+			if !activeII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, activeII.Spec) {
+				conflictingIntercept = activeII
+				break
+			}
+		}
+
+		// Check for conflicts with other waiting intercepts that would become active
+		// Only check intercepts that come before this one (first wins policy)
+		if conflictingIntercept == nil {
+			for j, otherII := range candidateIntercepts {
+				if j < i && !otherII.Spec.Wiretap && interceptSpecsConflict(ii.Spec, otherII.Spec) {
+					conflictingIntercept = otherII
+					break
+				}
+			}
+		}
+
+		if conflictingIntercept != nil {
+			// Reject due to actual conflict
+			chosenID := conflictingIntercept.Id
+			dlog.Infof(ctx, "Setting intercept %q as AGENT_ERROR; as it conflicts with %q", ii.Id, chosenID)
 			var msg string
-			if activeIntercept.Disposition == manager.InterceptDispositionType_ACTIVE {
+			if conflictingIntercept.Disposition == manager.InterceptDispositionType_ACTIVE {
 				msg = fmt.Sprintf("Conflicts with the currently-served intercept %q", chosenID)
 			} else {
 				msg = fmt.Sprintf("Conflicts with the currently-waiting-to-be-served intercept %q", chosenID)
@@ -208,6 +278,38 @@ func (fs *fwdState) HandlePort(ctx context.Context, cepts []*manager.InterceptIn
 				Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
 				Message:           msg,
 				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+			})
+		} else {
+			// No conflict detected, allow this intercept to become active
+			container := ii.Spec.ContainerName
+			if container == "" {
+				container = fs.container
+			}
+			cs := fs.containerStates[container]
+			if cs == nil {
+				reviews = append(reviews, &manager.ReviewInterceptRequest{
+					Id:                ii.Id,
+					Disposition:       manager.InterceptDispositionType_AGENT_ERROR,
+					Message:           fmt.Sprintf("No match for container %q", container),
+					MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+				})
+				continue
+			}
+			if !ii.Spec.Wiretap && activeIntercept == nil {
+				// Set the first non-wiretap intercept as the active one for the forwarder
+				activeIntercept = ii
+			}
+			dlog.Infof(ctx, "Allowing non-conflicting intercept %q to become active", ii.Id)
+			reviews = append(reviews, &manager.ReviewInterceptRequest{
+				Id:                ii.Id,
+				Disposition:       manager.InterceptDispositionType_ACTIVE,
+				PodIp:             fs.PodIP().String(),
+				FtpPort:           int32(fs.FtpPort()),
+				SftpPort:          int32(fs.SftpPort()),
+				MountPoint:        cs.MountPoint(),
+				Mounts:            cs.Mounts().ToRPC(),
+				MechanismArgsDesc: generateMechanismDescription(ii.Spec),
+				Environment:       cs.Env(),
 			})
 		}
 	}

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -411,6 +411,22 @@ func TestInterceptSpecsConflict(t *testing.T) {
 			conflicts: false,
 		},
 		{
+			name: "Mixed case header variants - X-USER, x-User, X-user should all normalize to X-User",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"X-USER": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-User": "adam",
+				},
+			},
+			conflicts: true,
+		},
+		{
 			name: "Wildcard header matching - x-user:dev-* should work properly",
 			spec1: &manager.InterceptSpec{
 				Mechanism: "http",

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -104,3 +104,134 @@ func TestGenerateMechanismDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestInterceptSpecsConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec1     *manager.InterceptSpec
+		spec2     *manager.InterceptSpec
+		conflicts bool
+	}{
+		{
+			name: "Issue #3969: Different header values for same key - should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "bertil",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Same header key and value - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Different header keys - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-session": "abc123",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "TCP intercepts (no filters) - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "tcp",
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "tcp",
+			},
+			conflicts: true,
+		},
+		{
+			name: "Different path filters - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/api/v1/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/api/v2/*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Same path filters - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/api/*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Mixed filters: headers vs paths - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/admin/*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Multiple headers with one overlap - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":        "adam",
+					"x-environment": "dev",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":    "adam", // This overlaps!
+					"x-session": "xyz789",
+				},
+			},
+			conflicts: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := interceptSpecsConflict(tt.spec1, tt.spec2)
+			assert.Equal(t, tt.conflicts, result)
+		})
+	}
+}

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -209,7 +209,7 @@ func TestInterceptSpecsConflict(t *testing.T) {
 			conflicts: false,
 		},
 		{
-			name: "Multiple headers with one overlap - should conflict",
+			name: "Multiple headers with one overlap - should NOT conflict (not a subset)",
 			spec1: &manager.InterceptSpec{
 				Mechanism: "http",
 				HeaderFilters: map[string]string{
@@ -220,7 +220,139 @@ func TestInterceptSpecsConflict(t *testing.T) {
 			spec2: &manager.InterceptSpec{
 				Mechanism: "http",
 				HeaderFilters: map[string]string{
-					"x-user":    "adam", // This overlaps!
+					"x-user":    "adam",
+					"x-session": "xyz789",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Header subset - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":    "adam",
+					"x-session": "xyz789",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Global intercept vs HTTP with filters - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "tcp",
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Same headers, different paths - should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/admin/*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Same headers, overlapping paths - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Subset headers with disjoint paths - should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":    "adam",
+					"x-session": "xyz789",
+				},
+				PathFilters: []string{"/admin/*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Subset headers with overlapping paths - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":    "adam",
+					"x-session": "xyz789",
+				},
+				PathFilters: []string{"/api/*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "HTTP with only paths vs global - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{"/api/*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "tcp",
+			},
+			conflicts: true,
+		},
+		{
+			name: "HTTP with only headers, no paths - should conflict if headers are subset",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user":    "adam",
 					"x-session": "xyz789",
 				},
 			},

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -37,18 +37,18 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					"X-Environment": "staging",
 				},
 			},
-			expected: "HTTP filters: header X-User-ID=dev123, header X-Environment=staging",
+			expected: "HTTP filters: header X-Environment=staging, header X-User-ID=dev123",
 		},
 		{
 			name: "HTTP mechanism with path filters only",
 			spec: &manager.InterceptSpec{
 				Mechanism: "http",
 				PathFilters: []string{
-					"/api/v1/*",
-					"/admin/*",
+					":path-prefix:/api/v1/",
+					":path-prefix:/admin/",
 				},
 			},
-			expected: "HTTP filters: path /api/v1/*, path /admin/*",
+			expected: "HTTP filters: path (prefix) /api/v1/, path (prefix) /admin/",
 		},
 		{
 			name: "HTTP mechanism with both header and path filters",
@@ -58,10 +58,10 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					"X-User-ID": "dev123",
 				},
 				PathFilters: []string{
-					"/api/*",
+					":path-prefix:/api/",
 				},
 			},
-			expected: "HTTP filters: header X-User-ID=dev123, path /api/*",
+			expected: "HTTP filters: header X-User-ID=dev123, path (prefix) /api/",
 		},
 		{
 			name: "HTTP mechanism with single header filter",
@@ -77,9 +77,29 @@ func TestGenerateMechanismDescription(t *testing.T) {
 			name: "HTTP mechanism with single path filter",
 			spec: &manager.InterceptSpec{
 				Mechanism:   "http",
-				PathFilters: []string{"/health"},
+				PathFilters: []string{":path-equal:/health"},
 			},
-			expected: "HTTP filters: path /health",
+			expected: "HTTP filters: path (equal) /health",
+		},
+		{
+			name: "HTTP mechanism with regex path filter",
+			spec: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v[0-9]+/.*$"},
+			},
+			expected: "HTTP filters: path (regex) ^/api/v[0-9]+/.*$",
+		},
+		{
+			name: "HTTP mechanism with mixed path filter types",
+			spec: &manager.InterceptSpec{
+				Mechanism: "http",
+				PathFilters: []string{
+					":path-equal:/health",
+					":path-prefix:/api/",
+					":path-regex:^/admin/.*$",
+				},
+			},
+			expected: "HTTP filters: path (equal) /health, path (prefix) /api/, path (regex) ^/admin/.*$",
 		},
 		{
 			name: "unknown mechanism defaults to TCP",
@@ -355,6 +375,114 @@ func TestInterceptSpecsConflict(t *testing.T) {
 					"x-user":    "adam",
 					"x-session": "xyz789",
 				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Case-insensitive header matching - X-User vs x-user should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"X-User": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Case-insensitive header matching with different values - should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"X-User": "adam",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "bertil",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Wildcard header matching - x-user:dev-* should work properly",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev-*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev-*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Path prefix overlap - :path-prefix:/api/ vs :path-prefix:/api/v1/ should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/v1/"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Path prefix no overlap - :path-prefix:/api/ vs :path-prefix:/admin/ should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/admin/"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Path equal vs prefix overlap - :path-equal:/api/users vs :path-prefix:/api/ should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-equal:/api/users"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Path equal vs prefix no overlap - :path-equal:/admin/users vs :path-prefix:/api/ should NOT conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-equal:/admin/users"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Path regex - :path-regex: always conflicts conservatively",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/.*$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/admin/"},
 			},
 			conflicts: true,
 		},

--- a/cmd/traffic/cmd/agent/state_test.go
+++ b/cmd/traffic/cmd/agent/state_test.go
@@ -121,7 +121,7 @@ func TestState_HandleIntercepts(t *testing.T) {
 
 	a.Equal(rpc.InterceptDispositionType_ACTIVE, reviews[0].Disposition)
 	a.Equal(rpc.InterceptDispositionType_AGENT_ERROR, reviews[1].Disposition)
-	a.Equal("Conflicts with the currently-waiting-to-be-served intercept \"intercept-01\"", reviews[1].Message)
+	a.Equal("Conflicts with the currently-waiting-to-be-served intercept \"intercept-01\": one intercept has no filters (intercepts all traffic)", reviews[1].Message)
 
 	// Handle conflicts
 
@@ -133,7 +133,7 @@ func TestState_HandleIntercepts(t *testing.T) {
 	a.Equal(cepts[1].Id, reviews[0].Id)
 
 	a.Equal(rpc.InterceptDispositionType_AGENT_ERROR, reviews[0].Disposition)
-	a.Equal("Conflicts with the currently-served intercept \"intercept-01\"", reviews[0].Message)
+	a.Equal("Conflicts with the currently-served intercept \"intercept-01\": one intercept has no filters (intercepts all traffic)", reviews[0].Message)
 
 	// Handle resets state on an empty intercept list again
 

--- a/docs/howtos/engage.md
+++ b/docs/howtos/engage.md
@@ -206,7 +206,10 @@ and tasks not directly related to the intercepted traffic.
     ```
 
    * For `--http-header`: specify the HTTP header you want to filter on. You can specify multiple headers by repeating
-     the flag.
+     the flag. Header-based intercepts take priority over path-only intercepts. When multiple intercepts are active on
+     the same workload, requests are evaluated against header-based filters first, then path-only filters. This allows
+     different developers to use header-based personal intercepts (e.g., `x-user=alice`) while others use path-based
+     intercepts (e.g., `--http-path-prefix /admin/`) without conflicts.
 
    * For `--port`: specify the port the local instance of your application is running on, and optionally the remote port
      that you want to intercept. Telepresence will select the remote port automatically when there's only one service

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,17 @@ version automatically unless you work in an air-gapped environment.
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[HTTP Intercepts with HTTP header and path filtering](https://github.com/telepresenceio/telepresence/issues/3852)</div></div>
 <div style="margin-left: 15px">
 
-Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts. Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http` flag along with `--header` and `--path` filters. This allows multiple developers to work on the same service simultaneously by intercepting only their specific traffic patterns, rather than intercepting all traffic to a service. The feature maintains full backward compatibility with existing TCP intercepts.
+Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts. Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http-header`, `--http-path-prefix`, `--http-path-equal`, and `--http-path-regex` flags. This allows multiple developers to work on the same service simultaneously by intercepting only their specific traffic patterns, rather than intercepting all traffic to a service.
+
+**Routing Precedence Model**: Header-based intercepts take priority over path-only intercepts. When multiple intercepts are active on the same workload, requests are evaluated against header-based filters first, then path-only filters. This enables different developers to use header-based personal intercepts (e.g., `x-user=alice`) while others use path-based intercepts (e.g., `/admin/*`) without conflicts.
+
+**Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different destinations. Key rules:
+- Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
+- Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
+- Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+- Path-only intercepts operate at a lower priority tier than header-based intercepts
+
+The feature maintains full backward compatibility with existing TCP intercepts.
 </div>
 
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">More efficient DNS handling in the traffic-manager</div></div>

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -30,7 +30,17 @@ version automatically unless you work in an air-gapped environment.
 <Note>
 	<Title type="feature" docs="https://github.com/telepresenceio/telepresence/issues/3852">HTTP Intercepts with HTTP header and path filtering</Title>
 	<Body>
-Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts. Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http` flag along with `--header` and `--path` filters. This allows multiple developers to work on the same service simultaneously by intercepting only their specific traffic patterns, rather than intercepting all traffic to a service. The feature maintains full backward compatibility with existing TCP intercepts.
+Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts. Users can intercept only specific HTTP requests based on headers and URL paths using the new `--http-header`, `--http-path-prefix`, `--http-path-equal`, and `--http-path-regex` flags. This allows multiple developers to work on the same service simultaneously by intercepting only their specific traffic patterns, rather than intercepting all traffic to a service.
+
+**Routing Precedence Model**: Header-based intercepts take priority over path-only intercepts. When multiple intercepts are active on the same workload, requests are evaluated against header-based filters first, then path-only filters. This enables different developers to use header-based personal intercepts (e.g., `x-user=alice`) while others use path-based intercepts (e.g., `/admin/*`) without conflicts.
+
+**Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different destinations. Key rules:
+- Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
+- Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
+- Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+- Path-only intercepts operate at a lower priority tier than header-based intercepts
+
+The feature maintains full backward compatibility with existing TCP intercepts.
   </Body>
 </Note>
 <Note>

--- a/integration_test/http_intercepts_test.go
+++ b/integration_test/http_intercepts_test.go
@@ -87,6 +87,84 @@ func (s *httpInterceptsSuite) Test_BackwardCompatibility() {
 	require.NoError(err)
 }
 
+func (s *httpInterceptsSuite) Test_HTTPInterceptCoexistence() {
+	require := s.Require()
+	ctx := s.Context()
+
+	// This test verifies that multiple personal intercepts with different HTTP headers
+	// can coexist on the same workload without conflicts (fixes issue #3969)
+
+	// Start first personal intercept with x-user=adam
+	stdout1, stderr1, err1 := itest.Telepresence(ctx, "intercept", "echo-one",
+		"--workload", s.ServiceName(),
+		"--http-header", "x-user=adam",
+		"--port", "8080:80",
+		"--mount", "false")
+	require.NoError(err1, "First intercept failed - stderr: %s", stderr1)
+	require.Contains(stdout1, "Using Deployment")
+
+	// Start second personal intercept with x-user=bertil
+	stdout2, stderr2, err2 := itest.Telepresence(ctx, "intercept", "echo-two",
+		"--workload", s.ServiceName(),
+		"--http-header", "x-user=bertil",
+		"--port", "8081:80",
+		"--mount", "false")
+	require.NoError(err2, "Second intercept failed - stderr: %s", stderr2)
+	require.Contains(stdout2, "Using Deployment")
+
+	// Verify both intercepts are active and listed
+	listOutput, listStderr, listErr := itest.Telepresence(ctx, "list", "--intercepts")
+	require.NoError(listErr, "Failed to list intercepts - stderr: %s", listStderr)
+	require.Contains(listOutput, "echo-one: intercepted")
+	require.Contains(listOutput, "echo-two: intercepted")
+
+	// Clean up both intercepts
+	_, _, err3 := itest.Telepresence(ctx, "leave", "echo-one")
+	require.NoError(err3, "Failed to leave first intercept")
+
+	_, _, err4 := itest.Telepresence(ctx, "leave", "echo-two")
+	require.NoError(err4, "Failed to leave second intercept")
+}
+
+func (s *httpInterceptsSuite) Test_TCPPortConflictDetection() {
+	require := s.Require()
+	ctx := s.Context()
+
+	// This test verifies that real TCP port conflicts are still properly detected
+	// when two intercepts try to use the same local port
+
+	// Start first intercept using port 8080
+	stdout1, stderr1, err1 := itest.Telepresence(ctx, "intercept", "tcp-conflict-one",
+		"--workload", s.ServiceName(),
+		"--http-header", "x-user=adam",
+		"--port", "8080:80",
+		"--mount", "false")
+	require.NoError(err1, "First intercept should succeed - stderr: %s", stderr1)
+	require.Contains(stdout1, "Using Deployment")
+
+	// Attempt second intercept using the SAME local port 8080
+	// This should fail with a TCP port conflict, not an agent intercept conflict
+	_, stderr2, err2 := itest.Telepresence(ctx, "intercept", "tcp-conflict-two",
+		"--workload", s.ServiceName(),
+		"--http-header", "x-user=bertil",
+		"--port", "8080:80",  // Same local port as first intercept
+		"--mount", "false")
+
+	// Should fail due to real TCP port conflict
+	require.Error(err2, "Second intercept should fail due to TCP port conflict")
+
+	// Verify it's a TCP port binding error, not an agent intercept conflict
+	require.Contains(stderr2, "127.0.0.1:8080", "Error should mention the conflicting local port")
+	require.Contains(stderr2, "already in use", "Error should indicate port is already in use")
+
+	// Should NOT contain agent intercept conflict message
+	require.NotContains(stderr2, "Conflicts with", "Should not be an agent intercept conflict")
+
+	// Clean up the successful intercept
+	_, _, err3 := itest.Telepresence(ctx, "leave", "tcp-conflict-one")
+	require.NoError(err3, "Failed to leave first intercept")
+}
+
 func init() {
 	itest.AddSingleServiceSuite("", "echo", func(h itest.SingleService) itest.TestingSuite {
 		return &httpInterceptsSuite{Suite: itest.Suite{Harness: h}, SingleService: h}

--- a/integration_test/http_intercepts_test.go
+++ b/integration_test/http_intercepts_test.go
@@ -147,7 +147,7 @@ func (s *httpInterceptsSuite) Test_TCPPortConflictDetection() {
 	_, stderr2, err2 := itest.Telepresence(ctx, "intercept", "tcp-conflict-two",
 		"--workload", s.ServiceName(),
 		"--http-header", "x-user=bertil",
-		"--port", "8080:80",  // Same local port as first intercept
+		"--port", "8080:80", // Same local port as first intercept
 		"--mount", "false")
 
 	// Should fail due to real TCP port conflict

--- a/integration_test/http_intercepts_test.go
+++ b/integration_test/http_intercepts_test.go
@@ -115,8 +115,8 @@ func (s *httpInterceptsSuite) Test_HTTPInterceptCoexistence() {
 	// Verify both intercepts are active and listed
 	listOutput, listStderr, listErr := itest.Telepresence(ctx, "list", "--intercepts")
 	require.NoError(listErr, "Failed to list intercepts - stderr: %s", listStderr)
-	require.Contains(listOutput, "echo-one: intercepted")
-	require.Contains(listOutput, "echo-two: intercepted")
+	require.Contains(listOutput, "Intercept name: echo-one")
+	require.Contains(listOutput, "Intercept name: echo-two")
 
 	// Clean up both intercepts
 	_, _, err3 := itest.Telepresence(ctx, "leave", "echo-one")

--- a/pkg/forwarder/http.go
+++ b/pkg/forwarder/http.go
@@ -21,25 +21,52 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
 
+type interceptWithFilters struct {
+	intercept     *manager.InterceptInfo
+	headerFilters map[string]string
+	pathFilters   []string
+}
+
 type httpInterceptor struct {
 	interceptor
-	headerFilters  map[string]string
-	pathFilters    []string
+	intercepts     []*interceptWithFilters
 	originalTarget netip.AddrPort
 }
 
 func (h *httpInterceptor) SetIntercepting(ctx context.Context, info *manager.InterceptInfo) {
+	if info == nil {
+		h.SetInterceptingMultiple(ctx, nil)
+		return
+	}
+	h.SetInterceptingMultiple(ctx, []*manager.InterceptInfo{info})
+}
+
+func (h *httpInterceptor) SetInterceptingMultiple(ctx context.Context, infos []*manager.InterceptInfo) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.intercept = info
 
-	// Extract header filters from the intercept spec
-	if spec := info.Spec; spec != nil {
-		h.headerFilters = spec.HeaderFilters
-		h.pathFilters = spec.PathFilters
-		dlog.Debugf(ctx, "HTTP interceptor configured with %d header filters and %d path filters",
-			len(h.headerFilters), len(h.pathFilters))
+	// Clear existing intercepts
+	h.intercepts = nil
+	h.intercept = nil
+
+	if len(infos) == 0 {
+		dlog.Debugf(ctx, "HTTP interceptor cleared")
+		return
 	}
+
+	// Set up multiple intercepts
+	h.intercepts = make([]*interceptWithFilters, 0, len(infos))
+	for _, info := range infos {
+		if spec := info.Spec; spec != nil {
+			h.intercepts = append(h.intercepts, &interceptWithFilters{
+				intercept:     info,
+				headerFilters: spec.HeaderFilters,
+				pathFilters:   spec.PathFilters,
+			})
+		}
+	}
+
+	dlog.Debugf(ctx, "HTTP interceptor configured with %d intercepts", len(h.intercepts))
 }
 
 func (h *httpInterceptor) Serve(ctx context.Context, initCh chan<- netip.AddrPort) error {
@@ -112,9 +139,9 @@ func (h *httpInterceptor) handleHTTPConn(clientConn net.Conn) error {
 	h.mu.Lock()
 	ctx := h.tCtx
 	originalTarget := h.originalTarget
-	intercept := h.intercept
-	headerFilters := h.headerFilters
-	pathFilters := h.pathFilters
+	// Copy intercepts to avoid holding lock during request processing
+	intercepts := make([]*interceptWithFilters, len(h.intercepts))
+	copy(intercepts, h.intercepts)
 	h.mu.Unlock()
 
 	ctx = dlog.WithField(ctx, "client", clientConn.RemoteAddr().String())
@@ -127,16 +154,33 @@ func (h *httpInterceptor) handleHTTPConn(clientConn net.Conn) error {
 		return fmt.Errorf("failed to read HTTP request: %w", err)
 	}
 
-	// Check if this request should be intercepted
-	shouldIntercept := h.shouldInterceptRequest(ctx, req, headerFilters, pathFilters)
+	// Check each intercept to see if it matches this request
+	// Use precedence model: headers take priority over path-only intercepts
 
-	if shouldIntercept && intercept != nil {
-		dlog.Debugf(ctx, "Intercepting HTTP request %s %s", req.Method, req.URL.Path)
-		return h.interceptHTTPConn(ctx, clientConn, req, intercept)
+	// Pass 1: Check intercepts with headers (high priority tier)
+	for _, interceptInfo := range intercepts {
+		if len(interceptInfo.headerFilters) > 0 {
+			if h.shouldInterceptRequest(ctx, req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
+				dlog.Debugf(ctx, "Intercepting HTTP request %s %s with header-based intercept %s",
+					req.Method, req.URL.Path, interceptInfo.intercept.Id)
+				return h.interceptHTTPConn(ctx, clientConn, req, interceptInfo.intercept)
+			}
+		}
 	}
 
-	// Forward to original service
-	dlog.Debugf(ctx, "Forwarding HTTP request %s %s to original service", req.Method, req.URL.Path)
+	// Pass 2: Check intercepts with only paths (low priority tier)
+	for _, interceptInfo := range intercepts {
+		if len(interceptInfo.headerFilters) == 0 && len(interceptInfo.pathFilters) > 0 {
+			if h.shouldInterceptRequest(ctx, req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
+				dlog.Debugf(ctx, "Intercepting HTTP request %s %s with path-based intercept %s",
+					req.Method, req.URL.Path, interceptInfo.intercept.Id)
+				return h.interceptHTTPConn(ctx, clientConn, req, interceptInfo.intercept)
+			}
+		}
+	}
+
+	// No intercepts matched, forward to original service
+	dlog.Debugf(ctx, "Forwarding HTTP request %s %s to original service (no intercepts matched)", req.Method, req.URL.Path)
 	return h.forwardToOriginalService(ctx, clientConn, req, originalTarget)
 }
 

--- a/pkg/forwarder/http_test.go
+++ b/pkg/forwarder/http_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestHTTPInterceptor_shouldInterceptRequest(t *testing.T) {
-	h := &httpInterceptor{
-		headerFilters: map[string]string{
-			"X-User-ID":     "dev123",
-			"X-Environment": "staging",
-		},
-		pathFilters: []string{":path-prefix:/api/v1/", ":path-prefix:/admin/"},
+	h := &httpInterceptor{}
+
+	headerFilters := map[string]string{
+		"X-User-ID":     "dev123",
+		"X-Environment": "staging",
 	}
+	pathFilters := []string{":path-prefix:/api/v1/", ":path-prefix:/admin/"}
 
 	tests := []struct {
 		name            string
@@ -76,7 +76,7 @@ func TestHTTPInterceptor_shouldInterceptRequest(t *testing.T) {
 				req.Header.Set(k, v)
 			}
 
-			result := h.shouldInterceptRequest(req.Context(), req, h.headerFilters, h.pathFilters)
+			result := h.shouldInterceptRequest(req.Context(), req, headerFilters, pathFilters)
 			assert.Equal(t, tt.shouldIntercept, result)
 		})
 	}
@@ -109,14 +109,14 @@ func TestHTTPInterceptor_matchesPattern(t *testing.T) {
 }
 
 func TestHTTPInterceptor_noFilters(t *testing.T) {
-	h := &httpInterceptor{
-		headerFilters: map[string]string{},
-		pathFilters:   []string{},
-	}
+	h := &httpInterceptor{}
+
+	headerFilters := map[string]string{}
+	pathFilters := []string{}
 
 	req, _ := http.NewRequest(http.MethodGet, "http://example.com/any/path", nil)
 
 	// No filters means intercept everything
-	result := h.shouldInterceptRequest(req.Context(), req, h.headerFilters, h.pathFilters)
+	result := h.shouldInterceptRequest(req.Context(), req, headerFilters, pathFilters)
 	assert.True(t, result)
 }

--- a/pkg/forwarder/interceptor.go
+++ b/pkg/forwarder/interceptor.go
@@ -24,6 +24,7 @@ type Interceptor interface {
 	InterceptInfo() *restapi.InterceptInfo
 	Serve(context.Context, chan<- netip.AddrPort) error
 	SetIntercepting(context.Context, *manager.InterceptInfo)
+	SetInterceptingMultiple(context.Context, []*manager.InterceptInfo)
 	SetStreamProvider(tunnel.ClientStreamProvider)
 	Target() netip.AddrPort
 	AddWiretap(*manager.InterceptInfo)
@@ -189,6 +190,19 @@ func (f *interceptor) SetIntercepting(ctx context.Context, intercept *manager.In
 		// Set up a new target and lifetime
 		f.tCtx, f.tCancel = context.WithCancel(f.lCtx)
 	}
+}
+
+func (f *interceptor) SetInterceptingMultiple(ctx context.Context, intercepts []*manager.InterceptInfo) {
+	// For TCP interceptors, multiple intercepts with different routing isn't supported.
+	// Use the first non-wiretap intercept, or nil if none exist.
+	var activeIntercept *manager.InterceptInfo
+	for _, intercept := range intercepts {
+		if !intercept.Spec.Wiretap {
+			activeIntercept = intercept
+			break
+		}
+	}
+	f.SetIntercepting(ctx, activeIntercept)
 }
 
 func (f *interceptor) Tag() tunnel.Tag {

--- a/pkg/forwarder/tcp.go
+++ b/pkg/forwarder/tcp.go
@@ -56,10 +56,10 @@ func (f *tcp) SetInterceptingMultiple(ctx context.Context, intercepts []*manager
 	f.httpIntercepts = httpIntercepts
 
 	// Set global/TCP intercept using base implementation
-	f.interceptor.intercept = globalIntercept
-	if f.interceptor.lCtx != nil {
-		f.interceptor.tCancel()
-		f.interceptor.tCtx, f.interceptor.tCancel = context.WithCancel(f.interceptor.lCtx)
+	f.intercept = globalIntercept
+	if f.lCtx != nil {
+		f.tCancel()
+		f.tCtx, f.tCancel = context.WithCancel(f.lCtx)
 	}
 }
 
@@ -296,7 +296,13 @@ func (f *tcp) rerouteConn(ctx context.Context, conn net.Conn, clientSession tunn
 }
 
 // forwardHTTPConn handles HTTP-aware connection forwarding with header/path filtering.
-func (f *tcp) forwardHTTPConn(ctx context.Context, clientConn net.Conn, httpIntercepts []*manager.InterceptInfo, target netip.AddrPort, wtIntercepts []*manager.InterceptInfo) error {
+func (f *tcp) forwardHTTPConn(
+	ctx context.Context,
+	clientConn net.Conn,
+	httpIntercepts []*manager.InterceptInfo,
+	target netip.AddrPort,
+	wtIntercepts []*manager.InterceptInfo,
+) error {
 	// Create a temporary HTTP interceptor to handle this connection
 	httpInterceptor := &httpInterceptor{
 		interceptor: interceptor{

--- a/pkg/forwarder/tcp.go
+++ b/pkg/forwarder/tcp.go
@@ -18,6 +18,7 @@ import (
 
 type tcp struct {
 	interceptor
+	httpIntercepts []*manager.InterceptInfo // Store multiple HTTP intercepts with filters
 }
 
 func newTCP(listenPort uint16, tag tunnel.Tag, target netip.AddrPort) Interceptor {
@@ -29,6 +30,45 @@ func newTCP(listenPort uint16, tag tunnel.Tag, target netip.AddrPort) Intercepto
 			lCancel:    func() {},
 		},
 	}
+}
+
+// SetInterceptingMultiple overrides the base implementation to handle HTTP intercepts.
+func (f *tcp) SetInterceptingMultiple(ctx context.Context, intercepts []*manager.InterceptInfo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Separate HTTP intercepts (with filters) from global/TCP intercepts
+	var httpIntercepts []*manager.InterceptInfo
+	var globalIntercept *manager.InterceptInfo
+
+	for _, intercept := range intercepts {
+		if intercept.Spec.Wiretap {
+			continue
+		}
+		if len(intercept.Spec.HeaderFilters) > 0 || len(intercept.Spec.PathFilters) > 0 {
+			httpIntercepts = append(httpIntercepts, intercept)
+		} else if globalIntercept == nil {
+			globalIntercept = intercept
+		}
+	}
+
+	// Store HTTP intercepts for DispatchByMechanism
+	f.httpIntercepts = httpIntercepts
+
+	// Set global/TCP intercept using base implementation
+	f.interceptor.intercept = globalIntercept
+	if f.interceptor.lCtx != nil {
+		f.interceptor.tCancel()
+		f.interceptor.tCtx, f.interceptor.tCancel = context.WithCancel(f.interceptor.lCtx)
+	}
+}
+
+// SetIntercepting overrides the base implementation to clear HTTP intercepts.
+func (f *tcp) SetIntercepting(ctx context.Context, intercept *manager.InterceptInfo) {
+	f.mu.Lock()
+	f.httpIntercepts = nil // Clear HTTP intercepts when setting single intercept
+	f.mu.Unlock()
+	f.interceptor.SetIntercepting(ctx, intercept)
 }
 
 func (f *tcp) Serve(ctx context.Context, initCh chan<- netip.AddrPort) error {
@@ -256,7 +296,7 @@ func (f *tcp) rerouteConn(ctx context.Context, conn net.Conn, clientSession tunn
 }
 
 // forwardHTTPConn handles HTTP-aware connection forwarding with header/path filtering.
-func (f *tcp) forwardHTTPConn(ctx context.Context, clientConn net.Conn, intercept *manager.InterceptInfo, target netip.AddrPort, wtIntercepts []*manager.InterceptInfo) error {
+func (f *tcp) forwardHTTPConn(ctx context.Context, clientConn net.Conn, httpIntercepts []*manager.InterceptInfo, target netip.AddrPort, wtIntercepts []*manager.InterceptInfo) error {
 	// Create a temporary HTTP interceptor to handle this connection
 	httpInterceptor := &httpInterceptor{
 		interceptor: interceptor{
@@ -267,9 +307,9 @@ func (f *tcp) forwardHTTPConn(ctx context.Context, clientConn net.Conn, intercep
 		originalTarget: target,
 	}
 
-	// Configure the HTTP interceptor with stream provider and intercept info
+	// Configure the HTTP interceptor with stream provider and all HTTP intercepts
 	httpInterceptor.SetStreamProvider(f.streamProvider)
-	httpInterceptor.SetIntercepting(ctx, intercept)
+	httpInterceptor.SetInterceptingMultiple(ctx, httpIntercepts)
 
 	// Add wiretaps if any
 	for _, wt := range wtIntercepts {
@@ -281,33 +321,28 @@ func (f *tcp) forwardHTTPConn(ctx context.Context, clientConn net.Conn, intercep
 }
 
 // DispatchByMechanism implements mechanism-specific per-connection dispatch for TCP.
-// It currently only routes HTTP-aware intercepts when requested.
+// It routes HTTP intercepts (with filters) to the HTTP interceptor.
 func (f *tcp) DispatchByMechanism(ctx context.Context, clientConn net.Conn, intercept *manager.InterceptInfo) (bool, error) {
-	var spec *manager.InterceptSpec
-	if intercept != nil {
-		spec = intercept.Spec
+	f.mu.Lock()
+	httpIntercepts := f.httpIntercepts
+	target := f.target
+	tapCount := len(f.wiretaps)
+	var wtIntercepts []*manager.InterceptInfo
+	if tapCount > 0 {
+		wtIntercepts = make([]*manager.InterceptInfo, tapCount)
+		i := 0
+		for _, wt := range f.wiretaps {
+			wtIntercepts[i] = wt
+			i++
+		}
 	}
+	f.mu.Unlock()
 
-	httpMechanism := spec != nil && (len(spec.HeaderFilters) > 0 || len(spec.PathFilters) > 0)
+	httpMechanism := len(httpIntercepts) > 0
 
 	switch {
 	case httpMechanism:
-		// Collect wiretaps under lock to maintain existing behavior
-		f.mu.Lock()
-		target := f.target
-		tapCount := len(f.wiretaps)
-		var wtIntercepts []*manager.InterceptInfo
-		if tapCount > 0 {
-			wtIntercepts = make([]*manager.InterceptInfo, tapCount)
-			i := 0
-			for _, wt := range f.wiretaps {
-				wtIntercepts[i] = wt
-				i++
-			}
-		}
-		f.mu.Unlock()
-
-		err := f.forwardHTTPConn(ctx, clientConn, intercept, target, wtIntercepts)
+		err := f.forwardHTTPConn(ctx, clientConn, httpIntercepts, target, wtIntercepts)
 		return true, err
 	default:
 		return false, nil

--- a/pkg/forwarder/tcp_test.go
+++ b/pkg/forwarder/tcp_test.go
@@ -27,6 +27,9 @@ func TestTCPDispatch_HTTPMechanism_Handled(t *testing.T) {
 		HeaderFilters: map[string]string{"X-Test": "value"},
 	}}
 
+	// Set the HTTP intercepts (simulates what fwdstate.HandlePort does)
+	f.SetInterceptingMultiple(context.Background(), []*manager.InterceptInfo{intercept})
+
 	// Call dispatch. Since the connection is closed, the HTTP handler
 	// will get EOF when trying to read and return an error.
 	handled, err := f.DispatchByMechanism(context.Background(), clientConn, intercept)


### PR DESCRIPTION
## Description

Issue #3969:
  - Personal intercepts with different HTTP headers now coexist
  - x-user=adam vs x-user=bertil = NO conflict

Performance Optimized:
  - Fast path: TCP conflicts detected immediately
  - Complex HTTP logic only runs when needed

Architecture Respects Design:
  - Different ports → Different InterceptState → No conflicts possible
  - Same port → Same InterceptState → Smart conflict detection applied

Backward Compatibility Preserved:
  - TCP intercepts still conflict correctly
  - All existing tests pass

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.