### PR TITLE
Fix HTTP intercept routing across replicas

### DIFF
--- a/cmd/traffic/cmd/agent/fwd/http.go
+++ b/cmd/traffic/cmd/agent/fwd/http.go
@@ -3,6 +3,7 @@ package fwd
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -155,7 +156,7 @@ func (f *tcp) handleHTTPRequest(writer http.ResponseWriter, req *http.Request, d
 			if shouldInterceptRequest(req, spec.HeaderFilters, spec.PathFilters) {
 				clog.Debugf(f.lCtx, "Intercepting HTTP request %s %s with header-based intercept %s",
 					req.Method, req.URL.Path, ic.Id)
-				f.serveHTTPIntercept(ic.ctx, src, writer, req, ic.InterceptInfo)
+				f.serveHTTPIntercept(ic.ctx, src, writer, req, ic.InterceptInfo, defaultHandler)
 				return
 			}
 		}
@@ -168,7 +169,7 @@ func (f *tcp) handleHTTPRequest(writer http.ResponseWriter, req *http.Request, d
 			if shouldInterceptRequest(req, spec.HeaderFilters, spec.PathFilters) {
 				clog.Debugf(f.lCtx, "Intercepting HTTP request %s %s with path-based intercept %s",
 					req.Method, req.URL.Path, ic.Id)
-				f.serveHTTPIntercept(ic.ctx, src, writer, req, ic.InterceptInfo)
+				f.serveHTTPIntercept(ic.ctx, src, writer, req, ic.InterceptInfo, defaultHandler)
 				return
 			}
 		}
@@ -202,7 +203,14 @@ func (f *tcp) configureUpstreamTransport(ctx context.Context, plaintext bool) *h
 	return trn
 }
 
