### PR TITLE
Route also-proxy destinations through traffic-manager

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -47,6 +47,16 @@ items:
           environments, such as VMs that reach cluster networks through a default
           gateway, from receiving unusable on-link routes for never-proxied
           destinations.
+      - type: bugfix
+        title: Route also-proxy traffic through the traffic-manager
+        body: >-
+          Connections to addresses covered by <code>--also-proxy</code> or
+          <code>client.routing.alsoProxySubnets</code> now use the traffic-manager
+          tunnel unless the destination was explicitly translated by
+          <code>--proxy-via</code>. This prevents arbitrary also-proxy traffic
+          from being sent through an unrelated traffic-agent when mapped namespaces
+          or active intercepts make an agent available.
+        docs: reference/config#alsoproxysubnets
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,12 @@ The <code>intercept</code>, <code>wiretap</code>, and <code>replace</code> comma
 Static routes installed for <code>--never-proxy</code> and <code>client.routing.neverProxySubnets</code> now preserve the matching default route gateway and source address. This prevents routed client environments, such as VMs that reach cluster networks through a default gateway, from receiving unusable on-link routes for never-proxied destinations.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Route also-proxy traffic through the traffic-manager](reference/config#alsoproxysubnets)</div></div>
+<div style="margin-left: 15px">
+
+Connections to addresses covered by <code>--also-proxy</code> or <code>client.routing.alsoProxySubnets</code> now use the traffic-manager tunnel unless the destination was explicitly translated by <code>--proxy-via</code>. This prevents arbitrary also-proxy traffic from being sent through an unrelated traffic-agent when mapped namespaces or active intercepts make an agent available.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -20,6 +20,12 @@ The <code>intercept</code>, <code>wiretap</code>, and <code>replace</code> comma
 Static routes installed for <code>--never-proxy</code> and <code>client.routing.neverProxySubnets</code> now preserve the matching default route gateway and source address. This prevents routed client environments, such as VMs that reach cluster networks through a default gateway, from receiving unusable on-link routes for never-proxied destinations.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix" docs="reference/config#alsoproxysubnets">Route also-proxy traffic through the traffic-manager</Title>
+	<Body>
+Connections to addresses covered by <code>--also-proxy</code> or <code>client.routing.alsoProxySubnets</code> now use the traffic-manager tunnel unless the destination was explicitly translated by <code>--proxy-via</code>. This prevents arbitrary also-proxy traffic from being sent through an unrelated traffic-agent when mapped namespaces or active intercepts make an agent available.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>

--- a/pkg/client/rootd/stream_creator.go
+++ b/pkg/client/rootd/stream_creator.go
@@ -77,8 +77,10 @@ func (s *session) streamCreator() tunnel.StreamCreator {
 		}
 
 		if tp == nil {
-			tp = s.getAgentClient(destAddr)
-			if tp != nil {
+			if s.isAlsoProxyDestination(destAddr) {
+				tp = tunnel.ManagerProvider(s.managerClient())
+				clog.Debugf(c, "Opening traffic-manager tunnel for also-proxy id %s", id)
+			} else if tp = s.getAgentClient(destAddr); tp != nil {
 				clog.Debugf(c, "Opening traffic-agent tunnel for id %s using agent %s", id, tp)
 			} else {
 				tp = tunnel.ManagerProvider(s.managerClient())
@@ -97,6 +99,15 @@ func (s *session) streamCreator() tunnel.StreamCreator {
 		return tunnel.NewClientStream(
 			c, tunnel.TunToClient, ct, id, tunnel.SessionID(s.session.SessionId), tc.Get(client.TimeoutRoundtripLatency), tc.Get(client.TimeoutEndpointDial))
 	}
+}
+
+func (s *session) isAlsoProxyDestination(ip netip.Addr) bool {
+	for _, sn := range s.alsoProxySubnets {
+		if sn.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *session) getAgentVIP(dest netip.Addr) (a agentVIP, ok bool) {

--- a/pkg/client/rootd/stream_creator_test.go
+++ b/pkg/client/rootd/stream_creator_test.go
@@ -1,0 +1,22 @@
+package rootd
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAlsoProxyDestination(t *testing.T) {
+	s := &session{
+		alsoProxySubnets: []netip.Prefix{
+			netip.MustParsePrefix("240.240.0.0/16"),
+			netip.MustParsePrefix("fd00::/8"),
+		},
+	}
+
+	require.True(t, s.isAlsoProxyDestination(netip.MustParseAddr("240.240.0.33")))
+	require.True(t, s.isAlsoProxyDestination(netip.MustParseAddr("fd00::1")))
+	require.False(t, s.isAlsoProxyDestination(netip.MustParseAddr("10.128.0.10")))
+	require.False(t, s.isAlsoProxyDestination(netip.MustParseAddr("2001:db8::1")))
+}


### PR DESCRIPTION
Avoid sending also-proxy destinations through the traffic-agent fallback path.

Destinations covered by alsoProxySubnets should use the traffic-manager tunnel unless they were explicitly translated by proxy-via. Falling back to an available traffic-agent can route arbitrary also-proxy traffic through an unrelated agent when agents exist in mapped namespaces or an intercept is active.

Add a small rootd test for also-proxy destination matching.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.