### PR TITLE
Fix Docker Compose default network subnet conflicts with Kubernetes cluster CIDRs

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -36,6 +36,13 @@ items:
           Telepresence now pre-computes a non-conflicting RFC 1918 subnet by checking both existing
           Docker networks and the cluster's routing CIDRs before creating the teleroute network.
         docs: https://github.com/telepresenceio/telepresence/issues/4005
+      - type: bugfix
+        title: Fix Docker Compose default network subnet conflicts with Kubernetes cluster CIDRs
+        body: >-
+          When using <code>telepresence compose</code>, Docker Compose auto-creates a default network
+          whose subnet could overlap with Kubernetes cluster CIDRs, causing cluster traffic to be
+          misrouted. Telepresence now configures the default network with an explicit non-conflicting
+          subnet in the rendered compose file.
   - version: 2.27.2
     date: 2026-03-09
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 When using <code>telepresence connect --docker</code> or <code>telepresence compose</code>, Docker's default IPAM could assign a subnet that overlaps with the Kubernetes cluster's service CIDR (e.g., <code>172.20.0.0/16</code> on EKS), causing network creation to fail. Telepresence now pre-computes a non-conflicting RFC 1918 subnet by checking both existing Docker networks and the cluster's routing CIDRs before creating the teleroute network.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Fix Docker Compose default network subnet conflicts with Kubernetes cluster CIDRs</div></div>
+<div style="margin-left: 15px">
+
+When using <code>telepresence compose</code>, Docker Compose auto-creates a default network whose subnet could overlap with Kubernetes cluster CIDRs, causing cluster traffic to be misrouted. Telepresence now configures the default network with an explicit non-conflicting subnet in the rendered compose file.
+</div>
+
 ## Version 2.27.2 <span style="font-size: 16px;">(March  9)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Fix duplicate Section field in .deb package causing dpkg install failure](https://github.com/telepresenceio/telepresence/issues/4073)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 When using <code>telepresence connect --docker</code> or <code>telepresence compose</code>, Docker's default IPAM could assign a subnet that overlaps with the Kubernetes cluster's service CIDR (e.g., <code>172.20.0.0/16</code> on EKS), causing network creation to fail. Telepresence now pre-computes a non-conflicting RFC 1918 subnet by checking both existing Docker networks and the cluster's routing CIDRs before creating the teleroute network.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Fix Docker Compose default network subnet conflicts with Kubernetes cluster CIDRs</Title>
+	<Body>
+When using <code>telepresence compose</code>, Docker Compose auto-creates a default network whose subnet could overlap with Kubernetes cluster CIDRs, causing cluster traffic to be misrouted. Telepresence now configures the default network with an explicit non-conflicting subnet in the rendered compose file.
+  </Body>
+</Note>
 ## Version 2.27.2 <span style={{fontSize:'16px'}}>(March  9)</span>
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4073">Fix duplicate Section field in .deb package causing dpkg install failure</Title>

--- a/integration_test/compose_test.go
+++ b/integration_test/compose_test.go
@@ -2,11 +2,15 @@ package integration_test
 
 import (
 	"context"
+	"net/netip"
 	"os"
 	"path/filepath"
 	goRuntime "runtime"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types/network"
+	dockerClient "github.com/docker/docker/client"
 
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
@@ -404,4 +408,102 @@ func (s *composeSuite) Test_ComposeWiretap() {
 		clog.Info(ctx, "compose logs wiretap", "stdout", so, "stderr", se, "err", err)
 		return false
 	}, 30*time.Second, 3*time.Second, "wiretap container should receive copies of traffic")