-func (f *tcp) serveHTTPIntercept(ctx context.Context, src netip.AddrPort, writer http.ResponseWriter, request *http.Request, ii *manager.InterceptInfo) {
+func (f *tcp) serveHTTPIntercept(
+	ctx context.Context,
+	src netip.AddrPort,
+	writer http.ResponseWriter,
+	request *http.Request,
+	ii *manager.InterceptInfo,
+	defaultHandler http.Handler,
+) {
 	spec := ii.Spec
 	f.mu.Lock()
 	sp := f.streamProvider
@@ -243,7 +251,14 @@ func (f *tcp) serveHTTPIntercept(ctx context.Context, src netip.AddrPort, writer
 		clog.Debugf(ctx, "No TLS config used when connecting to %s", trg)
 	}
 	targetProxy := httputil.NewSingleHostReverseProxy(trg)
-	targetProxy.ErrorHandler = proxyErrorHandler
+	targetProxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		if errors.Is(err, errClientStream) {
+			clog.Warnf(ctx, "Intercept tunnel unavailable for %s %s; failing open to app container: %v", req.Method, req.URL.Path, err)
+			defaultHandler.ServeHTTP(rw, req)
+			return
+		}
+		proxyErrorHandler(rw, req, err)
+	}
 	targetProxy.Transport = trn
 	targetProxy.ServeHTTP(writer, request)
 

--- a/cmd/traffic/cmd/agent/fwd/tcp.go
+++ b/cmd/traffic/cmd/agent/fwd/tcp.go
@@ -2,6 +2,7 @@ package fwd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -16,6 +17,8 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
+
+var errClientStream = errors.New("failed to create client stream")
 
 type tcp struct {
 	*interceptor
@@ -190,7 +193,7 @@ func (f *tcp) createStream(ctx context.Context, src netip.AddrPort, ii *manager.
 	f.mu.Unlock()
 	s, err := sp.CreateClientStream(ctx, tunnel.AgentToClient, clientSession, id, latency, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create client stream: %w", err)
+		return nil, fmt.Errorf("%w: %w", errClientStream, err)
 	}
 	return s, nil
 }

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -473,7 +473,7 @@ func (s *service) WatchAgentPods(session *rpc.SessionInfo, stream grpc.ServerStr
 				Namespace:    a.Namespace,
 				PodIp:        aip.AsSlice(),
 				ApiPort:      a.ApiPort,
-				Intercepted:  s.state.IsInterceptedBy(aip, clientSessionID),
+				Intercepted:  s.state.IsInterceptedBy(aip, a.Name, a.Namespace, clientSessionID),
 			}
 			agents = append(agents, ap)
 			return true
@@ -527,7 +527,7 @@ func (s *service) WatchAgentPodsDelta(session *rpc.SessionInfo, stream grpc.Serv
 						Namespace:    a.Namespace,
 						PodIp:        aip.AsSlice(),
 						ApiPort:      a.ApiPort,
-						Intercepted:  s.state.IsInterceptedBy(aip, clientSessionID),
+						Intercepted:  s.state.IsInterceptedBy(aip, a.Name, a.Namespace, clientSessionID),
 					}
 					agentPodInfos.Store(string(k), ap)
 				}
@@ -544,7 +544,7 @@ func (s *service) WatchAgentPodsDelta(session *rpc.SessionInfo, stream grpc.Serv
 				return true
 			}
 			aip, _ := netip.AddrFromSlice(a.PodIp)
-			intercepted := s.state.IsInterceptedBy(aip, clientSessionID)
+			intercepted := s.state.IsInterceptedBy(aip, a.WorkloadName, a.Namespace, clientSessionID)
 			agentPodInfos.Compute(k, func(a *rpc.AgentPodInfo, loaded bool) (*rpc.AgentPodInfo, xsync.ComputeOp) {
 				if loaded && a.Intercepted != intercepted {
 					a := proto.Clone(a).(*rpc.AgentPodInfo)

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -491,17 +491,37 @@ func (s *State) CountTunnelEgress() uint64 {
 	return atomic.LoadUint64(&s.tunnelEgressCounter)
 }
 
-func (s *State) IsInterceptedBy(agentPodIP netip.Addr, client tunnel.SessionID) (found bool) {
+func (s *State) IsInterceptedBy(agentPodIP netip.Addr, agentName, namespace string, client tunnel.SessionID) (found bool) {
 	clientSessionID := string(client)
 	podIPStr := agentPodIP.String()
 	s.intercepts.Range(func(id string, ii *Intercept) bool {
-		if ii.PodIp == podIPStr && ii.ClientSession.SessionId == clientSessionID {
+		if ii.ClientSession.SessionId != clientSessionID || ii.Disposition != rpc.InterceptDispositionType_ACTIVE {
+			return true
+		}
+		if ii.Spec.Namespace != namespace || ii.Spec.Agent != agentName {
+			return true
+		}
+		if ii.PodIp == podIPStr {
 			found = true
 			return false
 		}
-		return true
+		if !interceptNeedsDialWatcherOnAllPods(ii.Spec) {
+			return true
+		}
+		found = true
+		return false
 	})
 	return found
+}
+
+func interceptNeedsDialWatcherOnAllPods(spec *rpc.InterceptSpec) bool {
+	if spec == nil || IsChildIntercept(spec) || spec.Replace {
+		return false
+	}
+	if spec.Mechanism == "http" {
+		return true
+	}
+	return len(spec.HeaderFilters) > 0 || len(spec.PathFilters) > 0
 }
 
 // Sessions: Agents ////////////////////////////////////////////////////////////////////////////////

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"log/slog"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -178,6 +179,60 @@ func (s *suiteState) TestRemoveSession() {
 	s.state.RemoveSession(s.ctx, s2) // won't fail trying to delete consumption.
 
 	assert.Equal(s.T(), s.state.CountSessions(), 0)
+}
+
+func TestIsInterceptedBy(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(t, false)
+	st := &State{
+		backgroundCtx:    ctx,
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, 5*time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, 5*time.Millisecond),
+		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		workloadWatchers: xsync.NewMap[string, Watcher](),
+		timedLogLevel:    log.NewTimedLevel(slog.LevelDebug, clog.SetTreeLevel),
+		llSubs:           newLoglevelSubscribers(),
+	}
+
+	clientID := tunnel.SessionID("client")
+
+	st.intercepts.Store("http", &Intercept{InterceptInfo: &manager.InterceptInfo{
+		Id:          "http",
+		Disposition: manager.InterceptDispositionType_ACTIVE,
+		PodIp:       "10.0.0.1",
+		ClientSession: &manager.SessionInfo{
+			SessionId: string(clientID),
+		},
+		Spec: &manager.InterceptSpec{
+			Agent:     "demo",
+			Namespace: "default",
+			Mechanism: "http",
+			Client:    "alice",
+		},
+	}})
+
+	st.intercepts.Store("tcp", &Intercept{InterceptInfo: &manager.InterceptInfo{
+		Id:          "tcp",
+		Disposition: manager.InterceptDispositionType_ACTIVE,
+		PodIp:       "10.0.0.3",
+		ClientSession: &manager.SessionInfo{
+			SessionId: string(clientID),
+		},
+		Spec: &manager.InterceptSpec{
+			Agent:     "api",
+			Namespace: "default",
+			Mechanism: "tcp",
+			Client:    "alice",
+		},
+	}})
+
+	require.True(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.1"), "demo", "default", clientID))
+	require.True(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.2"), "demo", "default", clientID))
+	require.True(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.3"), "api", "default", clientID))
+	require.False(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.4"), "api", "default", clientID))
+	require.False(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.2"), "other", "default", clientID))
+	require.False(t, st.IsInterceptedBy(netip.MustParseAddr("10.0.0.2"), "demo", "other", clientID))
 }
 
 func TestSuiteState(testing *testing.T) {

--- a/integration_test/multi_replica_intercept_test.go
+++ b/integration_test/multi_replica_intercept_test.go
@@ -1,0 +1,138 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+type multiReplicaInterceptSuite struct {
+	itest.Suite
+	itest.TrafficManager
+	svc       string
+	localPort int
+}
+
+func (s *multiReplicaInterceptSuite) SuiteName() string {
+	return "MultiReplicaIntercept"
+}
+
+func init() {
+	itest.AddTrafficManagerSuite("", func(h itest.TrafficManager) itest.TestingSuite {
+		return &multiReplicaInterceptSuite{Suite: itest.Suite{Harness: h}, TrafficManager: h, svc: "echo-4replicas"}
+	})
+}
+
+func (s *multiReplicaInterceptSuite) SetupSuite() {
+	s.Suite.SetupSuite()
+	ctx := s.Context()
+	itest.ApplyApp(ctx, s.svc, s.AppNamespace(), "deploy/"+s.svc)
+	s.Require().Eventually(func() bool {
+		return len(itest.RunningPodNames(ctx, s.svc, s.AppNamespace())) == 4
+	}, itest.PodCreateTimeout(ctx), 6*time.Second, "waiting for 4 running pods")
+
+	// The upstream echo-server image supports h2c, so the traffic-agent will probe it
+	// and forward intercepted requests via h2c. The local server must also support h2c.
+	var cancel func()
+	s.localPort, cancel = startLocalH2CEchoServer(ctx, s.svc)
+	s.T().Cleanup(cancel)
+}
+
+func (s *multiReplicaInterceptSuite) TearDownSuite() {
+	ctx := s.Context()
+	itest.DeleteApp(ctx, s.svc, s.AppNamespace())
+}
+
+// Test_PersonalInterceptAllReplicasRouted is a regression test for #4085:
+// personal HTTP intercepts must route all requests through all N replicas,
+// not just the one pod whose IP was first written to InterceptInfo.
+func (s *multiReplicaInterceptSuite) Test_PersonalInterceptAllReplicasRouted() {
+	require := s.Require()
+	ctx := s.Context()
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceQuitOk(ctx)
+
+	stdout, stderr, err := itest.Telepresence(ctx, "intercept", s.svc,
+		"--http-header", "x-intercept-id=fix-4085",
+		"--port", fmt.Sprintf("%d:80", s.localPort),
+		"--mount=false",
+	)
+	require.NoError(err, "stdout: %s\nstderr: %s", stdout, stderr)
+	defer func() {
+		_, _, _ = itest.Telepresence(ctx, "leave", s.svc)
+	}()
+
+	// The intercept triggers a rolling restart that injects the traffic-agent
+	// sidecar into every replica. Wait for that rollout to complete before sending
+	// any traffic — otherwise some requests would land on stale pods that have no
+	// agent and time out, masking the actual multi-replica routing behaviour.
+	require.NoError(itest.RolloutStatusWait(ctx, s.AppNamespace(), "deploy/"+s.svc))
+	require.Eventually(func() bool {
+		pods := itest.RunningPodNames(ctx, s.svc, s.AppNamespace())
+		return len(pods) == 4
+	}, 60*time.Second, 2*time.Second, "waiting for all 4 agent-injected pods to be running")
+
+	s.CapturePodLogs(ctx, s.svc, "traffic-agent", s.AppNamespace())
+
+	// Wait for the intercept to become ACTIVE
+	require.Eventually(func() bool {
+		out, _, err := itest.Telepresence(ctx, "list", "--intercepts")
+		if err != nil {
+			return false
+		}
+		return s.Contains(out, "ACTIVE")
+	}, 30*time.Second, 2*time.Second)
+
+	// Allow a short settling period for all agent pods to register with the intercept.
+	time.Sleep(5 * time.Second)
+
+	// Fire 100 concurrent requests with the intercept header. Each request opens a
+	// fresh TCP connection (keep-alives disabled) so it is independently
+	// load-balanced across the replicas. Before the fix, ~75% of requests would
+	// fail because agents on pods B/C/D lack a WatchDial connection back to the
+	// client. A small random jitter staggers the requests so they don't all hit
+	// the service in lock-step.
+	expect := s.svc + " from intercept at /"
+	hc := http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	var failures atomic.Int64
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Duration(rand.IntN(500)) * time.Millisecond)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+s.svc, nil)
+			if err != nil {
+				clog.Infof(ctx, "request %d: build error: %v", i, err)
+				failures.Add(1)
+				return
+			}
+			req.Header.Set("x-intercept-id", "fix-4085")
+			resp, err := hc.Do(req)
+			if err != nil {
+				clog.Infof(ctx, "request %d: error: %v", i, err)
+				failures.Add(1)
+				return
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if string(body) != expect {
+				clog.Infof(ctx, "request %d: unexpected body: %q", i, string(body))
+				failures.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Zero(failures.Load(), "%d out of 100 requests did not return the intercepted response", failures.Load())
+}

--- a/integration_test/testdata/k8s/echo-4replicas.yaml
+++ b/integration_test/testdata/k8s/echo-4replicas.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "echo-4replicas"
+spec:
+  type: ClusterIP
+  selector:
+    app: echo-4replicas
+  ports:
+    - name: proxied
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "echo-4replicas"
+  labels:
+    app: echo-4replicas
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: echo-4replicas
+  template:
+    metadata:
+      labels:
+        app: echo-4replicas
+    spec:
+      containers:
+        - name: echo-4replicas
+          image: ghcr.io/telepresenceio/echo-server:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -191,6 +191,12 @@ func (ac *client) refresh(ai *manager.AgentPodInfo) {
 	oldStatus := ac.info.Intercepted
 	ac.info = ai
 	if ai.Intercepted == oldStatus {
+		if ai.Intercepted && ac.cancelDialWatch == nil {
+			clog.Debugf(ac, "Agent %s(%s) is intercepted but has no dial watcher; ensuring connection", ai.PodName, net.IP(ai.PodIp))
+			if _, err := ac.ensureConnectLocked(ac); err != nil {
+				clog.Errorf(ac, "failed to ensure client watcher for %s(%s): %v", ai.PodName, net.IP(ai.PodIp), err)
+			}
+		}
 		return
 	}
 	if ai.Intercepted {
@@ -577,7 +583,7 @@ func (s *clients) updateClients(ais []*manager.AgentPodInfo) error {
 	}
 
 	addClient := func(k string, ai *manager.AgentPodInfo) {
-		_, _ = s.clients.LoadOrCompute(k, func() (*client, bool) {
+		ac, loaded := s.clients.LoadOrCompute(k, func() (*client, bool) {
 			ac := &client{
 				Cluster: s.Cluster,
 				session: s.session,
@@ -589,6 +595,12 @@ func (s *clients) updateClients(ais []*manager.AgentPodInfo) error {
 			clog.Debugf(s, "Adding agent pod %s (%s)", k, net.IP(ai.PodIp))
 			return ac, false
 		})
+		if !loaded && ai.Intercepted {
+			clog.Debugf(s, "Newly discovered intercepted agent pod %s (%s); eagerly starting dial watcher", k, net.IP(ai.PodIp))
+			if _, err := ac.ensureConnect(s); err != nil {
+				clog.Errorf(s, "failed to eagerly start client watcher for %s (%s): %v", k, net.IP(ai.PodIp), err)
+			}
+		}
 	}
 
 	// Add clients for newly arrived agents.


### PR DESCRIPTION
## Description

Fixes #4085.

This updates HTTP personal intercept handling for multi-replica workloads so all intercepted agent pods are reported to the client and get dial watchers started, instead of only the pod selected when the intercept was created. It also makes HTTP intercept traffic fail open to the app container if the client tunnel is unavailable, avoiding dead-end timeouts.

Tested with a local Docker Desktop Kubernetes cluster using a 4-replica `nginx` deployment and a header-based personal intercept. Before the fix, repeated requests returned a mix of `200` and `000` timeouts; after the fix, 20/20 requests reached the local intercept server.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [x] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.
