### PR TITLE
Reconnect root daemon when it drops

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -87,6 +87,14 @@ items:
           Ensures /usr/sbin is in the PATH used by the root daemon when it is run
           by systemd.  This ensures iptables can be found by the daemon.
       - type: bugfix
+        title: Reconnect the root daemon when its activity watcher fails
+        body: >-
+          The user daemon now reconnects to the root daemon when the root daemon's
+          activity watcher fails, instead of leaving the session stuck until the
+          user manually reconnects. Telepresence reuses the saved network
+          configuration, clears stale DNS routing state before reconnecting, swaps
+          in the new root daemon client, and re-posts DNS domains after reconnecting.
+      - type: bugfix
         title: Handle pod IP output traffic in agent init
         body: >-
           Injected init containers now route pod IP output traffic through the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -44,6 +44,12 @@ Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>ap
 Ensures /usr/sbin is in the PATH used by the root daemon when it is run by systemd.  This ensures iptables can be found by the daemon.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Reconnect the root daemon when its activity watcher fails</div></div>
+<div style="margin-left: 15px">
+
+The user daemon now reconnects to the root daemon when the root daemon's activity watcher fails, instead of leaving the session stuck until the user manually reconnects. Telepresence reuses the saved network configuration, clears stale DNS routing state before reconnecting, swaps in the new root daemon client, and re-posts DNS domains after reconnecting.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Handle pod IP output traffic in agent init</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -51,6 +51,12 @@ Ensures /usr/sbin is in the PATH used by the root daemon when it is run by syste
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Reconnect the root daemon when its activity watcher fails</Title>
+	<Body>
+The user daemon now reconnects to the root daemon when the root daemon's activity watcher fails, instead of leaving the session stuck until the user manually reconnects. Telepresence reuses the saved network configuration, clears stale DNS routing state before reconnecting, swaps in the new root daemon client, and re-posts DNS domains after reconnecting.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix">Handle pod IP output traffic in agent init</Title>
 	<Body>
 Injected init containers now route pod IP output traffic through the same traffic-agent iptables chains used for loopback traffic. This lets service mesh sidecars and traffic-agent forwarding paths that connect to the application through the pod IP reach the expected redirect and DNAT rules, avoiding missed routing when the pod IP does not use the loopback interface.

