### PR TITLE
Add /usr/sbin to the systemd service PATH

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -81,6 +81,11 @@ items:
           <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2
           probing for known HTTP/1 services, avoiding request latency when those
           probes cannot connect through the inactive proxy port.
+      - type: bugfix
+        title: Add /usr/sbin to systemd root daemon path
+        body: >-
+          Ensures /usr/sbin is in the PATH used by the root daemon when it is run
+          by systemd.  This ensures iptables can be found by the daemon.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/build-aux/systemd-installer/telepresence-rootd.service
+++ b/build-aux/systemd-installer/telepresence-rootd.service
@@ -30,7 +30,7 @@ StandardOutput=journal
 StandardError=journal
 
 # Environment
-Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/usr/sbin:/usr/local/bin:/usr/bin:/bin
 # Telepresence sometimes expects a writable HOME
 Environment=HOME=/var/root
 


### PR DESCRIPTION
## Description

This ensures that iptables can be found by the root daemon.

fixes #4099

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [X] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [X] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.