### PR TITLE
Replace unsafe close with sync.Once.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -60,6 +60,11 @@ items:
           The Traffic Agent's retry interval when it establishes its watcher for intercepts is now configurable using the Helm chart value
           `agent.watchRetryInterval`. The default retry interval was also increased from 2 seconds to 10 seconds to improve resilience when
           connections to the traffic manager are lost.
+      - type: bugfix
+        title: Fix "close of closed channel" panic in the root daemon process.
+        body: >-
+          The root daemon process would sometimes panic with "close of closed channel" due to a race condition in the DNS cache logic.
+          This issue has been fixed.
   - version: 2.25.2
     date: 2025-12-26
     notes:

--- a/cmd/traffic/cmd/manager/mutator/service.go
+++ b/cmd/traffic/cmd/manager/mutator/service.go
@@ -197,16 +197,12 @@ func (l *logFilter) Write(data []byte) (int, error) {
 }
 
 func serveAndWatchTLS(ctx context.Context, s *http.Server, addr string, certGetter InjectorCertGetter, rdy chan error) (err error) {
+	var rdyClose sync.Once
 	defer func() {
-		select {
-		case <-rdy:
-		// Already closed
-		default:
-			if err != nil {
-				rdy <- err
-			}
-			close(rdy)
+		if err != nil {
+			rdy <- err
 		}
+		rdyClose.Do(func() { close(rdy) })
 	}()
 
 	certPEM, keyPEM, err := certGetter.LoadCert()
@@ -231,7 +227,7 @@ func serveAndWatchTLS(ctx context.Context, s *http.Server, addr string, certGett
 		// Give the http server some time to start accepting calls from the listener. We don't want
 		// our own rollouts to happen before we are able to receive events from the mutating webhook.
 		time.Sleep(3 * time.Second)
-		close(rdy)
+		rdyClose.Do(func() { close(rdy) })
 		<-ctx.Done()
 		errc <- s.Shutdown(dcontext.HardContext(ctx))
 	}()

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,12 @@ The watchable map has been refactored into a client/server model that supports d
 The Traffic Agent's retry interval when it establishes its watcher for intercepts is now configurable using the Helm chart value `agent.watchRetryInterval`. The default retry interval was also increased from 2 seconds to 10 seconds to improve resilience when connections to the traffic manager are lost.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Fix "close of closed channel" panic in the root daemon process.</div></div>
+<div style="margin-left: 15px">
+
+The root daemon process would sometimes panic with "close of closed channel" due to a race condition in the DNS cache logic. This issue has been fixed.
+</div>
+
 ## Version 2.25.2 <span style="font-size: 16px;">(December 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ensure that the exit code from a docker command becomes the exit code of the Telepresence command.</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -38,6 +38,12 @@ The watchable map has been refactored into a client/server model that supports d
 The Traffic Agent's retry interval when it establishes its watcher for intercepts is now configurable using the Helm chart value `agent.watchRetryInterval`. The default retry interval was also increased from 2 seconds to 10 seconds to improve resilience when connections to the traffic manager are lost.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Fix "close of closed channel" panic in the root daemon process.</Title>
+	<Body>
+The root daemon process would sometimes panic with "close of closed channel" due to a race condition in the DNS cache logic. This issue has been fixed.
+  </Body>
+</Note>
 ## Version 2.25.2 <span style={{fontSize:'16px'}}>(December 26)</span>
 <Note>
 	<Title type="bugfix">Ensure that the exit code from a docker command becomes the exit code of the Telepresence command.</Title>

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -678,6 +678,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	ready := make(chan string, 1)
+	readyClosed := false
 	go func() {
 		defer func() {
 			_ = logFile.Close()
@@ -692,6 +693,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 			}
 			ready <- logFile.Name()
 			close(ready)
+			readyClosed = true
 			err = cmd.Wait()
 		}
 		if err != nil {
@@ -700,9 +702,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 			} else {
 				dlog.Errorf(ctx, "log capture for pod %s, container %s failed: %v", pod, container, err)
 			}
-			select {
-			case <-ready:
-			default:
+			if !readyClosed {
 				close(ready)
 			}
 		}

--- a/pkg/client/cli/progress/tty.go
+++ b/pkg/client/cli/progress/tty.go
@@ -40,6 +40,7 @@ type ttyWriter struct {
 	eventIDs        []string
 	repeated        bool
 	numLines        int
+	doneOnce        sync.Once
 	done            chan struct{}
 	mtx             sync.Mutex
 	skipChildEvents bool
@@ -87,14 +88,10 @@ func (w *ttyWriter) IsNoOp() bool {
 }
 
 func (w *ttyWriter) Stop() {
-	select {
-	case <-w.done:
-		// Already closed
-		return
-	default:
+	w.doneOnce.Do(func() {
 		close(w.done)
 		w.print()
-	}
+	})
 }
 
 func (w *ttyWriter) event(e *Event) {

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -116,6 +116,8 @@ type Server struct {
 
 	error string
 
+	readyClose sync.Once
+
 	// ready is closed when the DNS server is fully configured
 	ready chan struct{}
 }
@@ -132,14 +134,6 @@ const cacheTTL = 60 * time.Second
 
 func (dv *cacheEntry) expired() bool {
 	return time.Since(dv.created) > cacheTTL
-}
-
-func (dv *cacheEntry) close() {
-	select {
-	case <-dv.wait:
-	default:
-		close(dv.wait)
-	}
 }
 
 func sliceToLower(ss []string) []string {
@@ -406,11 +400,7 @@ func (s *Server) Ready() <-chan struct{} {
 
 func (s *Server) Stop() {
 	// Close s.ready unless it's already closed
-	select {
-	case <-s.ready:
-	default:
-		close(s.ready)
-	}
+	s.readyClose.Do(func() { close(s.ready) })
 }
 
 func (s *Server) SetClusterDNS(dns *manager.DNS, vifDNS netip.AddrPort) {
@@ -445,10 +435,7 @@ func (s *Server) SetTopLevelDomainsAndSearchPath(ctx context.Context, domains []
 func (s *Server) purgeRecordsFromCache(keyName string) {
 	keyName = strings.TrimSuffix(keyName, ".") + "."
 	for _, qType := range []uint16{dns.TypeA, dns.TypeAAAA} {
-		toDeleteKey := cacheKey{name: keyName, qType: qType}
-		if old, ok := s.cache.LoadAndDelete(toDeleteKey); ok {
-			old.close()
-		}
+		s.cache.Delete(cacheKey{name: keyName, qType: qType})
 	}
 }
 
@@ -557,12 +544,7 @@ func (s *Server) processSearchPaths(g *dgroup.Group, processor func(context.Cont
 }
 
 func (s *Server) flushDNS() {
-	s.cache.Range(func(key cacheKey, _ *cacheEntry) bool {
-		if old, ok := s.cache.LoadAndDelete(key); ok {
-			old.close()
-		}
-		return true
-	})
+	s.cache.Clear()
 }
 
 // splitToUDPAddr splits the given address into an address and port. It's
@@ -719,7 +701,7 @@ func (s *Server) resolveThruCache(q *dns.Question) (answer dnsproxy.RRs, rCode i
 		<-dv.wait
 		return dv.answer, dv.rCode, nil
 	}
-	defer dv.close()
+	defer close(dv.wait)
 
 	answer, rCode, err = s.resolveInCluster(s.ctx, q)
 	if err != nil {
@@ -769,11 +751,10 @@ func (s *Server) resolveThruCache(q *dns.Question) (answer dnsproxy.RRs, rCode i
 				if loaded {
 					oldValue.answer = rrs
 					oldValue.rCode = rCode
-					oldValue.close()
 					return oldValue, xsync.CancelOp
 				}
 				ce := &cacheEntry{wait: make(chan struct{}), created: time.Now(), answer: rrs, rCode: rCode}
-				ce.close()
+				close(ce.wait)
 				return ce, xsync.UpdateOp
 			})
 		}
@@ -792,12 +773,12 @@ func (d dfs) String() string {
 
 func (s *Server) performRecursionCheck(c context.Context) {
 	if proc.RunningInContainer() || !client.GetConfig(c).DNS().RecursionCheck {
-		close(s.ready)
+		s.readyClose.Do(func() { close(s.ready) })
 		return
 	}
 	defer func() {
 		dlog.Debug(c, "Recursion check finished")
-		close(s.ready)
+		s.readyClose.Do(func() { close(s.ready) })
 	}()
 	rc := recursionCheck + tel2SubDomain
 	dlog.Debugf(c, "Performing initial recursion check with %s", rc)

--- a/pkg/client/userd/k8s/outbound.go
+++ b/pkg/client/userd/k8s/outbound.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"sort"
+	"sync"
 	"time"
 
 	auth "k8s.io/api/authorization/v1"
@@ -42,13 +43,13 @@ func (kc *Cluster) StartNamespaceWatcher(ctx context.Context) {
 func (kc *Cluster) namespacesEventHandler(ctx context.Context, evCh <-chan watch.Event, nsSynced chan struct{}) {
 	// The delay timer will initially sleep forever. It's reset to a very short
 	// delay when the file is modified.
+	var synced sync.Once
+	defer func() {
+		synced.Do(func() { close(nsSynced) })
+	}()
 	delay := time.AfterFunc(time.Duration(math.MaxInt64), func() {
 		kc.refreshNamespaces(ctx)
-		select {
-		case <-nsSynced:
-		default:
-			close(nsSynced)
-		}
+		synced.Do(func() { close(nsSynced) })
 	})
 	defer delay.Stop()
 


### PR DESCRIPTION
Ensure thread-safe channel closing by introducing `sync.Once` guards where applicable.