### PR TITLE
Fix missing Mounts in ReviewInterceptRequest for container replacements

### DIFF
--- a/cmd/traffic/cmd/agent/containerstate.go
+++ b/cmd/traffic/cmd/agent/containerstate.go
@@ -85,6 +85,7 @@ func (c *containerState) HandleContainer(ctx context.Context, iis []*manager.Int
 					SftpPort:    int32(c.SftpPort()),
 					FtpPort:     int32(c.FtpPort()),
 					MountPoint:  c.MountPoint(),
+					Mounts:      c.Mounts().ToRPC(),
 					Environment: c.Env(),
 				})
 			}


### PR DESCRIPTION
## Description

When using `telepresence replace --container --docker-run` on multi-container pods, volumes were not mounted because HandleContainer omitted the Mounts field from ReviewInterceptRequest. The parallel code paths in fwdState (HandlePort) correctly included Mounts. Add the missing field so volume mount policies are propagated to the client.

Fixes #4086

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.