### PR TITLE
Linux installer fixes and improvements

### DIFF
--- a/build-aux/systemd-installer/nfpm.yaml.in
+++ b/build-aux/systemd-installer/nfpm.yaml.in
@@ -6,13 +6,13 @@ arch: ${ARCH}
 platform: linux
 version: ${PKG_VERSION}
 release: ${PKG_RELEASE}
-maintainer: Telepresence Maintainers <telepresence@datawire.io>
+maintainer: https://github.com/telepresenceio/telepresence
 description: |
   Telepresence: fast, local development for Kubernetes.
   Telepresence connects your local workstation to a remote Kubernetes cluster,
   allowing you to run services locally while accessing cluster resources.
 vendor: Telepresence.io
-homepage: https://www.telepresence.io/
+homepage: https://telepresence.io/
 license: Apache-2.0
 
 # Package dependencies

--- a/build-aux/systemd-installer/nfpm.yaml.in
+++ b/build-aux/systemd-installer/nfpm.yaml.in
@@ -55,13 +55,6 @@ contents:
       owner: root
       group: root
 
-  - dst: /var/log/telepresence
-    type: dir
-    file_info:
-      mode: 0755
-      owner: root
-      group: root
-
 scripts:
   postinstall: ./postinstall.sh
   preremove: ./preremove.sh

--- a/build-aux/systemd-installer/postinstall.sh
+++ b/build-aux/systemd-installer/postinstall.sh
@@ -3,11 +3,9 @@ set -e
 
 # Create required directories
 mkdir -p /var/cache/telepresence/rootd
-mkdir -p /var/log/telepresence
 mkdir -p /etc/telepresence
 chmod 755 /var/cache/telepresence
 chmod 755 /var/cache/telepresence/rootd
-chmod 755 /var/log/telepresence
 
 # Reload systemd to pick up the new service file (may fail in containers)
 systemctl daemon-reload 2>/dev/null || true
@@ -24,5 +22,6 @@ echo ""
 echo "To check service status:"
 echo "  sudo systemctl status telepresence-rootd"
 echo ""
-echo "Service logs are written to /var/log/telepresence/rootd.log"
+echo "To view service logs:"
+echo "  sudo journalctl -u telepresence-rootd"
 echo ""

--- a/build-aux/systemd-installer/telepresence-rootd.service
+++ b/build-aux/systemd-installer/telepresence-rootd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Telepresence root daemon (rootd)
-Documentation=https://www.telepresence.io/
+Documentation=https://telepresence.io/
 After=network.target
 
 [Service]
@@ -25,9 +25,9 @@ RuntimeDirectoryMode=0755
 Restart=always
 RestartSec=3
 
-# Logging
-StandardOutput=append:/var/log/telepresence/rootd.log
-StandardError=append:/var/log/telepresence/rootd.log
+# Logging (use journalctl -u telepresence-rootd to view logs)
+StandardOutput=journal
+StandardError=journal
 
 # Environment
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
@@ -37,7 +37,7 @@ Environment=HOME=/var/root
 # Security hardening (recommended)
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/var/cache/telepresence /var/log/telepresence
+ReadWritePaths=/var/cache/telepresence
 ProtectHome=read-only
 PrivateTmp=yes
 RestrictSUIDSGID=yes

--- a/docs/install/client.md
+++ b/docs/install/client.md
@@ -88,6 +88,22 @@ curl -fLO https://github.com/telepresenceio/telepresence/releases/latest/downloa
 sudo dnf install ./telepresence-linux-*.rpm
 ```
 
+### Viewing service logs
+
+The root daemon service logs to the systemd journal:
+
+```shell
+journalctl -u telepresence-rootd
+```
+
+> [!NOTE]
+> If you get a permission error, your user needs to be in a group that can read the journal.
+> On Fedora/RHEL, add yourself to the `wheel` group. On Debian/Ubuntu, use `systemd-journal` or `adm`:
+> ```shell
+> sudo usermod -aG systemd-journal $USER
+> ```
+> Log out and back in for the change to take effect.
+
 ## OR download the binary manually
 
 ```shell

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -95,7 +95,11 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 		sessionCancel()
 		return nil, err
 	}
-	client.ReloadLogLevel(sn)
+	if !s.managed {
+		// Only reload log level from client config if not running as a managed service.
+		// A managed service should maintain its own log level configuration.
+		client.ReloadLogLevel(sn)
+	}
 	reply.OutboundConfig = sn.getNetworkConfig()
 	initErrCh := make(chan error, 1)
 
@@ -103,7 +107,10 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 	go func() {
 		defer func() {
 			sessionCancel()
-			client.ReloadLogLevel(s)
+			if !s.managed {
+				// Restore log level from service config after session ends.
+				client.ReloadLogLevel(s)
+			}
 			close(sessionRunning)
 		}()
 		sn.run(initErrCh)


### PR DESCRIPTION
## Summary

Various fixes and improvements for the Linux systemd installer.

### Changes

- **Fix maintainer and homepage fields in nfpm configuration**
  - Change maintainer to GitHub repository URL
  - Remove www. prefix from homepage URL

- **Use systemd journal for logging instead of file**
  - Change StandardOutput/StandardError to journal
  - Remove /var/log/telepresence directory creation
  - The `--logfile managed` flag outputs without timestamps/priority (journal adds those) and separates errors to stderr

- **Add journalctl instructions to Linux installer documentation**
  - Document how to view root daemon service logs using journalctl
  - Show command without sudo since the purpose of the systemd service is to avoid needing elevated privileges
  - Include note explaining how to get journal access via group membership

- **Don't override log level for managed root daemon**
  - When running as a managed service (systemd/launchd), the root daemon maintains its own log level configuration
  - User daemon's client config no longer overrides the managed service's log level

## Test plan
- [ ] Install Linux package and verify service logs to journal
- [ ] Verify `journalctl -u telepresence-rootd` shows logs
- [ ] Verify managed root daemon maintains its log level when user daemon connects

🤖 Generated with [Claude Code](https://claude.ai/code)