### PR TITLE
FQDN for traffic manager host, agent UID for iptables rules

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -57,6 +57,22 @@ items:
           from being sent through an unrelated traffic-agent when mapped namespaces
           or active intercepts make an agent available.
         docs: reference/config#alsoproxysubnets
+      - type: bugfix
+        title: Use traffic-agent UID for init-container iptables rules
+        body: >-
+          Injected init containers now program owner-based iptables exclusions
+          from the traffic-agent container's configured <code>runAsUser</code>
+          when available, rather than the init process UID. This prevents pods
+          that run application containers as the same user as the init container
+          from accidentally bypassing mesh or agent routing rules.
+      - type: bugfix
+        title: Use fully-qualified traffic-manager hostnames for injected agents
+        body: >-
+          Injected traffic-agent configs now use a fully-qualified
+          traffic-manager service DNS name when the cluster domain can be
+          determined. This avoids relying on workload DNS search paths to resolve
+          the manager service from another namespace, while preserving the
+          existing short name fallback.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/cmd/traffic/cmd/agentinit/agent_init.go
+++ b/cmd/traffic/cmd/agentinit/agent_init.go
@@ -44,14 +44,28 @@ func loadConfig() (*config, error) {
 	return &c, nil
 }
 
+func trafficAgentUID() (string, error) {
+	if uid, ok := os.LookupEnv(agentconfig.EnvAgentUID); ok && uid != "" {
+		parsed, err := strconv.ParseUint(uid, 10, 32)
+		if err != nil {
+			return "", fmt.Errorf("invalid %s %q: %w", agentconfig.EnvAgentUID, uid, err)
+		}
+		return strconv.FormatUint(parsed, 10), nil
+	}
+	return strconv.Itoa(os.Getuid()), nil
+}
+
 func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTables, loopback string, localHostCIDR netip.Prefix, podIP netip.Addr) error {
 	// These iptables rules implement routing such that a packet directed to the appPort will hit the agentPort instead.
 	// If there's no mesh this is simply request -> agent -> app (or intercept)
 	// However, if there's a service mesh we want to make sure we don't bypass the mesh, so the traffic
 	// will flow request -> mesh -> agent -> app
 
-	// A service mesh will typically use an UID different from the one used by this process
-	agentUID := strconv.Itoa(os.Getuid())
+	// A service mesh will typically use a UID different from the traffic-agent.
+	agentUID, err := trafficAgentUID()
+	if err != nil {
+		return err
+	}
 
 	outputInsertCount := 0
 	for _, proto := range []types.Proto{types.ProtoTCP, types.ProtoUDP} {
@@ -166,7 +180,7 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 	// Finally, any other traffic heading out of the traffic agent should pass by unperturbed -- it should obviously not be
 	// redirected back into the agent, but it also should not pass through a mesh proxy.
 	// This will include not just agent->manager traffic but also the agent requesting 127.0.0.1:appPort to serve the application
-	err := iptables.Insert(nat, "OUTPUT", 1+outputInsertCount,
+	err = iptables.Insert(nat, "OUTPUT", 1+outputInsertCount,
 		"-m", "owner", "--uid-owner", agentUID,
 		"-j", "RETURN")
 	if err != nil {

--- a/cmd/traffic/cmd/agentinit/agent_init_test.go
+++ b/cmd/traffic/cmd/agentinit/agent_init_test.go
@@ -1,0 +1,34 @@
+package agentinit
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+)
+
+func TestTrafficAgentUIDDefaultsToProcessUID(t *testing.T) {
+	t.Setenv(agentconfig.EnvAgentUID, "")
+
+	uid, err := trafficAgentUID()
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(os.Getuid()), uid)
+}
+
+func TestTrafficAgentUIDUsesEnvironment(t *testing.T) {
+	t.Setenv(agentconfig.EnvAgentUID, "1000")
+
+	uid, err := trafficAgentUID()
+	require.NoError(t, err)
+	require.Equal(t, "1000", uid)
+}
+
+func TestTrafficAgentUIDRejectsInvalidEnvironment(t *testing.T) {
+	t.Setenv(agentconfig.EnvAgentUID, "not-a-uid")
+
+	_, err := trafficAgentUID()
+	require.Error(t, err)
+}

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/dnsproxy"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -95,6 +96,7 @@ func (e *Env) GeneratorConfig(qualifiedAgentImage string) (*agentmap.GeneratorCo
 		ManagerPort:         e.ServerPort,
 		QualifiedAgentImage: qualifiedAgentImage,
 		ManagerNamespace:    e.ManagerNamespace,
+		ClusterDomain:       e.clusterDomain(),
 		LogLevel:            e.AgentLogLevel,
 		InitResources:       e.AgentInitResources,
 		Resources:           e.AgentResources,
@@ -107,6 +109,29 @@ func (e *Env) GeneratorConfig(qualifiedAgentImage string) (*agentmap.GeneratorCo
 		EnableMetrics:       e.AgentConsumptionMetrics && e.PrometheusPort != 0,
 		WatchRetryInterval:  e.AgentWatchRetryInterval,
 	}, nil
+}
+
+func (e *Env) clusterDomain() string {
+	conf, err := dnsproxy.ReadResolveFile("/etc/resolv.conf")
+	if err != nil || len(conf.Search) < 3 {
+		return ""
+	}
+	nsSvc := e.ManagerNamespace + ".svc."
+	if !strings.HasPrefix(conf.Search[0], nsSvc) || !strings.HasPrefix(conf.Search[1], "svc.") {
+		return ""
+	}
+	domain := strings.TrimPrefix(conf.Search[1], "svc.")
+	third := conf.Search[2]
+	if !strings.HasSuffix(domain, ".") {
+		domain += "."
+	}
+	if !strings.HasSuffix(third, ".") {
+		third += "."
+	}
+	if !strings.EqualFold(third, domain) {
+		return ""
+	}
+	return strings.TrimSuffix(domain, ".")
 }
 
 func (e *Env) QualifiedAgentImage() string {

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -177,7 +177,10 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 
 func createPatch(ctx context.Context, config *agentconfig.Sidecar, pod *core.Pod, wlTpl *core.PodTemplateSpec) (patches PatchOps, err error) {
 	var anns map[string]string
-	patches = addInitContainer(ctx, pod, config, patches)
+	patches, err = addInitContainer(ctx, pod, wlTpl, config, patches)
+	if err != nil {
+		return nil, err
+	}
 	patches, anns, err = addAgentContainer(ctx, pod, wlTpl, config, patches)
 	if err != nil {
 		return nil, err
@@ -259,27 +262,35 @@ func maybeRemoveAppContainer(pod *core.Pod, config *agentconfig.Sidecar, patches
 	return patches
 }
 
-func addInitContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Sidecar, patches PatchOps) PatchOps {
+func addInitContainer(ctx context.Context, pod *core.Pod, wlTpl *core.PodTemplateSpec, config *agentconfig.Sidecar, patches PatchOps) (PatchOps, error) {
 	if !needInitContainer(ctx, config) {
 		for i, oc := range pod.Spec.InitContainers {
 			if agentconfig.InitContainerName == oc.Name {
 				return append(patches, PatchOperation{
 					Op:   "remove",
 					Path: fmt.Sprintf("/spec/initContainers/%d", i),
-				})
+				}), nil
 			}
 		}
-		return patches
+		return patches, nil
 	}
 
 	pis := pod.Spec.InitContainers
-	ic := agentconfig.InitContainer(config)
+	ab := agentconfig.ContainerBuilder{
+		Pod:    wlTpl,
+		Config: config,
+	}
+	agentSecurityContext, err := ab.AgentSecurityContext()
+	if err != nil {
+		return nil, err
+	}
+	ic := agentconfig.InitContainer(config, agentSecurityContext)
 	if len(pis) == 0 {
 		return append(patches, PatchOperation{
 			Op:    "replace",
 			Path:  "/spec/initContainers",
 			Value: []core.Container{*ic},
-		})
+		}), nil
 	}
 
 	for i := range pis {
@@ -287,15 +298,16 @@ func addInitContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Si
 		if ic.Name == oc.Name {
 			if ic.Image == oc.Image &&
 				slices.Equal(ic.Args, oc.Args) &&
+				compareAgentUIDEnv(ic.Env, oc.Env) &&
 				compareVolumeMounts(ic.VolumeMounts, oc.VolumeMounts) &&
 				compareCapabilities(ic.SecurityContext, oc.SecurityContext) {
-				return patches
+				return patches, nil
 			}
 			return append(patches, PatchOperation{
 				Op:    "replace",
 				Path:  fmt.Sprintf("/spec/initContainers/%d", i),
 				Value: ic,
-			})
+			}), nil
 		}
 	}
 