+}
+
+func (s *composeSuite) Test_ComposeDefaultNetworkNoSubnetConflict() {
+	ctx := s.Context()
+	rq := s.Require()
+
+	const svc = "echo-easy"
+	s.ApplyEchoService(ctx, svc, 80)
+	defer s.DeleteSvcAndWorkload(ctx, "deploy", svc)
+
+	// Use multiple named connections to the same namespace. Each connection creates a separate
+	// daemon container with its own teleroute network, consuming Docker network address space.
+	// Combined with existing Docker networks (bridge, kind, etc.), this pushes Docker's sequential
+	// IPAM allocation toward the cluster's service CIDR (e.g. 172.20.0.0/16). Without the fix,
+	// the compose default network would get a conflicting subnet.
+	const projectName = "tp-subnet-test"
+	composeDir := itest.TempDir(ctx)
+	composeFile := filepath.Join(composeDir, "docker-compose.yml")
+	ns := s.AppNamespace()
+	mgrNs := s.ManagerNamespace()
+	composeContent := strings.Join([]string{
+		"x-tele:",
+		"  connections:",
+		"    - name: conn-1",
+		"      namespace: " + ns,
+		"      manager-namespace: " + mgrNs,
+		"    - name: conn-2",
+		"      namespace: " + ns,
+		"      manager-namespace: " + mgrNs,
+		"    - name: conn-3",
+		"      namespace: " + ns,
+		"      manager-namespace: " + mgrNs,
+		"services:",
+		"  tester-1:",
+		"    x-tele:",
+		"      type: connect",
+		"      connection: conn-1",
+		"    image: busybox",
+		"    command: sleep infinity",
+		"  tester-2:",
+		"    x-tele:",
+		"      type: connect",
+		"      connection: conn-2",
+		"    image: busybox",
+		"    command: sleep infinity",
+		"  tester-3:",
+		"    x-tele:",
+		"      type: connect",
+		"      connection: conn-3",
+		"    image: busybox",
+		"    command: sleep infinity",
+	}, "\n")
+	rq.NoError(os.WriteFile(composeFile, []byte(composeContent), 0o644))
+
+	_, _, err := itest.Telepresence(ctx, "compose", "-f", composeFile, "--project-name", projectName, "up", "-d")
+	rq.NoError(err, "compose up failed")
+	defer func() {
+		_, _, _ = itest.Telepresence(ctx, "compose", "-f", composeFile, "--project-name", projectName, "down")
+	}()
+
+	// Collect cluster CIDRs from the first connection's status.
+	status := itest.TelepresenceStatusOk(ctx, "--use", "conn-1")
+	rq.NotNil(status.RootDaemon)
+	clusterSubnets := status.RootDaemon.RoutingSnake.Subnets
+	alsoProxy := status.RootDaemon.RoutingSnake.AlsoProxy
+	allClusterCIDRs := append(append([]netip.Prefix{}, clusterSubnets...), alsoProxy...)
+	rq.NotEmpty(allClusterCIDRs, "expected at least one cluster subnet in status")
+
+	// Inspect the compose default network and verify its subnet doesn't overlap with any cluster CIDR.
+	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
+	rq.NoError(err)
+	defer cli.Close()
+
+	defaultNetworkName := projectName + "_default"
+	ni, err := cli.NetworkInspect(ctx, defaultNetworkName, network.InspectOptions{})
+	rq.NoError(err, "failed to inspect network %s", defaultNetworkName)
+	rq.NotEmpty(ni.IPAM.Config, "expected at least one IPAM config on default network %s", defaultNetworkName)
+
+	for _, cfg := range ni.IPAM.Config {
+		subnet, err := netip.ParsePrefix(cfg.Subnet)
+		if err != nil {
+			continue // skip non-IPv4 or unparseable entries
+		}
+		for _, clusterCIDR := range allClusterCIDRs {
+			s.Falsef(subnet.Overlaps(clusterCIDR),
+				"compose default network %s subnet %s overlaps with cluster CIDR %s", defaultNetworkName, subnet, clusterCIDR)
+		}
+	}
+
+	// Verify that cluster connectivity works from one of the connect containers.
+	s.Assert().EventuallyContext(ctx, func() bool {
+		so, se, err := itest.Telepresence(ctx, "compose", "-f", composeFile, "--project-name", projectName, "exec", "tester-1", "wget", "-qO-", "http://"+svc)
+		if err == nil && len(so) > 0 {
+			return true
+		}
+		clog.Info(ctx, "wget", "stdout", so, "stderr", se, "err", err)
+		return false
+	}, 30*time.Second, 3*time.Second, "wget of %s from connect container should succeed", svc)
 }

