### PR TITLE
Add macOS pkg signing and refocus install docs on native installers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,13 +53,54 @@ jobs:
           cd build-aux/wix-installer
           make bundle ARCH=${{ matrix.arch }}
           cp ../../build-output/bin/TelepresenceInstall.exe ../../build-output/release/telepresence-windows-${{ matrix.arch }}-setup.exe
+      - name: Import Apple certificates
+        if: runner.os == 'macOS' && env.MACOS_CERTIFICATE_P12 != ''
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificates from base64-encoded P12
+          echo "$MACOS_CERTIFICATE_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm $RUNNER_TEMP/certificate.p12
+
+          # Add keychain to search list and set as default
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          # Allow codesign to access the keychain without prompting
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Store keychain path for cleanup
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
       - name: Build macOS Installer
         if: runner.os == 'macOS'
         shell: bash
+        env:
+          MACOS_SIGN_APPLICATION: ${{ secrets.MACOS_SIGN_APPLICATION }}
+          MACOS_SIGN_INSTALLER: ${{ secrets.MACOS_SIGN_INSTALLER }}
+          MACOS_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
+          MACOS_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
+          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
         run: |
           cd build-aux/pkg-installer
           VERSION="${TELEPRESENCE_VERSION#v}" ARCH=${{ matrix.arch }} ./build-pkg.sh
           cp ../../build-output/Telepresence.pkg ../../build-output/release/telepresence-darwin-${{ matrix.arch }}.pkg
+
+      - name: Cleanup macOS keychain
+        if: runner.os == 'macOS' && always() && env.KEYCHAIN_PATH != ''
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true
       - name: Install nfpm
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,10 +41,10 @@ jobs:
         if: runner.os == 'Windows' && matrix.arch == 'amd64'
         shell: pwsh
         run: |
-          dotnet tool install --global wix
-          wix extension add -g WixToolset.BootstrapperApplications.wixext
-          wix extension add -g WixToolset.UI.wixext
-          wix extension add -g WixToolset.Util.wixext
+          dotnet tool install --global wix --version 6.0.2
+          wix extension add -g WixToolset.BootstrapperApplications.wixext/6.0.2
+          wix extension add -g WixToolset.UI.wixext/6.0.2
+          wix extension add -g WixToolset.Util.wixext/6.0.2
       - name: Build WiX Installer
         if: runner.os == 'Windows' && matrix.arch == 'amd64'
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,54 +53,6 @@ jobs:
           cd build-aux/wix-installer
           make bundle ARCH=${{ matrix.arch }}
           cp ../../build-output/bin/TelepresenceInstall.exe ../../build-output/release/telepresence-windows-${{ matrix.arch }}-setup.exe
-      - name: Import Apple certificates
-        if: runner.os == 'macOS' && env.MACOS_CERTIFICATE_P12 != ''
-        env:
-          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
-          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-        run: |
-          # Create a temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import certificates from base64-encoded P12
-          echo "$MACOS_CERTIFICATE_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          rm $RUNNER_TEMP/certificate.p12
-
-          # Add keychain to search list and set as default
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
-          security default-keychain -s "$KEYCHAIN_PATH"
-
-          # Allow codesign to access the keychain without prompting
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Store keychain path for cleanup
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
-          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
-
-      - name: Build macOS Installer
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          MACOS_SIGN_APPLICATION: ${{ secrets.MACOS_SIGN_APPLICATION }}
-          MACOS_SIGN_INSTALLER: ${{ secrets.MACOS_SIGN_INSTALLER }}
-          MACOS_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
-          MACOS_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
-          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
-        run: |
-          cd build-aux/pkg-installer
-          VERSION="${TELEPRESENCE_VERSION#v}" ARCH=${{ matrix.arch }} ./build-pkg.sh
-          cp ../../build-output/Telepresence.pkg ../../build-output/release/telepresence-darwin-${{ matrix.arch }}.pkg
-
-      - name: Cleanup macOS keychain
-        if: runner.os == 'macOS' && always() && env.KEYCHAIN_PATH != ''
-        run: |
-          security delete-keychain "$KEYCHAIN_PATH" || true
       - name: Install nfpm
         if: runner.os == 'Linux'
         shell: bash
@@ -275,6 +227,85 @@ jobs:
           delete-partial-images: true
           delete-orphaned-images: true
 