@@ -303,7 +315,7 @@ func addInitContainer(ctx context.Context, pod *core.Pod, config *agentconfig.Si
 		Op:    "add",
 		Path:  "/spec/initContainers/-",
 		Value: ic,
-	})
+	}), nil
 }
 
 func addAgentVolumes(agentName string, pod *core.Pod, patches PatchOps) (PatchOps, error) {
@@ -392,6 +404,20 @@ func compareVolumeMounts(a, b []core.VolumeMount) bool {
 	}
 	eq := cmp.Equal(stripKubeAPI(a), stripKubeAPI(b))
 	return eq
+}
+
+func compareAgentUIDEnv(a, b []core.EnvVar) bool {
+	agentUID := func(evs []core.EnvVar) (string, bool) {
+		for _, ev := range evs {
+			if ev.Name == agentconfig.EnvAgentUID {
+				return ev.Value, true
+			}
+		}
+		return "", false
+	}
+	av, aok := agentUID(a)
+	bv, bok := agentUID(b)
+	return aok == bok && av == bv
 }
 
 func containerEqual(ctx context.Context, a, b *core.Container) bool {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,18 @@ Static routes installed for <code>--never-proxy</code> and <code>client.routing.
 Connections to addresses covered by <code>--also-proxy</code> or <code>client.routing.alsoProxySubnets</code> now use the traffic-manager tunnel unless the destination was explicitly translated by <code>--proxy-via</code>. This prevents arbitrary also-proxy traffic from being sent through an unrelated traffic-agent when mapped namespaces or active intercepts make an agent available.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Use traffic-agent UID for init-container iptables rules</div></div>
+<div style="margin-left: 15px">
+
+Injected init containers now program owner-based iptables exclusions from the traffic-agent container's configured <code>runAsUser</code> when available, rather than the init process UID. This prevents pods that run application containers as the same user as the init container from accidentally bypassing mesh or agent routing rules.
+</div>
+
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Use fully-qualified traffic-manager hostnames for injected agents</div></div>
+<div style="margin-left: 15px">
+
+Injected traffic-agent configs now use a fully-qualified traffic-manager service DNS name when the cluster domain can be determined. This avoids relying on workload DNS search paths to resolve the manager service from another namespace, while preserving the existing short name fallback.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -26,6 +26,18 @@ Static routes installed for <code>--never-proxy</code> and <code>client.routing.
 Connections to addresses covered by <code>--also-proxy</code> or <code>client.routing.alsoProxySubnets</code> now use the traffic-manager tunnel unless the destination was explicitly translated by <code>--proxy-via</code>. This prevents arbitrary also-proxy traffic from being sent through an unrelated traffic-agent when mapped namespaces or active intercepts make an agent available.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Use traffic-agent UID for init-container iptables rules</Title>
+	<Body>
+Injected init containers now program owner-based iptables exclusions from the traffic-agent container's configured <code>runAsUser</code> when available, rather than the init process UID. This prevents pods that run application containers as the same user as the init container from accidentally bypassing mesh or agent routing rules.
+  </Body>
+</Note>
+<Note>
+	<Title type="bugfix">Use fully-qualified traffic-manager hostnames for injected agents</Title>
+	<Body>
+Injected traffic-agent configs now use a fully-qualified traffic-manager service DNS name when the cluster domain can be determined. This avoids relying on workload DNS search paths to resolve the manager service from another namespace, while preserving the existing short name fallback.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>

--- a/pkg/agentconfig/container.go
+++ b/pkg/agentconfig/container.go
@@ -182,17 +182,21 @@ func (a *ContainerBuilder) AgentContainer(ctx context.Context) (*core.Container,
 		ac.Resources = *r
 	}
 
-	appSc := a.Config.SecurityContext
-	if appSc == nil {
-		// Assign the security context of the first container to the traffic agent.
-		appSc, err = a.firstAppSecurityContext()
-		if err != nil {
-			return nil, nil, err
-		}
+	appSc, err := a.AgentSecurityContext()
+	if err != nil {
+		return nil, nil, err
 	}
 	ac.SecurityContext = appSc
 
 	return ac, anns, nil
+}
+
+func (a *ContainerBuilder) AgentSecurityContext() (*core.SecurityContext, error) {
+	if appSc := a.Config.SecurityContext; appSc != nil {
+		return appSc, nil
+	}
+	// Assign the security context of the first container to the traffic agent.
+	return a.firstAppSecurityContext()
 }
 
 func (a *ContainerBuilder) mountSecrets(annotation, certPath string, anns map[string]string, mounts []core.VolumeMount) ([]core.VolumeMount, error) {

--- a/pkg/agentconfig/initcontainer.go
+++ b/pkg/agentconfig/initcontainer.go
@@ -2,13 +2,14 @@ package agentconfig
 
 import (
 	"fmt"
+	"strconv"
 
 	core "k8s.io/api/core/v1"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
 )
 
-func InitContainer(config *Sidecar) *core.Container {
+func InitContainer(config *Sidecar, agentSecurityContext *core.SecurityContext) *core.Container {
 	ic := &core.Container{
 		Name:  InitContainerName,
 		Image: config.AgentImage,
@@ -42,6 +43,12 @@ func InitContainer(config *Sidecar) *core.Container {
 				Add: []core.Capability{"NET_ADMIN"},
 			},
 		},
+	}
+	if agentSecurityContext != nil && agentSecurityContext.RunAsUser != nil {
+		ic.Env = append(ic.Env, core.EnvVar{
+			Name:  EnvAgentUID,
+			Value: strconv.FormatInt(*agentSecurityContext.RunAsUser, 10),
+		})
 	}
 	if r := config.InitResources; r != nil {
 		ic.Resources = *r

--- a/pkg/agentconfig/initcontainer_test.go
+++ b/pkg/agentconfig/initcontainer_test.go
@@ -1,0 +1,32 @@
+package agentconfig
+
+import (
+	"testing"
+
+	core "k8s.io/api/core/v1"
+)
+
+func TestInitContainerSetsAgentUID(t *testing.T) {
+	uid := int64(1000)
+	ic := InitContainer(&Sidecar{AgentImage: "traffic-agent"}, &core.SecurityContext{RunAsUser: &uid})
+
+	for _, env := range ic.Env {
+		if env.Name == EnvAgentUID {
+			if env.Value != "1000" {
+				t.Fatalf("%s = %q, want 1000", EnvAgentUID, env.Value)
+			}
+			return
+		}
+	}
+	t.Fatalf("%s was not set", EnvAgentUID)
+}
+
+func TestInitContainerOmitsAgentUIDWhenUnknown(t *testing.T) {
+	ic := InitContainer(&Sidecar{AgentImage: "traffic-agent"}, nil)
+
+	for _, env := range ic.Env {
+		if env.Name == EnvAgentUID {
+			t.Fatalf("%s = %q, want unset", EnvAgentUID, env.Value)
+		}
+	}
+}

--- a/pkg/agentconfig/sidecar.go
+++ b/pkg/agentconfig/sidecar.go
@@ -38,6 +38,9 @@ const (
 	// EnvAgentConfig is the environment variable where the traffic-agent finds its own config.
 	EnvAgentConfig = "AGENT_CONFIG"
 
+	// EnvAgentUID is the user ID that the traffic-agent runs as.
+	EnvAgentUID = "AGENT_UID"
+
 	// EnvInterceptContainer intercepted container propagated to client during intercept.
 	EnvInterceptContainer = "TELEPRESENCE_CONTAINER"
 

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -31,6 +31,7 @@ type GeneratorConfig struct {
 	APIPort             uint16
 	QualifiedAgentImage string
 	ManagerNamespace    string
+	ClusterDomain       string
 	LogLevel            slog.Level
 	InitResources       *core.ResourceRequirements
 	Resources           *core.ResourceRequirements
@@ -175,7 +176,7 @@ func (cfg *GeneratorConfig) Generate(
 		Namespace:           wl.GetNamespace(),
 		WorkloadName:        wl.GetName(),
 		WorkloadKind:        wl.GetKind(),
-		ManagerHost:         agentconfig.ManagerAppName + "." + cfg.ManagerNamespace,
+		ManagerHost:         ManagerHost(cfg.ManagerNamespace, cfg.ClusterDomain),
 		ManagerPort:         cfg.ManagerPort,
 		APIPort:             cfg.APIPort,
 		ClientConnectionTTL: cfg.ClientConnectionTTL,
@@ -191,6 +192,15 @@ func (cfg *GeneratorConfig) Generate(
 		EnableMetrics:       cfg.EnableMetrics,
 		WatchRetryInterval:  cfg.WatchRetryInterval,
 	}, nil
+}
+
+func ManagerHost(managerNamespace, clusterDomain string) string {
+	host := agentconfig.ManagerAppName + "." + managerNamespace
+	clusterDomain = strings.Trim(clusterDomain, ".")
+	if clusterDomain == "" || strings.Contains(managerNamespace, ".") {
+		return host
+	}
+	return host + ".svc." + clusterDomain
 }
 
 func (cfg *GeneratorConfig) appendAgentContainerConfigs(

--- a/pkg/agentmap/generator_test.go
+++ b/pkg/agentmap/generator_test.go
@@ -1,0 +1,19 @@
+package agentmap
+
+import "testing"
+
+func TestManagerHostUsesClusterDomain(t *testing.T) {
+	got := ManagerHost("traffic", "cluster.local.")
+	want := "traffic-manager.traffic.svc.cluster.local"
+	if got != want {
+		t.Fatalf("ManagerHost() = %q, want %q", got, want)
+	}
+}
+
+func TestManagerHostKeepsLegacyHostWhenClusterDomainUnknown(t *testing.T) {
+	got := ManagerHost("traffic", "")
+	want := "traffic-manager.traffic"
+	if got != want {
+		t.Fatalf("ManagerHost() = %q, want %q", got, want)
+	}
+}

--- a/pkg/client/cli/cmd/genyaml.go
+++ b/pkg/client/cli/cmd/genyaml.go
@@ -388,7 +388,7 @@ func (g *genInitContainerInfo) run(*cobra.Command, map[string]string) error {
 	for _, cc := range cm.Containers {
 		for _, ic := range cc.Intercepts {
 			if ic.Headless || ic.TargetPortNumeric {
-				return g.writeObjToOutput(agentconfig.InitContainer(cm))
+				return g.writeObjToOutput(agentconfig.InitContainer(cm, cm.SecurityContext))
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This is two changes that made telepresence work reliably in our environment.

- Use the configured traffic-agent UID when generating owner-based init-container iptables exclusions, instead of using the init process UID.
- Use a fully-qualified traffic-manager DNS name in injected agent configs when the cluster domain is known.

Together, these avoid accidentally excluding workload traffic in pods where the init container and application run as the same user, and make injected agents less dependent on workload namespace DNS search paths to resolve the traffic-manager service. 

(We have a somewhat unique dns config, `ndots` among other things)


I am running this set of patches in prod currently with a custom image as validation. Things are working well. 

Also I promise [ I think] this is the last set of changes - sorry and thank you for all of the great help and stewardship so far! 
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.