--- a/integration_test/compose_test.go
+++ b/integration_test/compose_test.go
@@ -471,8 +471,8 @@ func (s *composeSuite) Test_ComposeDefaultNetworkNoSubnetConflict() {
 	// Collect cluster CIDRs from the first connection's status.
 	status := itest.TelepresenceStatusOk(ctx, "--use", "conn-1")
 	rq.NotNil(status.RootDaemon)
-	clusterSubnets := status.RootDaemon.RoutingSnake.Subnets
-	alsoProxy := status.RootDaemon.RoutingSnake.AlsoProxy
+	clusterSubnets := status.RootDaemon.Subnets
+	alsoProxy := status.RootDaemon.AlsoProxy
 	allClusterCIDRs := append(append([]netip.Prefix{}, clusterSubnets...), alsoProxy...)
 	rq.NotEmpty(allClusterCIDRs, "expected at least one cluster subnet in status")
 

--- a/pkg/client/cli/docker/compose/connection.go
+++ b/pkg/client/cli/docker/compose/connection.go
@@ -123,7 +123,11 @@ func (cc *connectionConfig) Connect(ctx context.Context, es map[string]serviceEx
 	if err != nil {
 		return nil, err
 	}
-	return &connection{Context: ctx, connectionConfig: cc, dnsIP: dns, proxies: proxies, subnets: rootCfg.Routing().Subnets}, nil
+	routing := rootCfg.Routing()
+	clusterSubnets := make([]netip.Prefix, 0, len(routing.Subnets)+len(routing.AlsoProxy))
+	clusterSubnets = append(clusterSubnets, routing.Subnets...)
+	clusterSubnets = append(clusterSubnets, routing.AlsoProxy...)
+	return &connection{Context: ctx, connectionConfig: cc, dnsIP: dns, proxies: proxies, subnets: clusterSubnets}, nil
 }
 
 // resolveProxies resolves the name of the proxy definition into its remote service IP. This IP will then be

--- a/pkg/client/cli/docker/compose/transform.go
+++ b/pkg/client/cli/docker/compose/transform.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"os"
 	"os/exec"
 	"slices"
@@ -16,6 +17,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/flags"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/progress"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/docker"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/docker/teleroute"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/json"
@@ -252,7 +254,7 @@ func (t *transformer) withProfiles(profiles []string) error {
 }
 
 // ApplyEngagements ensures that the compose-spec is modified in accordance with the engagements.
-func (t *transformer) applyEngagements() error {
+func (t *transformer) applyEngagements(ctx context.Context) error {
 	if len(t.engagements) == 0 {
 		return nil
 	}
@@ -283,6 +285,8 @@ func (t *transformer) applyEngagements() error {
 	for _, e := range t.engagements {
 		e.engageProject(p)
 	}
+
+	t.configureDefaultNetwork(ctx, p)
 
 	if t.tpVolumes != nil {
 		t.tpVolumes.Range(func(k string, v *compose.VolumeConfig) bool {
@@ -323,6 +327,46 @@ func (t *transformer) ensureTopLevelExtension(p *compose.Project) error {
 	return nil
 }
 
+// configureDefaultNetwork sets an explicit IPAM subnet on the compose project's default network
+// to prevent Docker from assigning a CIDR that conflicts with Kubernetes cluster subnets.
+func (t *transformer) configureDefaultNetwork(ctx context.Context, p *compose.Project) {
+	// Don't override if the user explicitly configured the default network with IPAM.
+	if existing, ok := p.Networks["default"]; ok && len(existing.Ipam.Config) > 0 {
+		return
+	}
+
+	// Aggregate cluster subnets from all connections.
+	var allSubnets []netip.Prefix
+	for _, c := range t.connections() {
+		allSubnets = append(allSubnets, c.subnets...)
+	}
+	if len(allSubnets) == 0 {
+		return
+	}
+
+	cli, err := docker.GetClient(ctx)
+	if err != nil {
+		clog.Warnf(ctx, "Unable to get Docker client for default network IPAM configuration: %v", err)
+		return
+	}
+	subnet, err := teleroute.FindNonConflictingSubnet(ctx, cli, allSubnets)
+	if err != nil {
+		clog.Warnf(ctx, "Unable to pre-compute a non-conflicting subnet for the compose default network: %v. Falling back to Docker default IPAM", err)
+		return
+	}
+	clog.Debugf(ctx, "Using pre-computed subnet %s for compose default network", subnet)
+	if p.Networks == nil {
+		p.Networks = make(compose.Networks)
+	}
+	p.Networks["default"] = compose.NetworkConfig{
+		Ipam: compose.IPAMConfig{
+			Config: []*compose.IPAMPool{{
+				Subnet: subnet.String(),
+			}},
+		},
+	}
+}
+
 func (t *transformer) connections() []*connection {
 	ccs := t.config.Connections
 	cs := make([]*connection, 0, len(ccs))
@@ -358,7 +402,7 @@ func (t *transformer) createConfigFile(ctx context.Context, canCreate, forceRecr
 		clog.Debugf(ctx, "Recreating existing compose file %q", composeFile)
 	}
 
-	err = t.applyEngagements()
+	err = t.applyEngagements(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/client/docker/teleroute/network.go
+++ b/pkg/client/docker/teleroute/network.go
@@ -55,7 +55,7 @@ func CreateNetwork(
 		},
 	}
 	if len(clusterSubnets) > 0 {
-		subnet, findErr := findNonConflictingSubnet(ctx, cli, clusterSubnets)
+		subnet, findErr := FindNonConflictingSubnet(ctx, cli, clusterSubnets)
 		if findErr != nil {
 			clog.Warnf(ctx, "Unable to pre-compute a non-conflicting subnet: %v. Falling back to Docker default IPAM", findErr)
 		} else {
@@ -164,9 +164,9 @@ func ReconnectNetwork(ctx context.Context, cli *dockerClient.Client, name string
 	}
 }
 
-// findNonConflictingSubnet finds a subnet that doesn't overlap with any existing
+// FindNonConflictingSubnet finds a subnet that doesn't overlap with any existing
 // Docker network or the given cluster CIDRs.
-func findNonConflictingSubnet(ctx context.Context, cli *dockerClient.Client, clusterSubnets []netip.Prefix) (netip.Prefix, error) {
+func FindNonConflictingSubnet(ctx context.Context, cli *dockerClient.Client, clusterSubnets []netip.Prefix) (netip.Prefix, error) {
 	avoid := append([]netip.Prefix{}, clusterSubnets...)
 	nets, err := cli.NetworkList(ctx, network.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
## Summary

- When using `telepresence compose`, Docker Compose auto-creates a `<project>_default` network whose CIDR could overlap with Kubernetes cluster CIDRs (e.g., `172.20.0.0/16` on EKS), causing cluster traffic to be misrouted to the local bridge
- Telepresence now configures the default network in the rendered compose file with an explicit non-conflicting RFC 1918 subnet, reusing the existing `FindNonConflictingSubnet` logic from the teleroute package
- Also includes `AlsoProxy` subnets in the compose connection's cluster CIDRs to match the teleroute path behavior

## Changes

- `pkg/client/docker/teleroute/network.go` — Export `FindNonConflictingSubnet` for reuse
- `pkg/client/cli/docker/compose/connection.go` — Include `AlsoProxy` in connection subnets
- `pkg/client/cli/docker/compose/transform.go` — Add `configureDefaultNetwork` method, wire into `applyEngagements`
- `integration_test/compose_test.go` — Add `Test_ComposeDefaultNetworkNoSubnetConflict`
- `CHANGELOG.yml` + docs — Add changelog entry under 2.27.3

## Test plan

- [x] Run `Test_ComposeDefaultNetworkNoSubnetConflict` — uses 3 named connections to consume Docker network address space, pushing allocation toward the conflicting range
- [x] Run full `Compose` test suite — all 8 tests pass, no regressions
- [x] Run `Test_DockerDaemon_networkNoSubnetConflict` — confirms exported function still works
- [x] Run teleroute unit tests — all pass

### Kind cluster setup for integration tests

The integration test requires a kind cluster with `serviceSubnet: 172.20.0.0/16` so Docker's sequential IPAM allocation (`172.17`, `172.18`, `172.19`, `172.20`...) would collide with the cluster's service CIDR if the fix is not in place.

```bash
cat <<KINDEOF > /tmp/kind-config.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  serviceSubnet: "172.20.0.0/16"
KINDEOF
kind create cluster --name tp-test --config /tmp/kind-config.yaml
```

On arm64 hosts, a local arm64 echo-server image must be built and loaded into kind since `ghcr.io/telepresenceio/echo-server:0.3.1` is amd64-only.