### PR TITLE
Add versionless Linux package assets for /latest/download/ URLs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,10 +179,10 @@ jobs:
 
             | Platform | Architecture | Package |
             |----------|--------------|---------|
-            | Linux (Debian/Ubuntu) | amd64 | [telepresence-linux-amd64.deb](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-${{ steps.semver_check.outputs.semver }}-linux-amd64.deb) |
-            | Linux (Debian/Ubuntu) | arm64 | [telepresence-linux-arm64.deb](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-${{ steps.semver_check.outputs.semver }}-linux-arm64.deb) |
-            | Linux (Fedora/RHEL) | amd64 | [telepresence-linux-amd64.rpm](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-${{ steps.semver_check.outputs.semver }}-linux-amd64.rpm) |
-            | Linux (Fedora/RHEL) | arm64 | [telepresence-linux-arm64.rpm](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-${{ steps.semver_check.outputs.semver }}-linux-arm64.rpm) |
+            | Linux (Debian/Ubuntu) | amd64 | [telepresence-linux-amd64.deb](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-amd64.deb) |
+            | Linux (Debian/Ubuntu) | arm64 | [telepresence-linux-arm64.deb](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-arm64.deb) |
+            | Linux (Fedora/RHEL) | amd64 | [telepresence-linux-amd64.rpm](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-amd64.rpm) |
+            | Linux (Fedora/RHEL) | arm64 | [telepresence-linux-arm64.rpm](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-linux-arm64.rpm) |
             | macOS | amd64 | [telepresence-darwin-amd64.pkg](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-amd64.pkg) |
             | macOS | arm64 | [telepresence-darwin-arm64.pkg](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-darwin-arm64.pkg) |
             | Windows | amd64 | [telepresence-windows-amd64-setup.exe](https://github.com/telepresenceio/telepresence/releases/download/${{ github.ref_name }}/telepresence-windows-amd64-setup.exe) |

--- a/build-aux/systemd-installer/build-packages.sh
+++ b/build-aux/systemd-installer/build-packages.sh
@@ -93,6 +93,13 @@ nfpm package \
     --packager rpm \
     --target "${build_output}/release/telepresence-${VERSION}-linux-${ARCH}.rpm"
 
+# Create versionless copies so that GitHub's /latest/download/ URLs work
+# (e.g., /releases/latest/download/telepresence-linux-amd64.deb)
+cp "${build_output}/release/telepresence-${VERSION}-linux-${ARCH}.deb" \
+   "${build_output}/release/telepresence-linux-${ARCH}.deb"
+cp "${build_output}/release/telepresence-${VERSION}-linux-${ARCH}.rpm" \
+   "${build_output}/release/telepresence-linux-${ARCH}.rpm"
+
 echo ""
 echo "Packages built successfully:"
 ls -la "${build_output}/release/"*.deb "${build_output}/release/"*.rpm 2>/dev/null || true


### PR DESCRIPTION
## Summary
- The .deb and .rpm release assets were only uploaded with version-embedded names (e.g., `telepresence-2.27.4-linux-amd64.deb`), causing 404s when using GitHub's `/releases/latest/download/` redirect with the versionless names referenced in the install documentation.
- The build script now creates versionless copies alongside the versioned ones, and the release body links use the versionless URLs.
- Versionless assets were also manually uploaded to the existing v2.27.4 release to fix the issue immediately.

Fixes #4102