+  build-macos-pkg:
+    # This job builds signed and notarized macOS .pkg installers.
+    # It uses a protected environment requiring approval from authorized reviewers.
+    # If not approved, the release proceeds without .pkg installers (standalone binaries are still available).
+    environment: macos-signing
+    needs:
+      - publish-release
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: macos-latest
+    env:
+      GOARCH: ${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/install-dependencies
+        name: install dependencies
+      - name: set version
+        shell: bash
+        run: echo "TELEPRESENCE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: generate binaries
+        run: make release-binary
+      - name: Import Apple certificates
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificates from base64-encoded P12
+          echo "$MACOS_CERTIFICATE_P12" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm $RUNNER_TEMP/certificate.p12
+
+          # Add keychain to search list and set as default
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          # Allow codesign to access the keychain without prompting
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Store keychain path for cleanup
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+
+      - name: Build signed macOS Installer
+        env:
+          MACOS_SIGN_APPLICATION: ${{ secrets.MACOS_SIGN_APPLICATION }}
+          MACOS_SIGN_INSTALLER: ${{ secrets.MACOS_SIGN_INSTALLER }}
+          MACOS_NOTARIZE_APPLE_ID: ${{ secrets.MACOS_NOTARIZE_APPLE_ID }}
+          MACOS_NOTARIZE_TEAM_ID: ${{ secrets.MACOS_NOTARIZE_TEAM_ID }}
+          MACOS_NOTARIZE_PASSWORD: ${{ secrets.MACOS_NOTARIZE_PASSWORD }}
+        run: |
+          cd build-aux/pkg-installer
+          VERSION="${TELEPRESENCE_VERSION#v}" ARCH=${{ matrix.arch }} ./build-pkg.sh
+
+      - name: Cleanup macOS keychain
+        if: always() && env.KEYCHAIN_PATH != ''
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" || true
+
+      - name: Add signed package to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            build-output/Telepresence.pkg#telepresence-darwin-${{ matrix.arch }}.pkg \
+            --clobber
+
   test-release:
     needs:
       - push-images
@@ -328,4 +359,3 @@ jobs:
               echo "Version does not match!"
               exit 1
           fi
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,9 +302,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.ref_name }} \
-            build-output/Telepresence.pkg#telepresence-darwin-${{ matrix.arch }}.pkg \
-            --clobber
+          cp build-output/Telepresence.pkg telepresence-darwin-${{ matrix.arch }}.pkg
+          gh release upload ${{ github.ref_name }} telepresence-darwin-${{ matrix.arch }}.pkg --clobber
 
   test-release:
     needs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,3 +305,84 @@ The documentation website at [telepresence.io](https://telepresence.io) is manag
 - `DOCS_VERSION` - Major.minor version to generate or update (e.g., `2.27`)
 
 See the telepresence.io repository for full instructions.
+
+### macOS Installer Signing and Notarization
+
+The macOS `.pkg` installers are signed and notarized to pass Gatekeeper verification. This requires the following GitHub secrets to be configured:
+
+| Secret Name | Description |
+|-------------|-------------|
+| `MACOS_CERTIFICATE_P12` | Base64-encoded P12 file containing both Developer ID certificates |
+| `MACOS_CERTIFICATE_PASSWORD` | Password for the P12 file |
+| `MACOS_SIGN_APPLICATION` | Developer ID Application certificate name |
+| `MACOS_SIGN_INSTALLER` | Developer ID Installer certificate name |
+| `MACOS_NOTARIZE_APPLE_ID` | Apple ID email for notarization |
+| `MACOS_NOTARIZE_TEAM_ID` | Apple Developer Team ID |
+| `MACOS_NOTARIZE_PASSWORD` | App-specific password for notarization |
+
+If these secrets are not configured, packages will be built unsigned (suitable for testing but will trigger Gatekeeper warnings on user machines).
+
+#### Obtaining the Certificates
+
+You need an [Apple Developer Program](https://developer.apple.com/programs/) membership ($99/year) to obtain signing certificates.
+
+1. **Create certificates in Apple Developer Portal:**
+   - Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/certificates/list)
+   - Click the + button to create a new certificate
+   - Create **Developer ID Application** certificate (for signing binaries)
+   - Create **Developer ID Installer** certificate (for signing .pkg files)
+   - Download both certificates and double-click to install in Keychain Access
+
+2. **Find your Team ID:**
+   - Go to [Membership Details](https://developer.apple.com/account#MembershipDetailsCard)
+   - Copy the Team ID (10-character alphanumeric string)
+   - Set as `MACOS_NOTARIZE_TEAM_ID`
+
+3. **Find the certificate names:**
+   - Open Keychain Access and look under "My Certificates"
+   - The names will be like:
+     - `Developer ID Application: Your Name (TEAMID)` → `MACOS_SIGN_APPLICATION`
+     - `Developer ID Installer: Your Name (TEAMID)` → `MACOS_SIGN_INSTALLER`
+   - You can also list them with: `security find-identity -v -p codesigning`
+
+4. **Export certificates to P12:**
+   ```bash
+   # Export each certificate from Keychain Access:
+   # - Right-click certificate → Export
+   # - Choose .p12 format
+   # - Set a strong password (will be MACOS_CERTIFICATE_PASSWORD)
+
+   # If you have both in separate .p12 files, you can import them together
+   # or export them together from Keychain Access by selecting both
+
+   # Base64-encode for GitHub secrets:
+   base64 -i certificates.p12 | pbcopy
+   # Paste as MACOS_CERTIFICATE_P12
+   ```
+
+5. **Create app-specific password for notarization:**
+   - Go to [appleid.apple.com](https://appleid.apple.com/) → Sign-In and Security → App-Specific Passwords
+   - Generate a new password with a descriptive name (e.g., "GitHub Actions Notarization")
+   - Copy the generated password → `MACOS_NOTARIZE_PASSWORD`
+   - Use your Apple ID email → `MACOS_NOTARIZE_APPLE_ID`
+
+#### Testing Locally
+
+To test signing locally before configuring GitHub secrets:
+
+```bash
+# Set environment variables
+export MACOS_SIGN_APPLICATION="Developer ID Application: Your Name (TEAMID)"
+export MACOS_SIGN_INSTALLER="Developer ID Installer: Your Name (TEAMID)"
+export MACOS_NOTARIZE_APPLE_ID="your@email.com"
+export MACOS_NOTARIZE_TEAM_ID="ABCD123456"
+export MACOS_NOTARIZE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+
+# Build the signed and notarized package
+cd build-aux/pkg-installer
+VERSION=2.26.0 ./build-pkg.sh
+
+# Verify the signature
+pkgutil --check-signature ../../build-output/Telepresence.pkg
+spctl --assess --type install ../../build-output/Telepresence.pkg
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,17 @@ See the telepresence.io repository for full instructions.
 
 ### macOS Installer Signing and Notarization
 
-The macOS `.pkg` installers are signed and notarized to pass Gatekeeper verification. This requires the following GitHub secrets to be configured:
+The macOS `.pkg` installers are signed and notarized to pass Gatekeeper verification. The signing process uses a protected GitHub Environment to secure the signing credentials.
+
+#### Environment Setup
+
+The `build-macos-pkg` job uses the `macos-signing` environment, which must be configured in the repository settings:
+
+1. Go to https://github.com/telepresenceio/telepresence/settings/environments
+2. Create an environment named `macos-signing`
+3. Enable "Required reviewers" and add authorized personnel
+4. Optionally restrict deployment branches to `release/*`
+5. Add the following secrets to the environment (not repository-level):
 
 | Secret Name | Description |
 |-------------|-------------|
@@ -320,7 +330,21 @@ The macOS `.pkg` installers are signed and notarized to pass Gatekeeper verifica
 | `MACOS_NOTARIZE_TEAM_ID` | Apple Developer Team ID |
 | `MACOS_NOTARIZE_PASSWORD` | App-specific password for notarization |
 
-If these secrets are not configured, packages will be built unsigned (suitable for testing but will trigger Gatekeeper warnings on user machines).
+#### Release Workflow
+
+When a release tag is pushed:
+1. All platform binaries (Linux, Windows, macOS) are built immediately
+2. Linux `.deb`/`.rpm` and Windows `.exe` installers are built
+3. The release is published with all binaries and Linux/Windows installers
+4. The `build-macos-pkg` job waits for approval from a required reviewer
+5. Once approved, signed `.pkg` installers are built and added to the release
+
+This design ensures:
+- **Emergency releases can proceed** without the signing approver being available (all binaries and Linux/Windows installers are released)
+- **Signing credentials are protected** by requiring explicit approval before they are exposed
+- **Signed packages are added later** when the approver reviews and approves the job
+
+If the environment is not configured or never approved, the release will contain macOS standalone binaries but not `.pkg` installers.
 
 #### Obtaining the Certificates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,10 +322,10 @@ The `build-macos-pkg` job uses the `macos-signing` environment, which must be co
 
 | Secret Name | Description |
 |-------------|-------------|
-| `MACOS_CERTIFICATE_P12` | Base64-encoded P12 file containing both Developer ID certificates |
+| `MACOS_CERTIFICATE_P12` | Base64-encoded P12 file containing both Application and Developer ID Installer certificates |
 | `MACOS_CERTIFICATE_PASSWORD` | Password for the P12 file |
-| `MACOS_SIGN_APPLICATION` | Developer ID Application certificate name |
-| `MACOS_SIGN_INSTALLER` | Developer ID Installer certificate name |
+| `MACOS_SIGN_APPLICATION` | Developer ID Application certificate name (e.g., `Developer ID Application: Your Name (TEAMID)`) |
+| `MACOS_SIGN_INSTALLER` | Developer ID Installer certificate name (e.g., `Developer ID Installer: Your Name (TEAMID)`) |
 | `MACOS_NOTARIZE_APPLE_ID` | Apple ID email for notarization |
 | `MACOS_NOTARIZE_TEAM_ID` | Apple Developer Team ID |
 | `MACOS_NOTARIZE_PASSWORD` | App-specific password for notarization |

--- a/build-aux/pkg-installer/build-pkg.sh
+++ b/build-aux/pkg-installer/build-pkg.sh
@@ -50,11 +50,13 @@ notarize_package() {
     local pkg="$1"
     if [[ -n "${MACOS_NOTARIZE_APPLE_ID}" && -n "${MACOS_NOTARIZE_TEAM_ID}" && -n "${MACOS_NOTARIZE_PASSWORD}" ]]; then
         echo "Submitting package for notarization: $pkg"
+        # Use --timeout to prevent indefinite waiting (15 minutes should be plenty)
         xcrun notarytool submit "$pkg" \
             --apple-id "${MACOS_NOTARIZE_APPLE_ID}" \
             --team-id "${MACOS_NOTARIZE_TEAM_ID}" \
             --password "${MACOS_NOTARIZE_PASSWORD}" \
-            --wait
+            --wait \
+            --timeout 15m
 
         echo "Stapling notarization ticket to: $pkg"
         xcrun stapler staple "$pkg"

--- a/build-aux/pkg-installer/build-pkg.sh
+++ b/build-aux/pkg-installer/build-pkg.sh
@@ -14,6 +14,56 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
+# === Signing and Notarization Configuration ===
+# These environment variables enable code signing and notarization:
+#   MACOS_SIGN_APPLICATION - Developer ID Application certificate name (for codesign)
+#   MACOS_SIGN_INSTALLER   - Developer ID Installer certificate name (for productsign)
+#   MACOS_NOTARIZE_APPLE_ID - Apple ID for notarization
+#   MACOS_NOTARIZE_TEAM_ID  - Apple Developer Team ID
+#   MACOS_NOTARIZE_PASSWORD - App-specific password for notarization
+#
+# If signing variables are not set, packages will be built unsigned (suitable for local development).
+
+sign_binary() {
+    local binary="$1"
+    if [[ -n "${MACOS_SIGN_APPLICATION}" ]]; then
+        echo "Signing binary: $binary"
+        codesign --force --options runtime --timestamp --sign "${MACOS_SIGN_APPLICATION}" "$binary"
+        codesign --verify --verbose "$binary"
+    fi
+}
+
+sign_package() {
+    local unsigned_pkg="$1"
+    local signed_pkg="$2"
+    if [[ -n "${MACOS_SIGN_INSTALLER}" ]]; then
+        echo "Signing package: $unsigned_pkg -> $signed_pkg"
+        productsign --sign "${MACOS_SIGN_INSTALLER}" "$unsigned_pkg" "$signed_pkg"
+        pkgutil --check-signature "$signed_pkg"
+    else
+        # No signing, just rename
+        mv "$unsigned_pkg" "$signed_pkg"
+    fi
+}
+
+notarize_package() {
+    local pkg="$1"
+    if [[ -n "${MACOS_NOTARIZE_APPLE_ID}" && -n "${MACOS_NOTARIZE_TEAM_ID}" && -n "${MACOS_NOTARIZE_PASSWORD}" ]]; then
+        echo "Submitting package for notarization: $pkg"
+        xcrun notarytool submit "$pkg" \
+            --apple-id "${MACOS_NOTARIZE_APPLE_ID}" \
+            --team-id "${MACOS_NOTARIZE_TEAM_ID}" \
+            --password "${MACOS_NOTARIZE_PASSWORD}" \
+            --wait
+
+        echo "Stapling notarization ticket to: $pkg"
+        xcrun stapler staple "$pkg"
+        xcrun stapler validate "$pkg"
+    else
+        echo "Skipping notarization (credentials not provided)"
+    fi
+}
+
 # Allow ARCH override from environment (for CI cross-builds), otherwise detect
 if [[ -n "${ARCH}" ]]; then
     arch="${ARCH}"
@@ -56,6 +106,7 @@ cli_payload="$build_output/cli/Payload"
 mkdir -p "$cli_payload/usr/local/bin"
 cp "$telepresence_binary" "$cli_payload/usr/local/bin/telepresence"
 chmod +x "$cli_payload/usr/local/bin/telepresence"
+sign_binary "$cli_payload/usr/local/bin/telepresence"
 
 cp uninstall "$cli_payload/usr/local/bin/telepresence-uninstall"
 chmod +x "$cli_payload/usr/local/bin/telepresence-uninstall"
@@ -103,6 +154,12 @@ productbuild --distribution "$product/Distribution.xml" \
              --package-path "$product" \
              --resources "$resources" \
              --version "$VERSION" \
-             "$build_output/Telepresence.pkg"
+             "$build_output/Telepresence-unsigned.pkg"
+
+# Sign the package (or rename if no signing certificate)
+sign_package "$build_output/Telepresence-unsigned.pkg" "$build_output/Telepresence.pkg"
+
+# Notarize the signed package (if credentials are provided)
+notarize_package "$build_output/Telepresence.pkg"
 
 rm -rf cli rootd resources product

--- a/docs/install/client.md
+++ b/docs/install/client.md
@@ -1,236 +1,264 @@
----
-title: Install client
-hide_table_of_contents: true
----
-
-
-import Platform from '@site/src/components/Platform';
-
-# Client Installation
-
-Install the Telepresence client on your workstation by running the commands below for your OS.
-
-<Platform.Provider>
-<Platform.TabGroup>
-<Platform.MacOSTab>
-
-## Install with brew (Recommended):
-```shell
-brew install telepresenceio/telepresence/telepresence-oss
-```
-
-## OR install using the package installer
-
-The package installer includes the root daemon as a system service via launchd, eliminating the need for elevated privileges when using Telepresence.
-
-Download the appropriate installer for your architecture:
-- [telepresence-darwin-amd64.pkg](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64.pkg) (Intel Macs)
-- [telepresence-darwin-arm64.pkg](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64.pkg) (Apple Silicon Macs)
-
-Double-click the downloaded `.pkg` file and follow the installation prompts.
-
-## OR download the binary manually
-
-### AMD (Intel) Macs
-
-```shell
-# 1. Download the binary.
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
-
-# 2. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-
-### ARM (Apple Silicon) Macs
-
-```shell
-# 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
-# and just updating it in place will not work.
-sudo rm -f /usr/local/bin/telepresence
-
-# 2. Download the binary.
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64 -o /usr/local/bin/telepresence
-
-# 3. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-
-</Platform.MacOSTab>
-<Platform.GNULinuxTab>
-
-## Install using package manager (Recommended)
-
-The package installers include the root daemon as a systemd service, eliminating the need for elevated privileges when using Telepresence.
-
-### Debian/Ubuntu (.deb)
-
-```shell
-# Download the latest .deb package
-# AMD64
-curl -fLO https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64.deb
-# ARM64
-curl -fLO https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64.deb
-
-# Install the package
-sudo apt install ./telepresence-linux-*.deb
-```
-
-### Fedora/RHEL (.rpm)
-
-```shell
-# Download the latest .rpm package
-# AMD64
-curl -fLO https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64.rpm
-# ARM64
-curl -fLO https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64.rpm
-
-# Install the package
-sudo dnf install ./telepresence-linux-*.rpm
-```
-
-### Viewing service logs
-
-The root daemon service logs to the systemd journal:
-
-```shell
-journalctl -u telepresence-rootd
-```
-
-> [!NOTE]
-> If you get a permission error, your user needs to be in a group that can read the journal.
-> On Fedora/RHEL, add yourself to the `wheel` group. On Debian/Ubuntu, use `systemd-journal` or `adm`:
-> ```shell
-> sudo usermod -aG systemd-journal $USER
-> ```
-> Log out and back in for the change to take effect.
-
-## OR download the binary manually
-
-```shell
-# 1. Download the latest binary (~95 MB):
-# AMD
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64 -o /usr/local/bin/telepresence
-
-# ARM
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64 -o /usr/local/bin/telepresence
-
-# 2. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-
-</Platform.GNULinuxTab>
-<Platform.WindowsTab>
-
-## Install using the setup installer (Recommended)
-
-The setup installer includes the root daemon as a Windows service, eliminating the need for elevated privileges when using Telepresence. It also bundles WinFSP and SSHFS-Win for volume mount support.
-
-Download and run the installer:
-- [telepresence-windows-amd64-setup.exe](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-amd64-setup.exe)
-
-> [!NOTE]
-> The Windows installer is currently only available for AMD64. For ARM64, use the manual installation method below.
-
-## OR install manually using PowerShell
-
-We've developed a Powershell script to simplify the process of installing telepresence. Here are the commands you can execute:
-
-### Windows AMD64
-
-```powershell
-# To install Telepresence, run the following commands
-# from PowerShell as Administrator.
-
-# 1. Download the latest windows zip containing telepresence.exe and its dependencies (~60 MB):
-$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-amd64.zip -OutFile telepresence.zip
-
-# 2. Unzip the telepresence.zip file to the desired directory, then remove the zip file:
-Expand-Archive -Path telepresence.zip -DestinationPath telepresenceInstaller/telepresence
-Remove-Item 'telepresence.zip'
-cd telepresenceInstaller/telepresence
-
-# 3. Run the install-telepresence.ps1 to install telepresence's dependencies. It will install telepresence to
-# C:\telepresence by default, but you can specify a custom path by passing in -Path C:\my\custom\path
-powershell.exe -ExecutionPolicy bypass -c " . '.\install-telepresence.ps1';"
-
-# 4. Remove the unzipped directory:
-cd ../..
-Remove-Item telepresenceInstaller -Recurse -Confirm:$false -Force
-
-# 5. Telepresence is now installed and you can use telepresence commands in PowerShell.
-```
-
-### Windows ARM64
-
-```powershell
-# To install Telepresence, run the following commands
-# from PowerShell as Administrator.
-
-# 1. Download the latest windows zip containing telepresence.exe and its dependencies (~60 MB):
-$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-arm64.zip -OutFile telepresence.zip
-
-# 2. Unzip the telepresence.zip file to the desired directory, then remove the zip file:
-Expand-Archive -Path telepresence.zip -DestinationPath telepresenceInstaller/telepresence
-Remove-Item 'telepresence.zip'
-cd telepresenceInstaller/telepresence
-
-# 3. Run the install-telepresence.ps1 to install telepresence's dependencies. It will install telepresence to
-# C:\telepresence by default, but you can specify a custom path by passing in -Path C:\my\custom\path
-powershell.exe -ExecutionPolicy bypass -c " . '.\install-telepresence.ps1';"
-
-# 4. Remove the unzipped directory:
-cd ../..
-Remove-Item telepresenceInstaller -Recurse -Confirm:$false -Force
-
-# 5. Telepresence is now installed and you can use telepresence commands in PowerShell.
-```
-
-</Platform.WindowsTab>
-</Platform.TabGroup>
-
-> [!TIP]
-> What's Next?
-> Follow one of our [quick start guides](../quick-start.md) to start using Telepresence, either with our sample app or in your own environment.
-
-## Installing older versions of Telepresence
-
-Use these URLs to download an older version for your OS (including older nightly builds), replacing `x.y.z` with the versions you want.
-
-<Platform.TabGroup>
-<Platform.MacOSTab>
-
-```shell
-# AMD (Intel) Macs
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-amd64
-
-# ARM (Apple Silicon) Macs
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-arm64
-```
-
-</Platform.MacOSTab>
-<Platform.GNULinuxTab>
-
-```
-# AMD
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-amd64
-
-# ARM
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-arm64
-```
-
-</Platform.GNULinuxTab>
-<Platform.WindowsTab>
-
-```
-# Windows AMD64
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-windows-amd64.zip
-
-# Windows ARM64
-https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-windows-arm64.zip
-```
-
-</Platform.WindowsTab>
-</Platform.TabGroup>
-</Platform.Provider>
+commit 83c993cb843567ef6267042a48f3c71a2e4ce3e6
+Author: Thomas Hallgren <thomas@datawire.io>
+Date:   Sun Feb 15 22:36:18 2026 +0100
+
+    Refocus install docs on native package installers
+    
+    Restructure client install and upgrade documentation to recommend
+    native installers (pkg/deb/rpm/wix) as the primary method, with
+    Homebrew and manual binary downloads as alternatives. Add macOS
+    system extension approval instructions for Tada AB, a dedicated
+    uninstall section, and notes about what each install method provides.
+    
+    Signed-off-by: Thomas Hallgren <thomas@tada.se>
+
+diff --git a/docs/install/client.md b/docs/install/client.md
+index 45acccfef1..a91959fabc 100644
+--- a/docs/install/client.md
++++ b/docs/install/client.md
+@@ -14,24 +14,47 @@ Install the Telepresence client on your workstation by running the commands belo
+ <Platform.TabGroup>
+ <Platform.MacOSTab>
+ 
+-## Install with brew (Recommended):
+-```shell
+-brew install telepresenceio/telepresence/telepresence-oss
+-```
+-
+-## OR install using the package installer
++## Install with the package installer (Recommended)
+ 
+-The package installer includes the root daemon as a system service via launchd, eliminating the need for elevated privileges when using Telepresence.
++The package installer sets up the root daemon as a system service via launchd, eliminating the need for elevated
++privileges when using Telepresence.
+ 
+ Download the appropriate installer for your architecture:
+ - [telepresence-darwin-amd64.pkg](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64.pkg) (Intel Macs)
+ - [telepresence-darwin-arm64.pkg](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64.pkg) (Apple Silicon Macs)
+ 
+-Double-click the downloaded `.pkg` file and follow the installation prompts.
++Double-click the downloaded `.pkg` file and follow the installation prompts. You can optionally deselect the root
++daemon component during installation if you prefer to run it manually.
++
++### Allowing the system extension
++
++After installation, macOS will block the root daemon from running until you explicitly allow it. You need to:
++
++1. Open **System Settings**
++2. Go to **General > Login Items & Extensions**
++3. Find **Tada AB** in the list and enable it
++
++The macOS installer is signed and distributed by Tada AB, a Swedish company founded by the lead maintainer of the
++Telepresence open source project. This approval is required because the root daemon manages virtual network
++interfaces and DNS on your workstation, which macOS treats as a privileged operation.
++
++> [!NOTE]
++> If you skip this step, the root daemon service will not start and Telepresence will fall back to requesting
++> elevated privileges each time you run `telepresence connect`.
++
++## OR install with Homebrew
++
++```shell
++brew install telepresenceio/telepresence/telepresence-oss
++```
++
++> [!NOTE]
++> Homebrew installs the standalone binary only. The root daemon is not installed as a system service, so
++> Telepresence will request elevated privileges when connecting.
+ 
+ ## OR download the binary manually
+ 
+-### AMD (Intel) Macs
++### Intel Macs
+ 
+ ```shell
+ # 1. Download the binary.
+@@ -41,11 +64,11 @@ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/dow
+ sudo chmod a+x /usr/local/bin/telepresence
+ ```
+ 
+-### ARM (Apple Silicon) Macs
++### Apple Silicon Macs
+ 
+ ```shell
+-# 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
+-# and just updating it in place will not work.
++# 1. Ensure that no old binary exists. This is very important because Apple Silicon macs track the executable's
++# signature and just updating it in place will not work.
+ sudo rm -f /usr/local/bin/telepresence
+ 
+ # 2. Download the binary.
+@@ -58,9 +81,10 @@ sudo chmod a+x /usr/local/bin/telepresence
+ </Platform.MacOSTab>
+ <Platform.GNULinuxTab>
+ 
+-## Install using package manager (Recommended)
++## Install using a package manager (Recommended)
+ 
+-The package installers include the root daemon as a systemd service, eliminating the need for elevated privileges when using Telepresence.
++The package installers set up the root daemon as a systemd service, eliminating the need for elevated privileges
++when using Telepresence.
+ 
+ ### Debian/Ubuntu (.deb)
+ 
+@@ -108,33 +132,39 @@ journalctl -u telepresence-rootd
+ 
+ ```shell
+ # 1. Download the latest binary (~95 MB):
+-# AMD
++# AMD64
+ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64 -o /usr/local/bin/telepresence
+ 
+-# ARM
++# ARM64
+ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64 -o /usr/local/bin/telepresence
+ 
+ # 2. Make the binary executable:
+ sudo chmod a+x /usr/local/bin/telepresence
+ ```
+ 
++> [!NOTE]
++> Installing the standalone binary does not set up the root daemon as a system service. Telepresence will
++> request elevated privileges when connecting.
++
+ </Platform.GNULinuxTab>
+ <Platform.WindowsTab>
+ 
+ ## Install using the setup installer (Recommended)
+ 
+-The setup installer includes the root daemon as a Windows service, eliminating the need for elevated privileges when using Telepresence. It also bundles WinFSP and SSHFS-Win for volume mount support.
++The setup installer sets up the root daemon as a Windows service, eliminating the need for elevated privileges
++when using Telepresence. It also bundles WinFSP and SSHFS-Win for volume mount support.
+ 
+ Download and run the installer:
+ - [telepresence-windows-amd64-setup.exe](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-amd64-setup.exe)
+ 
++During installation, you can optionally configure the daemon port and log level. The defaults work for most users.
++You can also deselect the "Telepresence Network Service" feature if you prefer to run the daemon manually.
++
+ > [!NOTE]
+ > The Windows installer is currently only available for AMD64. For ARM64, use the manual installation method below.
+ 
+ ## OR install manually using PowerShell
+ 
+-We've developed a Powershell script to simplify the process of installing telepresence. Here are the commands you can execute:
+-
+ ### Windows AMD64
+ 
+ ```powershell
+@@ -187,6 +217,11 @@ Remove-Item telepresenceInstaller -Recurse -Confirm:$false -Force
+ # 5. Telepresence is now installed and you can use telepresence commands in PowerShell.
+ ```
+ 
++> [!NOTE]
++> Manual installation does not set up the root daemon as a Windows service or install WinFSP/SSHFS-Win.
++> Telepresence will request elevated privileges when connecting, and volume mounts will not work without
++> WinFSP and SSHFS-Win installed separately.
++
+ </Platform.WindowsTab>
+ </Platform.TabGroup>
+ 
+@@ -194,30 +229,83 @@ Remove-Item telepresenceInstaller -Recurse -Confirm:$false -Force
+ > What's Next?
+ > Follow one of our [quick start guides](../quick-start.md) to start using Telepresence, either with our sample app or in your own environment.
+ 
++## Uninstalling
++
++<Platform.TabGroup>
++<Platform.MacOSTab>
++
++If you installed using the package installer, run the uninstall script:
++
++```shell
++sudo telepresence-uninstall
++```
++
++This removes the Telepresence binaries and the root daemon launchd service.
++
++If you installed with Homebrew:
++
++```shell
++brew uninstall telepresenceio/telepresence/telepresence-oss
++```
++
++</Platform.MacOSTab>
++<Platform.GNULinuxTab>
++
++Use your package manager to remove Telepresence:
++
++```shell
++# Debian/Ubuntu
++sudo apt remove telepresence
++
++# Fedora/RHEL
++sudo dnf remove telepresence
++```
++
++This stops and removes the root daemon systemd service and the Telepresence binaries.
++
++</Platform.GNULinuxTab>
++<Platform.WindowsTab>
++
++Open **Settings > Apps > Installed apps**, find Telepresence, and select **Uninstall**.
++
++This removes the Telepresence binaries, the root daemon Windows service, and the bundled WinFSP and SSHFS-Win
++components.
++
++</Platform.WindowsTab>
++</Platform.TabGroup>
++
+ ## Installing older versions of Telepresence
+ 
+-Use these URLs to download an older version for your OS (including older nightly builds), replacing `x.y.z` with the versions you want.
++Use these URLs to download an older version for your OS (including older nightly builds), replacing `X.Y.Z` with the version you want.
+ 
+ <Platform.TabGroup>
+ <Platform.MacOSTab>
+ 
+ ```shell
+-# AMD (Intel) Macs
++# Intel Macs
+ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-amd64
+ 
+-# ARM (Apple Silicon) Macs
++# Apple Silicon Macs
+ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-arm64
++
++# Package installers (available from v2.27.0)
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-amd64.pkg
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-darwin-arm64.pkg
+ ```
+ 
+ </Platform.MacOSTab>
+ <Platform.GNULinuxTab>
+ 
+ ```
+-# AMD
++# AMD64
+ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-amd64
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-amd64.deb
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-amd64.rpm
+ 
+-# ARM
++# ARM64
+ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-arm64
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-arm64.deb
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-linux-arm64.rpm
+ ```
+ 
+ </Platform.GNULinuxTab>
+@@ -225,6 +313,7 @@ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepres
+ 
+ ```
+ # Windows AMD64
++https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-windows-amd64-setup.exe
+ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepresence-windows-amd64.zip
+ 
+ # Windows ARM64
+@@ -233,4 +322,4 @@ https://github.com/telepresenceio/telepresence/releases/download/vX.Y.Z/telepres
+ 
+ </Platform.WindowsTab>
+ </Platform.TabGroup>
+-</Platform.Provider>
++</Platform.Provider>
+\ No newline at end of file

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -1,81 +1,115 @@
----
-title: Upgrade client
-description: "How to upgrade your installation of Telepresence and install previous versions."
-hide_table_of_contents: true
----
+commit 83c993cb843567ef6267042a48f3c71a2e4ce3e6
+Author: Thomas Hallgren <thomas@datawire.io>
+Date:   Sun Feb 15 22:36:18 2026 +0100
 
-import Platform from '@site/src/components/Platform';
+    Refocus install docs on native package installers
+    
+    Restructure client install and upgrade documentation to recommend
+    native installers (pkg/deb/rpm/wix) as the primary method, with
+    Homebrew and manual binary downloads as alternatives. Add macOS
+    system extension approval instructions for Tada AB, a dedicated
+    uninstall section, and notes about what each install method provides.
+    
+    Signed-off-by: Thomas Hallgren <thomas@tada.se>
 
-# Upgrade Process
-The Telepresence CLI will periodically check for new versions and notify you when an upgrade is available.  Running the same commands used for installation will replace your current binary with the latest version.
-
-Before upgrading your CLI, you must stop any live Telepresence processes by issuing `telepresence quit -s` (or `telepresence quit -ur`
-if your current version is less than 2.8.0).
-
-<Platform.Provider>
-<Platform.TabGroup>
-<Platform.MacOSTab>
-
-## Upgrade with brew:
-```shell
-brew upgrade telepresenceio/telepresence/telepresence-oss
-```
-
-## OR upgrade by downloading the binary for your platform
-
-### Intel Macs
-
-```shell
-# 1. Download the binary.
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64
-
-# 2. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-
-### ARM (Apple Silicon) Macs
-
-```shell
-# 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
-# and just updating it in place will not work.
-
-# 2. Download the binary.
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64 -o /usr/local/bin/telepresence
-
-# 3. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-</Platform.MacOSTab>
-<Platform.GNULinuxTab>
-
-```shell
-
-# 1. Download the latest binary (~95 MB):
-### Intel
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64 -o /usr/local/bin/telepresence
-
-### ARM
-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64 -o /usr/local/bin/telepresence
-
-# 2. Make the binary executable:
-sudo chmod a+x /usr/local/bin/telepresence
-```
-
-</Platform.GNULinuxTab>
-<Platform.WindowsTab>
-
-To upgrade Telepresence,Click [here](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-amd64.zip)
-to download the Intel Telepresence binary or [here](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-arm64.zip)
-to download the ARM Telepresence binary.
-
-Once you have the binary downloaded and unzipped you will need to do a few things:
-
-1. Rename the binary from `telepresence-windows-[amd64|arm64].exe` to `telepresence.exe`
-2. Move the binary to `C:\Program Files (x86)\$USER\Telepresence\`
-
-</Platform.WindowsTab>
-</Platform.TabGroup>
-</Platform.Provider>
-
-The Telepresence CLI contains an embedded Helm chart. See [Install/Uninstall the Traffic Manager](manager.md) if you want to also upgrade
-the Traffic Manager in your cluster.
+diff --git a/docs/install/upgrade.md b/docs/install/upgrade.md
+index bdff321946..7e8ef4a12a 100644
+--- a/docs/install/upgrade.md
++++ b/docs/install/upgrade.md
+@@ -7,7 +7,7 @@ hide_table_of_contents: true
+ import Platform from '@site/src/components/Platform';
+ 
+ # Upgrade Process
+-The Telepresence CLI will periodically check for new versions and notify you when an upgrade is available.  Running the same commands used for installation will replace your current binary with the latest version.
++The Telepresence CLI will periodically check for new versions and notify you when an upgrade is available. Running the same commands used for installation will replace your current version with the latest.
+ 
+ Before upgrading your CLI, you must stop any live Telepresence processes by issuing `telepresence quit -s` (or `telepresence quit -ur`
+ if your current version is less than 2.8.0).
+@@ -16,28 +16,35 @@ if your current version is less than 2.8.0).
+ <Platform.TabGroup>
+ <Platform.MacOSTab>
+ 
+-## Upgrade with brew:
++## Upgrade with the package installer (Recommended)
++
++Download and install the latest `.pkg` for your architecture from the [install page](client.md). The installer
++will replace the previous version and restart the root daemon service.
++
++## OR upgrade with Homebrew
++
+ ```shell
+ brew upgrade telepresenceio/telepresence/telepresence-oss
+ ```
+ 
+-## OR upgrade by downloading the binary for your platform
++## OR upgrade by downloading the binary manually
+ 
+ ### Intel Macs
+ 
+ ```shell
+ # 1. Download the binary.
+-sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64
++sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-amd64 -o /usr/local/bin/telepresence
+ 
+ # 2. Make the binary executable:
+ sudo chmod a+x /usr/local/bin/telepresence
+ ```
+ 
+-### ARM (Apple Silicon) Macs
++### Apple Silicon Macs
+ 
+ ```shell
+-# 1. Ensure that no old binary exists. This is very important because Silicon macs track the executable's signature
+-# and just updating it in place will not work.
++# 1. Ensure that no old binary exists. This is very important because Apple Silicon macs track the executable's
++# signature and just updating it in place will not work.
++sudo rm -f /usr/local/bin/telepresence
+ 
+ # 2. Download the binary.
+ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64 -o /usr/local/bin/telepresence
+@@ -48,13 +55,20 @@ sudo chmod a+x /usr/local/bin/telepresence
+ </Platform.MacOSTab>
+ <Platform.GNULinuxTab>
+ 
+-```shell
++## Upgrade with a package manager (Recommended)
+ 
++Download and install the latest `.deb` or `.rpm` package using the same commands as the initial
++[installation](client.md). The package manager will handle replacing the previous version and restarting the
++root daemon service.
++
++## OR upgrade by downloading the binary manually
++
++```shell
+ # 1. Download the latest binary (~95 MB):
+-### Intel
++### AMD64
+ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-amd64 -o /usr/local/bin/telepresence
+ 
+-### ARM
++### ARM64
+ sudo curl -fL https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-linux-arm64 -o /usr/local/bin/telepresence
+ 
+ # 2. Make the binary executable:
+@@ -64,14 +78,15 @@ sudo chmod a+x /usr/local/bin/telepresence
+ </Platform.GNULinuxTab>
+ <Platform.WindowsTab>
+ 
+-To upgrade Telepresence,Click [here](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-amd64.zip)
+-to download the Intel Telepresence binary or [here](https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-windows-arm64.zip)
+-to download the ARM Telepresence binary.
++## Upgrade with the setup installer (Recommended)
++
++Download and run the latest setup installer from the [install page](client.md). The installer will replace the
++previous version and restart the root daemon service.
+ 
+-Once you have the binary downloaded and unzipped you will need to do a few things:
++## OR upgrade by downloading manually
+ 
+-1. Rename the binary from `telepresence-windows-[amd64|arm64].exe` to `telepresence.exe`
+-2. Move the binary to `C:\Program Files (x86)\$USER\Telepresence\`
++Download the latest zip from the [install page](client.md) and follow the manual installation steps, which will
++replace the existing installation.
+ 
+ </Platform.WindowsTab>
+ </Platform.TabGroup>


### PR DESCRIPTION
## Summary
- Add code signing and notarization support for macOS `.pkg` installers to pass Gatekeeper verification
- Update release workflow to import Apple Developer certificates and pass signing credentials
- Add comprehensive documentation for obtaining and configuring the required secrets
- Restructure install/upgrade docs to recommend native package installers (pkg/deb/rpm/wix) as the primary method
- Document macOS system extension approval for Tada AB and add a dedicated uninstall section

## Required GitHub Secrets
| Secret | Description |
|--------|-------------|
| `MACOS_CERTIFICATE_P12` | Base64-encoded P12 file with Developer ID certificates |
| `MACOS_CERTIFICATE_PASSWORD` | Password for the P12 file |
| `MACOS_SIGN_APPLICATION` | Developer ID Application certificate name |
| `MACOS_SIGN_INSTALLER` | Developer ID Installer certificate name |
| `MACOS_NOTARIZE_APPLE_ID` | Apple ID email for notarization |
| `MACOS_NOTARIZE_TEAM_ID` | Apple Developer Team ID |
| `MACOS_NOTARIZE_PASSWORD` | App-specific password for notarization |

