### PR TITLE
docs: fix outdated Helm chart references in traffic manager installation

### DIFF
--- a/docs/install/manager.md
+++ b/docs/install/manager.md
@@ -34,7 +34,7 @@ The telepresence cli can install the traffic manager for you. The basic install 
 
 ### Customizing the Traffic Manager.
 
-For details on what the Helm chart installs and what can be configured, see the Helm chart [configuration on artifacthub](https://artifacthub.io/packages/helm/datawire/telepresence).
+For details on what the Helm chart installs and what can be configured, see the Helm chart [configuration on artifacthub](https://artifacthub.io/packages/helm/telepresence-oss/telepresence-oss).
 
 1. Create a values.yaml file with your config values.
 
@@ -54,7 +54,7 @@ The Helm chart supports being installed into any namespace, not necessarily `amb
 `telepresence helm install`.  For example, if you wanted to deploy the traffic manager to the `staging` namespace:
 
 ```shell
-telepresence helm install traffic-manager --namespace staging datawire/telepresence
+telepresence helm install --namespace staging
 ```
 
 > [!NOTE]


### PR DESCRIPTION
- Update custom namespace installation command to remove outdated datawire/telepresence chart reference
- Update ArtifactHUB link from datawire/telepresence to telepresence-oss/telepresence-oss
- Align documentation with current Helm chart location at oci://ghcr.io/telepresenceio/telepresence-oss

## Description

The "Install into custom namespace" section contained an outdated reference to the `datawire/telepresence` Helm chart, which is no longer maintained. This PR also updates the documentation to align with the current Helm chart location ("oci://ghcr.io/telepresenceio/telepresence-oss") that
  is already correctly referenced in the "Install with Helm" section of the same document.

  ## Checklist

   - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
   - [x] I made sure to add any documentation changes required for my change.
   - [x] My change is adequately tested.
   - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
   - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
         [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.