### PR TITLE
Fix root daemon access when running with embedded root daemon

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -53,7 +53,7 @@ items:
           due to dependency constraints.
         docs: install/client
   - version: 2.26.2
-    date: 2026-02-05
+    date: (TBD)
     notes:
       - type: bugfix
         title: Fix HTTP intercepts via telepresence compose failing when httpFilters or httpPaths are set
@@ -62,6 +62,13 @@ items:
           This caused the traffic manager to reject the intercept with "global TCP/UDP intercepts are disabled".
           The mechanism is now correctly switched to "http" when any HTTP filters are specified, matching the behavior
           of the CLI intercept command.
+      - type: bugfix
+        title: Fix "root daemon is embedded" error on Windows elevated terminals
+        body: >-
+          When running Telepresence in an elevated (administrator) terminal on Windows, commands like connect and
+          loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process
+          root daemon session instead of returning an error.
+        docs: https://github.com/telepresenceio/telepresence/issues/4049
   - version: 2.26.1
     date: 2026-01-26
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,11 +20,17 @@ New Linux package installers (.deb for Debian/Ubuntu and .rpm for Fedora/RHEL) a
 A new Windows installer (.exe) is now available that installs Telepresence with the root daemon configured as a Windows service. The installer bundles WinFSP and SSHFS-Win dependencies for volume mount support, adds Telepresence to the system PATH, and optionally installs the TelepresenceDaemon service. This eliminates the need for elevated privileges when using Telepresence. Currently available for amd64 architecture only due to dependency constraints.
 </div>
 
-## Version 2.26.2 <span style="font-size: 16px;">(February  5)</span>
+## Version 2.26.2
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Fix HTTP intercepts via telepresence compose failing when httpFilters or httpPaths are set</div></div>
 <div style="margin-left: 15px">
 
 The compose extension set HeaderFilters and PathFilters on the intercept spec but left the mechanism as "tcp". This caused the traffic manager to reject the intercept with "global TCP/UDP intercepts are disabled". The mechanism is now correctly switched to "http" when any HTTP filters are specified, matching the behavior of the CLI intercept command.
+</div>
+
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Fix "root daemon is embedded" error on Windows elevated terminals](https://github.com/telepresenceio/telepresence/issues/4049)</div></div>
+<div style="margin-left: 15px">
+
+When running Telepresence in an elevated (administrator) terminal on Windows, commands like connect and loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process root daemon session instead of returning an error.
 </div>
 
 ## Version 2.26.1 <span style="font-size: 16px;">(January 26)</span>

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -26,11 +26,17 @@ New Linux package installers (.deb for Debian/Ubuntu and .rpm for Fedora/RHEL) a
 A new Windows installer (.exe) is now available that installs Telepresence with the root daemon configured as a Windows service. The installer bundles WinFSP and SSHFS-Win dependencies for volume mount support, adds Telepresence to the system PATH, and optionally installs the TelepresenceDaemon service. This eliminates the need for elevated privileges when using Telepresence. Currently available for amd64 architecture only due to dependency constraints.
   </Body>
 </Note>
-## Version 2.26.2 <span style={{fontSize:'16px'}}>(February  5)</span>
+## Version 2.26.2
 <Note>
 	<Title type="bugfix">Fix HTTP intercepts via telepresence compose failing when httpFilters or httpPaths are set</Title>
 	<Body>
 The compose extension set HeaderFilters and PathFilters on the intercept spec but left the mechanism as "tcp". This caused the traffic manager to reject the intercept with "global TCP/UDP intercepts are disabled". The mechanism is now correctly switched to "http" when any HTTP filters are specified, matching the behavior of the CLI intercept command.
+  </Body>
+</Note>
+<Note>
+	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4049">Fix "root daemon is embedded" error on Windows elevated terminals</Title>
+	<Body>
+When running Telepresence in an elevated (administrator) terminal on Windows, commands like connect and loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process root daemon session instead of returning an error.
   </Body>
 </Note>
 ## Version 2.26.1 <span style={{fontSize:'16px'}}>(January 26)</span>

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -448,6 +448,9 @@ func (s *service) TrafficManagerVersion(ctx context.Context, _ *empty.Empty) (vi
 }
 
 func (s *service) RootDaemonVersion(ctx context.Context, empty *empty.Empty) (vi *common.VersionInfo, err error) {
+	if s.rootSessionInProc {
+		return client.VersionInfo(ctx), nil
+	}
 	err = s.withRootDaemon(ctx, func(ctx context.Context, rd daemon.DaemonClient) error {
 		vi, err = rd.Version(s, empty)
 		return err
@@ -631,6 +634,12 @@ func (s *service) RerouteRemotePort(ctx context.Context, request *daemon.Reroute
 }
 
 func (s *service) withRootDaemon(ctx context.Context, f func(ctx context.Context, daemonClient daemon.DaemonClient) error) error {
+	s.sessionLock.RLock()
+	defer s.sessionLock.RUnlock()
+	if s.session != nil {
+		return s.session.WithRootClient(ctx, f)
+	}
+
 	if s.rootSessionInProc {
 		return status.Error(codes.Unavailable, "root daemon is embedded")
 	}


### PR DESCRIPTION
## Summary
- Fix `RootDaemonVersion` to return the local version directly when root daemon is embedded (in-process)
- Fix `withRootDaemon` to delegate to the session's `WithRootClient` when a session is available, instead of returning an "embedded" error

Closes #4049

## Test plan
- [ ] Run `telepresence connect` on Windows in an elevated (administrator) terminal
- [ ] Verify `telepresence loglevel` and other commands work with embedded root daemon
- [ ] Verify non-elevated terminal still works as before