### PR TITLE
Thallgren/http matcher

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -63,11 +63,11 @@ items:
           **Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different
           destinations. Key rules:
 
-          - Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
+          - Different header values (e.g., `X-User=adam` vs `X-User=bertil`) do NOT conflict
 
-          - Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
+          - Header filters use subset logic: `X-User=adam` conflicts with `X-User=adam, X-Session=123` (first is subset)
 
-          - Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+          - Same headers with different paths do NOT conflict: `X-User=adam + /api/*` vs `X-User=adam + /admin/*`
 
           - Path-only intercepts operate at a lower priority tier than header-based intercepts
 

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -47,17 +47,26 @@ func (fs *fwdState) Target() agentconfig.InterceptTarget {
 }
 
 func (fs *fwdState) InterceptInfo(ctx context.Context, callerID, path string, containerPort uint16, headers http.Header) (*restapi.InterceptInfo, error) {
-	// TODO: This must check against current intercepts now that HTTP-filters are supported.
 	fw := fs.forwarder
-	if containerPort == 0 {
-		return fw.InterceptInfo(), nil
+	r := &restapi.InterceptInfo{}
+	if containerPort != 0 && containerPort != fw.Target().Port() {
+		dlog.Debugf(ctx, "no match found for path %q, port %d, %s", path, containerPort, headers)
+		return r, nil
 	}
-	port := fw.Target().Port()
-	if containerPort == port {
-		return fw.InterceptInfo(), nil
+	for _, ii := range fw.InterceptInfos() {
+		if callerID != "" && callerID != ii.Id {
+			continue
+		}
+		if ii.Disposition == manager.InterceptDispositionType_ACTIVE {
+			m := matcher.NewRequest(ii.Spec.PathFilters, ii.Spec.HeaderFilters)
+			if m.MatchesPathAndHeader(path, headers) {
+				r.Intercepted = true
+				r.Metadata = ii.Metadata
+				break
+			}
+		}
 	}
-	dlog.Debugf(ctx, "no match found for path %q, port %d, %s", path, containerPort, headers)
-	return &restapi.InterceptInfo{Intercepted: false}, nil
+	return r, nil
 }
 
 type ProviderMux struct {

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/textproto"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -15,6 +13,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/forwarder"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/restapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
@@ -29,44 +28,7 @@ type fwdState struct {
 
 // generateMechanismDescription creates a human-readable description for the intercept mechanism.
 func generateMechanismDescription(spec *manager.InterceptSpec) string {
-	if spec.Mechanism != "http" {
-		return "all TCP connections"
-	}
-
-	// Build HTTP filter description
-	var filters []string
-
-	// Add header filters (sorted for deterministic output)
-	headerKeys := make([]string, 0, len(spec.HeaderFilters))
-	for key := range spec.HeaderFilters {
-		headerKeys = append(headerKeys, key)
-	}
-	slices.Sort(headerKeys)
-	for _, key := range headerKeys {
-		filters = append(filters, fmt.Sprintf("header %s=%s", key, spec.HeaderFilters[key]))
-	}
-
-	// Add path filters with type information (already in order from slice)
-	for _, path := range spec.PathFilters {
-		filterType, pattern := parsePathFilter(path)
-		switch filterType {
-		case "equal":
-			filters = append(filters, fmt.Sprintf("path (equal) %s", pattern))
-		case "prefix":
-			filters = append(filters, fmt.Sprintf("path (prefix) %s", pattern))
-		case "regex":
-			filters = append(filters, fmt.Sprintf("path (regex) %s", pattern))
-		default:
-			// Fallback for unknown format
-			filters = append(filters, fmt.Sprintf("path %s", path))
-		}
-	}
-
-	if len(filters) > 0 {
-		return fmt.Sprintf("HTTP filters: %s", strings.Join(filters, ", "))
-	}
-
-	return "all HTTP connections"
+	return matcher.NewRequest(spec.PathFilters, spec.HeaderFilters).String()
 }
 
 // NewInterceptState creates an InterceptState that performs intercepts by using an Interceptor which indiscriminately
@@ -85,7 +47,7 @@ func (fs *fwdState) Target() agentconfig.InterceptTarget {
 }
 
 func (fs *fwdState) InterceptInfo(ctx context.Context, callerID, path string, containerPort uint16, headers http.Header) (*restapi.InterceptInfo, error) {
-	// The OSS agent is either intercepting or it isn't. There's no way to tell what it is that's being intercepted.
+	// TODO: This must check against current intercepts now that HTTP-filters are supported.
 	fw := fs.forwarder
 	if containerPort == 0 {
 		return fw.InterceptInfo(), nil
@@ -112,32 +74,6 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 	return pm.AgentProvider.CreateClientStream(ctx, tag, sessionID, id, roundTripLatency, dialTimeout)
 }
 
-// normalizeHeaderFilters returns a new map with all header keys normalized to canonical MIME format.
-// HTTP headers are case-insensitive per RFC 7230, so we use the same canonicalization as net/http.
-// Examples: "x-user" -> "X-User", "content-type" -> "Content-Type".
-func normalizeHeaderFilters(headers map[string]string) map[string]string {
-	if len(headers) == 0 {
-		return headers
-	}
-	normalized := make(map[string]string, len(headers))
-	for key, value := range headers {
-		normalized[textproto.CanonicalMIMEHeaderKey(key)] = value
-	}
-	return normalized
-}
-
-// headerValueMatches checks if a header value matches a pattern, supporting wildcard matching.
-// This matches the runtime behavior in pkg/forwarder/http.go.
-func headerValueMatches(value, pattern string) bool {
-	// Support wildcard matching with *
-	if strings.Contains(pattern, "*") {
-		matched, _ := filepath.Match(pattern, value)
-		return matched
-	}
-	// Exact match
-	return value == pattern
-}
-
 // pathFiltersOverlap checks if two sets of path filters can match the same request path.
 // This properly handles the three path filter types: :path-equal:, :path-prefix:, and :path-regex:.
 func pathFiltersOverlap(paths1, paths2 []string) bool {
@@ -153,50 +89,37 @@ func pathFiltersOverlap(paths1, paths2 []string) bool {
 
 // pathsCanMatch determines if two path filters can match the same request path.
 func pathsCanMatch(filter1, filter2 string) bool {
-	type1, pattern1 := parsePathFilter(filter1)
-	type2, pattern2 := parsePathFilter(filter2)
+	return valuesCanMatch(matcher.PathValue(filter1), matcher.PathValue(filter2))
+}
+
+// valuesCanMatch determines if two matcher.Values can match the same string value.
+func valuesCanMatch(v1, v2 matcher.Value) bool {
+	op1 := v1.Op()
+	op2 := v2.Op()
+	pattern1 := v1.String()
+	pattern2 := v2.String()
 
 	switch {
-	case type1 == "equal" && type2 == "equal":
-		// Both exact matches - conflict only if same path
+	case op1 == matcher.ValueOpEqual && op2 == matcher.ValueOpEqual:
+		// Both exact matches - conflict only if the same value
 		return pattern1 == pattern2
 
-	case type1 == "prefix" && type2 == "prefix":
+	case op1 == matcher.ValueOpPrefix && op2 == matcher.ValueOpPrefix:
 		// Both prefixes - conflict if one is prefix of the other
 		return strings.HasPrefix(pattern1, pattern2) || strings.HasPrefix(pattern2, pattern1)
 
-	case type1 == "prefix" && type2 == "equal":
-		// Prefix can match an exact path if the path starts with the prefix
+	case op1 == matcher.ValueOpPrefix && op2 == matcher.ValueOpEqual:
+		// Prefix can match an exact value if the value starts with the prefix
 		return strings.HasPrefix(pattern2, pattern1)
 
-	case type1 == "equal" && type2 == "prefix":
-		// Exact path matches prefix if it starts with the prefix
+	case op1 == matcher.ValueOpEqual && op2 == matcher.ValueOpPrefix:
+		// Exact value matches prefix if it starts with the prefix
 		return strings.HasPrefix(pattern1, pattern2)
-
-	case type1 == "regex" || type2 == "regex":
-		// Conservative: assume regexes can overlap
-		// Proper regex intersection is computationally expensive
-		return true
-
-	default:
-		// Unknown types - assume no conflict
-		return false
 	}
-}
 
-// parsePathFilter extracts the filter type and pattern from a path filter string.
-func parsePathFilter(filter string) (filterType, pattern string) {
-	switch {
-	case strings.HasPrefix(filter, ":path-equal:"):
-		return "equal", strings.TrimPrefix(filter, ":path-equal:")
-	case strings.HasPrefix(filter, ":path-prefix:"):
-		return "prefix", strings.TrimPrefix(filter, ":path-prefix:")
-	case strings.HasPrefix(filter, ":path-regex:"):
-		return "regex", strings.TrimPrefix(filter, ":path-regex:")
-	default:
-		// Unknown format - treat as exact match
-		return "equal", filter
-	}
+	// Conservative: assume regexes can overlap
+	// Proper regex intersection is computationally expensive
+	return true
 }
 
 // explainConflict generates a human-readable explanation of why two intercept specs conflict.
@@ -213,11 +136,11 @@ func explainConflict(spec1, spec2 *manager.InterceptSpec) string {
 		return "one intercept has no filters (intercepts all traffic)"
 	}
 
-	// Normalize headers for comparison
-	headers1 := normalizeHeaderFilters(spec1.HeaderFilters)
-	headers2 := normalizeHeaderFilters(spec2.HeaderFilters)
-
 	if hasHeaders1 && hasHeaders2 {
+		// Normalize headers for comparison
+		headers1 := matcher.NewHeaders(spec1.HeaderFilters)
+		headers2 := matcher.NewHeaders(spec2.HeaderFilters)
+
 		// Check if headers form subset relationship
 		isSubset1of2 := isHeaderSubset(headers1, headers2)
 		isSubset2of1 := isHeaderSubset(headers2, headers1)
@@ -242,9 +165,10 @@ func explainConflict(spec1, spec2 *manager.InterceptSpec) string {
 
 // isHeaderSubset checks if all headers in subset exist in superset with matching values.
 // Uses wildcard matching for header values.
-func isHeaderSubset(subset, superset map[string]string) bool {
-	for key, value := range subset {
-		if superValue, exists := superset[key]; !exists || !headerValueMatches(value, superValue) {
+func isHeaderSubset(subset, superset matcher.Headers) bool {
+	supersetMap := superset.HeaderMap()
+	for key, value := range subset.HeaderMap() {
+		if superValue, exists := supersetMap[key]; !exists || !valuesCanMatch(value, superValue) {
 			return false
 		}
 	}
@@ -293,12 +217,12 @@ func interceptSpecsConflict(spec1, spec2 *manager.InterceptSpec) bool {
 		return false
 	}
 
-	// Normalize headers for case-insensitive comparison (HTTP headers per RFC 7230)
-	headers1 := normalizeHeaderFilters(spec1.HeaderFilters)
-	headers2 := normalizeHeaderFilters(spec2.HeaderFilters)
-
 	// Rule 3: Both have headers - check for subset relationship AND path overlap
 	if hasHeaders1 && hasHeaders2 {
+		// Normalize headers for case-insensitive comparison (HTTP headers per RFC 7230)
+		headers1 := matcher.NewHeaders(spec1.HeaderFilters)
+		headers2 := matcher.NewHeaders(spec2.HeaderFilters)
+
 		// Check if headers form a subset relationship
 		hasHeaderSubset := isHeaderSubset(headers1, headers2) ||
 			isHeaderSubset(headers2, headers1)

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -26,7 +26,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 			spec: &manager.InterceptSpec{
 				Mechanism: "http",
 			},
-			expected: "all HTTP connections",
+			expected: "all TCP connections",
 		},
 		{
 			name: "HTTP mechanism with header filters only",
@@ -37,7 +37,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					"X-Environment": "staging",
 				},
 			},
-			expected: "HTTP filters: header X-Environment=staging, header X-User-ID=dev123",
+			expected: "HTTP requests with headers\n 'X-Environment: staging'\n 'X-User-Id: dev123'",
 		},
 		{
 			name: "HTTP mechanism with path filters only",
@@ -48,7 +48,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					":path-prefix:/admin/",
 				},
 			},
-			expected: "HTTP filters: path (prefix) /api/v1/, path (prefix) /admin/",
+			expected: "HTTP requests with paths\n prefix /api/v1/\n prefix /admin/",
 		},
 		{
 			name: "HTTP mechanism with both header and path filters",
@@ -61,7 +61,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					":path-prefix:/api/",
 				},
 			},
-			expected: "HTTP filters: header X-User-ID=dev123, path (prefix) /api/",
+			expected: "HTTP requests with path prefix /api/ and header 'X-User-Id: dev123'",
 		},
 		{
 			name: "HTTP mechanism with single header filter",
@@ -71,7 +71,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					"Authorization": "Bearer token123",
 				},
 			},
-			expected: "HTTP filters: header Authorization=Bearer token123",
+			expected: "HTTP requests with header 'Authorization: Bearer token123'",
 		},
 		{
 			name: "HTTP mechanism with single path filter",
@@ -79,7 +79,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 				Mechanism:   "http",
 				PathFilters: []string{":path-equal:/health"},
 			},
-			expected: "HTTP filters: path (equal) /health",
+			expected: "HTTP requests with path == /health",
 		},
 		{
 			name: "HTTP mechanism with regex path filter",
@@ -87,7 +87,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 				Mechanism:   "http",
 				PathFilters: []string{":path-regex:^/api/v[0-9]+/.*$"},
 			},
-			expected: "HTTP filters: path (regex) ^/api/v[0-9]+/.*$",
+			expected: "HTTP requests with path =~ ^/api/v[0-9]+/.*$",
 		},
 		{
 			name: "HTTP mechanism with mixed path filter types",
@@ -99,7 +99,7 @@ func TestGenerateMechanismDescription(t *testing.T) {
 					":path-regex:^/admin/.*$",
 				},
 			},
-			expected: "HTTP filters: path (equal) /health, path (prefix) /api/, path (regex) ^/admin/.*$",
+			expected: "HTTP requests with paths\n == /health\n prefix /api/\n =~ ^/admin/.*$",
 		},
 		{
 			name: "unknown mechanism defaults to TCP",

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,9 +29,9 @@ Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic fi
 **Routing Precedence Model**: Header-based intercepts take priority over path-only intercepts. When multiple intercepts are active on the same workload, requests are evaluated against header-based filters first, then path-only filters. This enables different developers to use header-based personal intercepts (e.g., `x-user=alice`) while others use path-based intercepts (e.g., `/admin/*`) without conflicts.
 
 **Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different destinations. Key rules:
-- Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
-- Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
-- Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+- Different header values (e.g., `X-User=adam` vs `X-User=bertil`) do NOT conflict
+- Header filters use subset logic: `X-User=adam` conflicts with `X-User=adam, X-Session=123` (first is subset)
+- Same headers with different paths do NOT conflict: `X-User=adam + /api/*` vs `X-User=adam + /admin/*`
 - Path-only intercepts operate at a lower priority tier than header-based intercepts
 
 The feature maintains full backward compatibility with existing TCP intercepts.

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -35,9 +35,9 @@ Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic fi
 **Routing Precedence Model**: Header-based intercepts take priority over path-only intercepts. When multiple intercepts are active on the same workload, requests are evaluated against header-based filters first, then path-only filters. This enables different developers to use header-based personal intercepts (e.g., `x-user=alice`) while others use path-based intercepts (e.g., `/admin/*`) without conflicts.
 
 **Conflict Detection**: Intercepts conflict only when their filters would route the same traffic to different destinations. Key rules:
-- Different header values (e.g., `x-user=adam` vs `x-user=bertil`) do NOT conflict
-- Header filters use subset logic: `x-user=adam` conflicts with `x-user=adam, x-session=123` (first is subset)
-- Same headers with different paths do NOT conflict: `x-user=adam + /api/*` vs `x-user=adam + /admin/*`
+- Different header values (e.g., `X-User=adam` vs `X-User=bertil`) do NOT conflict
+- Header filters use subset logic: `X-User=adam` conflicts with `X-User=adam, X-Session=123` (first is subset)
+- Same headers with different paths do NOT conflict: `X-User=adam + /api/*` vs `X-User=adam + /admin/*`
 - Path-only intercepts operate at a lower priority tier than header-based intercepts
 
 The feature maintains full backward compatibility with existing TCP intercepts.

--- a/pkg/client/cli/intercept/command.go
+++ b/pkg/client/cli/intercept/command.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
 
@@ -426,19 +427,19 @@ func BuildPathFilters(equals, prefixes, regexps []string) []string {
 	// Add exact match filters
 	i := 0
 	for _, path := range equals {
-		allFilters[i] = ":path-equal:" + path
+		allFilters[i] = matcher.PathEqual + path
 		i++
 	}
 
 	// Add prefix match filters
 	for _, path := range prefixes {
-		allFilters[i] = ":path-prefix:" + path
+		allFilters[i] = matcher.PathPrefix + path
 		i++
 	}
 
 	// Add regex match filters
 	for _, path := range regexps {
-		allFilters[i] = ":path-regex:" + path
+		allFilters[i] = matcher.PathRegex + path
 		i++
 	}
 	return allFilters

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -984,11 +984,7 @@ func (s *session) newAPIServerForPort(port int) {
 }
 
 func (s *session) newMatcher(ic *manager.InterceptInfo) {
-	m, err := matcher.NewRequestFromMap(ic.Headers)
-	if err != nil {
-		dlog.Error(s.context, err)
-		return
-	}
+	m := matcher.NewRequestFromMap(ic.Headers)
 	if s.currentMatchers == nil {
 		s.currentMatchers = make(map[string]*apiMatcher)
 	}
@@ -1007,7 +1003,7 @@ func (s *session) InterceptInfo(_ context.Context, callerID, path string, _ uint
 	switch {
 	case am == nil:
 		dlog.Debugf(s.context, "no matcher found for callerID %s", callerID)
-	case am.requestMatcher.Matches(path, headers):
+	case am.requestMatcher.MatchesPathAndHeader(path, headers):
 		dlog.Debugf(s.context, "%s: matcher %s\nmatches path %q and headers\n%s", callerID, am.requestMatcher, path, matcher.HeaderStringer(headers))
 		r.Intercepted = true
 		r.Metadata = am.metadata

--- a/pkg/forwarder/http.go
+++ b/pkg/forwarder/http.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
-	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +15,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -160,7 +159,7 @@ func (h *httpInterceptor) handleHTTPConn(clientConn net.Conn) error {
 	// Pass 1: Check intercepts with headers (high priority tier)
 	for _, interceptInfo := range intercepts {
 		if len(interceptInfo.headerFilters) > 0 {
-			if h.shouldInterceptRequest(ctx, req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
+			if shouldInterceptRequest(req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
 				dlog.Debugf(ctx, "Intercepting HTTP request %s %s with header-based intercept %s",
 					req.Method, req.URL.Path, interceptInfo.intercept.Id)
 				return h.interceptHTTPConn(ctx, clientConn, req, interceptInfo.intercept)
@@ -171,7 +170,7 @@ func (h *httpInterceptor) handleHTTPConn(clientConn net.Conn) error {
 	// Pass 2: Check intercepts with only paths (low priority tier)
 	for _, interceptInfo := range intercepts {
 		if len(interceptInfo.headerFilters) == 0 && len(interceptInfo.pathFilters) > 0 {
-			if h.shouldInterceptRequest(ctx, req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
+			if shouldInterceptRequest(req, interceptInfo.headerFilters, interceptInfo.pathFilters) {
 				dlog.Debugf(ctx, "Intercepting HTTP request %s %s with path-based intercept %s",
 					req.Method, req.URL.Path, interceptInfo.intercept.Id)
 				return h.interceptHTTPConn(ctx, clientConn, req, interceptInfo.intercept)
@@ -184,63 +183,8 @@ func (h *httpInterceptor) handleHTTPConn(clientConn net.Conn) error {
 	return h.forwardToOriginalService(ctx, clientConn, req, originalTarget)
 }
 
-func (h *httpInterceptor) shouldInterceptRequest(ctx context.Context, req *http.Request, headerFilters map[string]string, pathFilters []string) bool {
-	// Check header filters (AND logic - all must match)
-	for key, expectedValue := range headerFilters {
-		actualValue := req.Header.Get(key)
-		if !h.matchesPattern(actualValue, expectedValue) {
-			dlog.Debugf(ctx, "Request header %s=%s does not match filter %s=%s",
-				key, actualValue, key, expectedValue)
-			return false
-		}
-	}
-
-	// Check path filters (OR logic - any must match)
-	if len(pathFilters) > 0 {
-		pathMatched := false
-		for _, filter := range pathFilters {
-			matched := false
-			switch {
-			case strings.HasPrefix(filter, ":path-equal:"):
-				// Exact match
-				path := strings.TrimPrefix(filter, ":path-equal:")
-				matched = req.URL.Path == path
-			case strings.HasPrefix(filter, ":path-prefix:"):
-				// Prefix match
-				prefix := strings.TrimPrefix(filter, ":path-prefix:")
-				matched = strings.HasPrefix(req.URL.Path, prefix)
-			case strings.HasPrefix(filter, ":path-regex:"):
-				// Regex match
-				pattern := strings.TrimPrefix(filter, ":path-regex:")
-				if re, err := regexp.Compile(pattern); err == nil {
-					matched = re.MatchString(req.URL.Path)
-				} else {
-					dlog.Debugf(ctx, "Invalid regex pattern %s: %v", pattern, err)
-				}
-			}
-
-			if matched {
-				pathMatched = true
-				break
-			}
-		}
-		if !pathMatched {
-			dlog.Debugf(ctx, "Request path %s does not match any path filters", req.URL.Path)
-			return false
-		}
-	}
-
-	return true
-}
-
-func (h *httpInterceptor) matchesPattern(value, pattern string) bool {
-	// Support wildcard matching with *
-	if strings.Contains(pattern, "*") {
-		matched, _ := filepath.Match(pattern, value)
-		return matched
-	}
-	// Exact match
-	return value == pattern
+func shouldInterceptRequest(req *http.Request, headerFilters map[string]string, pathFilters []string) bool {
+	return matcher.NewRequest(pathFilters, headerFilters).Matches(req)
 }
 
 func (h *httpInterceptor) interceptHTTPConn(ctx context.Context, clientConn net.Conn, req *http.Request, iCept *manager.InterceptInfo) error {

--- a/pkg/forwarder/http_test.go
+++ b/pkg/forwarder/http_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 )
 
 func TestHTTPInterceptor_shouldInterceptRequest(t *testing.T) {
-	h := &httpInterceptor{}
-
 	headerFilters := map[string]string{
 		"X-User-ID":     "dev123",
 		"X-Environment": "staging",
@@ -76,15 +76,13 @@ func TestHTTPInterceptor_shouldInterceptRequest(t *testing.T) {
 				req.Header.Set(k, v)
 			}
 
-			result := h.shouldInterceptRequest(req.Context(), req, headerFilters, pathFilters)
+			result := shouldInterceptRequest(req, headerFilters, pathFilters)
 			assert.Equal(t, tt.shouldIntercept, result)
 		})
 	}
 }
 
 func TestHTTPInterceptor_matchesPattern(t *testing.T) {
-	h := &httpInterceptor{}
-
 	tests := []struct {
 		name    string
 		value   string
@@ -93,30 +91,28 @@ func TestHTTPInterceptor_matchesPattern(t *testing.T) {
 	}{
 		{"exact match", "dev123", "dev123", true},
 		{"no match", "dev123", "prod456", false},
-		{"wildcard match", "dev123", "dev*", true},
-		{"wildcard no match", "prod123", "dev*", false},
-		{"complex wildcard", "dev-user-123", "dev-*-123", true},
+		{"wildcard match", "dev123", "dev.*", true},
+		{"wildcard no match", "prod123", "dev.*", false},
+		{"complex wildcard", "dev-user-123", "dev-.*-123", true},
 		{"empty value", "", "dev*", false},
 		{"empty pattern", "dev123", "", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := h.matchesPattern(tt.value, tt.pattern)
+			result := matcher.NewValue(tt.pattern).Matches(tt.value)
 			assert.Equal(t, tt.matches, result)
 		})
 	}
 }
 
 func TestHTTPInterceptor_noFilters(t *testing.T) {
-	h := &httpInterceptor{}
-
 	headerFilters := map[string]string{}
 	pathFilters := []string{}
 
 	req, _ := http.NewRequest(http.MethodGet, "http://example.com/any/path", nil)
 
 	// No filters means intercept everything
-	result := h.shouldInterceptRequest(req.Context(), req, headerFilters, pathFilters)
+	result := shouldInterceptRequest(req, headerFilters, pathFilters)
 	assert.True(t, result)
 }

--- a/pkg/forwarder/interceptor.go
+++ b/pkg/forwarder/interceptor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
-	"github.com/telepresenceio/telepresence/v2/pkg/restapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -21,7 +20,6 @@ type Interceptor interface {
 	io.Closer
 	Tag() tunnel.Tag
 	InterceptId() string
-	InterceptInfo() *restapi.InterceptInfo
 	Serve(context.Context, chan<- netip.AddrPort) error
 	SetIntercepting(context.Context, *manager.InterceptInfo)
 	SetInterceptingMultiple(context.Context, []*manager.InterceptInfo)
@@ -39,6 +37,10 @@ type Interceptor interface {
 	// returns true if the connection was fully handled and no further processing
 	// should occur.
 	DispatchByMechanism(ctx context.Context, conn net.Conn, intercept *manager.InterceptInfo) (bool, error)
+
+	// InterceptInfos returns the intercepts that are currently being handled by this interceptor. The
+	// wiretaps are not included.
+	InterceptInfos() []*manager.InterceptInfo
 }
 
 type interceptor struct {
@@ -67,6 +69,15 @@ func NewInterceptor(from types.PortAndProto, tag tunnel.Tag, target netip.AddrPo
 	default:
 		panic(fmt.Errorf("unsupported protocol %s", from.Proto))
 	}
+}
+
+func (f *interceptor) InterceptInfos() (infos []*manager.InterceptInfo) {
+	f.mu.Lock()
+	if f.intercept != nil {
+		infos = []*manager.InterceptInfo{f.intercept}
+	}
+	f.mu.Unlock()
+	return infos
 }
 
 func (f *interceptor) PruneTo(ctx context.Context, ids []string) {
@@ -99,17 +110,6 @@ func (f *interceptor) Target() netip.AddrPort {
 	defer f.mu.Unlock()
 
 	return f.target
-}
-
-func (f *interceptor) InterceptInfo() *restapi.InterceptInfo {
-	ii := &restapi.InterceptInfo{}
-	f.mu.Lock()
-	if f.intercept != nil {
-		ii.Intercepted = true
-		ii.Metadata = f.intercept.Metadata
-	}
-	f.mu.Unlock()
-	return ii
 }
 
 func (f *interceptor) InterceptId() (id string) {

--- a/pkg/forwarder/tcp.go
+++ b/pkg/forwarder/tcp.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"time"
 
@@ -30,6 +31,17 @@ func newTCP(listenPort uint16, tag tunnel.Tag, target netip.AddrPort) Intercepto
 			lCancel:    func() {},
 		},
 	}
+}
+
+func (f *tcp) InterceptInfos() (infos []*manager.InterceptInfo) {
+	f.mu.Lock()
+	if len(f.httpIntercepts) > 0 {
+		infos = slices.Clone(f.httpIntercepts)
+	} else if f.intercept != nil {
+		infos = []*manager.InterceptInfo{f.intercept}
+	}
+	f.mu.Unlock()
+	return infos
 }
 
 // SetInterceptingMultiple overrides the base implementation to handle HTTP intercepts.

--- a/pkg/matcher/headers.go
+++ b/pkg/matcher/headers.go
@@ -25,7 +25,10 @@ type Headers interface {
 	Matches(header http.Header) bool
 }
 
-// NewHeaders creates a new Headers.
+// NewHeaders creates a new Headers with all header keys normalized to canonical MIME format.
+// HTTP headers are case-insensitive per RFC 7230, so we use the same canonicalization as net/http.
+//
+// Examples: "x-user" -> "X-User", "content-type" -> "Content-Type".
 func NewHeaders(hs map[string]string) Headers {
 	hm := make(HeaderMap, len(hs))
 	for k, v := range hs {

--- a/pkg/matcher/headers.go
+++ b/pkg/matcher/headers.go
@@ -1,10 +1,12 @@
 package matcher
 
 import (
-	"fmt"
 	"net/http"
 	"net/textproto"
 	"strings"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
 
 type HeaderMap map[string]Value
@@ -24,16 +26,12 @@ type Headers interface {
 }
 
 // NewHeaders creates a new Headers.
-func NewHeaders(hs map[string]string) (Headers, error) {
+func NewHeaders(hs map[string]string) Headers {
 	hm := make(HeaderMap, len(hs))
 	for k, v := range hs {
-		vm, err := NewValue(v)
-		if err != nil {
-			return nil, fmt.Errorf("the value of match %s=%s is invalid: %w", k, v, err)
-		}
-		hm[textproto.CanonicalMIMEHeaderKey(k)] = vm
+		hm[textproto.CanonicalMIMEHeaderKey(k)] = NewValue(v)
 	}
-	return hm, nil
+	return hm
 }
 
 // Map returns the map correspondence of this instance. The returned value can be
@@ -46,7 +44,8 @@ func (m HeaderMap) Map() map[string]string {
 	return r
 }
 
-// HeaderMap returns HeaderMap correspondence of this instance.
+// HeaderMap returns the internal HeaderMap. Any modifications made to this map must
+// ensure that keys are canonicalized using textproto.CanonicalMIMEHeaderKey.
 func (m HeaderMap) HeaderMap() HeaderMap {
 	return m
 }
@@ -69,12 +68,30 @@ func (m HeaderMap) String() string {
 }
 
 func (m HeaderMap) appendString(sb *strings.Builder, indent string) {
-	for k, v := range m {
+	if len(m) == 0 {
+		return
+	}
+	sb.WriteString(indent)
+	sb.WriteString("header")
+	if len(m) > 1 {
+		sb.WriteString("s\n")
+		indent += " "
+	} else {
+		sb.WriteByte(' ')
+		indent = ""
+	}
+	first := true
+	for _, k := range maps.SortedKeys(m) {
+		if !first {
+			sb.WriteByte('\n')
+		}
+		first = false
+		v := m[k]
 		op := v.Op()
 		if op == "==" {
-			fmt.Fprintf(sb, "\n%s'%s: %s'", indent, k, v)
+			ioutil.Printf(sb, "%s'%s: %s'", indent, k, v)
 		} else {
-			fmt.Fprintf(sb, "\n%s'%s %s %s'", indent, k, v.Op(), v)
+			ioutil.Printf(sb, "%s'%s %s %s'", indent, k, v.Op(), v)
 		}
 	}
 }

--- a/pkg/matcher/headers_test.go
+++ b/pkg/matcher/headers_test.go
@@ -2,7 +2,6 @@ package matcher
 
 import (
 	"net/http"
-	"regexp/syntax"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,18 +74,16 @@ func Test_headers_Matches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hm, err := NewHeaders(tt.match)
-			assert.NoError(t, err)
+			hm := NewHeaders(tt.match)
 			assert.Equal(t, tt.want, hm.Matches(tt.header))
 		})
 	}
 }
 
 func Test_NewHeaders_error(t *testing.T) {
-	m, err := NewHeaders(map[string]string{"a": "un(balanced"})
-	sErr := &syntax.Error{}
-	require.ErrorAs(t, err, &sErr)
-	assert.Contains(t, err.Error(), "value of match a=")
-	assert.Equal(t, syntax.ErrMissingParen, sErr.Code)
-	assert.Nil(t, m)
+	m := NewHeaders(map[string]string{"a": "un(balanced"})
+	v, ok := m.HeaderMap()["A"]
+	require.True(t, ok)
+	assert.Equal(t, v.Op(), ValueOpEqual)
+	assert.Equal(t, v.String(), "un(balanced")
 }

--- a/pkg/matcher/paths.go
+++ b/pkg/matcher/paths.go
@@ -1,0 +1,99 @@
+package matcher
+
+import (
+	"slices"
+	"strings"
+)
+
+type Paths []Value
+
+const (
+	PathEqual  = ":path-equal:"
+	PathPrefix = ":path-prefix:"
+	PathRegex  = ":path-regex:"
+)
+
+func splitPath(path string) (string, string) {
+	if len(path) > 0 && path[0] == ':' {
+		nxt := strings.Index(path[1:], ":")
+		if nxt > 0 {
+			nxt += 2
+			return path[:nxt], path[nxt:]
+		}
+	}
+	return PathEqual, path
+}
+
+func PathValue(path string) (pv Value) {
+	p, v := splitPath(path)
+	switch p {
+	case PathPrefix:
+		pv = NewPrefix(v)
+	case PathRegex:
+		pv = NewRegex(v)
+	default:
+		pv = NewEqual(v)
+	}
+	return pv
+}
+
+func NewPaths(paths []string) Paths {
+	pvs := make(Paths, len(paths))
+	for i, pv := range paths {
+		pvs[i] = PathValue(pv)
+	}
+	return pvs
+}
+
+func (ps Paths) Slice() []string {
+	ss := make([]string, len(ps))
+	for i, p := range ps {
+		var pfx string
+		switch p.Op() {
+		case ValueOpRegex:
+			pfx = PathRegex
+		case ValueOpPrefix:
+			pfx = PathPrefix
+		default:
+			pfx = PathEqual
+		}
+		ss[i] = pfx + p.String()
+	}
+	return ss
+}
+
+// Matches returns true if at least one of the paths in this instance matches the given path
+// or if this instance is empty.
+func (ps Paths) Matches(path string) bool {
+	return len(ps) == 0 || slices.ContainsFunc(ps, func(v Value) bool { return v.Matches(path) })
+}
+
+func (ps Paths) String() string {
+	sb := strings.Builder{}
+	ps.appendString(&sb, "")
+	return sb.String()
+}
+
+func (ps Paths) appendString(sb *strings.Builder, indent string) {
+	if len(ps) == 0 {
+		return
+	}
+	sb.WriteString(indent)
+	sb.WriteString("path")
+	if len(ps) > 1 {
+		sb.WriteString("s\n")
+		indent += " "
+	} else {
+		sb.WriteByte(' ')
+		indent = ""
+	}
+	for i, p := range ps {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(indent)
+		sb.WriteString(string(p.Op()))
+		sb.WriteByte(' ')
+		sb.WriteString(p.String())
+	}
+}

--- a/pkg/matcher/request.go
+++ b/pkg/matcher/request.go
@@ -16,79 +16,76 @@ type Request interface {
 	// Headers returns Headers of this instance.
 	Headers() Headers
 
+	// IsGlobal returns true if this instance matches all requests.
+	IsGlobal() bool
+
 	// Map returns the map correspondence of this instance. The returned value can be
 	// used as an argument to NewRequest to create an identical Request.
 	Map() map[string]string
 
-	// Matches returns true if both the path Value matcher and the Headers matcher in this instance are
-	// matched by the given http.Request.
-	Matches(path string, headers http.Header) bool
+	// Matches returns true if given http.Request is matched.
+	Matches(req *http.Request) bool
 
-	// Path returns the path
-	Path() Value
+	// MatchesPathAndHeader returns true if both the path Headers match.
+	MatchesPathAndHeader(path string, req http.Header) bool
+
+	// Paths return the path matchers.
+	Paths() Paths
 }
 
 type request struct {
-	path    Value
+	paths   Paths
 	headers HeaderMap
 }
 
 // NewRequestFromMap creates a new Request based on the values of the given map. Aside from http headers,
-// the map may contain one of three special keys.
+// the map may contain a :path: entry with a semicolon delimited list of paths. Each path should be prefixed
+// with one of three special keys.
 //
 //	:path-equal: path will match if equal to the value
 //	:path-prefix: path will match prefixed by the value
 //	:path-regex: path will match it matches the regexp value
-func NewRequestFromMap(m map[string]string) (Request, error) {
-	var pm Value
-	hm := make(HeaderMap, len(m))
-
-	var err error
+func NewRequestFromMap(m map[string]string) Request {
+	if len(m) == 0 {
+		return &request{}
+	}
+	var ps Paths
+	var hm HeaderMap
 	for k, v := range m {
 		switch k {
-		case ":path-equal:":
-			pm = NewEqual(v)
-		case ":path-prefix:":
-			pm = NewPrefix(v)
-		case ":path-regex:":
-			if pm, err = NewRegex(v); err != nil {
-				return nil, err
-			}
+		case ":paths:":
+			ps = NewPaths(strings.Split(v, ";"))
 		default:
-			vm, err := NewValue(v)
-			if err != nil {
-				return nil, fmt.Errorf("the value of match %s=%s is invalid: %w", k, v, err)
+			vm := NewValue(v)
+			if hm == nil {
+				hm = make(HeaderMap)
 			}
 			hm[textproto.CanonicalMIMEHeaderKey(k)] = vm
 		}
 	}
-	return NewRequest(pm, hm), nil
+	return &request{paths: ps, headers: hm}
 }
 
-func NewRequest(path Value, hm HeaderMap) Request {
-	if len(hm) == 0 {
-		hm = nil
+func NewRequest(paths []string, hdrs map[string]string) Request {
+	rv := new(request)
+	if len(paths) > 0 {
+		rv.paths = NewPaths(paths)
 	}
-	return &request{path: path, headers: hm}
+	if len(hdrs) > 0 {
+		rv.headers = NewHeaders(hdrs).HeaderMap()
+	}
+	return rv
 }
 
 // Map returns the map correspondence of this instance. The returned value can be
 // used as an argument to NewRequest to create an identical Request.
 func (r *request) Map() map[string]string {
 	var m map[string]string
-	if r.headers != nil {
+	if len(r.headers) > 0 {
 		m = r.headers.Map()
 	}
-	if p := r.path; p != nil {
-		pm := make(map[string]string, len(m)+1)
-		switch p.(type) {
-		case textValue:
-			pm[":path-equal:"] = p.String()
-		case prefixValue:
-			pm[":path-prefix:"] = p.String()
-		case rxValue:
-			pm[":path-regex:"] = p.String()
-		}
+	if len(r.paths) > 0 {
+		pm := map[string]string{":paths:": strings.Join(r.paths.Slice(), ";")}
 		maps.Merge(pm, m)
 		m = pm
 	}
@@ -100,37 +97,56 @@ func (r *request) Headers() Headers {
 	return r.headers
 }
 
-// Matches returns true if both the path Value matcher and the Headers matcher in this instance are
-// matched by the given http.Request.
-func (r *request) Matches(path string, headers http.Header) bool {
-	return r == nil || (r.path == nil || r.path.Matches(path)) && (r.headers == nil || r.headers.Matches(headers))
+func (r *request) IsGlobal() bool {
+	return len(r.paths) == 0 && len(r.headers) == 0
 }
 
-// Path returns the path.
-func (r *request) Path() Value {
-	return r.path
+// Matches returns true if both the path Value matcher and the Headers matcher in this instance are
+// matched by the given http.Request.
+func (r *request) Matches(req *http.Request) bool {
+	return r.MatchesPathAndHeader(req.URL.Path, req.Header)
+}
+
+func (r *request) MatchesPathAndHeader(path string, header http.Header) bool {
+	return r.paths.Matches(path) && (len(r.headers) == 0 || r.headers.Matches(header))
+}
+
+// Paths return the path matchers.
+func (r *request) Paths() Paths {
+	return r.paths
 }
 
 func (r *request) String() string {
+	if r.IsGlobal() {
+		return "all TCP connections"
+	}
 	sb := strings.Builder{}
-	if r == nil || r.path == nil && len(r.headers) == 0 {
-		return "all requests"
-	}
-	sb.WriteString("requests with")
-	if r.path != nil {
-		if r.headers != nil {
-			sb.WriteString("\n ")
+	sb.WriteString("HTTP requests with")
+	switch len(r.paths) {
+	case 0:
+		sb.WriteByte(' ')
+		r.headers.appendString(&sb, "")
+	case 1:
+		if len(r.headers) < 2 {
+			sb.WriteByte(' ')
+			r.paths.appendString(&sb, "")
+			if len(r.headers) > 0 {
+				sb.WriteString(" and ")
+				r.headers.appendString(&sb, "")
+			}
+			break
 		}
-		fmt.Fprintf(&sb, " path %s %s", r.path.Op(), r.path.String())
-	}
-	if r.headers != nil {
-		indent := "  "
-		if r.path != nil {
-			indent += "  "
-			sb.WriteString("\n ")
+		fallthrough
+	default:
+		if len(r.headers) > 0 {
+			sb.WriteByte('\n')
+			r.paths.appendString(&sb, " ")
+			sb.WriteByte('\n')
+			r.headers.appendString(&sb, " ")
+		} else {
+			sb.WriteByte(' ')
+			r.paths.appendString(&sb, "")
 		}
-		sb.WriteString(" headers")
-		r.headers.appendString(&sb, indent)
 	}
 	return sb.String()
 }

--- a/pkg/matcher/request_test.go
+++ b/pkg/matcher/request_test.go
@@ -1,7 +1,6 @@
 package matcher
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 	"testing"
@@ -22,31 +21,28 @@ func TestNewRequest(t *testing.T) {
 		},
 		{
 			name: "path-equal",
-			args: map[string]string{":path-equal:": "/some/path"},
-			want: &request{path: NewEqual("/some/path")},
+			args: map[string]string{":paths:": ":path-equal:/some/path"},
+			want: &request{paths: Paths{NewEqual("/some/path")}},
 		},
 		{
 			name: "path-prefix",
-			args: map[string]string{":path-prefix:": "/some/path"},
-			want: &request{path: NewPrefix("/some/path")},
+			args: map[string]string{":paths:": ":path-prefix:/some/path"},
+			want: &request{paths: Paths{NewPrefix("/some/path")}},
 		},
 		{
 			name: "path-regex",
-			args: map[string]string{":path-regex:": ".*/path"},
-			want: &request{path: rxValue{regexp.MustCompile(".*/path")}},
+			args: map[string]string{":paths:": ":path-regex:.*/path"},
+			want: &request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}},
 		},
 		{
 			name: "path-regex and headers",
-			args: map[string]string{":path-regex:": ".*/path", "A": "b"},
-			want: &request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			args: map[string]string{":paths:": ":path-regex:.*/path", "A": "b"},
+			want: &request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewRequestFromMap(tt.args)
-			if !assert.NoError(t, err, fmt.Sprintf("NewRequest(%v)", tt.args)) {
-				return
-			}
+			got := NewRequestFromMap(tt.args)
 			assert.Equalf(t, tt.want, got, "NewRequest(%v)", tt.args)
 		})
 	}
@@ -65,23 +61,23 @@ func Test_request_Map(t *testing.T) {
 		},
 		{
 			"path-equal",
-			request{path: NewEqual("/some/path")},
-			map[string]string{":path-equal:": "/some/path"},
+			request{paths: Paths{NewEqual("/some/path")}},
+			map[string]string{":paths:": ":path-equal:/some/path"},
 		},
 		{
 			"path-prefix",
-			request{path: NewPrefix("/some/path")},
-			map[string]string{":path-prefix:": "/some/path"},
+			request{paths: Paths{NewPrefix("/some/path")}},
+			map[string]string{":paths:": ":path-prefix:/some/path"},
 		},
 		{
 			"path-regex",
-			request{path: rxValue{regexp.MustCompile(".*/path")}},
-			map[string]string{":path-regex:": ".*/path"},
+			request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}},
+			map[string]string{":paths:": ":path-regex:.*/path"},
 		},
 		{
 			"path-regex and headers",
-			request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
-			map[string]string{":path-regex:": ".*/path", "A": "b"},
+			request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			map[string]string{":paths:": ":path-regex:.*/path", "A": "b"},
 		},
 	}
 	for _, tt := range tests {
@@ -108,65 +104,65 @@ func Test_request_Matches(t *testing.T) {
 		},
 		{
 			name:    "path and headers",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
 			path:    "/some/path",
 			headers: http.Header(map[string][]string{"A": {"b"}}),
 			want:    true,
 		},
 		{
 			name:    "path and headers mismatch on just path",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
 			path:    "/some/path",
 			headers: nil,
 			want:    false,
 		},
 		{
 			name:    "path and headers mismatch on just headers",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
 			path:    "",
 			headers: http.Header(map[string][]string{"A": {"b"}}),
 			want:    false,
 		},
 		{
 			name:    "path-equal",
-			request: request{path: NewEqual("/some/path")},
+			request: request{paths: Paths{NewEqual("/some/path")}},
 			path:    "/some/path",
 			want:    true,
 		},
 		{
 			name:    "path-equal mismatch",
-			request: request{path: NewEqual("/some")},
+			request: request{paths: Paths{NewEqual("/some")}},
 			path:    "/some/path",
 			want:    false,
 		},
 		{
 			name:    "path-prefix",
-			request: request{path: NewPrefix("/some")},
+			request: request{paths: Paths{NewPrefix("/some")}},
 			path:    "/some/path",
 			want:    true,
 		},
 		{
 			name:    "path-prefix mismatch",
-			request: request{path: NewPrefix("/some")},
+			request: request{paths: Paths{NewPrefix("/some")}},
 			path:    "/other/path",
 			want:    false,
 		},
 		{
 			name:    "path-regex",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}},
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}},
 			path:    "/some/path",
 			want:    true,
 		},
 		{
 			name:    "path-regex mismatch",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}},
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}},
 			path:    "/some/road",
 			want:    false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, tt.request.Matches(tt.path, tt.headers), "Matches(%v, %v)", tt.path, tt.headers)
+			assert.Equalf(t, tt.want, tt.request.MatchesPathAndHeader(tt.path, tt.headers), "Matches(%v, %v)", tt.path, tt.headers)
 		})
 	}
 }
@@ -179,32 +175,42 @@ func Test_request_String(t *testing.T) {
 	}{
 		{
 			name: "empty",
-			want: "all requests",
+			want: "all TCP connections",
 		},
 		{
 			name:    "path-equal",
-			request: request{path: NewEqual("/some/path")},
-			want:    "requests with path == /some/path",
+			request: request{paths: Paths{NewEqual("/some/path")}},
+			want:    "HTTP requests with path == /some/path",
 		},
 		{
 			name:    "path-prefix",
-			request: request{path: NewPrefix("/some/path")},
-			want:    "requests with path prefix /some/path",
+			request: request{paths: Paths{NewPrefix("/some/path")}},
+			want:    "HTTP requests with path prefix /some/path",
 		},
 		{
-			name:    "path-equal",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}},
-			want:    "requests with path =~ .*/path",
+			name:    "path-regex",
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}},
+			want:    "HTTP requests with path =~ .*/path",
 		},
 		{
 			name:    "headers",
 			request: request{headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
-			want:    "requests with headers\n  'A: b'",
+			want:    "HTTP requests with header 'A: b'",
+		},
+		{
+			name:    "path and header",
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
+			want:    "HTTP requests with path =~ .*/path and header 'A: b'",
 		},
 		{
 			name:    "path and headers",
-			request: request{path: rxValue{regexp.MustCompile(".*/path")}, headers: HeaderMap(map[string]Value{"A": NewEqual("b")})},
-			want:    "requests with\n  path =~ .*/path\n  headers\n    'A: b'",
+			request: request{paths: Paths{rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b"), "B": NewEqual("c")})},
+			want:    "HTTP requests with\n path =~ .*/path\n headers\n  'A: b'\n  'B: c'",
+		},
+		{
+			name:    "paths and headers",
+			request: request{paths: Paths{NewPrefix("/some/path"), rxValue{regexp.MustCompile(".*/path")}}, headers: HeaderMap(map[string]Value{"A": NewEqual("b"), "B": NewEqual("c")})},
+			want:    "HTTP requests with\n paths\n  prefix /some/path\n  =~ .*/path\n headers\n  'A: b'\n  'B: c'",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/matcher/value.go
+++ b/pkg/matcher/value.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+type ValueOp string
+
+const (
+	ValueOpEqual  ValueOp = "=="
+	ValueOpRegex  ValueOp = "=~"
+	ValueOpPrefix ValueOp = "prefix"
+)
+
 // Value comes in three flavors. One that performs an exact match against a string, one that
 // uses a regular expression, and one that uses prefix matching.
 type Value interface {
@@ -15,7 +23,7 @@ type Value interface {
 	Matches(value string) bool
 
 	// Op returns either ==, =~, or prefix
-	Op() string
+	Op() ValueOp
 }
 
 type textValue string
@@ -28,8 +36,8 @@ func (t textValue) String() string {
 	return string(t)
 }
 
-func (t textValue) Op() string {
-	return "=="
+func (t textValue) Op() ValueOp {
+	return ValueOpEqual
 }
 
 type rxValue struct {
@@ -40,8 +48,8 @@ func (r rxValue) Matches(value string) bool {
 	return value != "" && r.MatchString(value)
 }
 
-func (r rxValue) Op() string {
-	return "=~"
+func (r rxValue) Op() ValueOp {
+	return ValueOpRegex
 }
 
 type prefixValue string
@@ -54,28 +62,41 @@ func (p prefixValue) String() string {
 	return string(p)
 }
 
-func (p prefixValue) Op() string {
-	return "prefix"
+func (p prefixValue) Op() ValueOp {
+	return ValueOpPrefix
 }
 
 // NewValue returns a Value that is either an exact or a regexp matcher. The latter is chosen
-// when the given string contains regexp meta characters. An error is returned if the string contains
-// meta characters but cannot be compiled into a regexp.
-func NewValue(v string) (Value, error) {
+// when the given string contains regexp meta-characters.
+func NewValue(v string) Value {
 	if regexp.QuoteMeta(v) == v {
-		return NewEqual(v), nil
+		return NewEqual(v)
 	}
 	return NewRegex(v)
 }
 
-// NewRegex returns a Value that is a regexp matcher. An error is returned if the string cannot be
+// NewOpValue returns a Value that is a matcher of the given type. If the given type is not
+// supported, an exact matcher is returned.
+func NewOpValue(op ValueOp, v string) Value {
+	switch op {
+	case ValueOpRegex:
+		return NewRegex(v)
+	case ValueOpPrefix:
+		return NewPrefix(v)
+	default:
+		return NewEqual(v)
+	}
+}
+
+// NewRegex returns a Value that is a regexp matcher. Returns an exact value if the string cannot be
 // compiled into a regexp.
-func NewRegex(v string) (Value, error) {
+func NewRegex(v string) Value {
 	rx, err := regexp.Compile(v)
 	if err != nil {
-		return nil, err
+		// Treat an invalid regexp as an exact match
+		return NewEqual(v)
 	}
-	return rxValue{rx}, nil
+	return rxValue{rx}
 }
 
 // NewPrefix returns a Value that is a prefix matcher.


### PR DESCRIPTION
This PR aims to consolidate some functionality that was somewhat scattered before, due to the fact that all HTTP-filtering was implemented in the proprietary version of the traffic-agent. Thanks to some significant contributions from @bgruszka that's no longer the case.

This PR has three main commits:
1. Improve the `matcher` package so that it handles multiple path filters, and improve how it outputs the string version of a filter.
2. Ensure that the `macher` package is used everywhere so that filters are handled uniformly.
3. Fix the RESTful API endpoint so that it recognizes http-filtered intercepts.

I've tested the RESTful API manually and I plan to add integration tests for it in a separate PR, but maybe after the release of the much anticipated 2.25.0 containing the HTTP-filters.