### PR TITLE
Inject cluster DNS into containers started by telepresence compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ fuseftp.bits
 .vagrant/
 tests.log
 /.claude/settings.local.json
+/bugs/

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -59,6 +59,13 @@ items:
           that the major.minor version differs from the running binary, it automatically quits running daemons and
           clears stale cache entries (preserving logs). This prevents issues caused by leftover cache files from a
           previous version. Patch and pre-release version changes do not trigger a cache cleanup.
+      - type: bugfix
+        title: Cluster DNS not injected into containers started by telepresence compose
+        body: >-
+          When using <code>telepresence compose up</code>, cluster hostnames did not resolve inside the compose 
+          container because the daemon DNS IP and the tel2-search DNS search domain were not being added to the
+          generated compose spec. DNS and dns_search are now correctly set for all engaged compose services.
+        docs: https://github.com/telepresenceio/telepresence/issues/4053
   - version: 2.26.2
     date: 2026-02-14
     notes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Telepresence is a Kubernetes development tool that enables fast local developmen
 - Never commit directly to the `release/v2` branch. Always create a feature branch with a name following the pattern `username/topic` (e.g., `thallgren/fix-dns-resolution`).
 - All commits must be signed and signed-off (`git commit -s -S`).
 - Push the branch and create a pull request for review.
+- Always merge PRs with a merge commit (never squash or rebase).
 
 ## Build Artifacts
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -26,6 +26,12 @@ A new Windows installer (.exe) is now available that installs Telepresence with 
 Telepresence now tracks its version in a version.json file in the cache directory. When the CLI detects that the major.minor version differs from the running binary, it automatically quits running daemons and clears stale cache entries (preserving logs). This prevents issues caused by leftover cache files from a previous version. Patch and pre-release version changes do not trigger a cache cleanup.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Cluster DNS not injected into containers started by telepresence compose](https://github.com/telepresenceio/telepresence/issues/4053)</div></div>
+<div style="margin-left: 15px">
+
+When using <code>telepresence compose up</code>, cluster hostnames did not resolve inside the compose  container because the daemon DNS IP and the tel2-search DNS search domain were not being added to the generated compose spec. DNS and dns_search are now correctly set for all engaged compose services.
+</div>
+
 ## Version 2.26.2 <span style="font-size: 16px;">(February 14)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Dial 127.0.0.1 instead of 0.0.0.0 when connecting to local daemons](https://github.com/telepresenceio/telepresence/issues/4048)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -32,6 +32,12 @@ A new Windows installer (.exe) is now available that installs Telepresence with 
 Telepresence now tracks its version in a version.json file in the cache directory. When the CLI detects that the major.minor version differs from the running binary, it automatically quits running daemons and clears stale cache entries (preserving logs). This prevents issues caused by leftover cache files from a previous version. Patch and pre-release version changes do not trigger a cache cleanup.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4053">Cluster DNS not injected into containers started by telepresence compose</Title>
+	<Body>
+When using <code>telepresence compose up</code>, cluster hostnames did not resolve inside the compose  container because the daemon DNS IP and the tel2-search DNS search domain were not being added to the generated compose spec. DNS and dns_search are now correctly set for all engaged compose services.
+  </Body>
+</Note>
 ## Version 2.26.2 <span style={{fontSize:'16px'}}>(February 14)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4048">Dial 127.0.0.1 instead of 0.0.0.0 when connecting to local daemons</Title>

--- a/integration_test/compose_test.go
+++ b/integration_test/compose_test.go
@@ -1,0 +1,96 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	goRuntime "runtime"
+	"strings"
+	"time"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+)
+
+type composeSuite struct {
+	itest.Suite
+	itest.TrafficManager
+	ctx context.Context
+}
+
+func (s *composeSuite) SuiteName() string {
+	return "Compose"
+}
+
+func init() {
+	itest.AddTrafficManagerSuite("", func(h itest.TrafficManager) itest.TestingSuite {
+		return &composeSuite{Suite: itest.Suite{Harness: h}, TrafficManager: h}
+	})
+}
+
+func (s *composeSuite) SetupSuite() {
+	if s.IsCI() && !(goRuntime.GOOS == "linux" && goRuntime.GOARCH == "amd64") {
+		s.T().Skip("CI can't run linux docker containers inside non-linux runners")
+		return
+	}
+	s.Suite.SetupSuite()
+	s.ctx = itest.WithConfig(s.HarnessContext(), func(cfg client.Config) {
+		cfg.Intercept().UseFtp = false
+	})
+}
+
+func (s *composeSuite) TearDownTest() {
+	itest.TelepresenceQuitOk(s.Context())
+}
+
+func (s *composeSuite) Context() context.Context {
+	return itest.WithT(s.ctx, s.T())
+}
+
+func (s *composeSuite) Test_ComposeDNS() {
+	ctx := s.Context()
+	require := s.Require()
+
+	const svc = "echo-easy"
+	s.ApplyEchoService(ctx, svc, 80)
+	defer s.DeleteSvcAndWorkload(ctx, "deploy", svc)
+
+	const svc2 = "echo-other"
+	s.ApplyEchoService(ctx, svc2, 80)
+	defer s.DeleteSvcAndWorkload(ctx, "deploy", svc2)
+
+	// Write a docker-compose.yml that replaces echo-other and sleeps.
+	composeDir := itest.TempDir(ctx)
+	composeFile := filepath.Join(composeDir, "docker-compose.yml")
+	ns := s.AppNamespace()
+	composeContent := strings.Join([]string{
+		"x-tele:",
+		"  connections:",
+		"    - namespace: " + ns,
+		"      manager-namespace: " + s.ManagerNamespace(),
+		"services:",
+		"  " + svc2 + ":",
+		"    x-tele:",
+		"      type: replace",
+		"    image: busybox",
+		"    command: sleep infinity",
+	}, "\n")
+	require.NoError(os.WriteFile(composeFile, []byte(composeContent), 0o644))
+
+	_, _, err := itest.Telepresence(ctx, "compose", "-f", composeFile, "up", "-d")
+	require.NoError(err, "compose up failed")
+	defer func() {
+		_, _, _ = itest.Telepresence(ctx, "compose", "-f", composeFile, "down")
+	}()
+
+	// Verify that cluster DNS resolves inside the compose container.
+	s.Assert().EventuallyContext(ctx, func() bool {
+		so, se, err := itest.Telepresence(ctx, "compose", "-f", composeFile, "exec", svc2, "nslookup", svc)
+		if err == nil && strings.Contains(so, "Address:") {
+			return true
+		}
+		clog.Info(ctx, "nslookup", "sdtout", so, "stderr", se, "err", err)
+		return false
+	}, 30*time.Second, 3*time.Second, "nslookup of %s in compose container should succeed", svc)
+}

