### PR TITLE
Improved efficiency of traffic manager map updates.

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Compatibility with older manager and agent
         if:  ${{ github.event.label.name == 'compatibility test' }}
         env:
-          DEV_MANAGER_VERSION: "2.23.6"
+          DEV_MANAGER_VERSION: "2.24.1"
         uses: nick-fields/retry/@v3
         with:
           max_attempts: 3
@@ -120,7 +120,7 @@ jobs:
       - name: Compatibility with older client
         if:  ${{ github.event.label.name == 'compatibility test' }}
         env:
-          DEV_CLIENT_VERSION: "2.23.6"
+          DEV_CLIENT_VERSION: "2.24.1"
         uses: nick-fields/retry/@v3
         with:
           max_attempts: 3

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -39,6 +39,13 @@ items:
           The Traffic Agent now has a new configuration option `agent.enableH2cProbing` that can be set to `false` to disable the
           HTTP2/Clear-Text probing. The default setting is `true` to preserve backwards compatibility, but this will be changed to `false`
           in a future release.
+      - type: feature
+        title: Improved efficiency of traffic manager map updates.
+        body: >-
+          The watchable map has been refactored into a client/server model that supports delta-based updates. Where supported, gRPC now
+          transmits only incremental changes instead of full snapshots, significantly reducing payload sizes. This improvement is especially
+          important for large clusters, where full snapshots can be sizable and costly to transmit. Full snapshot streaming remains
+          available as a backward-compatible fallback for clients that do not support delta methods.
   - version: 2.25.2
     date: 2025-12-26
     notes:

--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
 
 type interceptsStringer []*rpc.InterceptInfo
@@ -113,7 +114,7 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 	wg.Go("logLevelWatch", func(ctx context.Context) error {
 		return logLevelWatchLoop(ctx, manager)
 	})
-	snapshots := make(chan *rpc.InterceptInfoSnapshot)
+	snapshots := make(chan []*rpc.InterceptInfo)
 	wg.Go("interceptWatch", func(ctx context.Context) error {
 		return interceptWatchLoop(ctx, manager, session, info, snapshots)
 	})
@@ -150,23 +151,38 @@ func logLevelWatchLoop(ctx context.Context, manager rpc.ManagerClient) error {
 	)
 }
 
-func interceptWatchLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.SessionInfo, info *rpc.AgentInfo, snapshots chan<- *rpc.InterceptInfoSnapshot) error {
-	// Call WatchIntercepts and publish the snapshots on the channel
-	return watcher.WatchWithRetry(ctx, "WatchIntercepts", watchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[rpc.InterceptInfoSnapshot], error) {
-			return manager.WatchIntercepts(ctx, session)
-		},
-		func(snapshot *rpc.InterceptInfoSnapshot) error {
-			snapshots <- snapshot
-			return nil
-		},
-		func() error {
-			_, err := manager.ReconnectAgent(ctx, &rpc.ReconnectAgentRequest{
-				Session: session,
-				Agent:   info,
-			})
-			return err
+func interceptWatchLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.SessionInfo, info *rpc.AgentInfo, snapshots chan<- []*rpc.InterceptInfo) error {
+	reconnectAgent := func() error {
+		_, err := manager.ReconnectAgent(ctx, &rpc.ReconnectAgentRequest{
+			Session: session,
+			Agent:   info,
 		})
+		return err
+	}
+	// Call WatchIntercepts and publish the snapshots on the channel
+	snapMap := make(map[string]*rpc.InterceptInfo)
+	err := watcher.WatchWithRetry(ctx, "WatchInterceptsDelta", watchRetryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[rpc.InterceptInfoDelta], error) {
+			return manager.WatchInterceptsDelta(ctx, session)
+		},
+		func(delta *rpc.InterceptInfoDelta) error {
+			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
+			snapshots <- maps.Values(snapMap)
+			return nil
+		}, reconnectAgent)
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		// Fall back to streaming all intercepts if the traffic manager doesn't support delta updates.'
+		dlog.Warnf(ctx, "WatchInterceptsDelta is not implemented by the traffic-manager, falling back to WatchIntercepts and full snapshots")
+		err = watcher.WatchWithRetry(ctx, "WatchIntercepts", watchRetryInterval,
+			func(ctx context.Context) (grpc.ServerStreamingClient[rpc.InterceptInfoSnapshot], error) {
+				return manager.WatchIntercepts(ctx, session)
+			},
+			func(snapshot *rpc.InterceptInfoSnapshot) error {
+				snapshots <- snapshot.Intercepts
+				return nil
+			}, reconnectAgent)
+	}
+	return err
 }
 
 func remainLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.SessionInfo) error {
@@ -186,14 +202,14 @@ func remainLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.Ses
 	}
 }
 
