### PR TITLE
Avoid probing cleartext HTTP app protocols

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -73,6 +73,14 @@ items:
           determined. This avoids relying on workload DNS search paths to resolve
           the manager service from another namespace, while preserving the
           existing short name fallback.
+      - type: bugfix
+        title: Avoid probing cleartext HTTP app protocols
+        body: >-
+          Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service
+          <code>appProtocol</code> values such as <code>http</code> and
+          <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2
+          probing for known HTTP/1 services, avoiding request latency when those
+          probes cannot connect through the inactive proxy port.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/cmd/traffic/cmd/agent/tls/manager.go
+++ b/cmd/traffic/cmd/agent/tls/manager.go
@@ -222,7 +222,11 @@ func (m *manager) UseHTTP2(ctx context.Context, proxyPort uint16) bool {
 func (m *manager) configuredHTTP2(containerPort uint16) ValueState {
 	_, it := m.sidecarConfig.InterceptTarget(containerPort, types.ProtoTCP)
 	for _, ic := range it {
-		switch strings.ToLower(ic.AppProtocol) {
+		appProtocol := strings.ToLower(ic.AppProtocol)
+		if isCleartextHTTP1(appProtocol) {
+			return ValueNotSupported
+		}
+		switch appProtocol {
 		case "tcp", "udp": // No app-layer sniffing
 			return ValueNotSupported
 		case "h2c", "kubernetes.io/h2c": // HTTP/2 over cleartext
@@ -237,7 +241,11 @@ func (m *manager) configuredHTTP2(containerPort uint16) ValueState {
 func (m *manager) configuredTLS(containerPort uint16) ValueState {
 	_, it := m.sidecarConfig.InterceptTarget(containerPort, types.ProtoTCP)
 	for _, ic := range it {
-		switch strings.ToLower(ic.AppProtocol) {
+		appProtocol := strings.ToLower(ic.AppProtocol)
+		if isCleartextHTTP1(appProtocol) {
+			return ValueNotSupported
+		}
+		switch appProtocol {
 		case "tcp", "udp": // No app-layer sniffing
 			return ValueNotSupported
 		case "kubernetes.io/ws": // WebSocket over cleartext
@@ -256,4 +264,13 @@ func (m *manager) configuredTLS(containerPort uint16) ValueState {
 		}
 	}
 	return ValueUnknown
+}
+
+func isCleartextHTTP1(appProtocol string) bool {
+	switch appProtocol {
+	case "http", "kubernetes.io/http", "http1", "http1.0", "http1.1", "http/1.0", "http/1.1":
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/traffic/cmd/agent/tls/manager_test.go
+++ b/cmd/traffic/cmd/agent/tls/manager_test.go
@@ -1,0 +1,109 @@
+package tls
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
+)
+
+func TestNewManagerConfiguresHTTPAppProtocolWithoutProbing(t *testing.T) {
+	for _, appProtocol := range []string{
+		"http",
+		"kubernetes.io/http",
+		"http1",
+		"http1.0",
+		"http1.1",
+		"http/1.0",
+		"http/1.1",
+	} {
+		t.Run(appProtocol, func(t *testing.T) {
+			sidecar := sidecarWithAppProtocol(appProtocol)
+			mgr, err := NewManager(t.Context(), sidecar, netip.MustParseAddr("10.0.0.1"), nil)
+			require.NoError(t, err)
+
+			tlsManager := mgr.(*manager)
+			proxyPort := sidecar.ProxyPort(9900)
+			pc, ok := tlsManager.portConfigs[proxyPort]
+			require.True(t, ok)
+			require.Equal(t, ValueNotSupported, pc.TLS)
+			require.Equal(t, ValueNotSupported, pc.HTTP2)
+		})
+	}
+}
+
+func TestNewManagerConfiguresExplicitAppProtocols(t *testing.T) {
+	tests := []struct {
+		name           string
+		appProtocol    string
+		wantPortConfig bool
+		wantTLS        ValueState
+		wantHTTP2      ValueState
+	}{
+		{
+			name:           "unknown",
+			wantPortConfig: true,
+			wantTLS:        ValueUnknown,
+			wantHTTP2:      ValueUnknown,
+		},
+		{
+			name:           "https",
+			appProtocol:    "https",
+			wantPortConfig: true,
+			wantTLS:        ValueSupported,
+			wantHTTP2:      ValueUnknown,
+		},
+		{
+			name:           "h2c",
+			appProtocol:    "h2c",
+			wantPortConfig: true,
+			wantTLS:        ValueNotSupported,
+			wantHTTP2:      ValueSupported,
+		},
+		{
+			name:           "tcp",
+			appProtocol:    "tcp",
+			wantPortConfig: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sidecar := sidecarWithAppProtocol(tt.appProtocol)
+			mgr, err := NewManager(t.Context(), sidecar, netip.MustParseAddr("10.0.0.1"), nil)
+			require.NoError(t, err)
+
+			tlsManager := mgr.(*manager)
+			proxyPort := sidecar.ProxyPort(9900)
+			pc, ok := tlsManager.portConfigs[proxyPort]
+			require.Equal(t, tt.wantPortConfig, ok)
+			if !tt.wantPortConfig {
+				return
+			}
+			require.Equal(t, tt.wantTLS, pc.TLS)
+			require.Equal(t, tt.wantHTTP2, pc.HTTP2)
+		})
+	}
+}
+
+func sidecarWithAppProtocol(appProtocol string) *agentconfig.Sidecar {
+	return &agentconfig.Sidecar{
+		Containers: []*agentconfig.Container{
+			{
+				Name: "app",
+				Intercepts: []*agentconfig.Intercept{
+					{
+						ContainerPort:     8000,
+						ServicePort:       8000,
+						AgentPort:         9900,
+						Protocol:          types.ProtoTCP,
+						AppProtocol:       appProtocol,
+						TargetPortNumeric: true,
+					},
+				},
+			},
+		},
+	}
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,12 @@ Injected init containers now program owner-based iptables exclusions from the tr
 Injected traffic-agent configs now use a fully-qualified traffic-manager service DNS name when the cluster domain can be determined. This avoids relying on workload DNS search paths to resolve the manager service from another namespace, while preserving the existing short name fallback.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Avoid probing cleartext HTTP app protocols</div></div>
+<div style="margin-left: 15px">
+
+Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>appProtocol</code> values such as <code>http</code> and <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2 probing for known HTTP/1 services, avoiding request latency when those probes cannot connect through the inactive proxy port.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -38,6 +38,12 @@ Injected init containers now program owner-based iptables exclusions from the tr
 Injected traffic-agent configs now use a fully-qualified traffic-manager service DNS name when the cluster domain can be determined. This avoids relying on workload DNS search paths to resolve the manager service from another namespace, while preserving the existing short name fallback.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Avoid probing cleartext HTTP app protocols</Title>
+	<Body>
+Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>appProtocol</code> values such as <code>http</code> and <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2 probing for known HTTP/1 services, avoiding request latency when those probes cannot connect through the inactive proxy port.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>


### PR DESCRIPTION
## Description

Kubernetes Services can advertise cleartext HTTP/1 with `appProtocol`: `http` or `kubernetes.io/http`. The traffic agent previously treated those values as unknown, so it still probed TLS and HTTP/2 support through the inactive proxy port before forwarding. When that probe cannot connect, filtered intercepts can pay seconds of avoidable latency per request. In our environment- this latency was as high as 4s! With this patch - the latency was a much more tolerably ~150ms.

Classify common HTTP/1 appProtocol spellings as cleartext HTTP/1 and mark both TLS and HTTP/2 unsupported up front. This skips the probe path for known HTTP/1 services while leaving unknown app protocols unchanged.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.