### PR TITLE
Preserve default gateway for never-proxy routes

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -38,6 +38,15 @@ items:
           different namespaces, while preserving the connected namespace as the default
           when no engagement namespace is specified.
         docs: reference/engagements/cli
+      - type: bugfix
+        title: Preserve the default gateway for never-proxy routes
+        body: >-
+          Static routes installed for <code>--never-proxy</code> and
+          <code>client.routing.neverProxySubnets</code> now preserve the matching
+          default route gateway and source address. This prevents routed client
+          environments, such as VMs that reach cluster networks through a default
+          gateway, from receiving unusable on-link routes for never-proxied
+          destinations.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 The <code>intercept</code>, <code>wiretap</code>, and <code>replace</code> commands now accept <code>--namespace</code> to select the workload namespace for that engagement without changing the namespace used by <code>telepresence connect</code>. This allows a single connection with multiple mapped namespaces to run simultaneous personal HTTP intercepts in different namespaces, while preserving the connected namespace as the default when no engagement namespace is specified.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Preserve the default gateway for never-proxy routes</div></div>
+<div style="margin-left: 15px">
+
+Static routes installed for <code>--never-proxy</code> and <code>client.routing.neverProxySubnets</code> now preserve the matching default route gateway and source address. This prevents routed client environments, such as VMs that reach cluster networks through a default gateway, from receiving unusable on-link routes for never-proxied destinations.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 The <code>intercept</code>, <code>wiretap</code>, and <code>replace</code> commands now accept <code>--namespace</code> to select the workload namespace for that engagement without changing the namespace used by <code>telepresence connect</code>. This allows a single connection with multiple mapped namespaces to run simultaneous personal HTTP intercepts in different namespaces, while preserving the connected namespace as the default when no engagement namespace is specified.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Preserve the default gateway for never-proxy routes</Title>
+	<Body>
+Static routes installed for <code>--never-proxy</code> and <code>client.routing.neverProxySubnets</code> now preserve the matching default route gateway and source address. This prevents routed client environments, such as VMs that reach cluster networks through a default gateway, from receiving unusable on-link routes for never-proxied destinations.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>

--- a/pkg/vif/router.go
+++ b/pkg/vif/router.go
@@ -183,9 +183,9 @@ func (rt *Router) UpdateRoutes(ctx context.Context, pleaseProxy, dontProxy, dont
 	}
 
 	// All subnets in neverProxy have been verified as being routed by the TUN-device, so we
-	// route them to the default device.
+	// route them through the same interface and next hop as the default route.
 	for _, sn := range dontProxy {
-		staticRoutes = append(staticRoutes, routing.NewRoute(sn, dr.InterfaceIndex, dr.InterfaceName))
+		staticRoutes = append(staticRoutes, routeViaDefault(sn, dr))
 	}
 
 	// ... except for the never proxy overrides, which will be routed to our device.
@@ -208,6 +208,21 @@ func (rt *Router) UpdateRoutes(ctx context.Context, pleaseProxy, dontProxy, dont
 	}
 	rt.staticOverrides = staticRoutes
 	return nil
+}
+
+func routeViaDefault(sn netip.Prefix, dr *routing.Route) routing.Route {
+	r := routing.NewRoute(sn, dr.InterfaceIndex, dr.InterfaceName)
+	if sameAddrFamily(sn.Addr(), dr.Gateway) {
+		r.Gateway = dr.Gateway
+	}
+	if sameAddrFamily(sn.Addr(), dr.LocalIP) {
+		r.LocalIP = dr.LocalIP
+	}
+	return r
+}
+
+func sameAddrFamily(addr, candidate netip.Addr) bool {
+	return candidate.IsValid() && addr.Is4() == candidate.Is4()
 }
 
 func (rt *Router) createRoutesDelta(rs []routing.Route) (added, removed []routing.Route) {

--- a/pkg/vif/router_unit_test.go
+++ b/pkg/vif/router_unit_test.go
@@ -1,0 +1,53 @@
+package vif
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/routing"
+)
+
+func TestRouteViaDefaultPreservesGateway(t *testing.T) {
+	sn := netip.MustParsePrefix("10.224.1.135/32")
+	dr := routing.NewRoute(netip.MustParsePrefix("0.0.0.0/0"), 2, "enp1s0")
+	dr.Gateway = netip.MustParseAddr("10.0.2.1")
+	dr.LocalIP = netip.MustParseAddr("10.0.2.15")
+	dr.Default = true
+
+	r := routeViaDefault(sn, &dr)
+
+	if r.RoutedNet != sn {
+		t.Fatalf("RoutedNet = %s, want %s", r.RoutedNet, sn)
+	}
+	if r.InterfaceIndex != dr.InterfaceIndex {
+		t.Fatalf("InterfaceIndex = %d, want %d", r.InterfaceIndex, dr.InterfaceIndex)
+	}
+	if r.InterfaceName != dr.InterfaceName {
+		t.Fatalf("InterfaceName = %q, want %q", r.InterfaceName, dr.InterfaceName)
+	}
+	if r.Gateway != dr.Gateway {
+		t.Fatalf("Gateway = %s, want %s", r.Gateway, dr.Gateway)
+	}
+	if r.LocalIP != dr.LocalIP {
+		t.Fatalf("LocalIP = %s, want %s", r.LocalIP, dr.LocalIP)
+	}
+	if r.Default {
+		t.Fatal("routeViaDefault returned a default route")
+	}
+}
+
+func TestRouteViaDefaultDoesNotMixAddressFamilies(t *testing.T) {
+	sn := netip.MustParsePrefix("fdea:9f85:dc1e::1/128")
+	dr := routing.NewRoute(netip.MustParsePrefix("0.0.0.0/0"), 2, "enp1s0")
+	dr.Gateway = netip.MustParseAddr("10.0.2.1")
+	dr.LocalIP = netip.MustParseAddr("10.0.2.15")
+
+	r := routeViaDefault(sn, &dr)
+
+	if r.Gateway != netip.IPv6Unspecified() {
+		t.Fatalf("Gateway = %s, want %s", r.Gateway, netip.IPv6Unspecified())
+	}
+	if r.LocalIP != netip.IPv6Unspecified() {
+		t.Fatalf("LocalIP = %s, want %s", r.LocalIP, netip.IPv6Unspecified())
+	}
+}


### PR DESCRIPTION
Howdy again!

We hit an issue with telepresence specifically related to routing. 

When installing static routes for never-proxy subnets, Telepresence routed them to the default interface but discarded the default route's gateway and source address.

On some networks this creates an on-link route such as:

    10.224.1.135 dev enp1s0

instead of the usable route:

    10.224.1.135 via 10.0.2.1 dev enp1s0

Preserve the matching-family gateway and local source address from the selected default route when constructing never-proxy routes. This keeps the existing default-route selection behavior while avoiding unusable on-link routes for destinations that require the default gateway.

I _believe_ this is a safe change that should not break other uses of `never-proxy` - and it did unblock my specific vm test case. 

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.