### PR TITLE
Fix h2c prior knowledge by setting HTTP1=false on transport

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -77,6 +77,14 @@ items:
           loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process
           root daemon session instead of returning an error.
         docs: https://github.com/telepresenceio/telepresence/issues/4049
+      - type: bugfix
+        title: Fix h2c (HTTP/2 cleartext) prior knowledge not working on transport
+        body: >-
+          Since Go 1.24, having both HTTP1 and UnencryptedHTTP2 enabled on an HTTP transport causes Go to
+          default to HTTP/1.1 instead of using h2c prior knowledge. The transport now explicitly disables
+          HTTP1 when UnencryptedHTTP2 is enabled, fixing h2c communication for both the default forwarding
+          handler and intercepted traffic.
+        docs: https://github.com/telepresenceio/telepresence/issues/4056
   - version: 2.26.1
     date: 2026-01-26
     notes:

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -31,7 +31,7 @@ bindir ?= $(or $(shell go env GOBIN),$(shell go env GOPATH|cut -d: -f1)/bin)
 # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md.
 export DOCKER_BUILDKIT := 1
 
-GOLANGCI_VERSION:=v2.8.0
+GOLANGCI_VERSION:=v2.9.0
 
 .PHONY: FORCE
 FORCE:

--- a/cmd/traffic/cmd/agent/fwd/http.go
+++ b/cmd/traffic/cmd/agent/fwd/http.go
@@ -40,6 +40,9 @@ func (f *tcp) protocols(ctx context.Context, plainText bool) *http.Protocols {
 func (f *tcp) configureTransport(ctx context.Context, plainText bool) *http.Transport {
 	trn := http.DefaultTransport.(*http.Transport).Clone()
 	trn.Protocols = f.protocols(ctx, plainText)
+	if trn.Protocols.UnencryptedHTTP2() {
+		trn.Protocols.SetHTTP1(false)
+	}
 	return trn
 }
 
@@ -177,15 +180,11 @@ func shouldInterceptRequest(req *http.Request, headerFilters map[string]string, 
 	return matcher.NewRequest(pathFilters, headerFilters).Matches(req)
 }
 
-func (f *tcp) configureUpstreamTransport(ctx context.Context, requestProto int, plaintext bool) *http.Transport {
+func (f *tcp) configureUpstreamTransport(ctx context.Context, plaintext bool) *http.Transport {
 	tm := f.tlsManager
 	tp := f.Target().Port()
 	trn := f.configureTransport(ctx, plaintext)
 	if plaintext {
-		if requestProto == 2 && trn.Protocols.UnencryptedHTTP2() {
-			// Force upstream use of clear-text HTTP/2
-			trn.Protocols.SetHTTP1(false)
-		}
 		return trn
 	}
 	if tm == nil || !tm.UseTLS(ctx, tp) {
@@ -215,7 +214,7 @@ func (f *tcp) serveHTTPIntercept(ctx context.Context, src netip.AddrPort, writer
 		ingressBytes = tunnel.NewCounterProbe("FromClientBytes")
 		egressBytes = tunnel.NewCounterProbe("ToClientBytes")
 	}
-	trn := f.configureUpstreamTransport(ctx, request.ProtoMajor, spec.Plaintext)
+	trn := f.configureUpstreamTransport(ctx, spec.Plaintext)
 	trn.DialContext = func(context.Context, string, string) (net.Conn, error) {
 		s, err := f.createStream(ctx, src, ii)
 		if err != nil {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -39,6 +39,12 @@ The compose extension set HeaderFilters and PathFilters on the intercept spec bu
 When running Telepresence in an elevated (administrator) terminal on Windows, commands like connect and loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process root daemon session instead of returning an error.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Fix h2c (HTTP/2 cleartext) prior knowledge not working on transport](https://github.com/telepresenceio/telepresence/issues/4056)</div></div>
+<div style="margin-left: 15px">
+
+Since Go 1.24, having both HTTP1 and UnencryptedHTTP2 enabled on an HTTP transport causes Go to default to HTTP/1.1 instead of using h2c prior knowledge. The transport now explicitly disables HTTP1 when UnencryptedHTTP2 is enabled, fixing h2c communication for both the default forwarding handler and intercepted traffic.
+</div>
+
 ## Version 2.26.1 <span style="font-size: 16px;">(January 26)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Add support for "warning" as an alias for "warn" in log levels](https://github.com/telepresenceio/telepresence/issues/4043)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -45,6 +45,12 @@ The compose extension set HeaderFilters and PathFilters on the intercept spec bu
 When running Telepresence in an elevated (administrator) terminal on Windows, commands like connect and loglevel failed with "root daemon is embedded". The user daemon now correctly delegates to the in-process root daemon session instead of returning an error.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4056">Fix h2c (HTTP/2 cleartext) prior knowledge not working on transport</Title>
+	<Body>
+Since Go 1.24, having both HTTP1 and UnencryptedHTTP2 enabled on an HTTP transport causes Go to default to HTTP/1.1 instead of using h2c prior knowledge. The transport now explicitly disables HTTP1 when UnencryptedHTTP2 is enabled, fixing h2c communication for both the default forwarding handler and intercepted traffic.
+  </Body>
+</Note>
 ## Version 2.26.1 <span style={{fontSize:'16px'}}>(January 26)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4043">Add support for "warning" as an alias for "warn" in log levels</Title>

--- a/integration_test/h2c_intercept_test.go
+++ b/integration_test/h2c_intercept_test.go
@@ -1,0 +1,151 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/iputil"
+)
+
+type h2cInterceptSuite struct {
+	itest.Suite
+	itest.TrafficManager
+}
+
+func (s *h2cInterceptSuite) SuiteName() string {
+	return "H2CIntercept"
+}
+
+func init() {
+	itest.AddConnectedSuite("", func(h itest.TrafficManager) itest.TestingSuite {
+		return &h2cInterceptSuite{Suite: itest.Suite{Harness: h}, TrafficManager: h}
+	})
+}
+
+func (s *h2cInterceptSuite) SetupSuite() {
+	if !(s.ManagerIsVersion(">2.26.x") && s.ClientIsVersion(">2.26.x")) {
+		s.T().Skip("H2C intercepts require Telepresence 2.27.0 or later")
+	}
+	s.Suite.SetupSuite()
+}
+
+// startLocalH2CEchoServer starts a local HTTP server that supports h2c (HTTP/2 cleartext)
+// and echoes a line with the given name and the current URL path.
+func startLocalH2CEchoServer(ctx context.Context, name string) (int, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	lc := net.ListenConfig{}
+	l, err := lc.Listen(ctx, "tcp", "localhost:0")
+	if err != nil {
+		cancel()
+		panic(fmt.Sprintf("failed to listen: %v", err))
+	}
+	pr := new(http.Protocols)
+	pr.SetHTTP1(true)
+	pr.SetUnencryptedHTTP2(true)
+	sc := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "%s from intercept at %s", name, r.URL.Path)
+		}),
+		Protocols: pr,
+	}
+	go func() {
+		_ = sc.Serve(l)
+	}()
+	go func() {
+		<-ctx.Done()
+		sdCtx, sdCancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+		defer sdCancel()
+		_ = sc.Shutdown(sdCtx)
+	}()
+	return l.Addr().(*net.TCPAddr).Port, cancel
+}
+
+func (s *h2cInterceptSuite) Test_H2CInterceptPreservesProtocol() {
+	ctx := s.Context()
+	require := s.Require()
+
+	const svc = "echo-h2c"
+
+	// Deploy echo-server with appProtocol: kubernetes.io/h2c
+	itest.ApplyAppTemplate(ctx, s.AppNamespace(), &itest.AppData{
+		AppName: svc,
+		Ports: []itest.AppPort{
+			{
+				ServicePortNumber: 80,
+				TargetPortNumber:  8080,
+				AppProtocol:       "kubernetes.io/h2c",
+			},
+		},
+		Env: map[string]string{"PORTS": "8080:http"},
+	})
+	defer itest.DeleteSvcAndWorkload(ctx, "deploy", svc, s.AppNamespace())
+
+	// Start a local h2c-capable echo server to receive intercepted traffic.
+	// The upstream handler must support the same protocol as the app.
+	localPort, cancel := startLocalH2CEchoServer(ctx, svc)
+	defer cancel()
+
+	// Create a personal HTTP intercept with a header filter
+	stdout, stderr, err := itest.Telepresence(ctx, "intercept", svc,
+		"--http-header", "x-test=h2c",
+		"--port", strconv.Itoa(localPort)+":80",
+		"--mount=false")
+	require.NoError(err, "stderr: %s", stderr)
+	require.Contains(stdout, "Using Deployment")
+
+	// Capture traffic-agent logs for debugging
+	s.CapturePodLogs(ctx, svc, "traffic-agent", s.AppNamespace())
+
+	// Verify non-intercepted traffic uses HTTP/2 (h2c).
+	// The intercept is active so traffic goes through the agent's HTTP handler.
+	// Requests without the x-test header don't match the intercept and are forwarded
+	// by the default reverse proxy. The fix ensures that this proxy uses h2c prior
+	// knowledge, so the echo-server sees HTTP/2.0.
+	require.Eventually(func() bool {
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", svc)
+		if err != nil {
+			clog.Info(ctx, err)
+			return false
+		}
+		ips = iputil.UniqueSorted(ips)
+		if len(ips) != 1 {
+			clog.Infof(ctx, "Lookup for %s returned %v", svc, ips)
+			return false
+		}
+		hc := http.Client{Timeout: 2 * time.Second}
+		rq, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://%s", net.JoinHostPort(ips[0].String(), "80")), nil)
+		if err != nil {
+			clog.Info(ctx, err)
+			return false
+		}
+		resp, err := hc.Do(rq)
+		if err != nil {
+			clog.Info(ctx, err)
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			clog.Info(ctx, err)
+			return false
+		}
+		r := string(body)
+		clog.Infof(ctx, "non-intercepted response: %s", r)
+		return strings.Contains(r, "HTTP/2.0 GET /")
+	}, 30*time.Second, 3*time.Second, "expected HTTP/2.0 in non-intercepted response")
+
+	// Verify intercepted traffic reaches the local h2c handler
+	itest.PingInterceptedEchoServer(ctx, svc, "80", "x-test=h2c")
+
+	// Leave the intercept
+	_, _, err = itest.Telepresence(ctx, "leave", svc)
+	require.NoError(err)
+}


### PR DESCRIPTION
## Summary
- Since Go 1.24, having both HTTP1 and UnencryptedHTTP2 enabled on an HTTP transport causes Go to default to HTTP/1.1 instead of using h2c prior knowledge
- Move the `SetHTTP1(false)` logic into `configureTransport()` so all callers (default handler and intercepted traffic) get the fix automatically
- Remove the now-redundant conditional block from `configureUpstreamTransport()`

Fixes #4056

## Test plan
- [x] `go build ./cmd/traffic/...` compiles successfully
- [x] `go test ./cmd/traffic/cmd/agent/fwd/...` unit tests pass
- [ ] Verify h2c intercepts work end-to-end against a gRPC service using cleartext HTTP/2