-func handleInterceptLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.SessionInfo, snapshots <-chan *rpc.InterceptInfoSnapshot, state State) error {
+func handleInterceptLoop(ctx context.Context, manager rpc.ManagerClient, session *rpc.SessionInfo, snapshots <-chan []*rpc.InterceptInfo, state State) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case snapshot := <-snapshots:
-			dlog.Debugf(ctx, "HandleIntercepts %s", interceptsStringer(snapshot.Intercepts))
-			reviews := state.HandleIntercepts(ctx, snapshot.Intercepts)
+			dlog.Debugf(ctx, "HandleIntercepts %s", interceptsStringer(snapshot))
+			reviews := state.HandleIntercepts(ctx, snapshot)
 			for _, review := range reviews {
 				review.Session = session
 				if _, err := manager.ReviewIntercept(ctx, review); err != nil {

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -440,65 +442,63 @@ func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_Wa
 		return err
 	}
 
-	var interceptInfos map[string]*state.Intercept
+	agentSessions := cache.NewClientMap[tunnel.SessionID, *state.AgentSession]()
+
+	interceptInfos := cache.NewClientMap[string, *state.Intercept]()
 	isIntercepted := func(a *rpc.AgentPodInfo) bool {
-		for _, ii := range interceptInfos {
+		found := false
+		interceptInfos.Range(func(id string, ii *state.Intercept) bool {
 			if a.WorkloadName == ii.Spec.Agent && a.Namespace == ii.Spec.Namespace {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+
+	lock := sync.Mutex{}
+	var lastAgents []*rpc.AgentPodInfo
+
+	onChanged := func() (err error) {
+		lock.Lock()
+		defer lock.Unlock()
+		m := mutator.GetMap(ctx)
+		agents := make([]*rpc.AgentPodInfo, 0, agentSessions.Size())
+		agentNames := make([]string, 0, agentSessions.Size())
+		agentSessions.Range(func(id tunnel.SessionID, a *state.AgentSession) bool {
+			if m.IsInactive(types.UID(a.PodUid)) {
 				return true
 			}
-		}
-		return false
-	}
-	m := mutator.GetMap(ctx)
-	var agents []*rpc.AgentPodInfo
-	var agentNames []string
-	for {
-		select {
-		case <-sessionDone:
-			// Manager believes this session has ended.
-			return nil
-		case agm, ok := <-agentsCh:
-			if !ok {
-				return nil
+			aip, parseErr := netip.ParseAddr(a.PodIp)
+			if parseErr != nil {
+				dlog.Errorf(ctx, "error parsing agent pod ip %q: %v", a.PodIp, parseErr)
 			}
-			agents = make([]*rpc.AgentPodInfo, 0, len(agm))
-			agentNames = make([]string, 0, len(agm))
-			for _, a := range agm {
-				if m.IsInactive(types.UID(a.PodUid)) {
-					continue
-				}
-				aip, err := netip.ParseAddr(a.PodIp)
-				if err != nil {
-					dlog.Errorf(ctx, "error parsing agent pod ip %q: %v", a.PodIp, err)
-				}
-				ap := &rpc.AgentPodInfo{
-					WorkloadName: a.Name,
-					PodId:        a.PodUid,
-					PodName:      a.PodName,
-					Namespace:    a.Namespace,
-					PodIp:        aip.AsSlice(),
-					ApiPort:      a.ApiPort,
-				}
-				ap.Intercepted = isIntercepted(ap)
-				agents = append(agents, ap)
-				agentNames = append(agentNames, fmt.Sprintf("%s(%s)", ap.PodName, net.IP(ap.PodIp)))
+			ap := &rpc.AgentPodInfo{
+				WorkloadName: a.Name,
+				PodId:        a.PodUid,
+				PodName:      a.PodName,
+				Namespace:    a.Namespace,
+				PodIp:        aip.AsSlice(),
+				ApiPort:      a.ApiPort,
 			}
-		case is, ok := <-interceptsCh:
-			if !ok {
-				return nil
-			}
-			interceptInfos = is
-			for _, ap := range agents {
-				ap.Intercepted = isIntercepted(ap)
-			}
-		}
-		if agents != nil {
+			ap.Intercepted = isIntercepted(ap)
+			agents = append(agents, ap)
+			agentNames = append(agentNames, fmt.Sprintf("%s(%s)", ap.PodName, net.IP(ap.PodIp)))
+			return true
+		})
+		if !slices.Equal(lastAgents, agents) {
+			lastAgents = agents
 			dlog.Debugf(ctx, "Sending update for %s", agentNames)
-			if err = stream.Send(&rpc.AgentPodInfoSnapshot{Agents: agents}); err != nil {
-				return err
-			}
+			err = stream.Send(&rpc.AgentPodInfoSnapshot{Agents: agents})
 		}
+		return err
 	}
+
+	go func() {
+		_ = interceptInfos.Watch(sessionDone, interceptsCh, onChanged)
+	}()
+	return agentSessions.Watch(sessionDone, agentsCh, onChanged)
 }
 
 // WatchAgents notifies a client of the set of known Agents in the connected namespace.
@@ -543,60 +543,51 @@ func infosEqual(a, b *rpc.AgentInfo) bool {
 }
 
 func (s *service) watchAgents(ctx context.Context, includeAgent func(tunnel.SessionID, *state.AgentSession) bool, stream rpc.Manager_WatchAgentsServer) error {
-	snapshotCh := s.state.WatchAgents(ctx, includeAgent)
+	deltaCh := s.state.WatchAgents(ctx, includeAgent)
 	sessionDone, err := s.state.SessionDone(managerutil.GetSessionID(ctx))
 	if err != nil {
 		return err
 	}
-
+	snapshot := cache.NewClientMap[tunnel.SessionID, *state.AgentSession]()
 	// Ensure that the initial snapshot is not equal to lastSnap even if it is empty by
 	// creating a lastSnap with one nil entry.
 	lastSnap := make([]*rpc.AgentInfo, 1)
 
-	m := mutator.GetMap(ctx)
-	for {
-		select {
-		case snapshot, ok := <-snapshotCh:
-			if !ok {
-				// The request has been canceled.
-				dlog.Debug(ctx, "Request cancelled")
-				return nil
-			}
+	return snapshot.Watch(sessionDone, deltaCh, func() error {
+		m := mutator.GetMap(ctx)
 
-			// Sort snapshot by sessionID and discard inactive agents.
-			agentSessionIDs := slices.Sorted(maps.Keys(snapshot))
-			agents := make([]*rpc.AgentInfo, 0, len(agentSessionIDs))
-			for _, agentSessionID := range agentSessionIDs {
-				ag := snapshot[agentSessionID]
-				if !m.IsInactive(types.UID(ag.PodUid)) {
-					agents = append(agents, ag.AgentInfo)
-				}
+		// Sort snapshot by sessionID and discard inactive agents.
+		agentSessionIDs := make([]tunnel.SessionID, 0, snapshot.Size())
+		snapshot.Range(func(id tunnel.SessionID, _ *state.AgentSession) bool {
+			agentSessionIDs = append(agentSessionIDs, id)
+			return true
+		})
+		slices.Sort(agentSessionIDs)
+		agents := make([]*rpc.AgentInfo, 0, len(agentSessionIDs))
+		for _, agentSessionID := range agentSessionIDs {
+			ag, ok := snapshot.Load(agentSessionID)
+			if ok && !m.IsInactive(types.UID(ag.PodUid)) {
+				agents = append(agents, ag.AgentInfo)
 			}
-			if slices.EqualFunc(agents, lastSnap, infosEqual) {
-				continue
-			}
-			lastSnap = agents
-			if dlog.MaxLogLevel(ctx) >= dlog.LogLevelDebug {
-				names := make([]string, len(agents))
-				i := 0
-				for _, a := range agents {
-					names[i] = a.PodName + "." + a.Namespace
-					i++
-				}
-				dlog.Tracef(ctx, "Sending update %v", names)
-			}
-			resp := &rpc.AgentInfoSnapshot{
-				Agents: agents,
-			}
-			if err := stream.Send(resp); err != nil {
-				return err
-			}
-		case <-sessionDone:
-			// Manager believes this session has ended.
-			dlog.Debug(ctx, "Session cancelled")
+		}
+		if slices.EqualFunc(agents, lastSnap, infosEqual) {
 			return nil
 		}
-	}
+		lastSnap = agents
+		if dlog.MaxLogLevel(ctx) >= dlog.LogLevelDebug {
+			names := make([]string, len(agents))
+			i := 0
+			for _, a := range agents {
+				names[i] = a.PodName + "." + a.Namespace
+				i++
+			}
+			dlog.Debugf(ctx, "Sending update %v", names)
+		}
+		resp := &rpc.AgentInfoSnapshot{
+			Agents: agents,
+		}
+		return stream.Send(resp)
+	})
 }
 
 // WatchIntercepts notifies a client or agent of the set of intercepts
@@ -619,11 +610,11 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 		if agent := s.state.GetAgent(sessionID); agent != nil {
 			filter = func(id string, info *state.Intercept) bool {
 				if info.Spec.Namespace != agent.Namespace || info.Spec.Agent != agent.Name {
+					dlog.Debugf(ctx, "Intercept %q is not for agent %q", info.Spec.Name, agent.Name)
 					// Don't return intercepts for different agents.
 					return false
 				}
 				if as := s.state.GetAgent(sessionID); as == nil {
-					dlog.Debugf(ctx, "Session no longer active")
 					return false
 				}
 				// Don't return intercepts that aren't in a "agent-owned" state.
@@ -637,6 +628,7 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 					return true
 				default:
 					// otherwise: don't return this intercept
+					dlog.Debugf(ctx, "Intercept %q is in state %s", info.Spec.Name, info.Disposition)
 					return false
 				}
 			}
@@ -650,37 +642,22 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 		}
 	}
 
-	snapshotCh := s.state.WatchIntercepts(ctx, filter)
-	for {
-		select {
-		case snapshot, ok := <-snapshotCh:
-			if !ok {
-				dlog.Debugf(ctx, "Request cancelled")
-				return nil
-			}
-			dlog.Debugf(ctx, "Sending update")
-			intercepts := make([]*rpc.InterceptInfo, 0, len(snapshot))
-			for _, intercept := range snapshot {
-				intercepts = append(intercepts, intercept.InterceptInfo)
-			}
-			resp := &rpc.InterceptInfoSnapshot{
-				Intercepts: intercepts,
-			}
-			sort.Slice(intercepts, func(i, j int) bool {
-				return intercepts[i].Id < intercepts[j].Id
-			})
-			if err := stream.Send(resp); err != nil {
-				dlog.Debugf(ctx, "Encountered a write error: %v", err)
-				return err
-			}
-		case <-ctx.Done():
-			dlog.Debugf(ctx, "Context cancelled")
-			return nil
-		case <-sessionDone:
-			dlog.Debugf(ctx, "Session cancelled")
-			return nil
-		}
-	}
+	deltaCh := s.state.WatchIntercepts(ctx, filter)
+	snapshot := cache.NewClientMap[string, *state.Intercept]()
+	return snapshot.Watch(sessionDone, deltaCh, func() error {
+		dlog.Debug(ctx, "Sending update")
+		intercepts := make([]*rpc.InterceptInfo, 0, snapshot.Size())
+		snapshot.Range(func(_ string, intercept *state.Intercept) bool {
+			intercepts = append(intercepts, intercept.InterceptInfo)
+			return true
+		})
+		sort.Slice(intercepts, func(i, j int) bool {
+			return intercepts[i].Id < intercepts[j].Id
+		})
+		return stream.Send(&rpc.InterceptInfoSnapshot{
+			Intercepts: intercepts,
+		})
+	})
 }
 
 func (s *service) PrepareIntercept(ctx context.Context, request *rpc.CreateInterceptRequest) (pi *rpc.PreparedIntercept, err error) {

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net"
 	"net/netip"
 	"slices"
@@ -17,9 +16,11 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 	dns2 "github.com/miekg/dns"
+	"github.com/puzpuzpuz/xsync/v4"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	empty "google.golang.org/protobuf/types/known/emptypb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,7 +38,9 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
+	"github.com/telepresenceio/telepresence/v2/pkg/grpc/errors"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	maps2 "github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 	"github.com/telepresenceio/telepresence/v2/pkg/workload"
@@ -147,11 +150,9 @@ func (s *service) GetAgentImageFQN(ctx context.Context, _ *empty.Empty) (*rpc.Ag
 }
 
 func (s *service) GetAgentConfig(ctx context.Context, request *rpc.AgentConfigRequest) (*rpc.AgentConfigResponse, error) {
-	ctx = managerutil.WithSessionInfo(ctx, request.Session)
-	sessionID := tunnel.SessionID(request.GetSession().GetSessionId())
-	clientInfo := s.state.GetClient(sessionID)
-	if clientInfo == nil {
-		return nil, status.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	ctx, clientInfo, err := s.ensureClientSession(ctx, request.Session)
+	if err != nil {
+		return nil, err
 	}
 	scs, err := s.State().GetOrGenerateAgentConfig(ctx, request.Name, clientInfo.Namespace)
 	if err != nil {
@@ -203,8 +204,8 @@ func (s *service) ReconnectClient(ctx context.Context, info *rpc.ReconnectClient
 		return &empty.Empty{}, nil
 	}
 	client := info.Client
-	state := s.state
-	if !state.ManagesNamespace(ctx, client.Namespace) {
+	st := s.state
+	if !st.ManagesNamespace(ctx, client.Namespace) {
 		// Sorry, we no longer manage this namespace.
 		return nil, status.Error(codes.FailedPrecondition, fmt.Sprintf("namespace %s is not managed", client.Namespace))
 	}
@@ -212,9 +213,9 @@ func (s *service) ReconnectClient(ctx context.Context, info *rpc.ReconnectClient
 		return nil, status.Error(codes.InvalidArgument, val)
 	}
 	now := time.Now()
-	state.RestoreClient(sessionID, client, now)
-	state.RestoreAgents(info.Agents, now)
-	state.RestoreIntercepts(ctx, info.Intercepts, now)
+	st.RestoreClient(sessionID, client, now)
+	st.RestoreAgents(info.Agents, now)
+	st.RestoreIntercepts(ctx, info.Intercepts, now)
 	return &empty.Empty{}, nil
 }
 
@@ -338,11 +339,11 @@ func (s *service) removeUnusedAgent(ctx context.Context, workloadKey *mutator.Wo
 		mm := mutator.GetMap(ctx)
 		wl, err := k8sapi.GetWorkload(ctx, workloadKey.Name, ns, "")
 		if err != nil {
-			return status.Errorf(codes.NotFound, "Workload %s.%s not found", workloadKey.Name, ns)
+			return errors.Errorf(codes.NotFound, "Workload %s.%s not found", workloadKey.Name, ns)
 		}
 		mm.Delete(wl.GetName(), ns)
 		if err := mm.EvictPodsWithAgentConfig(ctx, wl); err != nil {
-			return status.Errorf(codes.Internal, "unable to delete agent for workload %s.%s: %v", wl.GetName(), ns, err)
+			return errors.Errorf(codes.Internal, "unable to delete agent for workload %s.%s: %v", wl.GetName(), ns, err)
 		}
 	}
 	return nil
@@ -421,42 +422,33 @@ func (f *AgentStateFile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// WatchAgentPods notifies a client of the set of known Agents.
-func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_WatchAgentPodsServer) error {
-	ctx := managerutil.WithSessionInfo(stream.Context(), session)
-	clientSession := tunnel.SessionID(session.SessionId)
-	clientInfo := s.state.GetClient(clientSession)
-	if clientInfo == nil {
-		return status.Errorf(codes.NotFound, "Client session %q not found", clientSession)
-	}
-	ns := clientInfo.Namespace
-
+func (s *service) createAgentPodWatchers(ctx context.Context, ns string) (
+	<-chan cache.Delta[tunnel.SessionID, *state.AgentSession],
+	<-chan cache.Delta[string, *state.Intercept],
+	<-chan struct{},
+) {
 	agentsCh := s.state.WatchAgents(ctx, func(_ tunnel.SessionID, info *state.AgentSession) bool {
 		return info.Namespace == ns
 	})
+	sessionID := managerutil.GetSessionID(ctx)
 	interceptsCh := s.state.WatchIntercepts(ctx, func(_ string, info *state.Intercept) bool {
-		return info.ClientSession.SessionId == string(clientSession)
+		return info.ClientSession.SessionId == string(sessionID)
 	})
-	sessionDone, err := s.state.SessionDone(clientSession)
+	sessionDone, _ := s.state.SessionDone(sessionID)
+	return agentsCh, interceptsCh, sessionDone
+}
+
+// WatchAgentPods notifies a client of the set of known Agents.
+func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_WatchAgentPodsServer) error {
+	ctx, clientInfo, err := s.ensureClientSession(stream.Context(), session)
 	if err != nil {
 		return err
 	}
-
+	clientSessionID := managerutil.GetSessionID(ctx)
+	agentsCh, interceptsCh, sessionDone := s.createAgentPodWatchers(ctx, clientInfo.Namespace)
 	agentSessions := cache.NewClientMap[tunnel.SessionID, *state.AgentSession]()
 
 	interceptInfos := cache.NewClientMap[string, *state.Intercept]()
-	isIntercepted := func(a *rpc.AgentPodInfo) bool {
-		found := false
-		interceptInfos.Range(func(id string, ii *state.Intercept) bool {
-			if a.WorkloadName == ii.Spec.Agent && a.Namespace == ii.Spec.Namespace {
-				found = true
-				return false
-			}
-			return true
-		})
-		return found
-	}
-
 	lock := sync.Mutex{}
 	var lastAgents []*rpc.AgentPodInfo
 
@@ -465,7 +457,6 @@ func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_Wa
 		defer lock.Unlock()
 		m := mutator.GetMap(ctx)
 		agents := make([]*rpc.AgentPodInfo, 0, agentSessions.Size())
-		agentNames := make([]string, 0, agentSessions.Size())
 		agentSessions.Range(func(id tunnel.SessionID, a *state.AgentSession) bool {
 			if m.IsInactive(types.UID(a.PodUid)) {
 				return true
@@ -481,15 +472,13 @@ func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_Wa
 				Namespace:    a.Namespace,
 				PodIp:        aip.AsSlice(),
 				ApiPort:      a.ApiPort,
+				Intercepted:  s.state.IsInterceptedBy(clientSessionID),
 			}
-			ap.Intercepted = isIntercepted(ap)
 			agents = append(agents, ap)
-			agentNames = append(agentNames, fmt.Sprintf("%s(%s)", ap.PodName, net.IP(ap.PodIp)))
 			return true
 		})
 		if !slices.Equal(lastAgents, agents) {
 			lastAgents = agents
-			dlog.Debugf(ctx, "Sending update for %s", agentNames)
 			err = stream.Send(&rpc.AgentPodInfoSnapshot{Agents: agents})
 		}
 		return err
@@ -501,12 +490,94 @@ func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream rpc.Manager_Wa
 	return agentSessions.Watch(sessionDone, agentsCh, onChanged)
 }
 
+func (s *service) WatchAgentPodsDelta(session *rpc.SessionInfo, stream grpc.ServerStreamingServer[rpc.AgentPodInfoDelta]) error {
+	ctx, clientInfo, err := s.ensureClientSession(stream.Context(), session)
+	if err != nil {
+		return err
+	}
+	clientSessionID := managerutil.GetSessionID(ctx)
+	agentsCh, interceptsCh, sessionDone := s.createAgentPodWatchers(ctx, clientInfo.Namespace)
+	agentPodInfos := cache.NewMap[string, *rpc.AgentPodInfo](func(a *rpc.AgentPodInfo, b *rpc.AgentPodInfo) bool {
+		return proto.Equal(a, b)
+	}, time.Millisecond)
+
+	m := mutator.GetMap(ctx)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sessionDone:
+				return
+			case delta := <-agentsCh:
+				for k, a := range delta.Upserts {
+					if m.IsInactive(types.UID(a.PodUid)) {
+						continue
+					}
+					aip, parseErr := netip.ParseAddr(a.PodIp)
+					if parseErr != nil {
+						dlog.Errorf(ctx, "error parsing agent pod ip %q: %v", a.PodIp, parseErr)
+						continue
+					}
+					ap := &rpc.AgentPodInfo{
+						WorkloadName: a.Name,
+						PodId:        a.PodUid,
+						PodName:      a.PodName,
+						Namespace:    a.Namespace,
+						PodIp:        aip.AsSlice(),
+						ApiPort:      a.ApiPort,
+						Intercepted:  s.state.IsInterceptedBy(clientSessionID),
+					}
+					agentPodInfos.Store(string(k), ap)
+				}
+				for k := range delta.Removals {
+					agentPodInfos.Delete(string(k))
+				}
+			}
+		}
+	}()
+
+	refreshIntercepted := func() {
+		agentPodInfos.Range(func(k string, a *rpc.AgentPodInfo) bool {
+			if m.IsInactive(types.UID(a.PodId)) {
+				return true
+			}
+			intercepted := s.state.IsInterceptedBy(clientSessionID)
+			agentPodInfos.Compute(k, func(a *rpc.AgentPodInfo, loaded bool) (*rpc.AgentPodInfo, xsync.ComputeOp) {
+				if loaded && a.Intercepted != intercepted {
+					a := proto.Clone(a).(*rpc.AgentPodInfo)
+					a.Intercepted = intercepted
+					return a, xsync.UpdateOp
+				}
+				return a, xsync.CancelOp
+			})
+			return true
+		})
+	}
+
+	agentPodInfosCh := agentPodInfos.Subscribe(ctx.Done(), nil)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sessionDone:
+			return nil
+		case <-interceptsCh:
+			refreshIntercepted()
+		case delta := <-agentPodInfosCh:
+			err = stream.Send(&rpc.AgentPodInfoDelta{Upserts: delta.Upserts, Removals: maps2.KeySlice(delta.Removals)})
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
 // WatchAgents notifies a client of the set of known Agents in the connected namespace.
 func (s *service) WatchAgents(session *rpc.SessionInfo, stream rpc.Manager_WatchAgentsServer) error {
-	ctx := managerutil.WithSessionInfo(stream.Context(), session)
-	clientInfo := s.state.GetClient(tunnel.SessionID(session.SessionId))
-	if clientInfo == nil {
-		return status.Errorf(codes.NotFound, "Client session %q not found", session.SessionId)
+	ctx, clientInfo, err := s.ensureClientSession(stream.Context(), session)
+	if err != nil {
+		return err
 	}
 	ns := clientInfo.Namespace
 	return s.watchAgents(ctx, func(_ tunnel.SessionID, a *state.AgentSession) bool { return a.Namespace == ns }, stream)
@@ -516,30 +587,7 @@ func infosEqual(a, b *rpc.AgentInfo) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	if a.Name != b.Name || a.Namespace != b.Namespace || a.Product != b.Product || a.Version != b.Version {
-		return false
-	}
-	ams := a.Mechanisms
-	bms := b.Mechanisms
-	if len(ams) != len(bms) {
-		return false
-	}
-	for i, am := range ams {
-		bm := bms[i]
-		if am == nil || bm == nil {
-			if am != bm {
-				return false
-			}
-		} else if am.Name != bm.Name || am.Product != bm.Product || am.Version != bm.Version {
-			return false
-		}
-	}
-	return maps.EqualFunc(a.Containers, b.Containers, func(ac *rpc.AgentInfo_ContainerInfo, bc *rpc.AgentInfo_ContainerInfo) bool {
-		if ac == nil || bc == nil {
-			return ac == bc
-		}
-		return ac.MountPoint == bc.MountPoint && maps.Equal(ac.Environment, bc.Environment)
-	})
+	return proto.Equal(a, b)
 }
 
 func (s *service) watchAgents(ctx context.Context, includeAgent func(tunnel.SessionID, *state.AgentSession) bool, stream rpc.Manager_WatchAgentsServer) error {
@@ -551,7 +599,8 @@ func (s *service) watchAgents(ctx context.Context, includeAgent func(tunnel.Sess
 	snapshot := cache.NewClientMap[tunnel.SessionID, *state.AgentSession]()
 	// Ensure that the initial snapshot is not equal to lastSnap even if it is empty by
 	// creating a lastSnap with one nil entry.
-	lastSnap := make([]*rpc.AgentInfo, 1)
+	var lastSnap []*rpc.AgentInfo
+	firstSnap := true
 
 	return snapshot.Watch(sessionDone, deltaCh, func() error {
 		m := mutator.GetMap(ctx)
@@ -570,7 +619,9 @@ func (s *service) watchAgents(ctx context.Context, includeAgent func(tunnel.Sess
 				agents = append(agents, ag.AgentInfo)
 			}
 		}
-		if slices.EqualFunc(agents, lastSnap, infosEqual) {
+		if firstSnap {
+			firstSnap = false
+		} else if slices.EqualFunc(agents, lastSnap, infosEqual) {
 			return nil
 		}
 		lastSnap = agents
@@ -590,10 +641,48 @@ func (s *service) watchAgents(ctx context.Context, includeAgent func(tunnel.Sess
 	})
 }
 
-// WatchIntercepts notifies a client or agent of the set of intercepts
-// relevant to that client or agent.
-func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_WatchInterceptsServer) error {
-	ctx := managerutil.WithSessionInfo(stream.Context(), session)
+func (s *service) WatchAgentsDelta(session *rpc.SessionInfo, stream grpc.ServerStreamingServer[rpc.AgentInfoDelta]) error {
+	ctx, clientInfo, err := s.ensureClientSession(stream.Context(), session)
+	if err != nil {
+		return err
+	}
+	ns := clientInfo.Namespace
+	deltaCh := s.state.WatchAgents(ctx, func(_ tunnel.SessionID, a *state.AgentSession) bool { return a.Namespace == ns })
+	sessionDone, err := s.state.SessionDone(managerutil.GetSessionID(ctx))
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sessionDone:
+			return nil
+		case delta := <-deltaCh:
+			aid := rpc.AgentInfoDelta{}
+			if rl := len(delta.Upserts); rl > 0 {
+				aid.Upserts = make(map[string]*rpc.AgentInfo, rl)
+				for k, v := range delta.Upserts {
+					aid.Upserts[string(k)] = v.AgentInfo
+				}
+			}
+			if rl := len(delta.Removals); rl > 0 {
+				aid.Removals = make([]string, rl)
+				for k := range delta.Removals {
+					rl--
+					aid.Removals[rl] = string(k)
+				}
+			}
+			dlog.Debugf(ctx, "Sending %d upserts and %d removals", len(aid.Upserts), len(aid.Removals))
+			err = stream.Send(&aid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *service) watchIntercepts(ctx context.Context, session *rpc.SessionInfo) (<-chan cache.Delta[string, *state.Intercept], <-chan struct{}, error) {
 	sessionID := tunnel.SessionID(session.GetSessionId())
 	var sessionDone <-chan struct{}
 	var filter func(id string, info *state.Intercept) bool
@@ -604,13 +693,12 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 	} else {
 		var err error
 		if sessionDone, err = s.state.SessionDone(sessionID); err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		if agent := s.state.GetAgent(sessionID); agent != nil {
 			filter = func(id string, info *state.Intercept) bool {
 				if info.Spec.Namespace != agent.Namespace || info.Spec.Agent != agent.Name {
-					dlog.Debugf(ctx, "Intercept %q is not for agent %q", info.Spec.Name, agent.Name)
 					// Don't return intercepts for different agents.
 					return false
 				}
@@ -642,7 +730,17 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 		}
 	}
 
-	deltaCh := s.state.WatchIntercepts(ctx, filter)
+	return s.state.WatchIntercepts(ctx, filter), sessionDone, nil
+}
+
+// WatchIntercepts notifies a client or agent of the set of intercepts
+// relevant to that client or agent.
+func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_WatchInterceptsServer) error {
+	ctx := managerutil.WithSessionInfo(stream.Context(), session)
+	deltaCh, sessionDone, err := s.watchIntercepts(ctx, session)
+	if err != nil {
+		return err
+	}
 	snapshot := cache.NewClientMap[string, *state.Intercept]()
 	return snapshot.Watch(sessionDone, deltaCh, func() error {
 		dlog.Debug(ctx, "Sending update")
@@ -660,14 +758,40 @@ func (s *service) WatchIntercepts(session *rpc.SessionInfo, stream rpc.Manager_W
 	})
 }
 
+func (s *service) WatchInterceptsDelta(session *rpc.SessionInfo, stream grpc.ServerStreamingServer[rpc.InterceptInfoDelta]) error {
+	ctx := managerutil.WithSessionInfo(stream.Context(), session)
+	deltaCh, sessionDone, err := s.watchIntercepts(ctx, session)
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sessionDone:
+			return nil
+		case delta := <-deltaCh:
+			iid := rpc.InterceptInfoDelta{Removals: maps2.KeySlice(delta.Removals)}
+			if rl := len(delta.Upserts); rl > 0 {
+				iid.Upserts = make(map[string]*rpc.InterceptInfo, rl)
+				for k, v := range delta.Upserts {
+					iid.Upserts[k] = v.InterceptInfo
+				}
+			}
+			dlog.Debugf(ctx, "Sending %d upserts and %d removals", len(iid.Upserts), len(iid.Removals))
+			err = stream.Send(&iid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
 func (s *service) PrepareIntercept(ctx context.Context, request *rpc.CreateInterceptRequest) (pi *rpc.PreparedIntercept, err error) {
 	dlog.Debugf(ctx, "Intercept name %s", request.InterceptSpec.Name)
-	session := request.GetSession()
-	ctx = managerutil.WithSessionInfo(ctx, session)
-	sessionID := tunnel.SessionID(session.GetSessionId())
-	client := s.state.GetClient(sessionID)
-	if client == nil {
-		return nil, status.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	ctx, _, err = s.ensureClientSession(ctx, request.Session)
+	if err != nil {
+		return nil, err
 	}
 	return s.state.PrepareIntercept(ctx, request)
 }
@@ -686,19 +810,16 @@ func (s *service) GetKnownWorkloadKinds(ctx context.Context, request *rpc.Sessio
 }
 
 func (s *service) EnsureAgent(ctx context.Context, request *rpc.EnsureAgentRequest) (*rpc.AgentInfoSnapshot, error) {
-	session := request.GetSession()
-	ctx = managerutil.WithSessionInfo(ctx, session)
-	sessionID := tunnel.SessionID(session.GetSessionId())
-	client := s.state.GetClient(sessionID)
-	if client == nil {
-		return nil, status.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	ctx, client, err := s.ensureClientSession(ctx, request.Session)
+	if err != nil {
+		return nil, err
 	}
 	as, err := s.state.EnsureAgent(ctx, request.Name, client.Namespace)
 	if err != nil {
 		return nil, status.Convert(err).Err()
 	}
 	if len(as) == 0 {
-		return nil, status.Errorf(codes.Internal, "failed to ensure agent for workload %s: no agents became active", request.Name)
+		return nil, errors.Errorf(codes.Internal, "failed to ensure agent for workload %s: no agents became active", request.Name)
 	}
 	rpcAs := make([]*rpc.AgentInfo, len(as))
 	for i, a := range as {
@@ -739,30 +860,25 @@ func (s *service) MakeInterceptID(_ context.Context, sessionID string, name stri
 	// use in requests.
 	if sessionID == "" {
 		return name, nil
-	} else {
-		if s.state.GetClient(tunnel.SessionID(sessionID)) == nil {
-			return "", status.Errorf(codes.NotFound, "Client session %q not found", sessionID)
-		}
-		return sessionID + ":" + name, nil
 	}
+	if s.state.GetClient(tunnel.SessionID(sessionID)) == nil {
+		return "", errors.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	}
+	return sessionID + ":" + name, nil
 }
 
 // RemoveIntercept lets a client remove an intercept.
 func (s *service) RemoveIntercept(ctx context.Context, riReq *rpc.RemoveInterceptRequest2) (*empty.Empty, error) {
-	ctx = managerutil.WithSessionInfo(ctx, riReq.GetSession())
-	sessionID := tunnel.SessionID(riReq.GetSession().GetSessionId())
 	name := riReq.Name
-
 	dlog.Debugf(ctx, "Intercept name %s", name)
 
-	client := s.state.GetClient(sessionID)
-	if client == nil {
-		return nil, status.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	ctx, client, err := s.ensureClientSession(ctx, riReq.Session)
+	if err != nil {
+		return nil, err
 	}
-
 	SetGauge(ctx, s.state.GetInterceptActiveStatus(), client.Name, client.InstallId, &name, 0)
 
-	s.state.RemoveIntercept(ctx, string(sessionID)+":"+name)
+	s.state.RemoveIntercept(ctx, string(managerutil.GetSessionID(ctx))+":"+name)
 	return &empty.Empty{}, nil
 }
 
@@ -774,9 +890,8 @@ func (s *service) GetIntercept(ctx context.Context, request *rpc.GetInterceptReq
 	}
 	if intercept, ok := s.state.GetIntercept(interceptID); ok {
 		return intercept.InterceptInfo, nil
-	} else {
-		return nil, status.Errorf(codes.NotFound, "Intercept named %q not found", request.Name)
 	}
+	return nil, status.Errorf(codes.NotFound, "Intercept named %q not found", request.Name)
 }
 
 // ReviewIntercept lets an agent approve or reject an intercept.
@@ -925,12 +1040,11 @@ func (s *service) Lookup(ctx context.Context, request *rpc.LookupRequest) (respo
 			dlog.Debugf(ctx, "lookup %q => %v", request.Name, ips)
 		}
 	}()
-	session := request.GetSession()
-	client := s.state.GetClient(tunnel.SessionID(session.SessionId))
-	if client == nil {
-		return nil, status.Errorf(codes.NotFound, "Client session %q not found", session.SessionId)
+	ctx, client, err := s.ensureClientSession(ctx, request.Session)
+	if err != nil {
+		return nil, err
 	}
-	ctx = managerutil.WithSessionInfo(ctx, session)
+
 	if svcIP := s.clusterInfo.ServiceIP(); svcIP != nil && (request.Name == s.serviceNameNs || request.Name == s.serviceNameFQN) {
 		addr, _ := netip.AddrFromSlice(svcIP)
 		b, _ := addr.MarshalBinary()
@@ -1145,4 +1259,14 @@ func (s *service) updateTrafficManagerConfigMap(ctx context.Context) error {
 		s.tmConfigMapUpdated.Store(false)
 	}
 	return err
+}
+
+func (s *service) ensureClientSession(ctx context.Context, sessionInfo *rpc.SessionInfo) (context.Context, *state.ClientSession, error) {
+	ctx = managerutil.WithSessionInfo(ctx, sessionInfo)
+	sessionID := tunnel.SessionID(sessionInfo.SessionId)
+	session := s.state.GetClient(sessionID)
+	if session == nil {
+		return ctx, nil, errors.Errorf(codes.NotFound, "Client session %q not found", sessionID)
+	}
+	return ctx, session, nil
 }

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -285,6 +285,7 @@ matchExpressions:
 		},
 		AgentInitContainerEnabled: true,
 		AgentMaxIdleTime:          24 * time.Hour,
+		ClientConnectionTTL:       24 * time.Minute,
 	}
 	ctx = managerutil.WithEnv(ctx, &env)
 	ctx = mutator.WithMap(ctx, mutator.Load(ctx))

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -705,7 +705,7 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 	name := ac.AgentName
 	namespace := ac.Namespace
 	dlog.Debugf(ctx, "Waiting for agent %s.%s", name, namespace)
-	snapshotCh := s.WatchAgents(ctx, func(_ tunnel.SessionID, agent *AgentSession) bool {
+	deltaCh := s.WatchAgents(ctx, func(_ tunnel.SessionID, agent *AgentSession) bool {
 		return agent.Name == name && agent.Namespace == namespace
 	})
 	failedContainerRx := regexp.MustCompile(`restarting failed container (\S+) in pod ([0-9A-Za-z_-]+)_` + namespace)
@@ -764,16 +764,17 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 				continue
 			}
 			return nil, errcat.User.New(msg)
-		case snapshot, ok := <-snapshotCh:
+		case delta, ok := <-deltaCh:
 			if !ok {
 				// The request has been canceled.
 				return nil, status.Error(codes.Canceled, fmt.Sprintf("channel closed while waiting for agent %s.%s to arrive", name, namespace))
 			}
-			if len(snapshot) == 0 {
+			upserts := delta.Upserts
+			if len(upserts) == 0 {
 				continue
 			}
-			as := make([]*AgentSession, 0, len(snapshot))
-			for _, a := range snapshot {
+			as := make([]*AgentSession, 0)
+			for _, a := range upserts {
 				if mm.IsInactive(k8sTypes.UID(a.PodUid)) {
 					dlog.Debugf(ctx, "Agent %s(%s) is blacklisted", a.PodName, a.PodIp)
 				} else {

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -30,6 +30,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+	grpcErrors "github.com/telepresenceio/telepresence/v2/pkg/grpc/errors"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -248,7 +249,7 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 	sessionID := tunnel.SessionID(clientSession.SessionId)
 	client := s.GetClient(sessionID)
 	if client == nil {
-		return nil, nil, status.Errorf(codes.NotFound, "session %q not found", sessionID)
+		return nil, nil, grpcErrors.Errorf(codes.NotFound, "session %q not found", sessionID)
 	}
 
 	spec := cir.InterceptSpec
@@ -260,7 +261,7 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		if k8sErrors.IsNotFound(err) {
 			code = codes.NotFound
 		}
-		return nil, nil, status.Error(code, err.Error())
+		return nil, nil, grpcErrors.Error(code, err.Error())
 	}
 
 	rp := agentconfig.ReplacePolicyIntercept
@@ -283,7 +284,7 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		from, to, err := pm.FromNumberAndTo()
 		if err != nil {
 			// Did PrepareIntercept create an invalid pod_port?
-			return nil, nil, status.Errorf(codes.Internal, "invalid pod_port %q: %v", pm, err)
+			return nil, nil, grpcErrors.Errorf(codes.Internal, "invalid pod_port %q: %v", pm, err)
 		}
 		pmCir := proto.Clone(cir).(*rpc.CreateInterceptRequest)
 		pmSpec := pmCir.InterceptSpec
@@ -354,7 +355,7 @@ func (s *State) addIntercept(id string, cir *rpc.CreateInterceptRequest) (*Inter
 
 	if existingValue, hasConflict := s.intercepts.LoadOrStore(id, is); hasConflict {
 		if existingValue.Disposition != rpc.InterceptDispositionType_REMOVED {
-			return nil, status.Errorf(codes.AlreadyExists, "Intercept named %q already exists", is.Spec.Name)
+			return nil, grpcErrors.Errorf(codes.AlreadyExists, "Intercept named %q already exists", is.Spec.Name)
 		}
 		s.intercepts.Store(id, is)
 	}
@@ -377,7 +378,7 @@ func (s *State) NewInterceptInfo(interceptID string, ciReq *rpc.CreateInterceptR
 func (s *State) AddInterceptFinalizer(interceptID string, finalizer InterceptFinalizer) error {
 	is, ok := s.intercepts.Load(interceptID)
 	if !ok {
-		return status.Errorf(codes.NotFound, "no such intercept %s", interceptID)
+		return grpcErrors.Errorf(codes.NotFound, "no such intercept %s", interceptID)
 	}
 	is.addFinalizer(finalizer)
 	return nil

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/namespaces"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/cache"
+	grpcErrors "github.com/telepresenceio/telepresence/v2/pkg/grpc/errors"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -378,7 +379,7 @@ func (s *State) SessionDone(id tunnel.SessionID) (<-chan struct{}, error) {
 	if as, ok := s.agents.Load(id); ok {
 		return as.done(), nil
 	}
-	return nil, status.Errorf(codes.NotFound, "session %q not found", id)
+	return nil, grpcErrors.Errorf(codes.NotFound, "session %q not found", id)
 }
 
 // Sessions: Clients ///////////////////////////////////////////////////////////////////////////////
@@ -481,6 +482,31 @@ func (s *State) CountTunnelIngress() uint64 {
 
 func (s *State) CountTunnelEgress() uint64 {
 	return atomic.LoadUint64(&s.tunnelEgressCounter)
+}
+
+func (s *State) IsIntercepted(name, namespace string) bool {
+	found := false
+	s.intercepts.Range(func(id string, ii *Intercept) bool {
+		if name == ii.Spec.Agent && namespace == ii.Spec.Namespace {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func (s *State) IsInterceptedBy(client tunnel.SessionID) bool {
+	found := false
+	clientSessionID := string(client)
+	s.intercepts.Range(func(id string, ii *Intercept) bool {
+		if ii.ClientSession.SessionId == clientSessionID {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // Sessions: Agents ////////////////////////////////////////////////////////////////////////////////
@@ -613,14 +639,14 @@ func (s *State) UninstallAgents(ctx context.Context, ur *rpc.UninstallAgentsRequ
 	id := tunnel.SessionID(ur.GetSessionInfo().GetSessionId())
 	clientInfo := s.GetClient(id)
 	if clientInfo == nil {
-		return status.Errorf(codes.NotFound, "Client session %q not found", id)
+		return grpcErrors.Errorf(codes.NotFound, "Client session %q not found", id)
 	}
 	ns := clientInfo.GetNamespace()
 	mm := mutator.GetMap(ctx)
 	agents := ur.Agents
 	if len(agents) == 0 {
 		if err := mm.EvictAllPodsWithAgentConfig(ctx, ns); err != nil {
-			return status.Errorf(codes.Internal, "unable to delete pods with agent: %v", err)
+			return grpcErrors.Errorf(codes.Internal, "unable to delete pods with agent: %v", err)
 		}
 		return nil
 	}
@@ -629,7 +655,7 @@ func (s *State) UninstallAgents(ctx context.Context, ur *rpc.UninstallAgentsRequ
 	for i, agent := range agents {
 		wl, err := k8sapi.GetWorkload(ctx, agent, ns, "")
 		if err != nil {
-			return status.Errorf(codes.NotFound, "Workload %s.%s not found", agent, ns)
+			return grpcErrors.Errorf(codes.NotFound, "Workload %s.%s not found", agent, ns)
 		}
 		wls[i] = wl
 	}
@@ -637,7 +663,7 @@ func (s *State) UninstallAgents(ctx context.Context, ur *rpc.UninstallAgentsRequ
 	for _, wl := range wls {
 		mm.Delete(wl.GetName(), ns)
 		if err := mm.EvictPodsWithAgentConfig(ctx, wl); err != nil {
-			return status.Errorf(codes.Internal, "unable to delete agent for workload %s.%s: %v", wl.GetName(), ns, err)
+			return grpcErrors.Errorf(codes.Internal, "unable to delete agent for workload %s.%s: %v", wl.GetName(), ns, err)
 		}
 	}
 	return nil
@@ -659,7 +685,7 @@ func (s *State) Tunnel(ctx context.Context, stream tunnel.Stream) error {
 	if cs, ok := s.clients.Load(id); ok {
 		return s.clientTunnel(ctx, cs, stream)
 	}
-	return status.Errorf(codes.NotFound, "Session %q not found", id)
+	return grpcErrors.Errorf(codes.NotFound, "Session %q not found", id)
 }
 
 func (s *State) clientTunnel(ctx context.Context, client *ClientSession, stream tunnel.Stream) error {

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -25,8 +25,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/namespaces"
-	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/watchable"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
@@ -73,9 +73,9 @@ type State struct {
 
 	allClientSessionsFinalizer allClientSessionsFinalizer
 	allInterceptsFinalizer     allInterceptsFinalizer
-	intercepts                 *watchable.Map[string, *Intercept]              // info for intercepts, keyed by intercept id
-	agents                     *watchable.Map[tunnel.SessionID, *AgentSession] // info for agent sessions, keyed by session id
-	clients                    *xsync.Map[tunnel.SessionID, *ClientSession]    // info for client sessions, keyed by session id
+	intercepts                 *cache.Map[string, *Intercept]               // info for intercepts, keyed by intercept id
+	agents                     *cache.Map[tunnel.SessionID, *AgentSession]  // info for agent sessions, keyed by session id
+	clients                    *xsync.Map[tunnel.SessionID, *ClientSession] // info for client sessions, keyed by session id
 	timedLogLevel              log.TimedLevel
 	llSubs                     *loglevelSubscribers
 	workloadWatchers           *xsync.Map[string, workload.Watcher] // workload watchers, created on demand and keyed by namespace
@@ -104,8 +104,8 @@ func NewState(ctx context.Context, g *dgroup.Group) *State {
 	loglevel := os.Getenv("LOG_LEVEL")
 	s := &State{
 		backgroundCtx:    ctx,
-		intercepts:       watchable.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
-		agents:           watchable.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
 		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
 		workloadWatchers: xsync.NewMap[string, workload.Watcher](),
 		timedLogLevel:    log.NewTimedLevel(loglevel, log.SetLevel),
@@ -561,7 +561,7 @@ func (s *State) HasAgent(name, namespace string) (ok bool) {
 func (s *State) WatchAgents(
 	ctx context.Context,
 	filter func(tunnel.SessionID, *AgentSession) bool,
-) <-chan map[tunnel.SessionID]*AgentSession {
+) <-chan cache.Delta[tunnel.SessionID, *AgentSession] {
 	return s.agents.Subscribe(ctx.Done(), filter)
 }
 
@@ -650,7 +650,7 @@ func (s *State) GetIntercept(interceptID string) (*Intercept, bool) {
 func (s *State) WatchIntercepts(
 	ctx context.Context,
 	filter func(sessionID string, intercept *Intercept) bool,
-) <-chan map[string]*Intercept {
+) <-chan cache.Delta[string, *Intercept] {
 	return s.intercepts.Subscribe(ctx.Done(), filter)
 }
 

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
 	testdata "github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/test"
-	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/watchable"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/workload"
@@ -33,8 +33,8 @@ func (s *suiteState) SetupTest() {
 	s.ctx = dlog.NewTestContext(s.T(), false)
 	s.state = &State{
 		backgroundCtx:    s.ctx,
-		intercepts:       watchable.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
-		agents:           watchable.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
 		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
 		workloadWatchers: xsync.NewMap[string, workload.Watcher](),
 		timedLogLevel:    log.NewTimedLevel("debug", log.SetLevel),

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -5,15 +5,16 @@ import (
 	"math"
 	"time"
 
+	"github.com/puzpuzpuz/xsync/v4"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/datawire/dlib/dlog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/workload"
@@ -28,12 +29,10 @@ type workloadInfoWatcher struct {
 	clientSession  tunnel.SessionID
 	namespace      string
 	stream         rpc.Manager_WatchWorkloadsServer
-	workloadEvents map[string]*rpc.WorkloadEvent
+	workloadEvents *xsync.Map[string, *rpc.WorkloadEvent]
 	lastEvents     map[string]*rpc.WorkloadEvent
-	agentInfos     map[tunnel.SessionID]*AgentSession
-	interceptInfos map[string]*Intercept
 	start          time.Time
-	ticker         *time.Ticker
+	sendTimer      *time.Timer
 }
 
 func (s *State) NewWorkloadInfoWatcher(clientSession tunnel.SessionID, namespace string) WorkloadInfoWatcher {
@@ -46,18 +45,19 @@ func (s *State) NewWorkloadInfoWatcher(clientSession tunnel.SessionID, namespace
 
 func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream rpc.Manager_WatchWorkloadsServer) error {
 	wf.start = time.Now()
-	wf.ticker = time.NewTicker(time.Duration(math.MaxInt64))
 	defer func() {
-		wf.ticker.Stop()
+		wf.sendTimer.Stop()
 		wf.stream = nil
 		wf.lastEvents = nil
-		wf.agentInfos = nil
-		wf.interceptInfos = nil
 		wf.workloadEvents = nil
 	}()
 
+	wf.sendTimer = time.AfterFunc(time.Duration(math.MaxInt64), func() {
+		wf.sendEvents(ctx, false)
+	})
+
 	wf.stream = stream
-	wf.workloadEvents = make(map[string]*rpc.WorkloadEvent)
+	wf.workloadEvents = xsync.NewMap[string, *rpc.WorkloadEvent]()
 
 	sessionDone, err := wf.SessionDone(wf.clientSession)
 	if err != nil {
@@ -86,56 +86,54 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream rpc.Manager_Wat
 			return nil
 		case <-sessionDone:
 			return nil
-		case <-wf.ticker.C:
-			wf.sendEvents(ctx, false)
 		case wes, ok := <-workloadsCh:
 			if !ok {
 				dlog.Debug(ctx, "Workloads channel closed")
 				return nil
 			}
-			wf.handleWorkloadsSnapshot(ctx, wes, initial)
+			wf.handleWorkloadEvents(ctx, wes, initial)
 			initial = false
-		// Events that arrive at the agent channel should be counted as modifications.
-		case ais, ok := <-agentsCh:
-			if !ok {
-				dlog.Debug(ctx, "Agents channel closed")
-				return nil
-			}
-			wf.handleAgentSnapshot(ctx, ais)
-		// Events that arrive at the intercept channel should be counted as modifications.
-		case is, ok := <-interceptsCh:
-			if !ok {
-				dlog.Debug(ctx, "Intercepts channel closed")
-				return nil
-			}
-			wf.handleInterceptSnapshot(ctx, is)
+		case agentDelta := <-agentsCh:
+			wf.handleAgentDelta(ctx, agentDelta)
+		case interceptsDelta := <-interceptsCh:
+			wf.handleInterceptDelta(ctx, interceptsDelta)
 		}
 	}
 }
 
 func (wf *workloadInfoWatcher) getIntercepts(name, namespace string) (iis []*rpc.WorkloadInfo_Intercept) {
-	for _, ii := range wf.interceptInfos {
-		if name == ii.Spec.Agent && namespace == ii.Spec.Namespace && ii.Disposition == rpc.InterceptDispositionType_ACTIVE {
-			iis = append(iis, &rpc.WorkloadInfo_Intercept{
-				Client: ii.Spec.Client,
-			})
+	wf.intercepts.Range(func(key string, ii *Intercept) bool {
+		if name == ii.Spec.Agent && namespace == ii.Spec.Namespace {
+			switch ii.Disposition {
+			case rpc.InterceptDispositionType_ACTIVE, rpc.InterceptDispositionType_WAITING, rpc.InterceptDispositionType_NO_AGENT:
+				iis = append(iis, &rpc.WorkloadInfo_Intercept{
+					Client: ii.Spec.Client,
+				})
+			}
 		}
-	}
+		return true
+	})
 	return iis
 }
 
 func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) {
 	// Time to send what we have
-	wf.ticker.Reset(time.Duration(math.MaxInt64))
-	evs := make([]*rpc.WorkloadEvent, 0, len(wf.workloadEvents))
-	for k, rew := range wf.workloadEvents {
+	evz := wf.workloadEvents.Size()
+	evs := make([]*rpc.WorkloadEvent, 0, evz)
+	evm := make(map[string]*rpc.WorkloadEvent, evz)
+	wf.workloadEvents.Range(func(k string, rew *rpc.WorkloadEvent) bool {
+		evm[k] = rew
 		if lew, ok := wf.lastEvents[k]; ok {
 			if proto.Equal(lew, rew) {
-				continue
+				return true
 			}
 		}
 		evs = append(evs, rew)
-	}
+		return true
+	})
+	wf.workloadEvents.Clear()
+	wf.lastEvents = evm
+
 	if !sendEmpty && len(evs) == 0 {
 		return
 	}
@@ -148,13 +146,11 @@ func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) {
 		dlog.Warnf(ctx, "failed to send workload events delta: %v", err)
 		return
 	}
-	wf.lastEvents = wf.workloadEvents
-	wf.workloadEvents = make(map[string]*rpc.WorkloadEvent)
 	wf.start = time.Now()
 }
 
 func (wf *workloadInfoWatcher) resetTicker() {
-	wf.ticker.Reset(5 * time.Millisecond)
+	wf.sendTimer.Reset(5 * time.Millisecond)
 }
 
 func rpcWorkloadState(s workload.State) (state rpc.WorkloadInfo_State) {
@@ -183,102 +179,90 @@ func rpcWorkload(wl k8sapi.Workload, as rpc.WorkloadInfo_AgentState, iClients []
 	}
 }
 
-func (wf *workloadInfoWatcher) addEvent(
-	eventType workload.EventType,
-	wl k8sapi.Workload,
-	as rpc.WorkloadInfo_AgentState,
-	iClients []*rpc.WorkloadInfo_Intercept,
-) {
-	wf.workloadEvents[wl.GetName()] = &rpc.WorkloadEvent{
-		Type:     rpc.WorkloadEvent_Type(eventType),
-		Workload: rpcWorkload(wl, as, iClients),
-	}
-	wf.resetTicker()
-}
-
-func (wf *workloadInfoWatcher) handleWorkloadsSnapshot(ctx context.Context, wes []workload.Event, initial bool) {
+func (wf *workloadInfoWatcher) handleWorkloadEvents(ctx context.Context, wes []workload.Event, initial bool) {
 	if len(wes) == 0 {
 		if initial {
 			// The initial snapshot may be empty, but must be sent anyway.
 			wf.sendEvents(ctx, true)
+			return
 		}
-		return
+	} else {
+		wf.resetTicker()
 	}
 	for _, we := range wes {
 		wl := we.Workload
 		if wf.namespace != "" && wl.GetNamespace() != wf.namespace {
 			continue
 		}
-		if w, ok := wf.workloadEvents[wl.GetName()]; ok {
-			if we.Type == workload.EventTypeDelete && w.Type != rpc.WorkloadEvent_DELETED {
-				w.Type = rpc.WorkloadEvent_DELETED
-				dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s", we.Type, wl, workload.GetWorkloadState(wl))
-				wf.resetTicker()
-			}
-		} else {
-			var iClients []*rpc.WorkloadInfo_Intercept
+		wf.workloadEvents.Compute(wl.GetName(), func(w *rpc.WorkloadEvent, loaded bool) (*rpc.WorkloadEvent, xsync.ComputeOp) {
 			as := rpc.WorkloadInfo_NO_AGENT_UNSPECIFIED
-			if wf.HasAgent(wl.GetName(), wl.GetNamespace()) {
-				if iis := wf.getIntercepts(wl.GetName(), wl.GetNamespace()); len(iis) > 0 {
-					as = rpc.WorkloadInfo_INTERCEPTED
-					iClients = iis
+			if loaded {
+				if we.Type == workload.EventTypeDelete && w.Type != rpc.WorkloadEvent_DELETED {
+					w = &rpc.WorkloadEvent{
+						Type:     rpc.WorkloadEvent_DELETED,
+						Workload: w.Workload,
+					}
 				} else {
+					return w, xsync.CancelOp
+				}
+			} else {
+				iClients := wf.getIntercepts(wl.GetName(), wl.GetNamespace())
+				if len(iClients) > 0 {
+					as = rpc.WorkloadInfo_INTERCEPTED
+				} else if wf.HasAgent(wl.GetName(), wl.GetNamespace()) {
 					as = rpc.WorkloadInfo_INSTALLED
 				}
-			}
-
-			// If we've sent an ADDED event for this workload, and this is a MODIFIED event without any changes that
-			// we care about, then just skip it.
-			if we.Type == workload.EventTypeUpdate {
-				lew, ok := wf.lastEvents[wl.GetName()]
-				if ok && (lew.Type == rpc.WorkloadEvent_ADDED_UNSPECIFIED || lew.Type == rpc.WorkloadEvent_MODIFIED) &&
-					proto.Equal(lew.Workload, rpcWorkload(we.Workload, as, iClients)) {
-					break
+				w = &rpc.WorkloadEvent{
+					Type:     rpc.WorkloadEvent_Type(we.Type),
+					Workload: rpcWorkload(wl, as, iClients),
 				}
 			}
-			dlog.Debugf(ctx, "WorkloadInfoEvent: Workload %s %s %s %s", we.Type, wl, as, workload.GetWorkloadState(wl))
-			wf.addEvent(we.Type, wl, as, iClients)
-		}
+			dlog.Tracef(ctx, "WorkloadInfoEvent: Workload %s %s %s %s", we.Type, wl, as, w.Workload.State)
+			return w, xsync.UpdateOp
+		})
 	}
 }
 
-func (wf *workloadInfoWatcher) handleAgentSnapshot(ctx context.Context, ais map[tunnel.SessionID]*AgentSession) {
-	oldAgentInfos := wf.agentInfos
-	wf.agentInfos = ais
+func (wf *workloadInfoWatcher) handleAgentDelta(ctx context.Context, delta cache.Delta[tunnel.SessionID, *AgentSession]) {
+	wf.resetTicker()
 	m := mutator.GetMap(ctx)
-	for k, a := range oldAgentInfos {
-		ai, ok := ais[k]
-		if !ok || m.IsInactive(types.UID(ai.PodUid)) {
-			name := a.Name
-			as := rpc.WorkloadInfo_NO_AGENT_UNSPECIFIED
-			if w, ok := wf.workloadEvents[name]; ok && w.Type != rpc.WorkloadEvent_DELETED {
-				wl := w.Workload
-				if wl.AgentState != as {
-					wl.AgentState = as
-					dlog.Debugf(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, wl.State)
-					wf.resetTicker()
+	onDeleted := func(_ tunnel.SessionID, a *AgentSession) {
+		name := a.Name
+		as := rpc.WorkloadInfo_NO_AGENT_UNSPECIFIED
+		wf.workloadEvents.Compute(name, func(w *rpc.WorkloadEvent, loaded bool) (*rpc.WorkloadEvent, xsync.ComputeOp) {
+			if loaded {
+				if w.Type == rpc.WorkloadEvent_DELETED {
+					return w, xsync.CancelOp
 				}
-			} else if wl, err := agentmap.GetWorkload(ctx, name, a.Namespace, ""); err == nil {
-				dlog.Debugf(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, workload.GetWorkloadState(wl))
-				wf.addEvent(workload.EventTypeUpdate, wl, as, nil)
+				rwl := proto.Clone(w.Workload).(*rpc.WorkloadInfo)
+				rwl.AgentState = as
+				rwl.InterceptClients = nil
+				w = &rpc.WorkloadEvent{
+					Type:     w.Type,
+					Workload: rwl,
+				}
 			} else {
-				dlog.Debugf(ctx, "Unable to get workload %s.%s: %v", name, a.Namespace, err)
-				if errors.IsNotFound(err) {
-					wf.workloadEvents[name] = &rpc.WorkloadEvent{
-						Type: rpc.WorkloadEvent_DELETED,
-						Workload: &rpc.WorkloadInfo{
-							Name:       name,
-							Namespace:  a.Namespace,
-							AgentState: as,
-						},
-					}
-					wf.sendEvents(ctx, false)
+				wl, err := agentmap.GetWorkload(ctx, name, a.Namespace, "")
+				if err != nil {
+					// A delete event will have been generated for this workload.
+					return w, xsync.CancelOp
+				}
+				w = &rpc.WorkloadEvent{
+					Type:     rpc.WorkloadEvent_MODIFIED,
+					Workload: rpcWorkload(wl, as, nil),
 				}
 			}
-		}
+			dlog.Tracef(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, w.Workload.State)
+			return w, xsync.UpdateOp
+		})
 	}
-	for _, a := range ais {
+	for k, a := range delta.Removals {
+		onDeleted(k, a)
+	}
+
+	for k, a := range delta.Upserts {
 		if m.IsInactive(types.UID(a.PodUid)) {
+			onDeleted(k, a)
 			continue
 		}
 		name := a.Name
@@ -288,66 +272,131 @@ func (wf *workloadInfoWatcher) handleAgentSnapshot(ctx context.Context, ais map[
 			as = rpc.WorkloadInfo_INTERCEPTED
 			iClients = iis
 		}
-		if w, ok := wf.workloadEvents[name]; ok && w.Type != rpc.WorkloadEvent_DELETED {
-			wl := w.Workload
-			dlog.Debugf(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, w.Workload.State)
-			if wl.AgentState != as {
-				wl.AgentState = as
-				wl.InterceptClients = iClients
-				wf.resetTicker()
+
+		wf.workloadEvents.Compute(name, func(w *rpc.WorkloadEvent, loaded bool) (*rpc.WorkloadEvent, xsync.ComputeOp) {
+			if loaded {
+				if w.Type == rpc.WorkloadEvent_DELETED || w.Workload.AgentState == as {
+					return w, xsync.CancelOp
+				}
+				rwl := proto.Clone(w.Workload).(*rpc.WorkloadInfo)
+				rwl.AgentState = as
+				rwl.InterceptClients = iClients
+				w = &rpc.WorkloadEvent{
+					Type:     w.Type,
+					Workload: rwl,
+				}
+			} else {
+				wl, err := agentmap.GetWorkload(ctx, name, a.Namespace, "")
+				if err != nil {
+					// A delete event will have been generated for this workload.
+					return w, xsync.CancelOp
+				}
+				w = &rpc.WorkloadEvent{
+					Type:     rpc.WorkloadEvent_ADDED_UNSPECIFIED,
+					Workload: rpcWorkload(wl, as, iClients),
+				}
 			}
-		} else if wl, err := agentmap.GetWorkload(ctx, name, a.Namespace, ""); err == nil {
-			dlog.Debugf(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, workload.GetWorkloadState(wl))
-			wf.addEvent(workload.EventTypeUpdate, wl, as, iClients)
-		} else {
-			dlog.Debugf(ctx, "Unable to get workload %s.%s: %v", name, a.Namespace, err)
-		}
+			dlog.Tracef(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, w.Workload.State)
+			return w, xsync.UpdateOp
+		})
 	}
 }
 
-func (wf *workloadInfoWatcher) handleInterceptSnapshot(ctx context.Context, iis map[string]*Intercept) {
-	oldInterceptInfos := wf.interceptInfos
-	wf.interceptInfos = iis
-	for k, ii := range oldInterceptInfos {
-		if _, ok := wf.interceptInfos[k]; !ok {
-			name := ii.Spec.Agent
-			as := rpc.WorkloadInfo_INSTALLED
-			if w, ok := wf.workloadEvents[name]; ok && w.Type != rpc.WorkloadEvent_DELETED {
-				if w.Workload.AgentState != as {
-					w.Workload.AgentState = as
-					w.Workload.InterceptClients = nil
-					dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", w.Workload.Name, w.Workload.Namespace, as, w.Workload.State)
-					wf.resetTicker()
-				}
-			} else if wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, ""); err == nil {
-				dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", wl, as, workload.GetWorkloadState(wl))
-				wf.addEvent(workload.EventTypeUpdate, wl, as, nil)
-			}
-		}
-	}
+func (wf *workloadInfoWatcher) handleInterceptDelta(ctx context.Context, delta cache.Delta[string, *Intercept]) {
+	wf.resetTicker()
+
+	// Build a map of active intercepts by agent. This map must consider all intercepts, not just those that are provided as upserts.
+	// This is faster than calling getIntercepts() for each upserted intercept.
 	ipc := make(map[string][]*Intercept)
-	for _, ii := range wf.interceptInfos {
-		name := ii.Spec.Agent
-		if ii.Disposition == rpc.InterceptDispositionType_ACTIVE {
+	wf.intercepts.Range(func(key string, ii *Intercept) bool {
+		switch ii.Disposition {
+		case rpc.InterceptDispositionType_ACTIVE, rpc.InterceptDispositionType_WAITING, rpc.InterceptDispositionType_NO_AGENT:
+			name := ii.Spec.Agent
 			ipc[name] = append(ipc[name], ii)
 		}
+		return true
+	})
+
+	makeInterceptClients := func(ics []*Intercept) []*rpc.WorkloadInfo_Intercept {
+		iClients := make([]*rpc.WorkloadInfo_Intercept, len(ics))
+		for i, ic := range ics {
+			iClients[i] = &rpc.WorkloadInfo_Intercept{Client: ic.Spec.Client}
+		}
+		return iClients
 	}
-	for name, iis := range ipc {
-		iClients := make([]*rpc.WorkloadInfo_Intercept, len(iis))
-		as := rpc.WorkloadInfo_INTERCEPTED
-		for i, ii := range iis {
-			iClients[i] = &rpc.WorkloadInfo_Intercept{Client: ii.Spec.Client}
-		}
-		if w, ok := wf.workloadEvents[name]; ok && w.Type != rpc.WorkloadEvent_DELETED {
-			if w.Workload.AgentState != as {
-				w.Workload.AgentState = as
-				w.Workload.InterceptClients = iClients
-				dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", w.Workload.Name, w.Workload.Namespace, as, w.Workload.State)
-				wf.resetTicker()
+
+	for _, ii := range delta.Removals {
+		name := ii.Spec.Agent
+		as := rpc.WorkloadInfo_INSTALLED
+		wf.workloadEvents.Compute(name, func(w *rpc.WorkloadEvent, loaded bool) (*rpc.WorkloadEvent, xsync.ComputeOp) {
+			if loaded {
+				if w.Type == rpc.WorkloadEvent_DELETED {
+					return w, xsync.CancelOp
+				}
+				rwl := proto.Clone(w.Workload).(*rpc.WorkloadInfo)
+				rwl.AgentState = as
+				rwl.InterceptClients = makeInterceptClients(ipc[name])
+				if len(rwl.InterceptClients) > 0 {
+					as = rpc.WorkloadInfo_INTERCEPTED
+				}
+				w = &rpc.WorkloadEvent{
+					Type:     w.Type,
+					Workload: rwl,
+				}
+			} else {
+				wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, "")
+				if err != nil {
+					// A delete event will have been generated for this workload.
+					return w, xsync.CancelOp
+				}
+				iClients := makeInterceptClients(ipc[name])
+				if len(iClients) > 0 {
+					as = rpc.WorkloadInfo_INTERCEPTED
+				}
+				w = &rpc.WorkloadEvent{
+					Type:     rpc.WorkloadEvent_Type(workload.EventTypeUpdate),
+					Workload: rpcWorkload(wl, as, iClients),
+				}
 			}
-		} else if wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, ""); err == nil {
-			dlog.Debugf(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", wl, as, workload.GetWorkloadState(wl))
-			wf.addEvent(workload.EventTypeUpdate, wl, as, iClients)
+			dlog.Tracef(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", name, as, w.Workload.State)
+			return w, xsync.UpdateOp
+		})
+	}
+	if len(delta.Upserts) == 0 {
+		return
+	}
+
+	for _, ii := range delta.Upserts {
+		name := ii.Spec.Agent
+		iClients := makeInterceptClients(ipc[name])
+		as := rpc.WorkloadInfo_INTERCEPTED
+		if len(iClients) > 0 {
+			as = rpc.WorkloadInfo_INSTALLED
 		}
+		wf.workloadEvents.Compute(name, func(w *rpc.WorkloadEvent, loaded bool) (*rpc.WorkloadEvent, xsync.ComputeOp) {
+			if loaded {
+				if w.Type == rpc.WorkloadEvent_DELETED {
+					return w, xsync.CancelOp
+				}
+				rwl := proto.Clone(w.Workload).(*rpc.WorkloadInfo)
+				rwl.AgentState = as
+				rwl.InterceptClients = iClients
+				w = &rpc.WorkloadEvent{
+					Type:     w.Type,
+					Workload: rwl,
+				}
+			} else {
+				wl, err := agentmap.GetWorkload(ctx, name, wf.namespace, "")
+				if err != nil {
+					return nil, xsync.CancelOp
+				}
+				w = &rpc.WorkloadEvent{
+					Type:     rpc.WorkloadEvent_Type(workload.EventTypeUpdate),
+					Workload: rpcWorkload(wl, as, iClients),
+				}
+			}
+			dlog.Tracef(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", w.Workload.Name, w.Workload.Namespace, as, w.Workload.State)
+			return w, xsync.UpdateOp
+		})
 	}
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,12 @@ The Traffic Agent now has a new configuration option `agentInjector.mutationAwar
 The Traffic Agent now has a new configuration option `agent.enableH2cProbing` that can be set to `false` to disable the HTTP2/Clear-Text probing. The default setting is `true` to preserve backwards compatibility, but this will be changed to `false` in a future release.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Improved efficiency of traffic manager map updates.</div></div>
+<div style="margin-left: 15px">
+
+The watchable map has been refactored into a client/server model that supports delta-based updates. Where supported, gRPC now transmits only incremental changes instead of full snapshots, significantly reducing payload sizes. This improvement is especially important for large clusters, where full snapshots can be sizable and costly to transmit. Full snapshot streaming remains available as a backward-compatible fallback for clients that do not support delta methods.
+</div>
+
 ## Version 2.25.2 <span style="font-size: 16px;">(December 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ensure that the exit code from a docker command becomes the exit code of the Telepresence command.</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -20,6 +20,12 @@ The Traffic Agent now has a new configuration option `agentInjector.mutationAwar
 The Traffic Agent now has a new configuration option `agent.enableH2cProbing` that can be set to `false` to disable the HTTP2/Clear-Text probing. The default setting is `true` to preserve backwards compatibility, but this will be changed to `false` in a future release.
   </Body>
 </Note>
+<Note>
+	<Title type="feature">Improved efficiency of traffic manager map updates.</Title>
+	<Body>
+The watchable map has been refactored into a client/server model that supports delta-based updates. Where supported, gRPC now transmits only incremental changes instead of full snapshots, significantly reducing payload sizes. This improvement is especially important for large clusters, where full snapshots can be sizable and costly to transmit. Full snapshot streaming remains available as a backward-compatible fallback for clients that do not support delta methods.
+  </Body>
+</Note>
 ## Version 2.25.2 <span style={{fontSize:'16px'}}>(December 26)</span>
 <Note>
 	<Title type="bugfix">Ensure that the exit code from a docker command becomes the exit code of the Telepresence command.</Title>

--- a/integration_test/docker_run_test.go
+++ b/integration_test/docker_run_test.go
@@ -290,6 +290,9 @@ func (s *dockerDaemonSuite) Test_DockerRun_DockerDaemon() {
 }
 
 func (s *dockerDaemonSuite) Test_DockerRun_VolumePresent() {
+	if !s.ClientIsVersion(">2.24.x") {
+		s.T().Skip("Not part of compatibility tests. Docker volume plugin is unstable for versions < 2.25.0")
+	}
 	ctx := s.Context()
 	s.ApplyTemplate(ctx, filepath.Join("testdata", "k8s", "hello-w-volumes.goyaml"), nil)
 	defer s.DeleteSvcAndWorkload(ctx, "deploy", "hello")

--- a/integration_test/http_intercepts_test.go
+++ b/integration_test/http_intercepts_test.go
@@ -24,6 +24,13 @@ func (s *httpInterceptsSuite) SuiteName() string {
 	return "HTTPIntercepts"
 }
 
+func (s *httpInterceptsSuite) SetupSuite() {
+	if !(s.ManagerIsVersion(">2.24.x") && s.ClientIsVersion(">2.24.x")) {
+		s.T().Skip("HTTP intercepts require Telepresence 2.25.0 or later")
+	}
+	s.Suite.SetupSuite()
+}
+
 func (s *httpInterceptsSuite) Test_HTTPHeaderFiltering() {
 	require := s.Require()
 	ctx := s.Context()

--- a/integration_test/inject_policy_test.go
+++ b/integration_test/inject_policy_test.go
@@ -149,6 +149,9 @@ func (is *installSuite) applyOrDeleteMultipleServices(svcCount int, applyOrDelet
 }
 
 func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
+	if !(is.ManagerIsVersion(">2.24.x") && is.ClientIsVersion(">2.24.x")) {
+		is.T().Skip("Not part of compatibility tests.")
+	}
 	svcCount := 8
 	if runtime.GOOS != "linux" {
 		// The GitHub runner is probably using Colima for Kubernetes and running with limited
@@ -182,6 +185,9 @@ func (is *installSuite) Test_MultiOnDemandInjectOnInstall() {
 }
 
 func (is *installSuite) Test_MultiOnDemandInjectOnApply() {
+	if !(is.ManagerIsVersion(">2.24.x") && is.ClientIsVersion(">2.24.x")) {
+		is.T().Skip("Not part of compatibility tests.")
+	}
 	svcCount := 8
 	if runtime.GOOS != "linux" {
 		// The GitHub runner is probably using Colima for Kubernetes and running with limited

--- a/integration_test/injector_test.go
+++ b/integration_test/injector_test.go
@@ -147,6 +147,9 @@ func (s *singleServiceSuite) Test_HelmUpgradeWebhookSecret() {
 // Test_HelmUpgradeMountedWebhookSecret tests that updating the webhook secret does interfere with
 // intercept operations.
 func (s *singleServiceSuite) Test_HelmUpgradeMountedWebhookSecret() {
+	if !(s.ManagerIsVersion(">2.24.x") && s.ClientIsVersion(">2.24.x")) {
+		s.T().Skip("Not part of compatibility tests. Uninterrupted intercepts was implemented in 2.25.0")
+	}
 	ctx := s.Context()
 	rq := s.Require()
 

--- a/integration_test/large_files_test.go
+++ b/integration_test/large_files_test.go
@@ -65,8 +65,8 @@ func (s *largeFilesSuite) ServiceCount() int {
 }
 
 func (s *largeFilesSuite) SetupSuite() {
-	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
-		s.T().Skip("Not part of compatibility tests. Not enough transfer stability in versions < 2.22.0")
+	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.24.x")) {
+		s.T().Skip("Not part of compatibility tests. Not enough transfer stability")
 	}
 	s.Suite.SetupSuite()
 	ctx := s.Context()

--- a/integration_test/limitrange_test.go
+++ b/integration_test/limitrange_test.go
@@ -77,12 +77,20 @@ func (is *installSuite) TestLimitRange() {
 	}()
 
 	is.Run("Never", func() {
-		is.TelepresenceHelmInstallOK(is.Context(), false, "--set", "agentInjector.webhook.reinvocationPolicy=Never,agentInjector.mutationAware=false")
+		opts := []string{"--set", "agentInjector.webhook.reinvocationPolicy=Never"}
+		if is.ManagerIsVersion(">2.25.x") {
+			opts = append(opts, "--set", "agentInjector.mutationAware=false")
+		}
+		is.TelepresenceHelmInstallOK(is.Context(), false, opts...)
 		is.limitedRangeTest()
 	})
 
 	is.Run("IfNeeded", func() {
-		is.TelepresenceHelmInstallOK(is.Context(), true, "--set", "agentInjector.webhook.reinvocationPolicy=IfNeeded,agentInjector.mutationAware=true")
+		opts := []string{"--set", "agentInjector.webhook.reinvocationPolicy=IfNeeded"}
+		if is.ManagerIsVersion(">2.25.x") {
+			opts = append(opts, "--set", "agentInjector.mutationAware=true")
+		}
+		is.TelepresenceHelmInstallOK(is.Context(), true, opts...)
 		is.limitedRangeTest()
 	})
 }

--- a/integration_test/manual_agent_test.go
+++ b/integration_test/manual_agent_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 func (s *notConnectedSuite) Test_ManualAgent() {
@@ -20,8 +21,8 @@ func (s *notConnectedSuite) Test_ManualAgent() {
 }
 
 func testManualAgent(s *itest.Suite, nsp itest.NamespacePair) {
-	if !(s.ManagerIsVersion(">2.21.x") && s.ClientIsVersion(">2.21.x")) {
-		s.T().Skip("Not part of compatibility tests. Manual setup changed in 2.22.0")
+	if !(s.ManagerVersion().EQ(version.Structured) && s.ClientVersion().EQ(version.Structured)) {
+		s.T().Skip("Not part of compatibility tests. Manual setup often change between versions")
 	}
 	require := s.Require()
 	ctx := s.Context()

--- a/integration_test/proxy_via_test.go
+++ b/integration_test/proxy_via_test.go
@@ -41,6 +41,9 @@ const (
 )
 
 func (s *proxyViaSuite) SetupSuite() {
+	if !s.ClientIsVersion(">2.24.x") {
+		s.T().Skip("ProxyVia have some quirks in versions <2.25.0")
+	}
 	s.Suite.SetupSuite()
 	tpl := struct {
 		AliasIP string

--- a/integration_test/tls_test.go
+++ b/integration_test/tls_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func (s *dockerDaemonSuite) Test_TLSAnnotations() {
+	if !(s.ManagerIsVersion(">2.24.x") && s.ClientIsVersion(">2.24.x")) {
+		s.T().Skip("Not part of compatibility tests. Versions < 2.25.0 have no support for http intercepts")
+	}
 	const (
 		svc           = "hello"
 		containerPort = 8443

--- a/integration_test/workload_watch_test.go
+++ b/integration_test/workload_watch_test.go
@@ -7,9 +7,13 @@ import (
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
 func (s *notConnectedSuite) Test_WorkloadListener() {
+	if !s.ClientVersion().EQ(version.Structured) {
+		s.T().Skip(`Not part of compatibility tests. DoWithTrafficManager assumes compiled executable`)
+	}
 	s.Require().NoError(s.DoWithTrafficManager(s.Context(), func(ctx context.Context, cancel context.CancelFunc, client manager.ManagerClient, session *manager.SessionInfo) {
 		rq := s.Require()
 

--- a/integration_test/workload_watch_test.go
+++ b/integration_test/workload_watch_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 )
 
-func (s *notConnectedSuite) Test_WorkspaceListener() {
+func (s *notConnectedSuite) Test_WorkloadListener() {
 	s.Require().NoError(s.DoWithTrafficManager(s.Context(), func(ctx context.Context, cancel context.CancelFunc, client manager.ManagerClient, session *manager.SessionInfo) {
 		rq := s.Require()
 

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"github.com/puzpuzpuz/xsync/v4"
+)
+
+type Entry[K comparable, V any] interface {
+	Key() K
+	Value() V
+}
+
+type ClientMap[K comparable, V any] struct {
+	*xsync.Map[K, V]
+}
+
+func (c *ClientMap[K, V]) Watch(doneCh <-chan struct{}, deltaCh <-chan Delta[K, V], onChanges func() error) error {
+	for {
+		select {
+		case <-doneCh:
+			return nil
+		case delta, ok := <-deltaCh:
+			if !ok {
+				return nil
+			}
+			for k, v := range delta.Upserts {
+				c.Store(k, v)
+			}
+			for k := range delta.Removals {
+				c.Delete(k)
+			}
+			if onChanges != nil {
+				err := onChanges()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func NewClientMap[K comparable, V any](options ...func(config *xsync.MapConfig)) *ClientMap[K, V] {
+	return &ClientMap[K, V]{Map: xsync.NewMap[K, V](options...)}
+}
+
+type Server[K comparable, V any] interface {
+	Subscribe(done <-chan struct{}, filter func(K, V) bool) <-chan Delta[K, V]
+}

--- a/pkg/cache/map.go
+++ b/pkg/cache/map.go
@@ -1,7 +1,8 @@
-package watchable
+package cache
 
 import (
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -9,15 +10,46 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 )
 
+type Delta[K comparable, V any] struct {
+	Upserts  map[K]V
+	Removals map[K]V
+}
+
+func (delta *Delta[K, V]) Merge(other Delta[K, V]) {
+	if len(delta.Upserts) == 0 {
+		delta.Upserts = other.Upserts
+	} else {
+		for k, v := range other.Upserts {
+			delta.Upserts[k] = v
+		}
+		for k := range other.Removals {
+			delete(delta.Upserts, k)
+		}
+	}
+	if len(delta.Removals) == 0 {
+		delta.Removals = other.Removals
+	} else {
+		for k, v := range other.Removals {
+			delta.Removals[k] = v
+		}
+		for k := range other.Upserts {
+			delete(delta.Removals, k)
+		}
+	}
+}
+
 type subscription[K comparable, V any] struct {
-	channel chan map[K]V
-	filter  func(K, V) bool
-	mark    atomic.Bool
-	doneCh  <-chan struct{}
+	channel     chan Delta[K, V]
+	include     func(K, V) bool
+	initialized atomic.Bool
+	mark        atomic.Bool
+	doneCh      <-chan struct{}
 }
 
 type Map[K comparable, V any] struct {
 	*xsync.Map[K, V]
+	snapLock    sync.Mutex
+	snapshot    map[K]V
 	equal       func(V, V) bool
 	subscribers *xsync.Map[uuid.UUID, *subscription[K, V]]
 	notifyDelay time.Duration
@@ -36,32 +68,34 @@ func NewMap[K comparable, V any](equal func(V, V) bool, notifyDelay time.Duratio
 	return m
 }
 
-// Subscribe returns a channel that will emit a snapshot of the map that corresponds to the content
-// of the map filtered by the given filter. The filter is re-evaluated each time a snapshot is
-// emitted.
+// Subscribe returns a channel that will emit deltas that corresponds to modifications of the contained
+// values filtered by the given filter.
 //
-// The first snapshot is emitted immediately after the call to Subscribe(), and then whenever the map
-// changes, a key - value binding for which the filter evaluates to true.
+// The first delta is a snapshot of all values, and it is emitted immediately after the call to Subscribe().
+// After that, a new Delta is emitted then whenever the map changes a value for which the filter evaluates
+// to true.
 //
-// The snapshot content will reflect actual values in the map. Mutating them will thus mutate the
-// map without the map's knowledge and hence not trigger notifications to subscribers.
+// The values contained in a delta will reflect actual values in the map and must be considered immutable.
+// Mutating them will mutate the map without the map's knowledge and hence not trigger notifications to
+// subscribers.
 //
 // The returned channel will be closed when the given channel is closed.
-func (m *Map[K, V]) Subscribe(done <-chan struct{}, filter func(K, V) bool) <-chan map[K]V {
-	ch := make(chan map[K]V, 1)
+func (m *Map[K, V]) Subscribe(done <-chan struct{}, includeFilter func(K, V) bool) <-chan Delta[K, V] {
+	ch := make(chan Delta[K, V], 1)
 	select {
 	case <-done:
 		close(ch)
 	default:
+		m.notifier.Reset(math.MaxInt64)
+
 		id := uuid.New()
-		if filter == nil {
-			filter = func(K, V) bool { return true }
-		}
-		sb := &subscription[K, V]{filter: filter, channel: ch}
+		sb := &subscription[K, V]{include: includeFilter, channel: ch, doneCh: done}
+		sb.mark.Store(true)
 		m.subscribers.Store(id, sb)
+
+		// Fire notifier immediately to send the snapshot.
+		m.notify()
 		go func() {
-			// Trigger the initial snapshot, then wait for the subscription to end
-			m.sendSnapshot(sb)
 			<-done
 			m.subscribers.Delete(id)
 			close(ch)
@@ -79,23 +113,27 @@ func (m *Map[K, V]) Subscribe(done <-chan struct{}, filter func(K, V) bool) <-ch
 // This call locks a hash table bucket while the compute function is executed. It means that modifications
 // on other entries in the bucket will be blocked until the valueFn executes. Consider this when the function
 // includes long-running operations.
-func (m *Map[K, V]) Compute(key K, f func(oldValue V, loaded bool) (newValue V, op xsync.ComputeOp)) (actual V, ok bool) {
-	didMark := false
-	actual, ok = m.Map.Compute(key, func(oldValue V, loaded bool) (V, xsync.ComputeOp) {
-		value, del := f(oldValue, loaded)
-		if del == xsync.CancelOp {
-			return value, del
-		}
-		if del == xsync.DeleteOp {
-			if loaded && m.markSubscribers(key, oldValue) {
-				didMark = true
+func (m *Map[K, V]) Compute(key K, f func(V, bool) (V, xsync.ComputeOp)) (V, bool) {
+	modified := false
+	actual, ok := m.Map.Compute(key, func(v V, loaded bool) (V, xsync.ComputeOp) {
+		fv, op := f(v, loaded)
+		switch op {
+		case xsync.CancelOp:
+		case xsync.UpdateOp:
+			if loaded && m.equal(fv, v) {
+				fv = v
+				op = xsync.CancelOp
+			} else {
+				modified = true
+				m.markSubscribers(key, fv)
 			}
-		} else if !(loaded && m.equal(value, oldValue)) && m.markSubscribers(key, value) {
-			didMark = true
+		case xsync.DeleteOp:
+			modified = true
+			m.markSubscribers(key, v)
 		}
-		return value, del
+		return fv, op
 	})
-	if didMark {
+	if modified {
 		m.notifier.Reset(m.notifyDelay)
 	}
 	return actual, ok
@@ -211,25 +249,25 @@ func (m *Map[K, V]) Store(key K, value V) {
 }
 
 // markSubscribers marks all subscribers interested in the given key and value binding.
-func (m *Map[K, V]) markSubscribers(key K, value V) (didMark bool) {
+func (m *Map[K, V]) markSubscribers(key K, value V) {
 	m.subscribers.Range(func(_ uuid.UUID, sb *subscription[K, V]) bool {
 		// Don't run the filter if the subscriber is marked already.
-		if !sb.mark.Load() && sb.filter(key, value) && sb.mark.CompareAndSwap(false, true) {
-			didMark = true
+		if !sb.mark.Load() && sb.include(key, value) {
+			sb.mark.Store(true)
 		}
 		return true
 	})
-	return didMark
 }
 
 // notify will send a snapshot to all subscribers that have been marked.
 func (m *Map[K, V]) notify() {
 	// We need to loop until all marked snapshots have been sent, because new marks may be added during sending.
+	delta := m.makeDelta()
 	for didSend := true; didSend; {
 		didSend = false
 		m.subscribers.Range(func(_ uuid.UUID, sb *subscription[K, V]) bool {
 			if sb.mark.CompareAndSwap(true, false) {
-				m.sendSnapshot(sb)
+				delta.send(sb)
 				didSend = true
 			}
 			return true
@@ -237,18 +275,83 @@ func (m *Map[K, V]) notify() {
 	}
 }
 
-// sendSnapshot evaluates and sends a snapshot to the subscriber.
-func (m *Map[K, V]) sendSnapshot(sb *subscription[K, V]) {
-	snap := make(map[K]V)
-	m.Range(func(key K, value V) bool {
-		if sb.filter(key, value) {
-			snap[key] = value
+type allDelta[K comparable, V any] struct {
+	snapshot map[K]V
+	upserts  map[K]V
+	removals map[K]V
+}
+
+func filteredMap[K comparable, V any](m map[K]V, include func(K, V) bool) map[K]V {
+	if include == nil {
+		return m
+	}
+	fm := make(map[K]V)
+	for k, v := range m {
+		if include(k, v) {
+			fm[k] = v
 		}
-		return true
-	})
+	}
+	return fm
+}
+
+func (ad *allDelta[K, V]) filteredDelta(initialized bool, include func(K, V) bool) Delta[K, V] {
+	var upserts map[K]V
+	var removals map[K]V
+	if initialized {
+		upserts = ad.upserts
+		removals = ad.removals
+	} else {
+		upserts = ad.snapshot
+		removals = nil
+	}
+	return Delta[K, V]{Upserts: filteredMap(upserts, include), Removals: filteredMap(removals, include)}
+}
+
+func (ad *allDelta[K, V]) send(sb *subscription[K, V]) {
+	fd := ad.filteredDelta(sb.initialized.Swap(true), sb.include)
+	if len(fd.Upserts) == 0 && len(fd.Removals) == 0 {
+		return
+	}
 	select {
 	case <-sb.doneCh:
-	case sb.channel <- snap:
+	case prevDelta := <-sb.channel:
+		// The previous delta was not read by the subscriber yet, so we need to merge it with the new delta
+		// and put it back on the channel.
+		prevDelta.Merge(fd)
+		sb.channel <- prevDelta
 	default:
+		// The channel is empty, so we can just send the delta.
+		sb.channel <- fd
+	}
+}
+
+func (m *Map[K, V]) makeDelta() allDelta[K, V] {
+	m.snapLock.Lock()
+	previous := m.snapshot
+	current := m.LoadAll()
+	m.snapshot = current
+	var upserts map[K]V
+	for k, v := range current {
+		if prev, ok := previous[k]; !(ok && m.equal(prev, v)) {
+			if upserts == nil {
+				upserts = make(map[K]V)
+			}
+			upserts[k] = v
+		}
+	}
+	var removals map[K]V
+	for k, v := range previous {
+		if _, ok := current[k]; !ok {
+			if removals == nil {
+				removals = make(map[K]V)
+			}
+			removals[k] = v
+		}
+	}
+	m.snapLock.Unlock()
+	return allDelta[K, V]{
+		snapshot: current,
+		upserts:  upserts,
+		removals: removals,
 	}
 }

--- a/pkg/cache/map.go
+++ b/pkg/cache/map.go
@@ -252,7 +252,7 @@ func (m *Map[K, V]) Store(key K, value V) {
 func (m *Map[K, V]) markSubscribers(key K, value V) {
 	m.subscribers.Range(func(_ uuid.UUID, sb *subscription[K, V]) bool {
 		// Don't run the filter if the subscriber is marked already.
-		if !sb.mark.Load() && sb.include(key, value) {
+		if !sb.mark.Load() && (sb.include == nil || sb.include(key, value)) {
 			sb.mark.Store(true)
 		}
 		return true
@@ -308,8 +308,9 @@ func (ad *allDelta[K, V]) filteredDelta(initialized bool, include func(K, V) boo
 }
 
 func (ad *allDelta[K, V]) send(sb *subscription[K, V]) {
-	fd := ad.filteredDelta(sb.initialized.Swap(true), sb.include)
-	if len(fd.Upserts) == 0 && len(fd.Removals) == 0 {
+	initialized := sb.initialized.Swap(true)
+	fd := ad.filteredDelta(initialized, sb.include)
+	if initialized && len(fd.Upserts) == 0 && len(fd.Removals) == 0 {
 		return
 	}
 	select {

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -21,6 +21,7 @@ import (
 	tpClient "github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/k8sclient"
 	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
 
@@ -203,7 +204,7 @@ func (ac *client) refresh(ctx context.Context, ai *manager.AgentPodInfo) {
 	}
 }
 
-func (ac *client) startDialWatcherLocked(ctx context.Context) (err error) {
+func (ac *client) startDialWatcherLocked(ctx context.Context) error {
 	if ac.cancelDialWatch != nil {
 		// Already started
 		return nil
@@ -212,7 +213,7 @@ func (ac *client) startDialWatcherLocked(ctx context.Context) (err error) {
 
 	// Create the dial watcher
 	dlog.Debugf(ctx, "watching dials from agent pod %s", ac)
-	watcher, err := ac.cli.WatchDial(ctx, ac.session)
+	dialStream, err := ac.cli.WatchDial(ctx, ac.session)
 	if err != nil {
 		cancel()
 		return err
@@ -227,7 +228,7 @@ func (ac *client) startDialWatcherLocked(ctx context.Context) (err error) {
 	}
 
 	go func() {
-		err := tunnel.DialWaitLoop(ctx, tunnel.AgentToClient, tunnel.AgentProvider(ac.cli), watcher, tunnel.SessionID(ac.session.SessionId))
+		err := tunnel.DialWaitLoop(ctx, tunnel.AgentToClient, tunnel.AgentProvider(ac.cli), dialStream, tunnel.SessionID(ac.session.SessionId))
 		if err != nil {
 			// The traffic-agent closed the dial wait loop, which means that it's terminating.
 			dlog.Error(ctx, err)
@@ -383,7 +384,6 @@ func (s *clients) hasWaiterFor(info *manager.AgentPodInfo) bool {
 }
 
 func (s *clients) WatchAgentPods(ctx context.Context, rmc manager.ManagerClient) error {
-	dlog.Debug(ctx, "WatchAgentPods starting")
 	defer func() {
 		activeCount := 0
 		s.clients.Range(func(_ string, ac *client) bool {
@@ -395,8 +395,30 @@ func (s *clients) WatchAgentPods(ctx context.Context, rmc manager.ManagerClient)
 		dlog.Debugf(ctx, "WatchAgentPods ending with %d clients still active", activeCount)
 		s.disabled.Store(true)
 	}()
+
+	snapMap := make(map[string]*manager.AgentPodInfo)
+	err := watcher.WatchWithRetry(ctx, "WatchAgentPodsDelta", tpClient.GetConfig(ctx).Grpc().WatchRetryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoDelta], error) {
+			dlog.Debugf(ctx, "WatchAgentPodsDelta starting")
+			return rmc.WatchAgentPodsDelta(ctx, s.session)
+		},
+		func(delta *manager.AgentPodInfoDelta) error {
+			dlog.Debugf(ctx, "WatchAgentPodsDelta received %d upserts, %d removals", len(delta.Upserts), len(delta.Removals))
+			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
+			return s.updateClients(ctx, maps.Values(snapMap))
+		}, func() error {
+			clear(snapMap)
+			return nil
+		})
+	if err == nil || status.Code(err) != codes.Unimplemented {
+		return err
+	}
+
+	// Older traffic-manager. Fall back to watching all agents.
+	dlog.Warnf(ctx, "WatchAgentPodsDelta is not implemented by the traffic-manager, falling back to WatchAgentPods and full snapshots")
 	return watcher.WatchWithRetry(ctx, "WatchAgentPods", tpClient.GetConfig(ctx).Grpc().WatchRetryInterval,
 		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoSnapshot], error) {
+			dlog.Debugf(ctx, "No delta support in traffic-manager, starting WatchAgentPods instead")
 			return rmc.WatchAgentPods(ctx, s.session)
 		},
 		func(snapshot *manager.AgentPodInfoSnapshot) error {
@@ -404,26 +426,30 @@ func (s *clients) WatchAgentPods(ctx context.Context, rmc manager.ManagerClient)
 		}, nil)
 }
 
-func (s *clients) notifyWaiters() {
+func (ac *client) notify(ctx context.Context, waiter chan struct{}) {
+	// a client must be connected to be able to notify
+	if _, err := ac.ensureConnect(ctx); err != nil {
+		dlog.Errorf(ctx, "notifyWaiters %s (%s), ensureConnect failed: %v", ac.info.WorkloadName, net.IP(ac.info.PodIp), err)
+	}
+	close(waiter)
+}
+
+func (s *clients) notifyWaiters(ctx context.Context) {
 	s.clients.Range(func(name string, ac *client) bool {
-		// a client must be connected to be able to notify
-		if !ac.connected() {
-			return true
-		}
 		if podIP, ok := netip.AddrFromSlice(ac.info.PodIp); ok {
 			if waiter, ok := s.ipWaiters.LoadAndDelete(podIP); ok {
-				close(waiter)
+				ac.notify(ctx, waiter)
 			}
 		}
 		if waiter, ok := s.wlWaiters.LoadAndDelete(ac.info.WorkloadName); ok {
-			close(waiter)
+			ac.notify(ctx, waiter)
 		}
 		return true
 	})
 }
 
 func (s *clients) waitWithTimeout(ctx context.Context, timeout time.Duration, waitOn <-chan struct{}) error {
-	s.notifyWaiters()
+	s.notifyWaiters(ctx)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	select {
@@ -503,15 +529,8 @@ func (s *clients) WaitForWorkload(ctx context.Context, timeout time.Duration, na
 }
 
 func (s *clients) updateClients(ctx context.Context, ais []*manager.AgentPodInfo) error {
-	defer s.notifyWaiters()
+	defer s.notifyWaiters(ctx)
 
-	if dlog.MaxLogLevel(ctx) >= dlog.LogLevelDebug {
-		ns := make([]string, len(ais))
-		for i, ac := range ais {
-			ns[i] = fmt.Sprintf("%s(%s)", ac.PodName, net.IP(ac.PodIp))
-		}
-		dlog.Debugf(ctx, "updateClients %s", ns)
-	}
 	var aim map[string]*manager.AgentPodInfo
 	if len(ais) > 0 {
 		aim = make(map[string]*manager.AgentPodInfo, len(ais))

--- a/pkg/client/userd/trafficmgr/agents.go
+++ b/pkg/client/userd/trafficmgr/agents.go
@@ -5,23 +5,42 @@ import (
 	"slices"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/datawire/dlib/dlog"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
 
 func (s *session) watchAgentsLoop(ctx context.Context) error {
-	err := watcher.WatchWithRetry(ctx, "WatchAgents", client.GetConfig(ctx).Grpc().WatchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentInfoSnapshot], error) {
-			return s.managerClient.WatchAgents(ctx, s.SessionInfo())
+	snapMap := make(map[string]*manager.AgentInfo)
+	err := watcher.WatchWithRetry(ctx, "WatchAgentsDelta", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentInfoDelta], error) {
+			return s.managerClient.WatchAgentsDelta(ctx, s.SessionInfo())
 		},
-		func(snapshot *manager.AgentInfoSnapshot) error {
-			s.handleAgentSnapshot(ctx, snapshot.Agents)
+		func(delta *manager.AgentInfoDelta) error {
+			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
+			s.handleAgentSnapshot(ctx, maps.Values(snapMap))
 			return nil
-		}, nil)
+		}, func() error {
+			clear(snapMap)
+			return nil
+		})
 
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		dlog.Warnf(ctx, "WatchAgentsDelta is not implemented by the traffic-manager, falling back to WatchAgents and full snapshots")
+		err = watcher.WatchWithRetry(ctx, "WatchAgents", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+			func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentInfoSnapshot], error) {
+				return s.managerClient.WatchAgents(ctx, s.SessionInfo())
+			},
+			func(snapshot *manager.AgentInfoSnapshot) error {
+				s.handleAgentSnapshot(ctx, snapshot.Agents)
+				return nil
+			}, nil)
+	}
 	// Handle as if we had an empty snapshot. This will ensure that port forwards and volume mounts are canceled correctly.
 	s.handleAgentSnapshot(ctx, nil)
 	return err

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -144,14 +144,31 @@ func (s *session) watchInterceptsHandler(context.Context) error {
 
 func (s *session) watchInterceptsLoop(ctx context.Context) error {
 	pat := newPodAccessTracker()
-	err := watcher.WatchWithRetry(ctx, "WatchIntercepts", client.GetConfig(ctx).Grpc().WatchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[manager.InterceptInfoSnapshot], error) {
-			return s.managerClient.WatchIntercepts(s.context, s.SessionInfo())
+	snapMap := make(map[string]*manager.InterceptInfo)
+	err := watcher.WatchWithRetry(ctx, "WatchInterceptsDelta", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.InterceptInfoDelta], error) {
+			return s.managerClient.WatchInterceptsDelta(s.context, s.SessionInfo())
 		},
-		func(snapshot *manager.InterceptInfoSnapshot) error {
-			s.handleInterceptSnapshot(pat, snapshot.Intercepts)
+		func(delta *manager.InterceptInfoDelta) error {
+			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
+			s.handleInterceptSnapshot(pat, maps.Values(snapMap))
 			return nil
-		}, s.reconnectManager)
+		}, func() error {
+			clear(snapMap)
+			return s.reconnectManager()
+		})
+	if err != nil && grpcStatus.Code(err) == grpcCodes.Unimplemented {
+		// Fall back to streaming all intercepts if the traffic manager doesn't support delta updates.'
+		dlog.Warnf(ctx, "WatchInterceptsDelta is not implemented by the traffic-manager, falling back to WatchIntercepts and full snapshots")
+		err = watcher.WatchWithRetry(ctx, "WatchIntercepts", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+			func(ctx context.Context) (grpc.ServerStreamingClient[manager.InterceptInfoSnapshot], error) {
+				return s.managerClient.WatchIntercepts(s.context, s.SessionInfo())
+			},
+			func(snapshot *manager.InterceptInfoSnapshot) error {
+				s.handleInterceptSnapshot(pat, snapshot.Intercepts)
+				return nil
+			}, s.reconnectManager)
+	}
 	// Handle as if we had an empty snapshot. This will ensure that port forwards and volume mounts are cancelled correctly.
 	s.handleInterceptSnapshot(pat, nil)
 	return err

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -1021,7 +1021,7 @@ func (s *session) workloadsWatcher(ctx context.Context, namespace string, synced
 			synced.Done()
 		}
 	}()
-	return watcher.WatchWithRetry(ctx, "WatchAgentPods", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+	return watcher.WatchWithRetry(ctx, "WatchWorkloads", client.GetConfig(ctx).Grpc().WatchRetryInterval,
 		func(ctx context.Context) (grpc.ServerStreamingClient[manager.WorkloadEventsDelta], error) {
 			return s.managerClient.WatchWorkloads(ctx, &manager.WorkloadEventsRequest{SessionInfo: s.sessionInfo, Namespace: namespace})
 		},

--- a/pkg/dnsproxy/rpc.go
+++ b/pkg/dnsproxy/rpc.go
@@ -3,9 +3,9 @@ package dnsproxy
 import (
 	"github.com/miekg/dns"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	grpcErrors "github.com/telepresenceio/telepresence/v2/pkg/grpc/errors"
 )
 
 func ToRPC(rrs RRs, rCode int) (*manager.DNSResponse, error) {
@@ -19,7 +19,7 @@ func ToRPC(rrs RRs, rCode int) (*manager.DNSResponse, error) {
 	for _, rr := range rrs {
 		var err error
 		if off, err = dns.PackRR(rr, rrb, off, nil, false); err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to pack DNS reply: %v", err)
+			return nil, grpcErrors.Errorf(codes.Internal, "unable to pack DNS reply: %v", err)
 		}
 	}
 	rsp.Rrs = rrb
@@ -34,7 +34,7 @@ func FromRPC(r *manager.DNSResponse) (RRs, int, error) {
 		var rr dns.RR
 		var err error
 		if rr, off, err = dns.UnpackRR(rrb, off); err != nil {
-			return nil, dns.RcodeFormatError, status.Errorf(codes.InvalidArgument, "unable to unpack DNS response: %v", err)
+			return nil, dns.RcodeFormatError, grpcErrors.Errorf(codes.InvalidArgument, "unable to unpack DNS response: %v", err)
 		}
 		rrs = append(rrs, rr)
 	}

--- a/pkg/grpc/errors/errors.go
+++ b/pkg/grpc/errors/errors.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error is like status.Error, but it will never return nil. Instead, it panics if the code is codes.Ok
+//
+// The sole purpose of this function is to remedy https://youtrack.jetbrains.com/issue/GO-19802
+func Error(c codes.Code, msg string) error {
+	err := status.Error(c, msg)
+	if err == nil {
+		panic("foo")
+	}
+	return err
+}
+
+// Errorf is like status.Errorf, but it will never return nil. Instead, it panics if the code is codes.Ok
+//
+// The sole purpose of this function is to remedy https://youtrack.jetbrains.com/issue/GO-19802
+func Errorf(c codes.Code, format string, a ...any) error {
+	err := status.Errorf(c, format, a...)
+	if err == nil {
+		panic("foo")
+	}
+	return err
+}

--- a/pkg/grpc/watcher/watcher.go
+++ b/pkg/grpc/watcher/watcher.go
@@ -39,7 +39,7 @@ func WatchWithRetry[T any](
 		switch status.Code(err) {
 		case codes.OK:
 		case codes.Unimplemented:
-			return backoff.Permanent(fmt.Errorf("%s is not implemented by the server", name))
+			return backoff.Permanent(err)
 		default:
 			return fmt.Errorf("error when calling stream provider for %s: %w", name, err)
 		}
@@ -59,7 +59,7 @@ func WatchWithRetry[T any](
 						return backoff.Permanent(err)
 					}
 				case codes.Unimplemented:
-					return backoff.Permanent(fmt.Errorf("%s is not implemented by the server", name))
+					return backoff.Permanent(err)
 				default:
 					return fmt.Errorf("error when calling Recv for %s: %w", name, err)
 				}

--- a/pkg/maps/utils.go
+++ b/pkg/maps/utils.go
@@ -35,14 +35,21 @@ func Merge[K comparable, V any](dst, src map[K]V) {
 	}
 }
 
-// SortedKeys returns the keys of the map m sorted alphabetically.
-func SortedKeys[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
+// KeySlice returns the a slice containing the keys of the map m.
+func KeySlice[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
 	r := make([]K, len(m))
 	i := 0
 	for k := range m {
 		r[i] = k
 		i++
 	}
+	slices.Sort(r)
+	return r
+}
+
+// SortedKeys returns the keys of the map m sorted alphabetically.
+func SortedKeys[M ~map[K]V, K cmp.Ordered, V any](m M) []K {
+	r := KeySlice(m)
 	slices.Sort(r)
 	return r
 }
@@ -59,6 +66,25 @@ func ToSortedSlice[K cmp.Ordered, V any](m map[K]V) []V {
 	vs := make([]V, i)
 	for i, n := range ns {
 		vs[i] = m[n]
+	}
+	return vs
+}
+
+func DeltaUpdate[K comparable, V any](m map[K]V, upserts map[K]V, removals []K) {
+	for k, v := range upserts {
+		m[k] = v
+	}
+	for _, k := range removals {
+		delete(m, k)
+	}
+}
+
+func Values[K comparable, V any](m map[K]V) []V {
+	ml := len(m)
+	vs := make([]V, ml)
+	for _, v := range m {
+		ml--
+		vs[ml] = v
 	}
 	return vs
 }

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -169,7 +169,7 @@ func (x WorkloadInfo_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_Kind.Descriptor instead.
 func (WorkloadInfo_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45, 0}
 }
 
 type WorkloadInfo_State int32
@@ -229,7 +229,7 @@ func (x WorkloadInfo_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_State.Descriptor instead.
 func (WorkloadInfo_State) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42, 1}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45, 1}
 }
 
 type WorkloadInfo_AgentState int32
@@ -281,7 +281,7 @@ func (x WorkloadInfo_AgentState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_AgentState.Descriptor instead.
 func (WorkloadInfo_AgentState) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42, 2}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45, 2}
 }
 
 type WorkloadEvent_Type int32
@@ -330,7 +330,7 @@ func (x WorkloadEvent_Type) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadEvent_Type.Descriptor instead.
 func (WorkloadEvent_Type) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{43, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{46, 0}
 }
 
 // ClientInfo is the self-reported metadata that the on-laptop
@@ -1377,6 +1377,58 @@ func (x *AgentInfoSnapshot) GetAgents() []*AgentInfo {
 	return nil
 }
 
+type AgentInfoDelta struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Upserts       map[string]*AgentInfo  `protobuf:"bytes,1,rep,name=upserts,proto3" json:"upserts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Removals      []string               `protobuf:"bytes,2,rep,name=removals,proto3" json:"removals,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentInfoDelta) Reset() {
+	*x = AgentInfoDelta{}
+	mi := &file_manager_manager_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentInfoDelta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentInfoDelta) ProtoMessage() {}
+
+func (x *AgentInfoDelta) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentInfoDelta.ProtoReflect.Descriptor instead.
+func (*AgentInfoDelta) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AgentInfoDelta) GetUpserts() map[string]*AgentInfo {
+	if x != nil {
+		return x.Upserts
+	}
+	return nil
+}
+
+func (x *AgentInfoDelta) GetRemovals() []string {
+	if x != nil {
+		return x.Removals
+	}
+	return nil
+}
+
 type InterceptInfoSnapshot struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Intercepts    []*InterceptInfo       `protobuf:"bytes,1,rep,name=intercepts,proto3" json:"intercepts,omitempty"`
@@ -1386,7 +1438,7 @@ type InterceptInfoSnapshot struct {
 
 func (x *InterceptInfoSnapshot) Reset() {
 	*x = InterceptInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[10]
+	mi := &file_manager_manager_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1398,7 +1450,7 @@ func (x *InterceptInfoSnapshot) String() string {
 func (*InterceptInfoSnapshot) ProtoMessage() {}
 
 func (x *InterceptInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[10]
+	mi := &file_manager_manager_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1411,12 +1463,64 @@ func (x *InterceptInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterceptInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*InterceptInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{10}
+	return file_manager_manager_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *InterceptInfoSnapshot) GetIntercepts() []*InterceptInfo {
 	if x != nil {
 		return x.Intercepts
+	}
+	return nil
+}
+
+type InterceptInfoDelta struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Upserts       map[string]*InterceptInfo `protobuf:"bytes,1,rep,name=upserts,proto3" json:"upserts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Removals      []string                  `protobuf:"bytes,2,rep,name=removals,proto3" json:"removals,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InterceptInfoDelta) Reset() {
+	*x = InterceptInfoDelta{}
+	mi := &file_manager_manager_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterceptInfoDelta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterceptInfoDelta) ProtoMessage() {}
+
+func (x *InterceptInfoDelta) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterceptInfoDelta.ProtoReflect.Descriptor instead.
+func (*InterceptInfoDelta) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *InterceptInfoDelta) GetUpserts() map[string]*InterceptInfo {
+	if x != nil {
+		return x.Upserts
+	}
+	return nil
+}
+
+func (x *InterceptInfoDelta) GetRemovals() []string {
+	if x != nil {
+		return x.Removals
 	}
 	return nil
 }
@@ -1431,7 +1535,7 @@ type CreateInterceptRequest struct {
 
 func (x *CreateInterceptRequest) Reset() {
 	*x = CreateInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[11]
+	mi := &file_manager_manager_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1547,7 @@ func (x *CreateInterceptRequest) String() string {
 func (*CreateInterceptRequest) ProtoMessage() {}
 
 func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[11]
+	mi := &file_manager_manager_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1560,7 @@ func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInterceptRequest.ProtoReflect.Descriptor instead.
 func (*CreateInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{11}
+	return file_manager_manager_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateInterceptRequest) GetSession() *SessionInfo {
@@ -1483,7 +1587,7 @@ type EnsureAgentRequest struct {
 
 func (x *EnsureAgentRequest) Reset() {
 	*x = EnsureAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[12]
+	mi := &file_manager_manager_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1495,7 +1599,7 @@ func (x *EnsureAgentRequest) String() string {
 func (*EnsureAgentRequest) ProtoMessage() {}
 
 func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[12]
+	mi := &file_manager_manager_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1508,7 +1612,7 @@ func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnsureAgentRequest.ProtoReflect.Descriptor instead.
 func (*EnsureAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{12}
+	return file_manager_manager_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *EnsureAgentRequest) GetSession() *SessionInfo {
@@ -1546,7 +1650,7 @@ type PreparedIntercept struct {
 
 func (x *PreparedIntercept) Reset() {
 	*x = PreparedIntercept{}
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1558,7 +1662,7 @@ func (x *PreparedIntercept) String() string {
 func (*PreparedIntercept) ProtoMessage() {}
 
 func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1571,7 +1675,7 @@ func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedIntercept.ProtoReflect.Descriptor instead.
 func (*PreparedIntercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{13}
+	return file_manager_manager_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PreparedIntercept) GetError() string {
@@ -1675,7 +1779,7 @@ type RemoveInterceptRequest2 struct {
 
 func (x *RemoveInterceptRequest2) Reset() {
 	*x = RemoveInterceptRequest2{}
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1687,7 +1791,7 @@ func (x *RemoveInterceptRequest2) String() string {
 func (*RemoveInterceptRequest2) ProtoMessage() {}
 
 func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1700,7 +1804,7 @@ func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveInterceptRequest2.ProtoReflect.Descriptor instead.
 func (*RemoveInterceptRequest2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{14}
+	return file_manager_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RemoveInterceptRequest2) GetSession() *SessionInfo {
@@ -1727,7 +1831,7 @@ type GetInterceptRequest struct {
 
 func (x *GetInterceptRequest) Reset() {
 	*x = GetInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1739,7 +1843,7 @@ func (x *GetInterceptRequest) String() string {
 func (*GetInterceptRequest) ProtoMessage() {}
 
 func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1752,7 +1856,7 @@ func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInterceptRequest.ProtoReflect.Descriptor instead.
 func (*GetInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{15}
+	return file_manager_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetInterceptRequest) GetSession() *SessionInfo {
@@ -1794,7 +1898,7 @@ type ReviewInterceptRequest struct {
 
 func (x *ReviewInterceptRequest) Reset() {
 	*x = ReviewInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1806,7 +1910,7 @@ func (x *ReviewInterceptRequest) String() string {
 func (*ReviewInterceptRequest) ProtoMessage() {}
 
 func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1819,7 +1923,7 @@ func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewInterceptRequest.ProtoReflect.Descriptor instead.
 func (*ReviewInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{16}
+	return file_manager_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ReviewInterceptRequest) GetSession() *SessionInfo {
@@ -1908,7 +2012,7 @@ type RemainRequest struct {
 
 func (x *RemainRequest) Reset() {
 	*x = RemainRequest{}
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1920,7 +2024,7 @@ func (x *RemainRequest) String() string {
 func (*RemainRequest) ProtoMessage() {}
 
 func (x *RemainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1933,7 +2037,7 @@ func (x *RemainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemainRequest.ProtoReflect.Descriptor instead.
 func (*RemainRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{17}
+	return file_manager_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RemainRequest) GetSession() *SessionInfo {
@@ -1955,7 +2059,7 @@ type LogLevelRequest struct {
 
 func (x *LogLevelRequest) Reset() {
 	*x = LogLevelRequest{}
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1967,7 +2071,7 @@ func (x *LogLevelRequest) String() string {
 func (*LogLevelRequest) ProtoMessage() {}
 
 func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1980,7 +2084,7 @@ func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogLevelRequest.ProtoReflect.Descriptor instead.
 func (*LogLevelRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{18}
+	return file_manager_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LogLevelRequest) GetLogLevel() string {
@@ -2013,7 +2117,7 @@ type GetLogsRequest struct {
 
 func (x *GetLogsRequest) Reset() {
 	*x = GetLogsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2025,7 +2129,7 @@ func (x *GetLogsRequest) String() string {
 func (*GetLogsRequest) ProtoMessage() {}
 
 func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2038,7 +2142,7 @@ func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetLogsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{19}
+	return file_manager_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetLogsRequest) GetTrafficManager() bool {
@@ -2080,7 +2184,7 @@ type LogsResponse struct {
 
 func (x *LogsResponse) Reset() {
 	*x = LogsResponse{}
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2092,7 +2196,7 @@ func (x *LogsResponse) String() string {
 func (*LogsResponse) ProtoMessage() {}
 
 func (x *LogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2105,7 +2209,7 @@ func (x *LogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogsResponse.ProtoReflect.Descriptor instead.
 func (*LogsResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{20}
+	return file_manager_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LogsResponse) GetPodLogs() map[string]string {
@@ -2139,7 +2243,7 @@ type TelepresenceAPIInfo struct {
 
 func (x *TelepresenceAPIInfo) Reset() {
 	*x = TelepresenceAPIInfo{}
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2151,7 +2255,7 @@ func (x *TelepresenceAPIInfo) String() string {
 func (*TelepresenceAPIInfo) ProtoMessage() {}
 
 func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2164,7 +2268,7 @@ func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelepresenceAPIInfo.ProtoReflect.Descriptor instead.
 func (*TelepresenceAPIInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{21}
+	return file_manager_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TelepresenceAPIInfo) GetPort() int32 {
@@ -2186,7 +2290,7 @@ type VersionInfo2 struct {
 
 func (x *VersionInfo2) Reset() {
 	*x = VersionInfo2{}
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2198,7 +2302,7 @@ func (x *VersionInfo2) String() string {
 func (*VersionInfo2) ProtoMessage() {}
 
 func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2211,7 +2315,7 @@ func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionInfo2.ProtoReflect.Descriptor instead.
 func (*VersionInfo2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{22}
+	return file_manager_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *VersionInfo2) GetName() string {
@@ -2238,7 +2342,7 @@ type TunnelMessage struct {
 
 func (x *TunnelMessage) Reset() {
 	*x = TunnelMessage{}
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2250,7 +2354,7 @@ func (x *TunnelMessage) String() string {
 func (*TunnelMessage) ProtoMessage() {}
 
 func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2263,7 +2367,7 @@ func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMessage.ProtoReflect.Descriptor instead.
 func (*TunnelMessage) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{23}
+	return file_manager_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TunnelMessage) GetPayload() []byte {
@@ -2284,7 +2388,7 @@ type DialRequest struct {
 
 func (x *DialRequest) Reset() {
 	*x = DialRequest{}
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2296,7 +2400,7 @@ func (x *DialRequest) String() string {
 func (*DialRequest) ProtoMessage() {}
 
 func (x *DialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2309,7 +2413,7 @@ func (x *DialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialRequest.ProtoReflect.Descriptor instead.
 func (*DialRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{24}
+	return file_manager_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DialRequest) GetConnId() []byte {
@@ -2345,7 +2449,7 @@ type LookupRequest struct {
 
 func (x *LookupRequest) Reset() {
 	*x = LookupRequest{}
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2357,7 +2461,7 @@ func (x *LookupRequest) String() string {
 func (*LookupRequest) ProtoMessage() {}
 
 func (x *LookupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2370,7 +2474,7 @@ func (x *LookupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupRequest.ProtoReflect.Descriptor instead.
 func (*LookupRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{25}
+	return file_manager_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LookupRequest) GetSession() *SessionInfo {
@@ -2397,7 +2501,7 @@ type LookupResponse struct {
 
 func (x *LookupResponse) Reset() {
 	*x = LookupResponse{}
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2409,7 +2513,7 @@ func (x *LookupResponse) String() string {
 func (*LookupResponse) ProtoMessage() {}
 
 func (x *LookupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2422,7 +2526,7 @@ func (x *LookupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupResponse.ProtoReflect.Descriptor instead.
 func (*LookupResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{26}
+	return file_manager_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LookupResponse) GetIps() [][]byte {
@@ -2445,7 +2549,7 @@ type DNSRequest struct {
 
 func (x *DNSRequest) Reset() {
 	*x = DNSRequest{}
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2457,7 +2561,7 @@ func (x *DNSRequest) String() string {
 func (*DNSRequest) ProtoMessage() {}
 
 func (x *DNSRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2470,7 +2574,7 @@ func (x *DNSRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSRequest.ProtoReflect.Descriptor instead.
 func (*DNSRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{27}
+	return file_manager_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DNSRequest) GetSession() *SessionInfo {
@@ -2506,7 +2610,7 @@ type DNSResponse struct {
 
 func (x *DNSResponse) Reset() {
 	*x = DNSResponse{}
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2518,7 +2622,7 @@ func (x *DNSResponse) String() string {
 func (*DNSResponse) ProtoMessage() {}
 
 func (x *DNSResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2531,7 +2635,7 @@ func (x *DNSResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSResponse.ProtoReflect.Descriptor instead.
 func (*DNSResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{28}
+	return file_manager_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *DNSResponse) GetRCode() int32 {
@@ -2562,7 +2666,7 @@ type DNSAgentResponse struct {
 
 func (x *DNSAgentResponse) Reset() {
 	*x = DNSAgentResponse{}
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2574,7 +2678,7 @@ func (x *DNSAgentResponse) String() string {
 func (*DNSAgentResponse) ProtoMessage() {}
 
 func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2587,7 +2691,7 @@ func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSAgentResponse.ProtoReflect.Descriptor instead.
 func (*DNSAgentResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{29}
+	return file_manager_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *DNSAgentResponse) GetSession() *SessionInfo {
@@ -2622,7 +2726,7 @@ type IPNet struct {
 
 func (x *IPNet) Reset() {
 	*x = IPNet{}
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2634,7 +2738,7 @@ func (x *IPNet) String() string {
 func (*IPNet) ProtoMessage() {}
 
 func (x *IPNet) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2647,7 +2751,7 @@ func (x *IPNet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPNet.ProtoReflect.Descriptor instead.
 func (*IPNet) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{30}
+	return file_manager_manager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *IPNet) GetIp() []byte {
@@ -2695,7 +2799,7 @@ type ClusterInfo struct {
 
 func (x *ClusterInfo) Reset() {
 	*x = ClusterInfo{}
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2707,7 +2811,7 @@ func (x *ClusterInfo) String() string {
 func (*ClusterInfo) ProtoMessage() {}
 
 func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2720,7 +2824,7 @@ func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterInfo.ProtoReflect.Descriptor instead.
 func (*ClusterInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{31}
+	return file_manager_manager_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ClusterInfo) GetServiceCidrs() [][]byte {
@@ -2804,7 +2908,7 @@ type Routing struct {
 
 func (x *Routing) Reset() {
 	*x = Routing{}
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2816,7 +2920,7 @@ func (x *Routing) String() string {
 func (*Routing) ProtoMessage() {}
 
 func (x *Routing) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2829,7 +2933,7 @@ func (x *Routing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Routing.ProtoReflect.Descriptor instead.
 func (*Routing) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{32}
+	return file_manager_manager_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Routing) GetAlsoProxySubnets() []*IPNet {
@@ -2868,7 +2972,7 @@ type DNS struct {
 
 func (x *DNS) Reset() {
 	*x = DNS{}
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2880,7 +2984,7 @@ func (x *DNS) String() string {
 func (*DNS) ProtoMessage() {}
 
 func (x *DNS) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2893,7 +2997,7 @@ func (x *DNS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNS.ProtoReflect.Descriptor instead.
 func (*DNS) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{33}
+	return file_manager_manager_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DNS) GetIncludeSuffixes() []string {
@@ -2934,7 +3038,7 @@ type CLIConfig struct {
 
 func (x *CLIConfig) Reset() {
 	*x = CLIConfig{}
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2946,7 +3050,7 @@ func (x *CLIConfig) String() string {
 func (*CLIConfig) ProtoMessage() {}
 
 func (x *CLIConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2959,7 +3063,7 @@ func (x *CLIConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CLIConfig.ProtoReflect.Descriptor instead.
 func (*CLIConfig) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{34}
+	return file_manager_manager_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CLIConfig) GetConfigYaml() []byte {
@@ -2978,7 +3082,7 @@ type AgentImageFQN struct {
 
 func (x *AgentImageFQN) Reset() {
 	*x = AgentImageFQN{}
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2990,7 +3094,7 @@ func (x *AgentImageFQN) String() string {
 func (*AgentImageFQN) ProtoMessage() {}
 
 func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3003,7 +3107,7 @@ func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentImageFQN.ProtoReflect.Descriptor instead.
 func (*AgentImageFQN) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{35}
+	return file_manager_manager_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AgentImageFQN) GetFQN() string {
@@ -3028,7 +3132,7 @@ type AgentPodInfo struct {
 
 func (x *AgentPodInfo) Reset() {
 	*x = AgentPodInfo{}
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3040,7 +3144,7 @@ func (x *AgentPodInfo) String() string {
 func (*AgentPodInfo) ProtoMessage() {}
 
 func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3053,7 +3157,7 @@ func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfo.ProtoReflect.Descriptor instead.
 func (*AgentPodInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{36}
+	return file_manager_manager_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *AgentPodInfo) GetPodId() string {
@@ -3114,7 +3218,7 @@ type AgentPodInfoSnapshot struct {
 
 func (x *AgentPodInfoSnapshot) Reset() {
 	*x = AgentPodInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3126,7 +3230,7 @@ func (x *AgentPodInfoSnapshot) String() string {
 func (*AgentPodInfoSnapshot) ProtoMessage() {}
 
 func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3139,12 +3243,64 @@ func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*AgentPodInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{37}
+	return file_manager_manager_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *AgentPodInfoSnapshot) GetAgents() []*AgentPodInfo {
 	if x != nil {
 		return x.Agents
+	}
+	return nil
+}
+
+type AgentPodInfoDelta struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Upserts       map[string]*AgentPodInfo `protobuf:"bytes,1,rep,name=upserts,proto3" json:"upserts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Removals      []string                 `protobuf:"bytes,2,rep,name=removals,proto3" json:"removals,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentPodInfoDelta) Reset() {
+	*x = AgentPodInfoDelta{}
+	mi := &file_manager_manager_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentPodInfoDelta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentPodInfoDelta) ProtoMessage() {}
+
+func (x *AgentPodInfoDelta) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentPodInfoDelta.ProtoReflect.Descriptor instead.
+func (*AgentPodInfoDelta) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *AgentPodInfoDelta) GetUpserts() map[string]*AgentPodInfo {
+	if x != nil {
+		return x.Upserts
+	}
+	return nil
+}
+
+func (x *AgentPodInfoDelta) GetRemovals() []string {
+	if x != nil {
+		return x.Removals
 	}
 	return nil
 }
@@ -3159,7 +3315,7 @@ type AgentConfigRequest struct {
 
 func (x *AgentConfigRequest) Reset() {
 	*x = AgentConfigRequest{}
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3171,7 +3327,7 @@ func (x *AgentConfigRequest) String() string {
 func (*AgentConfigRequest) ProtoMessage() {}
 
 func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3184,7 +3340,7 @@ func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigRequest.ProtoReflect.Descriptor instead.
 func (*AgentConfigRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{38}
+	return file_manager_manager_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AgentConfigRequest) GetSession() *SessionInfo {
@@ -3210,7 +3366,7 @@ type AgentConfigResponse struct {
 
 func (x *AgentConfigResponse) Reset() {
 	*x = AgentConfigResponse{}
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3222,7 +3378,7 @@ func (x *AgentConfigResponse) String() string {
 func (*AgentConfigResponse) ProtoMessage() {}
 
 func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3235,7 +3391,7 @@ func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigResponse.ProtoReflect.Descriptor instead.
 func (*AgentConfigResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{39}
+	return file_manager_manager_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AgentConfigResponse) GetData() []byte {
@@ -3258,7 +3414,7 @@ type TunnelMetrics struct {
 
 func (x *TunnelMetrics) Reset() {
 	*x = TunnelMetrics{}
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3270,7 +3426,7 @@ func (x *TunnelMetrics) String() string {
 func (*TunnelMetrics) ProtoMessage() {}
 
 func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3283,7 +3439,7 @@ func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMetrics.ProtoReflect.Descriptor instead.
 func (*TunnelMetrics) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{40}
+	return file_manager_manager_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *TunnelMetrics) GetClientSessionId() string {
@@ -3316,7 +3472,7 @@ type KnownWorkloadKinds struct {
 
 func (x *KnownWorkloadKinds) Reset() {
 	*x = KnownWorkloadKinds{}
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3328,7 +3484,7 @@ func (x *KnownWorkloadKinds) String() string {
 func (*KnownWorkloadKinds) ProtoMessage() {}
 
 func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3341,7 +3497,7 @@ func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KnownWorkloadKinds.ProtoReflect.Descriptor instead.
 func (*KnownWorkloadKinds) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{41}
+	return file_manager_manager_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *KnownWorkloadKinds) GetKinds() []WorkloadInfo_Kind {
@@ -3368,7 +3524,7 @@ type WorkloadInfo struct {
 
 func (x *WorkloadInfo) Reset() {
 	*x = WorkloadInfo{}
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3380,7 +3536,7 @@ func (x *WorkloadInfo) String() string {
 func (*WorkloadInfo) ProtoMessage() {}
 
 func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3393,7 +3549,7 @@ func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *WorkloadInfo) GetKind() WorkloadInfo_Kind {
@@ -3455,7 +3611,7 @@ type WorkloadEvent struct {
 
 func (x *WorkloadEvent) Reset() {
 	*x = WorkloadEvent{}
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3467,7 +3623,7 @@ func (x *WorkloadEvent) String() string {
 func (*WorkloadEvent) ProtoMessage() {}
 
 func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3480,7 +3636,7 @@ func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadEvent) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{43}
+	return file_manager_manager_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *WorkloadEvent) GetType() WorkloadEvent_Type {
@@ -3512,7 +3668,7 @@ type WorkloadEventsDelta struct {
 
 func (x *WorkloadEventsDelta) Reset() {
 	*x = WorkloadEventsDelta{}
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3524,7 +3680,7 @@ func (x *WorkloadEventsDelta) String() string {
 func (*WorkloadEventsDelta) ProtoMessage() {}
 
 func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3537,7 +3693,7 @@ func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsDelta.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{44}
+	return file_manager_manager_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *WorkloadEventsDelta) GetSince() *timestamppb.Timestamp {
@@ -3571,7 +3727,7 @@ type WorkloadEventsRequest struct {
 
 func (x *WorkloadEventsRequest) Reset() {
 	*x = WorkloadEventsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3583,7 +3739,7 @@ func (x *WorkloadEventsRequest) String() string {
 func (*WorkloadEventsRequest) ProtoMessage() {}
 
 func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3596,7 +3752,7 @@ func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsRequest.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *WorkloadEventsRequest) GetSessionInfo() *SessionInfo {
@@ -3633,7 +3789,7 @@ type UninstallAgentsRequest struct {
 
 func (x *UninstallAgentsRequest) Reset() {
 	*x = UninstallAgentsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3645,7 +3801,7 @@ func (x *UninstallAgentsRequest) String() string {
 func (*UninstallAgentsRequest) ProtoMessage() {}
 
 func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3658,7 +3814,7 @@ func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UninstallAgentsRequest.ProtoReflect.Descriptor instead.
 func (*UninstallAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46}
+	return file_manager_manager_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UninstallAgentsRequest) GetSessionInfo() *SessionInfo {
@@ -3697,7 +3853,7 @@ type AgentInfo_Mechanism struct {
 
 func (x *AgentInfo_Mechanism) Reset() {
 	*x = AgentInfo_Mechanism{}
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3709,7 +3865,7 @@ func (x *AgentInfo_Mechanism) String() string {
 func (*AgentInfo_Mechanism) ProtoMessage() {}
 
 func (x *AgentInfo_Mechanism) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3760,7 +3916,7 @@ type AgentInfo_ContainerInfo struct {
 
 func (x *AgentInfo_ContainerInfo) Reset() {
 	*x = AgentInfo_ContainerInfo{}
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3772,7 +3928,7 @@ func (x *AgentInfo_ContainerInfo) String() string {
 func (*AgentInfo_ContainerInfo) ProtoMessage() {}
 
 func (x *AgentInfo_ContainerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3819,7 +3975,7 @@ type WorkloadInfo_Intercept struct {
 
 func (x *WorkloadInfo_Intercept) Reset() {
 	*x = WorkloadInfo_Intercept{}
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3831,7 +3987,7 @@ func (x *WorkloadInfo_Intercept) String() string {
 func (*WorkloadInfo_Intercept) ProtoMessage() {}
 
 func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3844,7 +4000,7 @@ func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo_Intercept.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo_Intercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45, 0}
 }
 
 func (x *WorkloadInfo_Intercept) GetClient() string {
@@ -3999,11 +4155,23 @@ const file_manager_manager_proto_rawDesc = "" +
 	"namespaces\x18\x02 \x03(\tR\n" +
 	"namespaces\"L\n" +
 	"\x11AgentInfoSnapshot\x127\n" +
-	"\x06agents\x18\x01 \x03(\v2\x1f.telepresence.manager.AgentInfoR\x06agents\"\\\n" +
+	"\x06agents\x18\x01 \x03(\v2\x1f.telepresence.manager.AgentInfoR\x06agents\"\xd6\x01\n" +
+	"\x0eAgentInfoDelta\x12K\n" +
+	"\aupserts\x18\x01 \x03(\v21.telepresence.manager.AgentInfoDelta.UpsertsEntryR\aupserts\x12\x1a\n" +
+	"\bremovals\x18\x02 \x03(\tR\bremovals\x1a[\n" +
+	"\fUpsertsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x125\n" +
+	"\x05value\x18\x02 \x01(\v2\x1f.telepresence.manager.AgentInfoR\x05value:\x028\x01\"\\\n" +
 	"\x15InterceptInfoSnapshot\x12C\n" +
 	"\n" +
 	"intercepts\x18\x01 \x03(\v2#.telepresence.manager.InterceptInfoR\n" +
-	"intercepts\"\xa7\x01\n" +
+	"intercepts\"\xe2\x01\n" +
+	"\x12InterceptInfoDelta\x12O\n" +
+	"\aupserts\x18\x01 \x03(\v25.telepresence.manager.InterceptInfoDelta.UpsertsEntryR\aupserts\x12\x1a\n" +
+	"\bremovals\x18\x02 \x03(\tR\bremovals\x1a_\n" +
+	"\fUpsertsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
+	"\x05value\x18\x02 \x01(\v2#.telepresence.manager.InterceptInfoR\x05value:\x028\x01\"\xa7\x01\n" +
 	"\x16CreateInterceptRequest\x12;\n" +
 	"\asession\x18\x01 \x01(\v2!.telepresence.manager.SessionInfoR\asession\x12J\n" +
 	"\x0eintercept_spec\x18\x02 \x01(\v2#.telepresence.manager.InterceptSpecR\rinterceptSpecJ\x04\b\x03\x10\x04\"e\n" +
@@ -4141,7 +4309,13 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\vintercepted\x18\x05 \x01(\bR\vintercepted\x12#\n" +
 	"\rworkload_name\x18\x06 \x01(\tR\fworkloadName\"R\n" +
 	"\x14AgentPodInfoSnapshot\x12:\n" +
-	"\x06agents\x18\x01 \x03(\v2\".telepresence.manager.AgentPodInfoR\x06agents\"e\n" +
+	"\x06agents\x18\x01 \x03(\v2\".telepresence.manager.AgentPodInfoR\x06agents\"\xdf\x01\n" +
+	"\x11AgentPodInfoDelta\x12N\n" +
+	"\aupserts\x18\x01 \x03(\v24.telepresence.manager.AgentPodInfoDelta.UpsertsEntryR\aupserts\x12\x1a\n" +
+	"\bremovals\x18\x02 \x03(\tR\bremovals\x1a^\n" +
+	"\fUpsertsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x128\n" +
+	"\x05value\x18\x02 \x01(\v2\".telepresence.manager.AgentPodInfoR\x05value:\x028\x01\"e\n" +
 	"\x12AgentConfigRequest\x12;\n" +
 	"\asession\x18\x01 \x01(\v2!.telepresence.manager.SessionInfoR\asession\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\")\n" +
@@ -4210,7 +4384,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\fNO_MECHANISM\x10\x05\x12\f\n" +
 	"\bNO_PORTS\x10\x06\x12\x0f\n" +
 	"\vAGENT_ERROR\x10\a\x12\f\n" +
-	"\bBAD_ARGS\x10\b2\xc9\x15\n" +
+	"\bBAD_ARGS\x10\b2\xf4\x17\n" +
 	"\aManager\x12E\n" +
 	"\aVersion\x12\x16.google.protobuf.Empty\x1a\".telepresence.manager.VersionInfo2\x12O\n" +
 	"\x10GetAgentImageFQN\x12\x16.google.protobuf.Empty\x1a#.telepresence.manager.AgentImageFQN\x12e\n" +
@@ -4225,9 +4399,12 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x06Depart\x12!.telepresence.manager.SessionInfo\x1a\x16.google.protobuf.Empty\x12L\n" +
 	"\vSetLogLevel\x12%.telepresence.manager.LogLevelRequest\x1a\x16.google.protobuf.Empty\x12S\n" +
 	"\aGetLogs\x12$.telepresence.manager.GetLogsRequest\x1a\".telepresence.manager.LogsResponse\x12a\n" +
-	"\x0eWatchAgentPods\x12!.telepresence.manager.SessionInfo\x1a*.telepresence.manager.AgentPodInfoSnapshot0\x01\x12[\n" +
-	"\vWatchAgents\x12!.telepresence.manager.SessionInfo\x1a'.telepresence.manager.AgentInfoSnapshot0\x01\x12c\n" +
-	"\x0fWatchIntercepts\x12!.telepresence.manager.SessionInfo\x1a+.telepresence.manager.InterceptInfoSnapshot0\x01\x12j\n" +
+	"\x0eWatchAgentPods\x12!.telepresence.manager.SessionInfo\x1a*.telepresence.manager.AgentPodInfoSnapshot0\x01\x12c\n" +
+	"\x13WatchAgentPodsDelta\x12!.telepresence.manager.SessionInfo\x1a'.telepresence.manager.AgentPodInfoDelta0\x01\x12[\n" +
+	"\vWatchAgents\x12!.telepresence.manager.SessionInfo\x1a'.telepresence.manager.AgentInfoSnapshot0\x01\x12]\n" +
+	"\x10WatchAgentsDelta\x12!.telepresence.manager.SessionInfo\x1a$.telepresence.manager.AgentInfoDelta0\x01\x12c\n" +
+	"\x0fWatchIntercepts\x12!.telepresence.manager.SessionInfo\x1a+.telepresence.manager.InterceptInfoSnapshot0\x01\x12e\n" +
+	"\x14WatchInterceptsDelta\x12!.telepresence.manager.SessionInfo\x1a(.telepresence.manager.InterceptInfoDelta0\x01\x12j\n" +
 	"\x0eWatchWorkloads\x12+.telepresence.manager.WorkloadEventsRequest\x1a).telepresence.manager.WorkloadEventsDelta0\x01\x12Z\n" +
 	"\x10WatchClusterInfo\x12!.telepresence.manager.SessionInfo\x1a!.telepresence.manager.ClusterInfo0\x01\x12`\n" +
 	"\vEnsureAgent\x12(.telepresence.manager.EnsureAgentRequest\x1a'.telepresence.manager.AgentInfoSnapshot\x12i\n" +
@@ -4257,7 +4434,7 @@ func file_manager_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_manager_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
+var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_manager_manager_proto_goTypes = []any{
 	(InterceptDispositionType)(0),   // 0: telepresence.manager.InterceptDispositionType
 	(WorkloadInfo_Kind)(0),          // 1: telepresence.manager.WorkloadInfo.Kind
@@ -4274,190 +4451,208 @@ var file_manager_manager_proto_goTypes = []any{
 	(*SessionInfo)(nil),             // 12: telepresence.manager.SessionInfo
 	(*AgentsRequest)(nil),           // 13: telepresence.manager.AgentsRequest
 	(*AgentInfoSnapshot)(nil),       // 14: telepresence.manager.AgentInfoSnapshot
-	(*InterceptInfoSnapshot)(nil),   // 15: telepresence.manager.InterceptInfoSnapshot
-	(*CreateInterceptRequest)(nil),  // 16: telepresence.manager.CreateInterceptRequest
-	(*EnsureAgentRequest)(nil),      // 17: telepresence.manager.EnsureAgentRequest
-	(*PreparedIntercept)(nil),       // 18: telepresence.manager.PreparedIntercept
-	(*RemoveInterceptRequest2)(nil), // 19: telepresence.manager.RemoveInterceptRequest2
-	(*GetInterceptRequest)(nil),     // 20: telepresence.manager.GetInterceptRequest
-	(*ReviewInterceptRequest)(nil),  // 21: telepresence.manager.ReviewInterceptRequest
-	(*RemainRequest)(nil),           // 22: telepresence.manager.RemainRequest
-	(*LogLevelRequest)(nil),         // 23: telepresence.manager.LogLevelRequest
-	(*GetLogsRequest)(nil),          // 24: telepresence.manager.GetLogsRequest
-	(*LogsResponse)(nil),            // 25: telepresence.manager.LogsResponse
-	(*TelepresenceAPIInfo)(nil),     // 26: telepresence.manager.TelepresenceAPIInfo
-	(*VersionInfo2)(nil),            // 27: telepresence.manager.VersionInfo2
-	(*TunnelMessage)(nil),           // 28: telepresence.manager.TunnelMessage
-	(*DialRequest)(nil),             // 29: telepresence.manager.DialRequest
-	(*LookupRequest)(nil),           // 30: telepresence.manager.LookupRequest
-	(*LookupResponse)(nil),          // 31: telepresence.manager.LookupResponse
-	(*DNSRequest)(nil),              // 32: telepresence.manager.DNSRequest
-	(*DNSResponse)(nil),             // 33: telepresence.manager.DNSResponse
-	(*DNSAgentResponse)(nil),        // 34: telepresence.manager.DNSAgentResponse
-	(*IPNet)(nil),                   // 35: telepresence.manager.IPNet
-	(*ClusterInfo)(nil),             // 36: telepresence.manager.ClusterInfo
-	(*Routing)(nil),                 // 37: telepresence.manager.Routing
-	(*DNS)(nil),                     // 38: telepresence.manager.DNS
-	(*CLIConfig)(nil),               // 39: telepresence.manager.CLIConfig
-	(*AgentImageFQN)(nil),           // 40: telepresence.manager.AgentImageFQN
-	(*AgentPodInfo)(nil),            // 41: telepresence.manager.AgentPodInfo
-	(*AgentPodInfoSnapshot)(nil),    // 42: telepresence.manager.AgentPodInfoSnapshot
-	(*AgentConfigRequest)(nil),      // 43: telepresence.manager.AgentConfigRequest
-	(*AgentConfigResponse)(nil),     // 44: telepresence.manager.AgentConfigResponse
-	(*TunnelMetrics)(nil),           // 45: telepresence.manager.TunnelMetrics
-	(*KnownWorkloadKinds)(nil),      // 46: telepresence.manager.KnownWorkloadKinds
-	(*WorkloadInfo)(nil),            // 47: telepresence.manager.WorkloadInfo
-	(*WorkloadEvent)(nil),           // 48: telepresence.manager.WorkloadEvent
-	(*WorkloadEventsDelta)(nil),     // 49: telepresence.manager.WorkloadEventsDelta
-	(*WorkloadEventsRequest)(nil),   // 50: telepresence.manager.WorkloadEventsRequest
-	(*UninstallAgentsRequest)(nil),  // 51: telepresence.manager.UninstallAgentsRequest
-	(*AgentInfo_Mechanism)(nil),     // 52: telepresence.manager.AgentInfo.Mechanism
-	(*AgentInfo_ContainerInfo)(nil), // 53: telepresence.manager.AgentInfo.ContainerInfo
-	nil,                             // 54: telepresence.manager.AgentInfo.ContainersEntry
-	nil,                             // 55: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	nil,                             // 56: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	nil,                             // 57: telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	nil,                             // 58: telepresence.manager.InterceptSpec.MetadataEntry
-	nil,                             // 59: telepresence.manager.InterceptInfo.EnvironmentEntry
-	nil,                             // 60: telepresence.manager.InterceptInfo.MountsEntry
-	nil,                             // 61: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	nil,                             // 62: telepresence.manager.ReviewInterceptRequest.MountsEntry
-	nil,                             // 63: telepresence.manager.LogsResponse.PodLogsEntry
-	nil,                             // 64: telepresence.manager.LogsResponse.PodYamlEntry
-	(*WorkloadInfo_Intercept)(nil),  // 65: telepresence.manager.WorkloadInfo.Intercept
-	(*timestamppb.Timestamp)(nil),   // 66: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),     // 67: google.protobuf.Duration
-	(*emptypb.Empty)(nil),           // 68: google.protobuf.Empty
+	(*AgentInfoDelta)(nil),          // 15: telepresence.manager.AgentInfoDelta
+	(*InterceptInfoSnapshot)(nil),   // 16: telepresence.manager.InterceptInfoSnapshot
+	(*InterceptInfoDelta)(nil),      // 17: telepresence.manager.InterceptInfoDelta
+	(*CreateInterceptRequest)(nil),  // 18: telepresence.manager.CreateInterceptRequest
+	(*EnsureAgentRequest)(nil),      // 19: telepresence.manager.EnsureAgentRequest
+	(*PreparedIntercept)(nil),       // 20: telepresence.manager.PreparedIntercept
+	(*RemoveInterceptRequest2)(nil), // 21: telepresence.manager.RemoveInterceptRequest2
+	(*GetInterceptRequest)(nil),     // 22: telepresence.manager.GetInterceptRequest
+	(*ReviewInterceptRequest)(nil),  // 23: telepresence.manager.ReviewInterceptRequest
+	(*RemainRequest)(nil),           // 24: telepresence.manager.RemainRequest
+	(*LogLevelRequest)(nil),         // 25: telepresence.manager.LogLevelRequest
+	(*GetLogsRequest)(nil),          // 26: telepresence.manager.GetLogsRequest
+	(*LogsResponse)(nil),            // 27: telepresence.manager.LogsResponse
+	(*TelepresenceAPIInfo)(nil),     // 28: telepresence.manager.TelepresenceAPIInfo
+	(*VersionInfo2)(nil),            // 29: telepresence.manager.VersionInfo2
+	(*TunnelMessage)(nil),           // 30: telepresence.manager.TunnelMessage
+	(*DialRequest)(nil),             // 31: telepresence.manager.DialRequest
+	(*LookupRequest)(nil),           // 32: telepresence.manager.LookupRequest
+	(*LookupResponse)(nil),          // 33: telepresence.manager.LookupResponse
+	(*DNSRequest)(nil),              // 34: telepresence.manager.DNSRequest
+	(*DNSResponse)(nil),             // 35: telepresence.manager.DNSResponse
+	(*DNSAgentResponse)(nil),        // 36: telepresence.manager.DNSAgentResponse
+	(*IPNet)(nil),                   // 37: telepresence.manager.IPNet
+	(*ClusterInfo)(nil),             // 38: telepresence.manager.ClusterInfo
+	(*Routing)(nil),                 // 39: telepresence.manager.Routing
+	(*DNS)(nil),                     // 40: telepresence.manager.DNS
+	(*CLIConfig)(nil),               // 41: telepresence.manager.CLIConfig
+	(*AgentImageFQN)(nil),           // 42: telepresence.manager.AgentImageFQN
+	(*AgentPodInfo)(nil),            // 43: telepresence.manager.AgentPodInfo
+	(*AgentPodInfoSnapshot)(nil),    // 44: telepresence.manager.AgentPodInfoSnapshot
+	(*AgentPodInfoDelta)(nil),       // 45: telepresence.manager.AgentPodInfoDelta
+	(*AgentConfigRequest)(nil),      // 46: telepresence.manager.AgentConfigRequest
+	(*AgentConfigResponse)(nil),     // 47: telepresence.manager.AgentConfigResponse
+	(*TunnelMetrics)(nil),           // 48: telepresence.manager.TunnelMetrics
+	(*KnownWorkloadKinds)(nil),      // 49: telepresence.manager.KnownWorkloadKinds
+	(*WorkloadInfo)(nil),            // 50: telepresence.manager.WorkloadInfo
+	(*WorkloadEvent)(nil),           // 51: telepresence.manager.WorkloadEvent
+	(*WorkloadEventsDelta)(nil),     // 52: telepresence.manager.WorkloadEventsDelta
+	(*WorkloadEventsRequest)(nil),   // 53: telepresence.manager.WorkloadEventsRequest
+	(*UninstallAgentsRequest)(nil),  // 54: telepresence.manager.UninstallAgentsRequest
+	(*AgentInfo_Mechanism)(nil),     // 55: telepresence.manager.AgentInfo.Mechanism
+	(*AgentInfo_ContainerInfo)(nil), // 56: telepresence.manager.AgentInfo.ContainerInfo
+	nil,                             // 57: telepresence.manager.AgentInfo.ContainersEntry
+	nil,                             // 58: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	nil,                             // 59: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	nil,                             // 60: telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	nil,                             // 61: telepresence.manager.InterceptSpec.MetadataEntry
+	nil,                             // 62: telepresence.manager.InterceptInfo.EnvironmentEntry
+	nil,                             // 63: telepresence.manager.InterceptInfo.MountsEntry
+	nil,                             // 64: telepresence.manager.AgentInfoDelta.UpsertsEntry
+	nil,                             // 65: telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	nil,                             // 66: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	nil,                             // 67: telepresence.manager.ReviewInterceptRequest.MountsEntry
+	nil,                             // 68: telepresence.manager.LogsResponse.PodLogsEntry
+	nil,                             // 69: telepresence.manager.LogsResponse.PodYamlEntry
+	nil,                             // 70: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	(*WorkloadInfo_Intercept)(nil),  // 71: telepresence.manager.WorkloadInfo.Intercept
+	(*timestamppb.Timestamp)(nil),   // 72: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),     // 73: google.protobuf.Duration
+	(*emptypb.Empty)(nil),           // 74: google.protobuf.Empty
 }
 var file_manager_manager_proto_depIdxs = []int32{
-	52, // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
-	54, // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
-	57, // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	58, // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
-	8,  // 4: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
-	12, // 5: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
-	0,  // 6: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	59, // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
-	60, // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
-	66, // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
-	12, // 10: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	6,  // 11: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
-	12, // 12: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
-	5,  // 13: telepresence.manager.ReconnectClientRequest.client:type_name -> telepresence.manager.ClientInfo
-	9,  // 14: telepresence.manager.ReconnectClientRequest.intercepts:type_name -> telepresence.manager.InterceptInfo
-	6,  // 15: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
-	12, // 16: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
-	6,  // 17: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
-	9,  // 18: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
-	12, // 19: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	8,  // 20: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
-	12, // 21: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	12, // 22: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
-	12, // 23: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	12, // 24: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	0,  // 25: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	61, // 26: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	62, // 27: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
-	12, // 28: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
-	67, // 29: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	63, // 30: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
-	64, // 31: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
-	12, // 32: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
-	12, // 33: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
-	12, // 34: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
-	32, // 35: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
-	33, // 36: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
-	35, // 37: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
-	35, // 38: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
-	37, // 39: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
-	38, // 40: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
-	35, // 41: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
-	35, // 42: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
-	35, // 43: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
-	41, // 44: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
-	12, // 45: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
-	1,  // 46: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
-	1,  // 47: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
-	3,  // 48: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
-	65, // 49: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
-	2,  // 50: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
-	4,  // 51: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
-	47, // 52: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
-	66, // 53: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
-	48, // 54: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
-	12, // 55: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	66, // 56: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
-	12, // 57: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	55, // 58: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	56, // 59: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	53, // 60: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
-	68, // 61: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
-	68, // 62: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
-	43, // 63: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	68, // 64: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
-	68, // 65: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
-	5,  // 66: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
-	10, // 67: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
-	11, // 68: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
-	6,  // 69: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
-	22, // 70: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
-	12, // 71: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
-	23, // 72: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	24, // 73: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
-	12, // 74: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
-	12, // 75: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
-	12, // 76: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
-	50, // 77: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
-	12, // 78: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
-	17, // 79: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
-	16, // 80: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	16, // 81: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	19, // 82: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	20, // 83: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	21, // 84: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
-	12, // 85: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
-	30, // 86: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
-	32, // 87: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
-	68, // 88: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
-	28, // 89: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
-	45, // 90: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
-	51, // 91: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
-	27, // 92: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
-	40, // 93: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	44, // 94: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	39, // 95: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
-	26, // 96: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
-	12, // 97: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
-	68, // 98: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
-	68, // 99: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
-	12, // 100: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
-	68, // 101: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
-	68, // 102: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
-	68, // 103: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
-	25, // 104: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
-	42, // 105: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
-	14, // 106: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
-	15, // 107: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
-	49, // 108: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
-	36, // 109: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
-	14, // 110: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
-	18, // 111: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
-	9,  // 112: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	68, // 113: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
-	9,  // 114: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	68, // 115: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
-	46, // 116: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	31, // 117: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
-	33, // 118: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
-	23, // 119: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
-	28, // 120: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
-	68, // 121: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
-	68, // 122: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
-	92, // [92:123] is the sub-list for method output_type
-	61, // [61:92] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	55,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
+	57,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
+	60,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	61,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
+	8,   // 4: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
+	12,  // 5: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
+	0,   // 6: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
+	62,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
+	63,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
+	72,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
+	12,  // 10: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	6,   // 11: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
+	12,  // 12: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
+	5,   // 13: telepresence.manager.ReconnectClientRequest.client:type_name -> telepresence.manager.ClientInfo
+	9,   // 14: telepresence.manager.ReconnectClientRequest.intercepts:type_name -> telepresence.manager.InterceptInfo
+	6,   // 15: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
+	12,  // 16: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
+	6,   // 17: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
+	64,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
+	9,   // 19: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
+	65,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	12,  // 21: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	8,   // 22: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
+	12,  // 23: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 24: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 25: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 26: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	0,   // 27: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
+	66,  // 28: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	67,  // 29: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
+	12,  // 30: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
+	73,  // 31: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	68,  // 32: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
+	69,  // 33: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
+	12,  // 34: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 35: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 36: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
+	34,  // 37: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
+	35,  // 38: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
+	37,  // 39: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
+	37,  // 40: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
+	39,  // 41: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
+	40,  // 42: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
+	37,  // 43: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
+	37,  // 44: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
+	37,  // 45: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
+	43,  // 46: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
+	70,  // 47: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	12,  // 48: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
+	1,   // 49: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
+	1,   // 50: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
+	3,   // 51: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
+	71,  // 52: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
+	2,   // 53: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
+	4,   // 54: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
+	50,  // 55: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
+	72,  // 56: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
+	51,  // 57: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
+	12,  // 58: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	72,  // 59: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
+	12,  // 60: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	58,  // 61: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	59,  // 62: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	56,  // 63: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
+	6,   // 64: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
+	9,   // 65: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
+	43,  // 66: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	74,  // 67: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
+	74,  // 68: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
+	46,  // 69: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	74,  // 70: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
+	74,  // 71: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
+	5,   // 72: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
+	10,  // 73: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
+	11,  // 74: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
+	6,   // 75: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
+	24,  // 76: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
+	12,  // 77: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
+	25,  // 78: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	26,  // 79: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
+	12,  // 80: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
+	12,  // 81: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
+	12,  // 82: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
+	12,  // 83: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
+	12,  // 84: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
+	12,  // 85: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
+	53,  // 86: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
+	12,  // 87: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
+	19,  // 88: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
+	18,  // 89: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	18,  // 90: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	21,  // 91: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	22,  // 92: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	23,  // 93: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
+	12,  // 94: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
+	32,  // 95: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
+	34,  // 96: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
+	74,  // 97: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
+	30,  // 98: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
+	48,  // 99: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
+	54,  // 100: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
+	29,  // 101: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
+	42,  // 102: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	47,  // 103: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	41,  // 104: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
+	28,  // 105: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
+	12,  // 106: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
+	74,  // 107: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
+	74,  // 108: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
+	12,  // 109: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
+	74,  // 110: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
+	74,  // 111: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
+	74,  // 112: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
+	27,  // 113: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
+	44,  // 114: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
+	45,  // 115: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	14,  // 116: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
+	15,  // 117: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
+	16,  // 118: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
+	17,  // 119: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
+	52,  // 120: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
+	38,  // 121: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
+	14,  // 122: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
+	20,  // 123: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
+	9,   // 124: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	74,  // 125: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
+	9,   // 126: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	74,  // 127: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
+	49,  // 128: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	33,  // 129: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
+	35,  // 130: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
+	25,  // 131: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
+	30,  // 132: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
+	74,  // 133: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
+	74,  // 134: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
+	101, // [101:135] is the sub-list for method output_type
+	67,  // [67:101] is the sub-list for method input_type
+	67,  // [67:67] is the sub-list for extension type_name
+	67,  // [67:67] is the sub-list for extension extendee
+	0,   // [0:67] is the sub-list for field type_name
 }
 
 func init() { file_manager_manager_proto_init() }
@@ -4472,7 +4667,7 @@ func file_manager_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_manager_manager_proto_rawDesc), len(file_manager_manager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   61,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -320,8 +320,18 @@ message AgentInfoSnapshot {
   repeated AgentInfo agents = 1;
 }
 
+message AgentInfoDelta {
+  map<string,AgentInfo>  upserts = 1;
+  repeated string removals = 2;
+}
+
 message InterceptInfoSnapshot {
   repeated InterceptInfo intercepts = 1;
+}
+
+message InterceptInfoDelta {
+  map <string,InterceptInfo> upserts = 1;
+  repeated string removals = 2;
 }
 
 message CreateInterceptRequest {
@@ -583,6 +593,11 @@ message AgentPodInfoSnapshot {
   repeated AgentPodInfo agents = 1;
 }
 
+message AgentPodInfoDelta {
+  map<string,AgentPodInfo> upserts = 1;
+  repeated string removals = 2;
+}
+
 message AgentConfigRequest {
   SessionInfo session = 1;
   string name = 2;
@@ -755,11 +770,19 @@ service Manager {
   // allowed.
   rpc WatchAgentPods(SessionInfo) returns (stream AgentPodInfoSnapshot);
 
+  // WatchAgentPods notifies a client of changes to the set of known Agents from the client
+  // connections namespace that the client can connect to when port-forwards are
+  // allowed.
+  rpc WatchAgentPodsDelta(SessionInfo) returns (stream AgentPodInfoDelta);
+
   // WatchAgents notifies a client of the set of known Agents.
   //
   // A session ID is required; if no session ID is given then the call
   // returns immediately, having not delivered any snapshots.
   rpc WatchAgents(SessionInfo) returns (stream AgentInfoSnapshot);
+
+  // WatchAgents notifies a client of changes to the set of known Agents.
+  rpc WatchAgentsDelta(SessionInfo) returns (stream AgentInfoDelta);
 
   // WatchIntercepts notifies a client or agent of the set of intercepts
   // relevant to that client or agent.
@@ -768,6 +791,10 @@ service Manager {
   // that session are watched.  If no session ID is given, then all
   // intercepts are watched.
   rpc WatchIntercepts(SessionInfo) returns (stream InterceptInfoSnapshot);
+
+  // WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
+  // relevant to that client or agent.
+  rpc WatchInterceptsDelta(SessionInfo) returns (stream InterceptInfoDelta);
 
   // WatchWorkloads notifies a client of the set of Workloads from the client
   // connection's namespace.

--- a/rpc/manager/manager_grpc.pb.go
+++ b/rpc/manager/manager_grpc.pb.go
@@ -38,8 +38,11 @@ const (
 	Manager_SetLogLevel_FullMethodName           = "/telepresence.manager.Manager/SetLogLevel"
 	Manager_GetLogs_FullMethodName               = "/telepresence.manager.Manager/GetLogs"
 	Manager_WatchAgentPods_FullMethodName        = "/telepresence.manager.Manager/WatchAgentPods"
+	Manager_WatchAgentPodsDelta_FullMethodName   = "/telepresence.manager.Manager/WatchAgentPodsDelta"
 	Manager_WatchAgents_FullMethodName           = "/telepresence.manager.Manager/WatchAgents"
+	Manager_WatchAgentsDelta_FullMethodName      = "/telepresence.manager.Manager/WatchAgentsDelta"
 	Manager_WatchIntercepts_FullMethodName       = "/telepresence.manager.Manager/WatchIntercepts"
+	Manager_WatchInterceptsDelta_FullMethodName  = "/telepresence.manager.Manager/WatchInterceptsDelta"
 	Manager_WatchWorkloads_FullMethodName        = "/telepresence.manager.Manager/WatchWorkloads"
 	Manager_WatchClusterInfo_FullMethodName      = "/telepresence.manager.Manager/WatchClusterInfo"
 	Manager_EnsureAgent_FullMethodName           = "/telepresence.manager.Manager/EnsureAgent"
@@ -95,11 +98,17 @@ type ManagerClient interface {
 	// connections namespace that the client can connect to when port-forwards are
 	// allowed.
 	WatchAgentPods(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentPodInfoSnapshot], error)
+	// WatchAgentPods notifies a client of changes to the set of known Agents from the client
+	// connections namespace that the client can connect to when port-forwards are
+	// allowed.
+	WatchAgentPodsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentPodInfoDelta], error)
 	// WatchAgents notifies a client of the set of known Agents.
 	//
 	// A session ID is required; if no session ID is given then the call
 	// returns immediately, having not delivered any snapshots.
 	WatchAgents(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentInfoSnapshot], error)
+	// WatchAgents notifies a client of changes to the set of known Agents.
+	WatchAgentsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentInfoDelta], error)
 	// WatchIntercepts notifies a client or agent of the set of intercepts
 	// relevant to that client or agent.
 	//
@@ -107,6 +116,9 @@ type ManagerClient interface {
 	// that session are watched.  If no session ID is given, then all
 	// intercepts are watched.
 	WatchIntercepts(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[InterceptInfoSnapshot], error)
+	// WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
+	// relevant to that client or agent.
+	WatchInterceptsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[InterceptInfoDelta], error)
 	// WatchWorkloads notifies a client of the set of Workloads from the client
 	// connection's namespace.
 	WatchWorkloads(ctx context.Context, in *WorkloadEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WorkloadEventsDelta], error)
@@ -316,9 +328,28 @@ func (c *managerClient) WatchAgentPods(ctx context.Context, in *SessionInfo, opt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchAgentPodsClient = grpc.ServerStreamingClient[AgentPodInfoSnapshot]
 
+func (c *managerClient) WatchAgentPodsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentPodInfoDelta], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[1], Manager_WatchAgentPodsDelta_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SessionInfo, AgentPodInfoDelta]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchAgentPodsDeltaClient = grpc.ServerStreamingClient[AgentPodInfoDelta]
+
 func (c *managerClient) WatchAgents(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentInfoSnapshot], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[1], Manager_WatchAgents_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[2], Manager_WatchAgents_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -335,9 +366,28 @@ func (c *managerClient) WatchAgents(ctx context.Context, in *SessionInfo, opts .
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchAgentsClient = grpc.ServerStreamingClient[AgentInfoSnapshot]
 
+func (c *managerClient) WatchAgentsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AgentInfoDelta], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[3], Manager_WatchAgentsDelta_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SessionInfo, AgentInfoDelta]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchAgentsDeltaClient = grpc.ServerStreamingClient[AgentInfoDelta]
+
 func (c *managerClient) WatchIntercepts(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[InterceptInfoSnapshot], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[2], Manager_WatchIntercepts_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[4], Manager_WatchIntercepts_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -354,9 +404,28 @@ func (c *managerClient) WatchIntercepts(ctx context.Context, in *SessionInfo, op
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchInterceptsClient = grpc.ServerStreamingClient[InterceptInfoSnapshot]
 
+func (c *managerClient) WatchInterceptsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[InterceptInfoDelta], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[5], Manager_WatchInterceptsDelta_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SessionInfo, InterceptInfoDelta]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchInterceptsDeltaClient = grpc.ServerStreamingClient[InterceptInfoDelta]
+
 func (c *managerClient) WatchWorkloads(ctx context.Context, in *WorkloadEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WorkloadEventsDelta], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[3], Manager_WatchWorkloads_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[6], Manager_WatchWorkloads_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +444,7 @@ type Manager_WatchWorkloadsClient = grpc.ServerStreamingClient[WorkloadEventsDel
 
 func (c *managerClient) WatchClusterInfo(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ClusterInfo], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[4], Manager_WatchClusterInfo_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[7], Manager_WatchClusterInfo_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +553,7 @@ func (c *managerClient) LookupDNS(ctx context.Context, in *DNSRequest, opts ...g
 
 func (c *managerClient) WatchLogLevel(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LogLevelRequest], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[5], Manager_WatchLogLevel_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[8], Manager_WatchLogLevel_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +572,7 @@ type Manager_WatchLogLevelClient = grpc.ServerStreamingClient[LogLevelRequest]
 
 func (c *managerClient) Tunnel(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TunnelMessage, TunnelMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[6], Manager_Tunnel_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[9], Manager_Tunnel_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -572,11 +641,17 @@ type ManagerServer interface {
 	// connections namespace that the client can connect to when port-forwards are
 	// allowed.
 	WatchAgentPods(*SessionInfo, grpc.ServerStreamingServer[AgentPodInfoSnapshot]) error
+	// WatchAgentPods notifies a client of changes to the set of known Agents from the client
+	// connections namespace that the client can connect to when port-forwards are
+	// allowed.
+	WatchAgentPodsDelta(*SessionInfo, grpc.ServerStreamingServer[AgentPodInfoDelta]) error
 	// WatchAgents notifies a client of the set of known Agents.
 	//
 	// A session ID is required; if no session ID is given then the call
 	// returns immediately, having not delivered any snapshots.
 	WatchAgents(*SessionInfo, grpc.ServerStreamingServer[AgentInfoSnapshot]) error
+	// WatchAgents notifies a client of changes to the set of known Agents.
+	WatchAgentsDelta(*SessionInfo, grpc.ServerStreamingServer[AgentInfoDelta]) error
 	// WatchIntercepts notifies a client or agent of the set of intercepts
 	// relevant to that client or agent.
 	//
@@ -584,6 +659,9 @@ type ManagerServer interface {
 	// that session are watched.  If no session ID is given, then all
 	// intercepts are watched.
 	WatchIntercepts(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoSnapshot]) error
+	// WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
+	// relevant to that client or agent.
+	WatchInterceptsDelta(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoDelta]) error
 	// WatchWorkloads notifies a client of the set of Workloads from the client
 	// connection's namespace.
 	WatchWorkloads(*WorkloadEventsRequest, grpc.ServerStreamingServer[WorkloadEventsDelta]) error
@@ -686,11 +764,20 @@ func (UnimplementedManagerServer) GetLogs(context.Context, *GetLogsRequest) (*Lo
 func (UnimplementedManagerServer) WatchAgentPods(*SessionInfo, grpc.ServerStreamingServer[AgentPodInfoSnapshot]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchAgentPods not implemented")
 }
+func (UnimplementedManagerServer) WatchAgentPodsDelta(*SessionInfo, grpc.ServerStreamingServer[AgentPodInfoDelta]) error {
+	return status.Errorf(codes.Unimplemented, "method WatchAgentPodsDelta not implemented")
+}
 func (UnimplementedManagerServer) WatchAgents(*SessionInfo, grpc.ServerStreamingServer[AgentInfoSnapshot]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchAgents not implemented")
 }
+func (UnimplementedManagerServer) WatchAgentsDelta(*SessionInfo, grpc.ServerStreamingServer[AgentInfoDelta]) error {
+	return status.Errorf(codes.Unimplemented, "method WatchAgentsDelta not implemented")
+}
 func (UnimplementedManagerServer) WatchIntercepts(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoSnapshot]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchIntercepts not implemented")
+}
+func (UnimplementedManagerServer) WatchInterceptsDelta(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoDelta]) error {
+	return status.Errorf(codes.Unimplemented, "method WatchInterceptsDelta not implemented")
 }
 func (UnimplementedManagerServer) WatchWorkloads(*WorkloadEventsRequest, grpc.ServerStreamingServer[WorkloadEventsDelta]) error {
 	return status.Errorf(codes.Unimplemented, "method WatchWorkloads not implemented")
@@ -1003,6 +1090,17 @@ func _Manager_WatchAgentPods_Handler(srv interface{}, stream grpc.ServerStream) 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchAgentPodsServer = grpc.ServerStreamingServer[AgentPodInfoSnapshot]
 
+func _Manager_WatchAgentPodsDelta_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SessionInfo)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ManagerServer).WatchAgentPodsDelta(m, &grpc.GenericServerStream[SessionInfo, AgentPodInfoDelta]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchAgentPodsDeltaServer = grpc.ServerStreamingServer[AgentPodInfoDelta]
+
 func _Manager_WatchAgents_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(SessionInfo)
 	if err := stream.RecvMsg(m); err != nil {
@@ -1014,6 +1112,17 @@ func _Manager_WatchAgents_Handler(srv interface{}, stream grpc.ServerStream) err
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchAgentsServer = grpc.ServerStreamingServer[AgentInfoSnapshot]
 
+func _Manager_WatchAgentsDelta_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SessionInfo)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ManagerServer).WatchAgentsDelta(m, &grpc.GenericServerStream[SessionInfo, AgentInfoDelta]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchAgentsDeltaServer = grpc.ServerStreamingServer[AgentInfoDelta]
+
 func _Manager_WatchIntercepts_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(SessionInfo)
 	if err := stream.RecvMsg(m); err != nil {
@@ -1024,6 +1133,17 @@ func _Manager_WatchIntercepts_Handler(srv interface{}, stream grpc.ServerStream)
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchInterceptsServer = grpc.ServerStreamingServer[InterceptInfoSnapshot]
+
+func _Manager_WatchInterceptsDelta_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SessionInfo)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ManagerServer).WatchInterceptsDelta(m, &grpc.GenericServerStream[SessionInfo, InterceptInfoDelta]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchInterceptsDeltaServer = grpc.ServerStreamingServer[InterceptInfoDelta]
 
 func _Manager_WatchWorkloads_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(WorkloadEventsRequest)
@@ -1374,13 +1494,28 @@ var Manager_ServiceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 		{
+			StreamName:    "WatchAgentPodsDelta",
+			Handler:       _Manager_WatchAgentPodsDelta_Handler,
+			ServerStreams: true,
+		},
+		{
 			StreamName:    "WatchAgents",
 			Handler:       _Manager_WatchAgents_Handler,
 			ServerStreams: true,
 		},
 		{
+			StreamName:    "WatchAgentsDelta",
+			Handler:       _Manager_WatchAgentsDelta_Handler,
+			ServerStreams: true,
+		},
+		{
 			StreamName:    "WatchIntercepts",
 			Handler:       _Manager_WatchIntercepts_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "WatchInterceptsDelta",
+			Handler:       _Manager_WatchInterceptsDelta_Handler,
 			ServerStreams: true,
 		},
 		{


### PR DESCRIPTION
The watchable map has been refactored into a client/server model that supports delta-based updates. Where supported, gRPC now transmits only incremental changes instead of full snapshots, significantly reducing payload sizes. This improvement is especially important for large clusters, where full snapshots can be sizable and costly to transmit. Full snapshot streaming remains available as a backward-compatible fallback for clients that do not support delta methods.