--- a/pkg/client/rootd/dns/cleanup_other.go
+++ b/pkg/client/rootd/dns/cleanup_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package dns
+
+import "context"
+
+// CleanupRouting removes DNS routing state that might have been left behind by
+// a previous root daemon process.
+func CleanupRouting(context.Context) {
+}

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -232,6 +232,12 @@ func runNatTableCmd(c context.Context, args ...string) error {
 
 const tpDNSChain = "TELEPRESENCE_DNS"
 
+// CleanupRouting removes DNS routing state that might have been left behind by
+// a previous root daemon process.
+func CleanupRouting(c context.Context) {
+	unrouteDNS(c)
+}
+
 // routeDNS creates a new chain in the "nat" table with two rules in it. One rule ensures
 // that all packets sent to the currently configured DNS service are rerouted to our local
 // DNS service. Another rule ensures that when our local DNS service cannot resolve and

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/logging"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/rootd/dns"
 	"github.com/telepresenceio/telepresence/v2/pkg/grpc/server"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -90,7 +91,7 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 
 	sessionCtx, sessionCancel := context.WithCancel(s)
 	var sn *session
-	sn, err = createSession(client.WithConfig(sessionCtx, cfg), ctx, info, s.activity)
+	sn, err = createSession(client.WithConfig(sessionCtx, cfg), ctx, info, s.activity, dns.CleanupRouting)
 	if err != nil {
 		sessionCancel()
 		return nil, err

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -203,8 +203,14 @@ type session struct {
 }
 
 // createSession will establish a connection to the traffic-manager and return a new properly initialized session object.
-func createSession(sessionCtx, dialCtx context.Context, mi *rpc.NetworkConfig, activity chan<- time.Time) (s *session, err error) {
+func createSession(
+	sessionCtx, dialCtx context.Context,
+	mi *rpc.NetworkConfig,
+	activity chan<- time.Time,
+	cleanupDNSRouting func(context.Context),
+) (s *session, err error) {
 	clog.Info(sessionCtx, "-- Starting new session")
+	cleanupDNSRouting(sessionCtx)
 	kc, err := k8s.NewKubeconfig(sessionCtx, true, mi.KubeFlags, mi.ManagerNamespace, mi.KubeconfigData)
 	if err != nil {
 		return nil, err

--- a/pkg/client/rootd/stream_creator_test.go
+++ b/pkg/client/rootd/stream_creator_test.go
@@ -1,11 +1,32 @@
 package rootd
 
 import (
+	"context"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
 )
+
+func TestCreateSessionCleansDNSRoutingBeforeKubeconfig(t *testing.T) {
+	ctx := client.WithConfig(context.Background(), client.GetDefaultConfig())
+
+	called := false
+	cleanupDNSRouting := func(context.Context) {
+		called = true
+	}
+
+	_, err := createSession(ctx, ctx, &rpc.NetworkConfig{
+		KubeconfigData: []byte("not: [valid"),
+	}, make(chan time.Time), cleanupDNSRouting)
+
+	require.Error(t, err)
+	require.True(t, called)
+}
 
 func TestIsAlsoProxyDestination(t *testing.T) {
 	s := &session{

--- a/pkg/client/userd/trafficmgr/agents.go
+++ b/pkg/client/userd/trafficmgr/agents.go
@@ -76,7 +76,7 @@ func (s *session) handleAgentSnapshot(ctx context.Context, infos []*manager.Agen
 				}
 				ig.AgentInfo = ai
 			}
-			s.ingestTracker.start(ig.podAccess(s.rootDaemon))
+			s.startIngestPodAccess(ctx, ig, false)
 		}
 		return true
 	})

--- a/pkg/client/userd/trafficmgr/ingest.go
+++ b/pkg/client/userd/trafficmgr/ingest.go
@@ -186,9 +186,23 @@ func (s *session) Ingest(ctx context.Context, rq *rpc.IngestRequest) (ir *rpc.In
 		}, false
 	})
 	if !loaded {
-		s.ingestTracker.initialStart(ig.podAccess(s.rootDaemon))
+		s.startIngestPodAccess(ctx, ig, true)
 	}
 	return ig.response(), nil
+}
+
+func (s *session) startIngestPodAccess(ctx context.Context, ig *ingest, initial bool) {
+	err := s.WithRootClient(ctx, func(_ context.Context, rd daemon.DaemonClient) error {
+		if initial {
+			s.ingestTracker.initialStart(ig.podAccess(rd))
+		} else {
+			s.ingestTracker.start(ig.podAccess(rd))
+		}
+		return nil
+	})
+	if err != nil {
+		clog.Errorf(ctx, "failed to start ingest pod access: %v", err)
+	}
 }
 
 func (s *session) translateContainerEnv(ctx context.Context, ai *manager.AgentInfo, container string) error {
@@ -197,7 +211,7 @@ func (s *session) translateContainerEnv(ctx context.Context, ai *manager.AgentIn
 		return fmt.Errorf("workload %s has no container named %s", ai.Name, container)
 	}
 	return s.WithRootClient(ctx, func(ctx context.Context, rd daemon.DaemonClient) (err error) {
-		env, err := s.rootDaemon.TranslateEnvIPs(s, &daemon.Environment{Env: cn.Environment})
+		env, err := rd.TranslateEnvIPs(ctx, &daemon.Environment{Env: cn.Environment})
 		if err == nil {
 			cn.Environment = env.Env
 		}

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -188,7 +188,9 @@ func (s *session) handleInterceptSnapshot(pat *podAccessTracker, intercepts []*m
 		pa := ic.podAccess()
 		var err error
 		if ii.Disposition == manager.InterceptDispositionType_ACTIVE {
-			err = pa.ensureAccess(ic.ctx, s.rootDaemon)
+			err = s.WithRootClient(ic.ctx, func(ctx context.Context, rd daemon.DaemonClient) error {
+				return pa.ensureAccess(ctx, rd)
+			})
 		} else {
 			err = fmt.Errorf("intercept in error state %v: %v", ii.Disposition, ii.Message)
 		}
@@ -691,7 +693,7 @@ func (s *session) AddIntercept(ctx context.Context, ir *rpc.CreateInterceptReque
 			case <-wr.mountsDone:
 			}
 			err := s.WithRootClient(ctx, func(ctx context.Context, rd daemon.DaemonClient) (err error) {
-				env, err := s.rootDaemon.TranslateEnvIPs(c, &daemon.Environment{Env: ii.Environment})
+				env, err := rd.TranslateEnvIPs(c, &daemon.Environment{Env: ii.Environment})
 				if err == nil {
 					ii.Environment = env.Env
 				}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -80,8 +80,16 @@ type workloadInfo struct {
 type session struct {
 	*k8s.Cluster
 	service            userd.Service
-	rootDaemon         rootdRpc.DaemonClient
 	subnetViaWorkloads []*rootdRpc.SubnetViaWorkload
+
+	rootDaemonLock          sync.RWMutex
+	rootDaemon              rootdRpc.DaemonClient
+	rootDaemonConn          *grpc.ClientConn
+	rootDaemonConfig        *rootdRpc.NetworkConfig
+	rootDaemonIsPodDaemon   bool
+	rootDaemonGeneration    uint64
+	rootDaemonReconnectLock sync.Mutex
+	dialRootDaemon          func(context.Context, bool) (*grpc.ClientConn, error)
 
 	// local information
 	installID string // telepresence's install ID
@@ -213,8 +221,7 @@ func NewSession(
 
 	tmgr.Context = tunnel.WithSyntheticIPResolver(tmgr.Context, tmgr)
 
-	tmgr.rootDaemon, err = tmgr.connectRootDaemon(ctx, oi, wg, cr.IsPodDaemon)
-	if err != nil {
+	if err = tmgr.connectRootDaemon(ctx, oi, wg, cr.IsPodDaemon); err != nil {
 		tmgr.managerConn.Close()
 		return nil, nil, err
 	}
@@ -245,6 +252,7 @@ func (s *session) Run() {
 			_, _ = rd.Disconnect(ctx, &empty.Empty{})
 			return nil
 		})
+		s.closeRootDaemon()
 		clog.Info(s, "-- session ended")
 	}()
 	s.startServices(g)
@@ -255,7 +263,11 @@ func (s *session) Run() {
 }
 
 func (s *session) WithRootClient(ctx context.Context, f func(context.Context, rootdRpc.DaemonClient) error) error {
-	return f(ctx, s.rootDaemon)
+	rd, _ := s.getRootDaemon()
+	if rd == nil {
+		return status.Error(codes.FailedPrecondition, "root daemon is reconnecting")
+	}
+	return f(ctx, rd)
 }
 
 func (s *session) ManagerClient() manager.ManagerClient {
@@ -446,6 +458,88 @@ func (s *session) updateDaemonNamespaces() {
 		clog.Errorf(s, "error posting domains %v to root daemon: %v", domains, err)
 	}
 	clog.Debug(s, "domains posted successfully")
+}
+
+func cloneNetworkConfig(nc *rootdRpc.NetworkConfig) *rootdRpc.NetworkConfig {
+	if nc == nil {
+		return nil
+	}
+	return proto.Clone(nc).(*rootdRpc.NetworkConfig)
+}
+
+func (s *session) getRootDaemon() (rootdRpc.DaemonClient, uint64) {
+	s.rootDaemonLock.RLock()
+	defer s.rootDaemonLock.RUnlock()
+	return s.rootDaemon, s.rootDaemonGeneration
+}
+
+func (s *session) setRootDaemon(rd rootdRpc.DaemonClient, conn *grpc.ClientConn, nc *rootdRpc.NetworkConfig, isPodDaemon bool) uint64 {
+	s.rootDaemonLock.Lock()
+	oldConn := s.rootDaemonConn
+	s.rootDaemon = rd
+	s.rootDaemonConn = conn
+	if nc != nil {
+		s.rootDaemonConfig = cloneNetworkConfig(nc)
+	}
+	s.rootDaemonIsPodDaemon = isPodDaemon
+	s.rootDaemonGeneration++
+	generation := s.rootDaemonGeneration
+	s.rootDaemonLock.Unlock()
+
+	if oldConn != nil && oldConn != conn {
+		go oldConn.Close()
+	}
+	return generation
+}
+
+func (s *session) clearRootDaemonIfGeneration(generation uint64) bool {
+	s.rootDaemonLock.Lock()
+	if s.rootDaemonGeneration != generation {
+		s.rootDaemonLock.Unlock()
+		return false
+	}
+	oldConn := s.rootDaemonConn
+	s.rootDaemon = nil
+	s.rootDaemonConn = nil
+	s.rootDaemonGeneration++
+	s.rootDaemonLock.Unlock()
+
+	if oldConn != nil {
+		go oldConn.Close()
+	}
+	return true
+}
+
+func (s *session) closeRootDaemon() {
+	s.rootDaemonLock.Lock()
+	oldConn := s.rootDaemonConn
+	s.rootDaemon = nil
+	s.rootDaemonConn = nil
+	s.rootDaemonConfig = nil
+	s.rootDaemonGeneration++
+	s.rootDaemonLock.Unlock()
+
+	if oldConn != nil {
+		oldConn.Close()
+	}
+}
+
+func (s *session) rootDaemonReconnectConfig() (*rootdRpc.NetworkConfig, bool) {
+	s.rootDaemonLock.RLock()
+	nc := cloneNetworkConfig(s.rootDaemonConfig)
+	isPodDaemon := s.rootDaemonIsPodDaemon
+	s.rootDaemonLock.RUnlock()
+	if nc == nil {
+		return nil, isPodDaemon
+	}
+
+	nc.Namespace = s.Namespace
+	nc.ManagerNamespace = k8s.GetManagerNamespace(s)
+	nc.MappedNamespaces = s.GetCurrentNamespaces(true)
+	nc.Session = s.sessionInfo
+	nc.SubnetViaWorkloads = s.subnetViaWorkloads
+	nc.ClientConfig, _ = json.Marshal(client.GetConfig(s))
+	return nc, isPodDaemon
 }
 
 func (s *session) startServices(g log.Group) {
@@ -864,17 +958,19 @@ func (s *session) getNetworkInfo(cr *rpc.ConnectRequest) *rootdRpc.NetworkConfig
 	}
 }
 
-func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.NetworkConfig, wg *sync.WaitGroup, isPodDaemon bool) (rd rootdRpc.DaemonClient, err error) {
+func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.NetworkConfig, wg *sync.WaitGroup, isPodDaemon bool) (err error) {
 	// establish a connection to the root daemon gRPC grpcService
 	clog.Info(s, "Connecting to root daemon...")
 	svc := s.GetService()
+	var rd rootdRpc.DaemonClient
+	var conn *grpc.ClientConn
 	if svc.RootSessionInProcess() {
 		// Just run the root session in-process.
 		activity := make(chan time.Time)
 		rootSession, err := rootd.NewInProcSession(s.Cluster, nc, s.managerConn, s.managerVersion, activity, isPodDaemon)
 		if err != nil {
 			close(activity)
-			return nil, err
+			return err
 		}
 		go func() {
 			for {
@@ -894,22 +990,27 @@ func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.Net
 
 		g := log.NewGroup(rootSession)
 		if err = rootSession.Start(g, svc.TeleroutePort()); err != nil {
-			return nil, err
+			return err
 		}
 		rd = rootSession
 
 		// Give in-proc root session services a chance to clean up.
-		wg.Go(func() {
-			err := g.Wait()
-			if err != nil && !errors.Is(err, context.Canceled) {
-				clog.Errorf(s, "root session exited with error: %v", err)
-			}
-		})
+		if wg != nil {
+			wg.Go(func() {
+				err := g.Wait()
+				if err != nil && !errors.Is(err, context.Canceled) {
+					clog.Errorf(s, "root session exited with error: %v", err)
+				}
+			})
+		}
 	} else {
-		var conn *grpc.ClientConn
-		conn, err = daemon.DialRootDaemon(timeoutCtx, true)
+		dialRootDaemon := s.dialRootDaemon
+		if dialRootDaemon == nil {
+			dialRootDaemon = daemon.DialRootDaemon
+		}
+		conn, err = dialRootDaemon(timeoutCtx, true)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		defer func() {
 			if err != nil {
@@ -922,12 +1023,12 @@ func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.Net
 			var rootStatus *rootdRpc.DaemonStatus
 			rootStatus, err = rd.Connect(timeoutCtx, nc)
 			if err != nil {
-				return nil, fmt.Errorf("failed to connect to root daemon: %w", err)
+				return fmt.Errorf("failed to connect to root daemon: %w", err)
 			}
 			oc := rootStatus.OutboundConfig
 			if oc == nil || oc.Session == nil {
 				// This is an internal error. Something is wrong with the root daemon.
-				return nil, errors.New("root daemon's OutboundConfig has no session")
+				return errors.New("root daemon's OutboundConfig has no session")
 			}
 			if oc.Session.SessionId == nc.Session.SessionId {
 				break
@@ -937,30 +1038,12 @@ func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.Net
 			// crashed without disconnecting. So let's do that now, and then reconnect...
 			if attempt == 2 {
 				// ...or not, since we've already done it.
-				return nil, errors.New("unable to reconnect to root daemon")
+				return errors.New("unable to reconnect to root daemon")
 			}
 			if _, err = rd.Disconnect(s, &empty.Empty{}); err != nil {
-				return nil, fmt.Errorf("failed to disconnect from the root daemon: %w", err)
+				return fmt.Errorf("failed to disconnect from the root daemon: %w", err)
 			}
 		}
-		aw, err := rd.ActivityWatcher(s, &empty.Empty{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get activity watcher: %w", err)
-		}
-		go func() {
-			for {
-				at, err := aw.Recv()
-				if err != nil {
-					if !errors.Is(err, context.Canceled) {
-						clog.Errorf(s, "activity watcher failed: %v", err)
-					}
-					return
-				}
-				ats := at.Activity.AsTime()
-				clog.Debugf(s, "root session last activity: %v", ats)
-				atomic.StoreInt64(&s.lastActivity, ats.UnixNano())
-			}
-		}()
 	}
 
 	// The root daemon needs time to set up the TUN-device and DNS, which involves interacting
@@ -969,10 +1052,85 @@ func (s *session) connectRootDaemon(timeoutCtx context.Context, nc *rootdRpc.Net
 		if se, ok := status.FromError(err); ok {
 			err = se.Err()
 		}
-		return nil, fmt.Errorf("failed to connect to root daemon: %v", err)
+		return fmt.Errorf("failed to connect to root daemon: %v", err)
+	}
+	generation := s.setRootDaemon(rd, conn, nc, isPodDaemon)
+	if !svc.RootSessionInProcess() {
+		s.startRootDaemonActivityWatcher(rd, generation)
 	}
 	clog.Debug(s, "Connected to root daemon")
-	return rd, nil
+	return nil
+}
+
+func (s *session) startRootDaemonActivityWatcher(rd rootdRpc.DaemonClient, generation uint64) {
+	go func() {
+		aw, err := rd.ActivityWatcher(s, &empty.Empty{})
+		if err != nil {
+			if !errors.Is(err, context.Canceled) && s.Err() == nil {
+				clog.Errorf(s, "activity watcher failed: %v", err)
+				s.reconnectRootDaemon(generation, err)
+			}
+			return
+		}
+		for {
+			at, err := aw.Recv()
+			if err != nil {
+				if !errors.Is(err, context.Canceled) && s.Err() == nil {
+					clog.Errorf(s, "activity watcher failed: %v", err)
+					s.reconnectRootDaemon(generation, err)
+				}
+				return
+			}
+			ats := at.Activity.AsTime()
+			clog.Debugf(s, "root session last activity: %v", ats)
+			atomic.StoreInt64(&s.lastActivity, ats.UnixNano())
+		}
+	}()
+}
+
+func (s *session) reconnectRootDaemon(failedGeneration uint64, cause error) {
+	s.rootDaemonReconnectLock.Lock()
+	defer s.rootDaemonReconnectLock.Unlock()
+
+	_, generation := s.getRootDaemon()
+	if generation != failedGeneration {
+		return
+	}
+	if !s.clearRootDaemonIfGeneration(failedGeneration) {
+		return
+	}
+	clog.Warnf(s, "root daemon connection lost: %v; reconnecting", cause)
+
+	backoff := 200 * time.Millisecond
+	for attempt := 1; s.Err() == nil; attempt++ {
+		nc, isPodDaemon := s.rootDaemonReconnectConfig()
+		if nc == nil {
+			clog.Error(s, "unable to reconnect root daemon: missing network configuration")
+			return
+		}
+
+		timeoutCtx, cancel := client.GetConfig(s).Timeouts().TimeoutContext(s, client.TimeoutTrafficManagerConnect)
+		err := s.connectRootDaemon(timeoutCtx, nc, nil, isPodDaemon)
+		cancel()
+		if err == nil {
+			clog.Info(s, "Reconnected to root daemon")
+			s.updateDaemonNamespaces()
+			return
+		}
+		clog.Errorf(s, "failed to reconnect to root daemon (attempt %d): %v", attempt, err)
+
+		select {
+		case <-s.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 5*time.Second {
+			backoff *= 2
+			if backoff > 5*time.Second {
+				backoff = 5 * time.Second
+			}
+		}
+	}
 }
 
 func (s *session) eachWorkload(namespaces []string, do func(kind manager.WorkloadInfo_Kind, name, namespace string, info workloadInfo)) {

--- a/pkg/client/userd/trafficmgr/session_rootd_test.go
+++ b/pkg/client/userd/trafficmgr/session_rootd_test.go
@@ -1,0 +1,214 @@
+package trafficmgr
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	connectorRpc "github.com/telepresenceio/telepresence/rpc/v2/connector"
+	rootdRpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/remotefs"
+)
+
+func TestRootDaemonActivityWatcherReconnectsRootDaemon(t *testing.T) {
+	const sessionID = "test-session"
+
+	ctx, cancel := context.WithCancel(client.WithConfig(context.Background(), client.GetDefaultConfig()))
+	defer cancel()
+
+	first := &rootDaemonReconnectTestServer{
+		name:        "first",
+		sessionID:   sessionID,
+		activityErr: status.Error(codes.Unavailable, "rootd exited"),
+	}
+	second := &rootDaemonReconnectTestServer{
+		name:      "second",
+		sessionID: sessionID,
+	}
+	servers := []*rootDaemonReconnectTestServer{first, second}
+
+	var dialCount atomic.Int32
+	var cleanupLock sync.Mutex
+	var cleanups []func()
+	dialRootDaemon := func(_ context.Context, _ bool) (*grpc.ClientConn, error) {
+		idx := int(dialCount.Add(1)) - 1
+		if idx >= len(servers) {
+			return nil, fmt.Errorf("unexpected root daemon dial %d", idx+1)
+		}
+		conn, cleanup, err := dialTestRootDaemon(servers[idx])
+		if err != nil {
+			return nil, err
+		}
+		cleanupLock.Lock()
+		cleanups = append(cleanups, cleanup)
+		cleanupLock.Unlock()
+		return conn, nil
+	}
+	t.Cleanup(func() {
+		cleanupLock.Lock()
+		defer cleanupLock.Unlock()
+		for _, cleanup := range cleanups {
+			cleanup()
+		}
+	})
+
+	s := &session{
+		Cluster: &k8s.Cluster{
+			Kubeconfig: &k8s.Kubeconfig{
+				Context:     ctx,
+				Namespace:   "default",
+				KubeContext: "test",
+				Server:      "https://cluster.example",
+			},
+		},
+		service:        rootDaemonReconnectTestService{},
+		sessionInfo:    &manager.SessionInfo{SessionId: sessionID},
+		dialRootDaemon: dialRootDaemon,
+	}
+	nc := &rootdRpc.NetworkConfig{
+		Namespace: "default",
+		Session:   s.sessionInfo,
+	}
+
+	require.NoError(t, s.connectRootDaemon(ctx, nc, nil, false))
+	require.Eventually(t, func() bool {
+		return second.connectCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.Equal(t, int32(2), dialCount.Load())
+	require.Equal(t, int32(1), first.connectCount.Load())
+	require.Equal(t, int32(1), second.connectCount.Load())
+
+	err := s.WithRootClient(ctx, func(ctx context.Context, rd rootdRpc.DaemonClient) error {
+		st, err := rd.Status(ctx, &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, "second", st.GetOutboundConfig().GetManagerNamespace())
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+type rootDaemonReconnectTestService struct{}
+
+func (rootDaemonReconnectTestService) ListenerAddress() netip.AddrPort {
+	return netip.AddrPort{}
+}
+
+func (rootDaemonReconnectTestService) SetListenerAddress(netip.AddrPort) {}
+
+func (rootDaemonReconnectTestService) Server() *grpc.Server {
+	return nil
+}
+
+func (rootDaemonReconnectTestService) ConnectorServer() connectorRpc.ConnectorServer {
+	return nil
+}
+
+func (rootDaemonReconnectTestService) FuseFTPMgr() remotefs.FuseFTPManager {
+	return nil
+}
+
+func (rootDaemonReconnectTestService) RootSessionInProcess() bool {
+	return false
+}
+
+func (rootDaemonReconnectTestService) TeleroutePort() uint16 {
+	return 0
+}
+
+func (rootDaemonReconnectTestService) LinkedFTP() bool {
+	return false
+}
+
+func (rootDaemonReconnectTestService) InitFTPServer(context.Context) error {
+	return nil
+}
+
+type rootDaemonReconnectTestServer struct {
+	rootdRpc.UnimplementedDaemonServer
+
+	name        string
+	sessionID   string
+	activityErr error
+
+	connectCount atomic.Int32
+}
+
+func (s *rootDaemonReconnectTestServer) Connect(_ context.Context, nc *rootdRpc.NetworkConfig) (*rootdRpc.DaemonStatus, error) {
+	s.connectCount.Add(1)
+	if nc.GetSession().GetSessionId() != s.sessionID {
+		return nil, status.Errorf(codes.InvalidArgument, "session id = %q, want %q", nc.GetSession().GetSessionId(), s.sessionID)
+	}
+	return s.daemonStatus(), nil
+}
+
+func (s *rootDaemonReconnectTestServer) Status(context.Context, *emptypb.Empty) (*rootdRpc.DaemonStatus, error) {
+	return s.daemonStatus(), nil
+}
+
+func (s *rootDaemonReconnectTestServer) WaitForNetwork(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (s *rootDaemonReconnectTestServer) SetDNSTopLevelDomains(context.Context, *rootdRpc.Domains) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (s *rootDaemonReconnectTestServer) ActivityWatcher(_ *emptypb.Empty, stream grpc.ServerStreamingServer[rootdRpc.Activity]) error {
+	if s.activityErr != nil {
+		return s.activityErr
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *rootDaemonReconnectTestServer) daemonStatus() *rootdRpc.DaemonStatus {
+	return &rootdRpc.DaemonStatus{
+		OutboundConfig: &rootdRpc.NetworkConfig{
+			ManagerNamespace: s.name,
+			Session:          &manager.SessionInfo{SessionId: s.sessionID},
+		},
+	}
+}
+
+func dialTestRootDaemon(server rootdRpc.DaemonServer) (*grpc.ClientConn, func(), error) {
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	rootdRpc.RegisterDaemonServer(grpcServer, server)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cleanup := func() {
+		if conn != nil {
+			conn.Close()
+		}
+		grpcServer.Stop()
+		listener.Close()
+	}
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return conn, cleanup, nil
+}


### PR DESCRIPTION
## Description

We had cases where (for reasons yet to be determined, possibly remote cluster control plane instability or $network things) we ended up with losing a watch and ending up with an `EOF`. This left the user daemon in a weird state in some cases / broken / hard to fix.  

The user daemon already has the network config it needs to rebuild the root daemon side of the session, so use that instead of making users bounce the whole connection when rootd goes away.

This wires the activity watcher failure path into a reconnect loop, swaps in the new root daemon client once it is ready, and re-posts DNS domains after reconnecting. Calls that need rootd get a short failed-precondition error while the new client is being established.

Also add the changelog entry and regenerate the release notes.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.