--- a/integration_test/inactive_client_test.go
+++ b/integration_test/inactive_client_test.go
@@ -38,7 +38,7 @@ func init() {
 			Suite:                itest.Suite{Harness: h},
 			NamespacePair:        h,
 			svc:                  "echo-easy",
-			inactiveBlockTimeout: 6 * time.Second,
+			inactiveBlockTimeout: 10 * time.Second,
 			pingInterval:         2 * time.Second,
 		}
 	})

--- a/pkg/client/cli/docker/compose/connection.go
+++ b/pkg/client/cli/docker/compose/connection.go
@@ -10,9 +10,9 @@ import (
 
 	compose "github.com/compose-spec/compose-go/v2/types"
 
-	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/connect"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/docker"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -30,6 +30,7 @@ type connectionConfig struct {
 type connection struct {
 	context.Context
 	*connectionConfig
+	dnsIP   netip.Addr
 	subnets []netip.Prefix
 	proxies map[string]netip.Addr
 }
@@ -98,7 +99,7 @@ func (cc *connectionConfig) Connect(ctx context.Context, es map[string]serviceEx
 		return nil, err
 	}
 	defer func() {
-		if err != nil {
+		if err != nil && !mustPreExist {
 			connect.Disconnect(ctx)
 		}
 	}()
@@ -110,14 +111,19 @@ func (cc *connectionConfig) Connect(ctx context.Context, es map[string]serviceEx
 	ds := daemon.MustGetSession(ctx)
 	rootCfg, err := daemon.GetRootClientConfig(ds.Info.DaemonStatus)
 	if err != nil {
-		clog.Errorf(ctx, "unable to obtain routing info for connection: %v", err)
+		return nil, fmt.Errorf("unable to obtain routing info for connection: %w", err)
+	}
+
+	dns, _, err := docker.GetDaemonContainerNetworkInfo(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	proxies, err := cc.resolveProxies(ctx, ds, es)
 	if err != nil {
 		return nil, err
 	}
-	return &connection{Context: ctx, connectionConfig: cc, proxies: proxies, subnets: rootCfg.Routing().Subnets}, nil
+	return &connection{Context: ctx, connectionConfig: cc, dnsIP: dns, proxies: proxies, subnets: rootCfg.Routing().Subnets}, nil
 }
 
 // resolveProxies resolves the name of the proxy definition into its remote service IP. This IP will then be

--- a/pkg/client/cli/docker/compose/engagement.go
+++ b/pkg/client/cli/docker/compose/engagement.go
@@ -102,6 +102,10 @@ func (a *engagement) maybeAddConnection(s *compose.ServiceConfig) bool {
 
 func (a *engagement) engageService(s *compose.ServiceConfig) {
 	a.maybeAddConnection(s)
+	dnsIP := a.connection().dnsIP
+	if ipS := dnsIP.String(); !slices.Contains(s.DNS, ipS) {
+		s.DNS = append(s.DNS, ipS)
+	}
 	env := a.environment
 	if len(env) > 0 {
 		if s.Environment == nil {
@@ -126,6 +130,7 @@ func (a *engagement) engageProxyDependents(p *compose.Project, n string, depende
 	conn := a.connection()
 	sm := p.Services
 
+	dnsIP := a.connection().dnsIP.String()
 	for _, d := range dependents {
 		// Dependent services need a new DNS for the proxy, and also the network
 		// that routes its IP.
@@ -144,8 +149,8 @@ func (a *engagement) engageProxyDependents(p *compose.Project, n string, depende
 				ds.ExtraHosts = extraHosts
 			}
 		}
-		if ipS := a.daemonIP.String(); !slices.Contains(ds.DNS, ipS) {
-			ds.DNS = append(ds.DNS, ipS)
+		if !slices.Contains(ds.DNS, dnsIP) {
+			ds.DNS = append(ds.DNS, dnsIP)
 		}
 		// A proxied service is simply removed from the compose-spec along with any dependents.
 		delete(ds.DependsOn, n)

--- a/pkg/client/cli/docker/compose/engagement.go
+++ b/pkg/client/cli/docker/compose/engagement.go
@@ -12,6 +12,7 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 
 	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/docker"
@@ -106,6 +107,9 @@ func (a *engagement) engageService(s *compose.ServiceConfig) {
 	if ipS := dnsIP.String(); !slices.Contains(s.DNS, ipS) {
 		s.DNS = append(s.DNS, ipS)
 	}
+	if !slices.Contains(s.DNSSearch, client.Tel2SubDomain) {
+		s.DNSSearch = append(s.DNSSearch, client.Tel2SubDomain)
+	}
 	env := a.environment
 	if len(env) > 0 {
 		if s.Environment == nil {
@@ -151,6 +155,9 @@ func (a *engagement) engageProxyDependents(p *compose.Project, n string, depende
 		}
 		if !slices.Contains(ds.DNS, dnsIP) {
 			ds.DNS = append(ds.DNS, dnsIP)
+		}
+		if !slices.Contains(ds.DNSSearch, client.Tel2SubDomain) {
+			ds.DNSSearch = append(ds.DNSSearch, client.Tel2SubDomain)
 		}
 		// A proxied service is simply removed from the compose-spec along with any dependents.
 		delete(ds.DependsOn, n)

--- a/pkg/client/cli/docker/compose/transform.go
+++ b/pkg/client/cli/docker/compose/transform.go
@@ -195,6 +195,7 @@ func (t *transformer) runCompose(ctx context.Context, name, composeFile string, 
 		return t.runAttachedUp(ctx, composeFile, opts)
 	}
 	cmd := proc.StdCommand(ctx, docker.Exe, append(opts, t.config.services...)...)
+	cmd.Stdin = dos.Stdin(ctx)
 	cmd.Env = os.Environ()
 	return cmd.Run()
 }

--- a/pkg/client/cli/docker/runner.go
+++ b/pkg/client/cli/docker/runner.go
@@ -193,7 +193,7 @@ func (s *Runner) start(ctx context.Context, envFile string, runFlags *RunFlags, 
 				ourArgs = append(ourArgs, "--mount", fmt.Sprintf("type=bind,src=%s,dst=%s%s", filepath.Join(s.Mount.LocalDir, path), path, ro))
 			}
 		}
-		ourArgs = append(ourArgs, "--dns-search", "tel2-search")
+		ourArgs = append(ourArgs, "--dns-search", client.Tel2SubDomain)
 	} else {
 		maps.DeleteFunc(mounts, func(s string, policy types.MountPolicy) bool {
 			return policy == types.MountPolicyIgnore || policy == types.MountPolicyLocal

--- a/pkg/client/const.go
+++ b/pkg/client/const.go
@@ -63,3 +63,5 @@ var ProcessName = func() string { //nolint:gochecknoglobals // extension point
 	}
 	return pn
 }
+
+const Tel2SubDomain = "tel2-search"

--- a/pkg/client/rootd/dns/server.go
+++ b/pkg/client/rootd/dns/server.go
@@ -37,7 +37,7 @@ const (
 
 	// sanityCheck is the query used when verifying that a DNS query reaches our DNS server. It should result
 	// in an increase of the requestCount but always yield an NXDOMAIN reply.
-	santiyCheck    = "jhfweoitnkgyeta." + tel2SubDomain
+	santiyCheck    = "jhfweoitnkgyeta." + client.Tel2SubDomain
 	santiyCheckDot = santiyCheck + "."
 
 	// dnsTTL is the number of seconds that a found DNS record should be allowed to live in the callers cache. We
@@ -159,7 +159,7 @@ func NewServer(config *client.DNS, namespace string, clusterLookup Resolver) *Se
 		routes:          make(map[string]struct{}),
 		domains:         make(map[string]struct{}),
 		dropSuffixes:    []string{tel2SubDomainDot},
-		search:          []string{tel2SubDomain},
+		search:          []string{client.Tel2SubDomain},
 		nsAndDomainsCh:  make(chan nsAndDomains, 5),
 		clusterDomain:   defaultClusterDomain,
 		namespaceDomain: namespace + ".",
@@ -183,8 +183,7 @@ func NewServer(config *client.DNS, namespace string, clusterLookup Resolver) *Se
 // the query. We then strip the "tel2-search" and send the original single label name to the
 // cluster, and we add it back before we forward the reply.
 const (
-	tel2SubDomain    = "tel2-search"
-	tel2SubDomainDot = tel2SubDomain + "."
+	tel2SubDomainDot = client.Tel2SubDomain + "."
 )
 
 // excludePrefixes are prefixes for name queries that we just want to respond NXNAME to
@@ -524,7 +523,7 @@ func (s *Server) processSearchPaths(g log.Group, processor func(context.Context,
 				// The connected namespace must be included as a search path for the cases
 				// where it's up to the traffic-manager to resolve. It cannot resolve a single
 				// label name intended for other namespaces.
-				s.search = []string{tel2SubDomain, das.namespace}
+				s.search = []string{client.Tel2SubDomain, das.namespace}
 				s.Unlock()
 
 				if err := processor(c, dev); err != nil {
@@ -778,7 +777,7 @@ func (s *Server) performRecursionCheck(c context.Context) {
 		clog.Debug(c, "Recursion check finished")
 		s.readyClose.Do(func() { close(s.ready) })
 	}()
-	rc := recursionCheck + tel2SubDomain
+	rc := recursionCheck + client.Tel2SubDomain
 	clog.Debugf(c, "Performing initial recursion check with %s", rc)
 	i := 0
 	atomic.StoreInt32(&s.recursive, recursionQueryNotYetReceived)

--- a/pkg/client/rootd/dns/server_darwin.go
+++ b/pkg/client/rootd/dns/server_darwin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/vif"
@@ -114,7 +115,7 @@ func (s *Server) updateResolverFiles(c context.Context, resolverDirName string, 
 	}
 	clusterDomain := strings.TrimSuffix(s.clusterDomain, ".")
 	domains[clusterDomain] = newDomainResolveFile(clusterDomain)
-	domains[tel2SubDomain] = newDomainResolveFile(tel2SubDomain)
+	domains[client.Tel2SubDomain] = newDomainResolveFile(client.Tel2SubDomain)
 
 nextSearch:
 	for _, search := range s.search {

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -689,7 +689,9 @@ func (s *session) remainLoop(_ context.Context) error {
 func (s *session) CheckStatus(cr *rpc.ConnectRequest) error {
 	config, err := k8s.DaemonKubeconfig(s, cr)
 	if err != nil {
-		return err
+		// Treat an incomplete request as OK. It stems from an implicit
+		// connect that doesn't define a kubeconfig at all.
+		config = s.Kubeconfig
 	}
 	if len(cr.MappedNamespaces) == 1 && cr.MappedNamespaces[0] == "all" {
 		cr.MappedNamespaces = nil


### PR DESCRIPTION
## Summary
- Fix cluster DNS not being injected into containers started by `telepresence compose up`, so that cluster hostnames now resolve correctly inside compose services
- Fix disconnect-on-error guard to not disconnect pre-existing connections
- Pass stdin through to compose subcommands
- Add a `Compose` integration test suite with a DNS resolution test reproducing the reported failure

Fixes #4053