### PR TITLE
Propagate agent-config annotation using a volume instead of env.

### DIFF
--- a/cmd/traffic/cmd/agent/config.go
+++ b/cmd/traffic/cmd/agent/config.go
@@ -8,12 +8,15 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/go-json-experiment/json"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
@@ -21,6 +24,7 @@ import (
 
 type Config interface {
 	AgentConfig() *agentconfig.Sidecar
+	Annotations() map[string]string
 	HasRemoteMounts() bool
 	PodName() string
 	PodIP() netip.Addr
@@ -28,20 +32,37 @@ type Config interface {
 }
 
 type config struct {
-	sidecar *agentconfig.Sidecar
-	podName string
-	podIP   netip.Addr
-	podUID  k8sTypes.UID
+	sidecar     *agentconfig.Sidecar
+	annotations map[string]string
+	podName     string
+	podIP       netip.Addr
+	podUID      k8sTypes.UID
 }
 
 func LoadConfig(ctx context.Context) (Config, error) {
-	cfgTight, ok := dos.LookupEnv(ctx, agentconfig.EnvAgentConfig)
+	var cfgTight string
+	var ok bool
+	c := config{}
+
+	annFile := filepath.Join(agentconfig.PodInfoMountPath, "annotations")
+	annData, err := dos.ReadFile(ctx, annFile)
+	if err != nil {
+		// Was an older traffic-manager in charge of injecting this agent so that the config can be found from the environment?
+		dlog.Warnf(ctx, "Unable to read annotations from %s: %v", annFile, err)
+		dlog.Warnf(ctx, "Loading agent config from env %s", agentconfig.EnvAgentConfig)
+		cfgTight, ok = dos.LookupEnv(ctx, agentconfig.EnvAgentConfig)
+	} else {
+		dlog.Infof(ctx, "Loading agent config from %s", annFile)
+		c.annotations, err = readMap(string(annData))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse annotations from %s: %v", annFile, err)
+		}
+		cfgTight, ok = c.annotations[annotation.Config]
+	}
 	if !ok {
-		return nil, errors.New("unable to retrieve agent ConfigMap entry")
+		return nil, errors.New("unable to retrieve agent config")
 	}
 
-	var err error
-	c := config{}
 	c.sidecar, err = agentconfig.UnmarshalJSON(cfgTight)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode agent ConfigMap: %w", err)
@@ -95,6 +116,10 @@ func (c *config) HasRemoteMounts() bool {
 		}
 	}
 	return false
+}
+
+func (c *config) Annotations() map[string]string {
+	return c.annotations
 }
 
 func (c *config) AgentConfig() *agentconfig.Sidecar {
@@ -222,4 +247,21 @@ func mountVRS(ctx context.Context, mps types.MountPolicies, ag *agentconfig.Cont
 		}
 	}
 	return nil
+}
+
+// readMap parses a multi-line string into a map[string]string. Each line is assumed to be in the form "key=value",
+// where the value is a JSON-encoded string.
+func readMap(annData string) (map[string]string, error) {
+	lines := strings.Split(annData, "\n")
+	anns := make(map[string]string, len(lines))
+	for _, line := range lines {
+		if i := strings.IndexByte(line, '='); i > 0 {
+			var st string
+			if err := json.Unmarshal([]byte(line[i+1:]), &st); err != nil {
+				return nil, err
+			}
+			anns[strings.TrimSpace(line[:i])] = st
+		}
+	}
+	return anns, nil
 }

--- a/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector_test.go
@@ -1182,11 +1182,6 @@ matchExpressions:
     env:
     - name: _TEL_APP_A_SOME_NAME
       value: some value
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1215,6 +1210,8 @@ matchExpressions:
         - /tmp/agent/ready
     resources: {}
     volumeMounts:
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
@@ -1222,6 +1219,12 @@ matchExpressions:
 - op: replace
   path: /spec/volumes
   value:
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
   - emptyDir: {}
     name: export-volume
   - emptyDir: {}
@@ -1272,11 +1275,6 @@ matchExpressions:
     env:
     - name: TELEPRESENCE_API_PORT
       value: "9981"
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1305,6 +1303,8 @@ matchExpressions:
         - /tmp/agent/ready
     resources: {}
     volumeMounts:
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
@@ -1312,6 +1312,12 @@ matchExpressions:
 - op: replace
   path: /spec/volumes
   value:
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
   - emptyDir: {}
     name: export-volume
   - emptyDir: {}
@@ -1417,11 +1423,6 @@ matchExpressions:
     args:
     - agent
     env:
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1450,6 +1451,8 @@ matchExpressions:
         - /tmp/agent/ready
     resources: {}
     volumeMounts:
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
@@ -1457,6 +1460,12 @@ matchExpressions:
 - op: replace
   path: /spec/volumes
   value:
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
   - emptyDir: {}
     name: export-volume
   - emptyDir: {}
