### PR TITLE
Allow regex support for http header

### DIFF
--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -101,7 +102,12 @@ func pathsCanMatch(filter1, filter2 string) bool {
 	return valuesCanMatch(matcher.PathValue(filter1), matcher.PathValue(filter2))
 }
 
-// valuesCanMatch determines if two matcher.Values can match the same string value.
+// valuesCanMatch determines if two matcher.Value objects could potentially match the same input.
+// It is used to detect conflicts between intercept path filters.
+// Supported operations: Equal, Prefix, Regex.
+//
+// The logic ensures that overlapping or equivalent patterns (e.g., /api/* vs /api/v1/*)
+// are treated as conflicts, while unrelated ones (e.g., /api/v1/* vs /api/v2/*) are not.
 func valuesCanMatch(v1, v2 matcher.Value) bool {
 	op1 := v1.Op()
 	op2 := v2.Op()
@@ -114,7 +120,7 @@ func valuesCanMatch(v1, v2 matcher.Value) bool {
 		return pattern1 == pattern2
 
 	case op1 == matcher.ValueOpPrefix && op2 == matcher.ValueOpPrefix:
-		// Both prefixes - conflict if one is prefix of the other
+		// Both are prefixes - conflict if one is prefix of the other
 		return strings.HasPrefix(pattern1, pattern2) || strings.HasPrefix(pattern2, pattern1)
 
 	case op1 == matcher.ValueOpPrefix && op2 == matcher.ValueOpEqual:
@@ -124,11 +130,98 @@ func valuesCanMatch(v1, v2 matcher.Value) bool {
 	case op1 == matcher.ValueOpEqual && op2 == matcher.ValueOpPrefix:
 		// Exact value matches prefix if it starts with the prefix
 		return strings.HasPrefix(pattern1, pattern2)
+
+	case op1 == matcher.ValueOpRegex && op2 == matcher.ValueOpRegex:
+		// --- Regex vs Regex ---
+		if pattern1 == pattern2 {
+			return true
+		}
+
+		anchored1 := strings.HasPrefix(pattern1, "^")
+		anchored2 := strings.HasPrefix(pattern2, "^")
+
+		prefix1 := regexLiteralPrefix(pattern1)
+		prefix2 := regexLiteralPrefix(pattern2)
+
+		// Both anchored → only overlap if one is prefix of the other
+		if anchored1 && anchored2 {
+			return strings.HasPrefix(prefix1, prefix2) || strings.HasPrefix(prefix2, prefix1)
+		}
+		// Fallback conservative
+		return true
+
+	case op1 == matcher.ValueOpRegex && (op2 == matcher.ValueOpEqual || op2 == matcher.ValueOpPrefix):
+		return regexCanMatchValue(pattern1, op2, pattern2)
+
+	case op2 == matcher.ValueOpRegex && (op1 == matcher.ValueOpEqual || op1 == matcher.ValueOpPrefix):
+		return regexCanMatchValue(pattern2, op1, pattern1)
 	}
 
-	// Conservative: assume regexes can overlap
-	// Proper regex intersection is computationally expensive
+	// Fallback: conservatively assume potential match
 	return true
+}
+
+// regexCanMatchValue checks if a regex could match an equal or prefix value.
+// Conservative: returns true if regex is invalid or overlap can't be ruled out.
+func regexCanMatchValue(regexPattern string, op matcher.ValueOp, value string) bool {
+	if value == "" {
+		return true
+	}
+
+	anchored := strings.HasPrefix(regexPattern, "^")
+
+	switch op {
+	case matcher.ValueOpEqual:
+		if anchored {
+			re, err := regexp.Compile(regexPattern)
+			if err != nil {
+				return true // invalid regex → assume conflict
+			}
+			return re.MatchString(value)
+		}
+		// Unanchored regex → can match anywhere in the string
+		return true
+
+	case matcher.ValueOpPrefix:
+		if anchored {
+			// Anchored regex → behaves like HasPrefix using literal prefix
+			prefix := regexLiteralPrefix(regexPattern)
+			if prefix == "" {
+				return true
+			}
+			return strings.HasPrefix(value, prefix) || strings.HasPrefix(prefix, value)
+		}
+
+		// Unanchored regex → can match anywhere in the string
+		return true
+	}
+	// fallback
+	return true
+}
+
+// regexLiteralPrefix safely extracts a literal prefix from a regex pattern.
+// Stops at first regex metacharacter. Conservative for complex regexes.
+func regexLiteralPrefix(pattern string) string {
+	if pattern == "" {
+		return ""
+	}
+
+	// Remove leading '^' (safe: TrimPrefix is a no-op if not present)
+	pattern = strings.TrimPrefix(pattern, "^")
+
+	// Remove trailing '.*' (safe: TrimSuffix is a no-op if not present)
+	pattern = strings.TrimSuffix(pattern, ".*")
+
+	var prefix strings.Builder
+	for _, r := range pattern {
+		// Stop at any regex metacharacter
+		if strings.ContainsRune("[](){}?+*|$.\\^", r) {
+			break
+		}
+		prefix.WriteRune(r)
+	}
+
+	return prefix.String()
 }
 
 // explainConflict generates a human-readable explanation of why two intercept specs conflict.

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -491,7 +491,7 @@ func TestInterceptSpecsConflict(t *testing.T) {
 			conflicts: false,
 		},
 		{
-			name: "Path regex - :path-regex: always conflicts conservatively",
+			name: "Path regex - :path-regex: should not conflict (distinct paths)",
 			spec1: &manager.InterceptSpec{
 				Mechanism:   "http",
 				PathFilters: []string{":path-regex:^/api/.*$"},
@@ -499,6 +499,446 @@ func TestInterceptSpecsConflict(t *testing.T) {
 			spec2: &manager.InterceptSpec{
 				Mechanism:   "http",
 				PathFilters: []string{":path-prefix:/admin/"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex vs Regex with same prefix - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v1/.*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs Regex with same prefix - non-anchor- should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api/v2/.*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs Regex with different prefix - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/admin/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/.*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex vs Exact with same value - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/health$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-equal:/health"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs Exact with different value - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/health$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-equal:/ready"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex vs Prefix with overlapping prefix - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v1/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs Prefix with non-overlapping prefix - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/admin/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/api/"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex vs Regex with exact equality pattern - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/status$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/status$"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs Regex with different exact patterns - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/status$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/health$"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Header regex - identical wildcard patterns should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam::.*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - identical wildcard patterns should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "^adam::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam::.*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - patterns with common suffix should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "^adam::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "bertil::adam::.*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - different prefixes in wildcard should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "^adam::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "^bertil::.*",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Header regex - different prefixes in wildcard should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "adam::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "bertil::.*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - overlapping wildcard patterns should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-env": "stage::[a-z]+",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-env": "stage::.*",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - one wildcard, one static exact value should conflict if regex includes it",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "prod::[a-z]+",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "prod::admin",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - non-overlapping static and wildcard should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::[0-9]+",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "prod::[a-z]+",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - different header keys should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::.*",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-env": "stage::.*",
+				},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Header regex - one regex fully includes another (subset overlap)",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::(admin|test)",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::admin",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Header regex - disjoint sets in alternation should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::(qa|test)",
+				},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism: "http",
+				HeaderFilters: map[string]string{
+					"x-user": "dev::prod",
+				},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex literal prefix with escaped dot - should detect same literal prefix",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v1\\.users/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v1\\.users/details.*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex literal prefix with escaped plus - should conflict due to same base literal",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/foo\\+bar/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/foo\\+bar/v1.*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex with group starts early - should NOT conflict if literal diverges before '('",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/(v1|v2)/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/admin/(v1|v2)/.*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex with nested group but same prefix - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/(v1|v2)/users.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/(v1|v2)/orders.*"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex with character class in middle - should conflict if literal prefix matches",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/user_[a-z]+/details"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/user_[0-9]+/settings"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex with non-overlapping prefixes - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/serviceA/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/serviceB/.*"},
+			},
+			conflicts: false,
+		},
+		{
+			name: "Regex with trailing literal only - should conflict if same literal",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api/v1/resource$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/api/v1/resource$"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex without ^ or .* but same base literal - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/foo/bar"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/foo/bar/v1"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex with escaped parentheses - same literal should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/file\\(test\\)/.*"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/file\\(test\\)/v1"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex with trailing $ anchor and identical literal - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:^/health$"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/health$"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs different Regex - non-anchored - should not conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/foo"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs different Prefix - non-anchored - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api/"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-prefix:/foo/api/"},
+			},
+			conflicts: true,
+		},
+		{
+			name: "Regex vs overlapping Regex - non-anchored - should conflict",
+			spec1: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/api/"},
+			},
+			spec2: &manager.InterceptSpec{
+				Mechanism:   "http",
+				PathFilters: []string{":path-regex:/foo/api/"},
 			},
 			conflicts: true,
 		},


### PR DESCRIPTION
 Regular expression support for http header

Issue: if one user one uses --http-header x-intercept-id: some-name::.* , then if another tries using --http-header with the same key 'x-intercept-id' , it  wouldn't allow. 

Fix: This change reduces false positives, assuming most different regexes won't match the same input.
Returns true by default, meaning assumes possible match/conflict unless proven otherwise.

This is very conservative, especially about regexes.