### PR TITLE
Handle pod IP output traffic in agent init

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -81,6 +81,15 @@ items:
           <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2
           probing for known HTTP/1 services, avoiding request latency when those
           probes cannot connect through the inactive proxy port.
+      - type: bugfix
+        title: Handle pod IP output traffic in agent init
+        body: >-
+          Injected init containers now route pod IP output traffic through the
+          same traffic-agent iptables chains used for loopback traffic. This
+          lets service mesh sidecars and traffic-agent forwarding paths that
+          connect to the application through the pod IP reach the expected
+          redirect and DNAT rules, avoiding missed routing when the pod IP does
+          not use the loopback interface.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/cmd/traffic/cmd/agentinit/agent_init.go
+++ b/cmd/traffic/cmd/agentinit/agent_init.go
@@ -29,6 +29,12 @@ type config struct {
 	*agentconfig.Sidecar
 }
 
+type iptablesConfigurer interface {
+	ClearChain(table, chain string) error
+	AppendUnique(table, chain string, rulespec ...string) error
+	Insert(table, chain string, pos int, rulespec ...string) error
+}
+
 func loadConfig() (*config, error) {
 	cfgTight, ok := os.LookupEnv(agentconfig.EnvAgentConfig)
 	if !ok {
@@ -55,7 +61,7 @@ func trafficAgentUID() (string, error) {
 	return strconv.Itoa(os.Getuid()), nil
 }
 
-func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTables, loopback string, localHostCIDR netip.Prefix, podIP netip.Addr) error {
+func (c *config) configureIptables(ctx context.Context, ipt iptablesConfigurer, loopback string, localHostCIDR netip.Prefix, podIP netip.Addr) error {
 	// These iptables rules implement routing such that a packet directed to the appPort will hit the agentPort instead.
 	// If there's no mesh this is simply request -> agent -> app (or intercept)
 	// However, if there's a service mesh we want to make sure we don't bypass the mesh, so the traffic
@@ -87,12 +93,12 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 		// Clearing the chains will create them if they don't exist or clear them out if they do.
 		protoStr := proto.String()
 		preRoutingChain := "TEL_PREROUTING_" + protoStr
-		err := iptables.ClearChain(nat, preRoutingChain)
+		err := ipt.ClearChain(nat, preRoutingChain)
 		if err != nil {
 			return fmt.Errorf("failed to clear chain %s: %w", preRoutingChain, err)
 		}
 		outputChain := "TEL_OUTPUT_" + protoStr
-		err = iptables.ClearChain(nat, outputChain)
+		err = ipt.ClearChain(nat, outputChain)
 		if err != nil {
 			return fmt.Errorf("failed to clear chain %s: %w", outputChain, err)
 		}
@@ -105,14 +111,14 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 					// Add REDIRECT to both PREROUTING and OUTPUT, because we want connections that
 					// originate from the agent to be subjected to this rule.
 					clog.Debugf(ctx, "preroute redirect %d -> %d", ic.ContainerPort, ic.AgentPort)
-					err = iptables.AppendUnique(nat, preRoutingChain,
+					err = ipt.AppendUnique(nat, preRoutingChain,
 						"-p", lcProto, "--dport", strconv.Itoa(int(ic.ContainerPort)),
 						"-j", "REDIRECT", "--to-ports", strconv.Itoa(int(ic.AgentPort)))
 					if err != nil {
 						return fmt.Errorf("failed to append rule to %s: %w", preRoutingChain, err)
 					}
 					clog.Debugf(ctx, "output redirect %d -> %d", ic.ContainerPort, ic.AgentPort)
-					err = iptables.AppendUnique(nat, outputChain,
+					err = ipt.AppendUnique(nat, outputChain,
 						"-p", lcProto, "--dport", strconv.Itoa(int(ic.ContainerPort)),
 						"-j", "REDIRECT", "--to-ports", strconv.Itoa(int(ic.AgentPort)))
 					if err != nil {
@@ -126,7 +132,7 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 						// prevent an endless loop that would otherwise occur here when the previous rule would
 						// loop it back into the agent.
 						clog.Debugf(ctx, "output DNAT %s:%d -> %s:%d", podIP, c.ProxyPort(ic.AgentPort), podIP, ic.ContainerPort)
-						err = iptables.AppendUnique(nat, outputChain,
+						err = ipt.AppendUnique(nat, outputChain,
 							"-p", lcProto, "-d", podIP.String(), "--dport", strconv.Itoa(int(c.ProxyPort(ic.AgentPort))),
 							"-j", "DNAT", "--to-destination", netip.AddrPortFrom(podIP, ic.ContainerPort).String())
 						if err != nil {
@@ -141,7 +147,7 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 		// We do this as an append instead of an insert because this will prevent us from interfering with a service mesh
 		// if one exists. If a service mesh exists, its PREROUTING rules will kick in before ours, ensuring traffic
 		// coming into the pod does not bypass the mesh.
-		err = iptables.AppendUnique(nat, "PREROUTING",
+		err = ipt.AppendUnique(nat, "PREROUTING",
 			"-p", lcProto,
 			"-j", preRoutingChain)
 		if err != nil {
@@ -151,7 +157,7 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 		// Any traffic heading out of the loopback and into the app port (other than traffic from the agent) needs to
 		// be redirected to the agent. This will ensure that if there's a service mesh, when the mesh's proxy goes to
 		// request the application, it will get a response via the traffic agent.
-		err = iptables.Insert(nat, "OUTPUT", 1,
+		err = ipt.Insert(nat, "OUTPUT", 1,
 			"-o", loopback,
 			"-p", lcProto,
 			"-m", "owner", "!", "--uid-owner", agentUID,
@@ -161,11 +167,23 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 		}
 		outputInsertCount++
 
+		// Some service meshes connect back to the app through the pod IP rather than a loopback
+		// address. Route those connections through the same output chain.
+		err = ipt.Insert(nat, "OUTPUT", 1,
+			"-p", lcProto,
+			"-d", podIP.String(),
+			"-m", "owner", "!", "--uid-owner", agentUID,
+			"-j", outputChain)
+		if err != nil {
+			return fmt.Errorf("failed to insert pod IP ! --uid-owner rule in OUTPUT: %w", err)
+		}
+		outputInsertCount++
+
 		// Any agent traffic heading out on the loopback but NOT towards localhost needs to be processed in case
 		// it needs to be redirected. This is so that if the traffic agent requests its own IP, it doesn't just
 		// serve the app but actually goes through the agent, and thus through any intercepts.
 		// This is needed to support requesting an intercepted pod by IP (or to intercept a headless service).
-		err = iptables.Insert(nat, "OUTPUT", 1,
+		err = ipt.Insert(nat, "OUTPUT", 1,
 			"-o", loopback,
 			"-p", lcProto,
 			"!", "-d", localHostCIDR.String(),
@@ -175,12 +193,25 @@ func (c *config) configureIptables(ctx context.Context, iptables *iptables.IPTab
 			return fmt.Errorf("failed to insert --uid-owner rule in OUTPUT: %w", err)
 		}
 		outputInsertCount++
+
+		// The traffic agent also uses the pod IP proxy port when forwarding to the
+		// inactive app container. Ensure that path works even when the pod IP does
+		// not route over the loopback interface.
+		err = ipt.Insert(nat, "OUTPUT", 1,
+			"-p", lcProto,
+			"-d", podIP.String(),
+			"-m", "owner", "--uid-owner", agentUID,
+			"-j", outputChain)
+		if err != nil {
+			return fmt.Errorf("failed to insert pod IP --uid-owner rule in OUTPUT: %w", err)
+		}
+		outputInsertCount++
 	}
 
 	// Finally, any other traffic heading out of the traffic agent should pass by unperturbed -- it should obviously not be
 	// redirected back into the agent, but it also should not pass through a mesh proxy.
 	// This will include not just agent->manager traffic but also the agent requesting 127.0.0.1:appPort to serve the application
-	err = iptables.Insert(nat, "OUTPUT", 1+outputInsertCount,
+	err = ipt.Insert(nat, "OUTPUT", 1+outputInsertCount,
 		"-m", "owner", "--uid-owner", agentUID,
 		"-j", "RETURN")
 	if err != nil {

--- a/cmd/traffic/cmd/agentinit/agent_init_test.go
+++ b/cmd/traffic/cmd/agentinit/agent_init_test.go
@@ -1,14 +1,56 @@
 package agentinit
 
 import (
+	"context"
+	"net/netip"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
+
+type iptablesCall struct {
+	op       string
+	table    string
+	chain    string
+	position int
+	rulespec []string
+}
+
+type fakeIPTables struct {
+	calls []iptablesCall
+}
+
+func (f *fakeIPTables) ClearChain(table, chain string) error {
+	f.calls = append(f.calls, iptablesCall{op: "clear", table: table, chain: chain})
+	return nil
+}
+
+func (f *fakeIPTables) AppendUnique(table, chain string, rulespec ...string) error {
+	f.calls = append(f.calls, iptablesCall{op: "append", table: table, chain: chain, rulespec: rulespec})
+	return nil
+}
+
+func (f *fakeIPTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	f.calls = append(f.calls, iptablesCall{op: "insert", table: table, chain: chain, position: pos, rulespec: rulespec})
+	return nil
+}
+
+func requireCall(t *testing.T, calls []iptablesCall, want iptablesCall) {
+	t.Helper()
+	for _, call := range calls {
+		if call.op == want.op && call.table == want.table && call.chain == want.chain &&
+			call.position == want.position && strings.Join(call.rulespec, "\x00") == strings.Join(want.rulespec, "\x00") {
+			return
+		}
+	}
+	require.Failf(t, "missing iptables call", "wanted %#v in %#v", want, calls)
+}
 
 func TestTrafficAgentUIDDefaultsToProcessUID(t *testing.T) {
 	t.Setenv(agentconfig.EnvAgentUID, "")
@@ -31,4 +73,81 @@ func TestTrafficAgentUIDRejectsInvalidEnvironment(t *testing.T) {
 
 	_, err := trafficAgentUID()
 	require.Error(t, err)
+}
+
+func TestConfigureIptablesCatchesPodIPOutputTraffic(t *testing.T) {
+	t.Setenv(agentconfig.EnvAgentUID, "1000")
+	podIP := netip.MustParseAddr("10.129.70.53")
+	ipt := &fakeIPTables{}
+	cfg := &config{Sidecar: &agentconfig.Sidecar{
+		Containers: []*agentconfig.Container{
+			{
+				Name: "app",
+				Intercepts: []*agentconfig.Intercept{
+					{
+						Protocol:          types.ProtoTCP,
+						ContainerPort:     8000,
+						AgentPort:         9900,
+						TargetPortNumeric: true,
+					},
+				},
+			},
+		},
+	}}
+
+	err := cfg.configureIptables(context.Background(), ipt, "lo", netip.MustParsePrefix("127.0.0.1/32"), podIP)
+	require.NoError(t, err)
+
+	requireCall(t, ipt.calls, iptablesCall{
+		op:    "append",
+		table: nat,
+		chain: "TEL_OUTPUT_TCP",
+		rulespec: []string{
+			"-p", "tcp", "--dport", "8000",
+			"-j", "REDIRECT", "--to-ports", "9900",
+		},
+	})
+	requireCall(t, ipt.calls, iptablesCall{
+		op:    "append",
+		table: nat,
+		chain: "TEL_OUTPUT_TCP",
+		rulespec: []string{
+			"-p", "tcp", "-d", "10.129.70.53", "--dport", "9912",
+			"-j", "DNAT", "--to-destination", "10.129.70.53:8000",
+		},
+	})
+	requireCall(t, ipt.calls, iptablesCall{
+		op:       "insert",
+		table:    nat,
+		chain:    "OUTPUT",
+		position: 1,
+		rulespec: []string{
+			"-p", "tcp",
+			"-d", "10.129.70.53",
+			"-m", "owner", "!", "--uid-owner", "1000",
+			"-j", "TEL_OUTPUT_TCP",
+		},
+	})
+	requireCall(t, ipt.calls, iptablesCall{
+		op:       "insert",
+		table:    nat,
+		chain:    "OUTPUT",
+		position: 1,
+		rulespec: []string{
+			"-p", "tcp",
+			"-d", "10.129.70.53",
+			"-m", "owner", "--uid-owner", "1000",
+			"-j", "TEL_OUTPUT_TCP",
+		},
+	})
+	requireCall(t, ipt.calls, iptablesCall{
+		op:       "insert",
+		table:    nat,
+		chain:    "OUTPUT",
+		position: 5,
+		rulespec: []string{
+			"-m", "owner", "--uid-owner", "1000",
+			"-j", "RETURN",
+		},
+	})
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,6 +38,12 @@ Injected traffic-agent configs now use a fully-qualified traffic-manager service
 Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>appProtocol</code> values such as <code>http</code> and <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2 probing for known HTTP/1 services, avoiding request latency when those probes cannot connect through the inactive proxy port.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Handle pod IP output traffic in agent init</div></div>
+<div style="margin-left: 15px">
+
+Injected init containers now route pod IP output traffic through the same traffic-agent iptables chains used for loopback traffic. This lets service mesh sidecars and traffic-agent forwarding paths that connect to the application through the pod IP reach the expected redirect and DNAT rules, avoiding missed routing when the pod IP does not use the loopback interface.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -44,6 +44,12 @@ Injected traffic-agent configs now use a fully-qualified traffic-manager service
 Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>appProtocol</code> values such as <code>http</code> and <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2 probing for known HTTP/1 services, avoiding request latency when those probes cannot connect through the inactive proxy port.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Handle pod IP output traffic in agent init</Title>
+	<Body>
+Injected init containers now route pod IP output traffic through the same traffic-agent iptables chains used for loopback traffic. This lets service mesh sidecars and traffic-agent forwarding paths that connect to the application through the pod IP reach the expected redirect and DNAT rules, avoiding missed routing when the pod IP does not use the loopback interface.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>


### PR DESCRIPTION
## Description

This fixes agent init iptables setup for pods where traffic reaches the application through the pod IP instead of loopback.

Some service mesh sidecars connect back to the app using the pod IP, and the traffic-agent also uses the pod IP proxy port when forwarding to the inactive app container. Previously, those output paths could miss the Telepresence redirect/DNAT chains when the pod IP did not route over loopback.

This change routes pod-IP output traffic through the same traffic-agent chains used for loopback traffic, covering both app-directed mesh traffic and traffic-agent-owned forwarding paths.

The force push was just to correct the merge conflict. 

Let me know what additional testing you'd like me to do for this one. 

## Checklist

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.