@@ -1526,11 +1535,6 @@ matchExpressions:
     args:
     - agent
     env:
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1558,6 +1562,8 @@ matchExpressions:
         - /tmp/agent/ready
     resources: {}
     volumeMounts:
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
@@ -1565,6 +1571,12 @@ matchExpressions:
 - op: replace
   path: /spec/volumes
   value:
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
   - emptyDir: {}
     name: export-volume
   - emptyDir: {}
@@ -1634,11 +1646,6 @@ matchExpressions:
     args:
     - agent
     env:
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1666,6 +1673,8 @@ matchExpressions:
         - /tmp/agent/ready
     resources: {}
     volumeMounts:
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
@@ -1673,6 +1682,12 @@ matchExpressions:
 - op: replace
   path: /spec/volumes
   value:
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
   - emptyDir: {}
     name: export-volume
   - emptyDir: {}
@@ -1736,15 +1751,6 @@ matchExpressions:
 								Name: "LOG_LEVEL",
 							},
 							{
-								Name: "AGENT_CONFIG",
-								ValueFrom: &core.EnvVarSource{
-									FieldRef: &core.ObjectFieldSelector{
-										APIVersion: "v1",
-										FieldPath:  "metadata.annotations['telepresence.io/agent-config']",
-									},
-								},
-							},
-							{
 								Name: "POD_IP",
 								ValueFrom: &core.EnvVarSource{
 									FieldRef: &core.ObjectFieldSelector{
@@ -1778,15 +1784,6 @@ matchExpressions:
 							EnvFrom: nil,
 							Env: []core.EnvVar{
 								{
-									Name: "AGENT_CONFIG",
-									ValueFrom: &core.EnvVarSource{
-										FieldRef: &core.ObjectFieldSelector{
-											APIVersion: "v1",
-											FieldPath:  "metadata.annotations['telepresence.io/agent-config']",
-										},
-									},
-								},
-								{
 									Name: "_TEL_AGENT_POD_IP",
 									ValueFrom: &core.EnvVarSource{
 										FieldRef: &core.ObjectFieldSelector{
@@ -1819,12 +1816,16 @@ matchExpressions:
 							TerminationMessagePolicy: "File",
 							VolumeMounts: []core.VolumeMount{
 								{
+									Name:      agentconfig.PodInfoVolumeName,
+									MountPath: agentconfig.PodInfoMountPath,
+								},
+								{
 									Name:      agentconfig.ExportsVolumeName,
-									MountPath: "/tel_app_exports",
+									MountPath: agentconfig.ExportsMountPoint,
 								},
 								{
 									Name:      agentconfig.TempVolumeName,
-									MountPath: "/tmp",
+									MountPath: agentconfig.TempMountPoint,
 								},
 							},
 							ReadinessProbe: &core.Probe{
@@ -1914,11 +1915,6 @@ matchExpressions:
       value: default-secret-name
     - name: _TEL_APP_A_BOTH_NAMES
       value: $(_TEL_APP_A_TOKEN_VOLUME) and $(_TEL_APP_A_SECRET_NAME)
-    - name: AGENT_CONFIG
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.annotations['telepresence.io/agent-config']
     - name: _TEL_AGENT_POD_IP
       valueFrom:
         fieldRef:
@@ -1950,10 +1946,21 @@ matchExpressions:
     - mountPath: /tel_app_mounts/some-container/var/run/secrets/kubernetes.io/serviceaccount
       name: $(_TEL_APP_A_TOKEN_VOLUME)
       readOnly: true
+    - mountPath: /etc/podinfo
+      name: pod-info
     - mountPath: /tel_app_exports
       name: export-volume
     - mountPath: /tmp
       name: tel-agent-tmp
+- op: add
+  path: /spec/volumes/-
+  value:
+    downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.annotations
+        path: annotations
+    name: pod-info
 - op: add
   path: /spec/volumes/-
   value:

--- a/integration_test/itest/apply_app.go
+++ b/integration_test/itest/apply_app.go
@@ -76,7 +76,7 @@ type AppData struct {
 func ApplyAppTemplate(ctx context.Context, namespace string, app *AppData) {
 	t := getT(ctx)
 	t.Helper()
-	r, err := OpenTemplate(WithWorkingDir(ctx, filepath.Join(GetOSSRoot(ctx), "testdata", "k8s")), "svc-deploy.goyaml", app)
+	r, err := OpenTemplate(ctx, filepath.Join(GetOSSRoot(ctx), "testdata", "k8s", "svc-deploy.goyaml"), app)
 	require.NoError(t, err)
 	require.NoError(t, Kubectl(dos.WithStdin(ctx, r), namespace, "apply", "-f", "-"), "failed to apply template")
 	wl := app.DeploymentName

--- a/integration_test/itest/namespace.go
+++ b/integration_test/itest/namespace.go
@@ -104,7 +104,7 @@ func (s *nsPair) setup(ctx context.Context) bool {
 	}
 	err := Kubectl(ctx, s.Namespace, "apply", "-f", filepath.Join(GetOSSRoot(ctx), "testdata", "k8s", "client_sa.yaml"))
 	if assert.NoError(t, err, "failed to create connect ServiceAccount") {
-		db, err := ReadTemplate(ctx, filepath.Join("testdata", "k8s", "client_rancher.goyaml"), map[string]string{
+		db, err := ReadTemplate(ctx, filepath.Join(GetOSSRoot(ctx), "testdata", "k8s", "client_rancher.goyaml"), map[string]string{
 			"ManagerNamespace": s.Namespace,
 		})
 		if assert.NoError(t, err) {

--- a/integration_test/itest/template.go
+++ b/integration_test/itest/template.go
@@ -101,23 +101,23 @@ type DisruptionBudget struct {
 	MaxUnavailable int
 }
 
-func OpenTemplate(ctx context.Context, name string, data any) (io.Reader, error) {
-	b, err := ReadTemplate(ctx, name, data)
+func OpenTemplate(ctx context.Context, path string, data any) (io.Reader, error) {
+	b, err := ReadTemplate(ctx, path, data)
 	if err != nil {
 		return nil, err
 	}
 	return bytes.NewReader(b), nil
 }
 
-func ReadTemplate(ctx context.Context, name string, data any) ([]byte, error) {
+func ReadTemplate(ctx context.Context, path string, data any) ([]byte, error) {
 	fnMap := sprig.FuncMap()
 	fnMap["toYaml"] = toYAML
-	tpl, err := template.New("").Funcs(fnMap).ParseFiles(filepath.Join(GetWorkingDir(ctx), name))
+	tpl, err := template.New("").Funcs(fnMap).ParseFiles(path)
 	if err != nil {
 		return nil, err
 	}
 	wr := bytes.Buffer{}
-	if err = tpl.ExecuteTemplate(&wr, filepath.Base(name), data); err != nil {
+	if err = tpl.ExecuteTemplate(&wr, filepath.Base(path), data); err != nil {
 		return nil, err
 	}
 	return wr.Bytes(), nil

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -2,7 +2,6 @@ package agentconfig
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -83,15 +82,6 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 	}
 	evs = append(evs,
 		core.EnvVar{
-			Name: "AGENT_CONFIG",
-			ValueFrom: &core.EnvVarSource{
-				FieldRef: &core.ObjectFieldSelector{
-					APIVersion: "v1",
-					FieldPath:  fmt.Sprintf("metadata.annotations['%s']", annotation.Config),
-				},
-			},
-		},
-		core.EnvVar{
 			Name: EnvPrefixAgent + "POD_IP",
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
@@ -124,6 +114,10 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 		mounts = a.appendVolumeMounts(app, cc, mounts)
 	})
 	mounts = append(mounts,
+		core.VolumeMount{
+			Name:      PodInfoVolumeName,
+			MountPath: PodInfoMountPath,
+		},
 		core.VolumeMount{
 			Name:      ExportsVolumeName,
 			MountPath: ExportsMountPoint,

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -25,6 +25,8 @@ const (
 	EnvPrefix         = "_TEL_"
 	EnvPrefixAgent    = EnvPrefix + "AGENT_"
 	EnvPrefixApp      = EnvPrefix + "APP_"
+	PodInfoVolumeName = "pod-info"
+	PodInfoMountPath  = "/etc/podinfo"
 
 	// EnvAgentConfig is the environment variable where the traffic-agent finds its own config.
 	EnvAgentConfig = "AGENT_CONFIG"

--- a/pkg/agentconfig/volumes.go
+++ b/pkg/agentconfig/volumes.go
@@ -11,6 +11,22 @@ import (
 func AgentVolumes(string, *core.Pod) []core.Volume {
 	volumes := []core.Volume{
 		{
+			Name: PodInfoVolumeName,
+			VolumeSource: core.VolumeSource{
+				DownwardAPI: &core.DownwardAPIVolumeSource{
+					Items: []core.DownwardAPIVolumeFile{
+						{
+							Path: "annotations",
+							FieldRef: &core.ObjectFieldSelector{
+								FieldPath: "metadata.annotations",
+							},
+						},
+					},
+					DefaultMode: nil,
+				},
+			},
+		},
+		{
 			Name: ExportsVolumeName,
 			VolumeSource: core.VolumeSource{
 				EmptyDir: &core.EmptyDirVolumeSource{},


### PR DESCRIPTION
The traffic-agent container will get its annotations via a downward-api volume instead of a downward-api env. This produces less clutter in the pod's environment and is also more flexible given that the traffic-agent can see all annotations instead of just one.