### PR TITLE
option to rollout agent instead of evict

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -455,6 +455,17 @@ items:
     date: 2025-10-16
     notes:
       - type: feature
+        title: Rollout mode for agent injection to prevent pod termination downtime
+        body: |-
+          Telepresence now supports a rollout mode for agent injection that prevents the issue where all pods are
+          terminated before new pods with traffic-agents are ready. When enabled via the AGENT_ROLLOUT_INSTEAD_OF_EVICT
+          flag or agent.rolloutInsteadOfEvict.enabled Helm value, Telepresence uses Kubernetes rolling update
+          mechanisms instead of direct pod eviction. This ensures pods are replaced gradually as new ones become
+          ready, respecting the deployment's maxSurge and maxUnavailable settings. The gradual rollout mode also
+          includes a 2-second delay to ensure ConfigMap changes are propagated to all admission webhook instances
+          before triggering the rolling update, preventing race conditions where pods might be created without
+          the agent configuration.
+      - type: feature
         title: HTTP Intercepts with HTTP header and path filtering
         body: |-
           Telepresence now supports HTTP Intercepts, enabling fine-grained HTTP traffic filtering for intercepts.

--- a/charts/telepresence-oss/templates/deployment.yaml
+++ b/charts/telepresence-oss/templates/deployment.yaml
@@ -166,6 +166,10 @@ spec:
           - name: AGENT_INIT_CONTAINER_ENABLED
             value: {{ .enabled | quote  }}
           {{- end }}
+          {{- with .rolloutInsteadOfEvict }}
+          - name: AGENT_ROLLOUT_INSTEAD_OF_EVICT
+            value: {{ .enabled | quote }}
+          {{- end }}
           {{- with .image }}
           {{- if .name }}
           - name: AGENT_IMAGE_NAME

--- a/charts/telepresence-oss/values.schema.yaml
+++ b/charts/telepresence-oss/values.schema.yaml
@@ -78,6 +78,13 @@ properties:
       resources:
         description: Resource requirements for the agent
         $ref: "#/$defs/resourceRequirements"
+      rolloutInsteadOfEvict:
+        description: Configuration for using rollout instead of direct eviction when updating pods with agent configuration changes
+        properties:
+          enabled:
+            description: When true, use Kubernetes rolling update instead of direct pod eviction
+            type: boolean
+        type: object
       securityContext:
         description: Security context for the agent
         $ref: "#/$defs/securityContext"

--- a/charts/telepresence-oss/values.yaml
+++ b/charts/telepresence-oss/values.yaml
@@ -137,6 +137,8 @@ agent:
     pullPolicy: IfNotPresent
   initContainer:
     enabled: true
+  rolloutInsteadOfEvict:
+    enabled: false
 
 ################################################################################
 ## Telepresence API Server Configuration

--- a/cmd/traffic/cmd/manager/managerutil/envconfig.go
+++ b/cmd/traffic/cmd/manager/managerutil/envconfig.go
@@ -71,6 +71,7 @@ type Env struct {
 	AgentInitContainerEnabled  bool `default:"true"`
 	AgentMaxIdleTime           time.Duration
 	AgentWatchRetryInterval    time.Duration `default:"10s"`
+	AgentRolloutInsteadOfEvict bool          `default:"false"`
 
 	ClientRoutingAlsoProxySubnets        []netip.Prefix `envSeparator:" "`
 	ClientRoutingNeverProxySubnets       []netip.Prefix `envSeparator:" "`

--- a/cmd/traffic/cmd/manager/mutator/eviction.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction.go
@@ -134,6 +134,30 @@ func (e disruptionBudgetError) Error() string {
 }
 
 func evictOrRollout(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, counter int) (didRollout bool, err error) {
+	// Check if rollout mode is enabled via environment variable
+	if managerutil.GetEnv(ctx).AgentRolloutInsteadOfEvict {
+		clog.Debugf(ctx, "Using rollout mode for %s (AGENT_ROLLOUT_INSTEAD_OF_EVICT=true)", wl)
+		// Add a small delay to ensure ConfigMap changes are propagated to admission webhook before rollout
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+		switch wl.GetKind() {
+		case k8sapi.StatefulSetKind, k8sapi.ReplicaSetKind:
+			return false, triggerScalingEviction(ctx, wl, pod)
+		default:
+			clog.Debugf(ctx, "Patching %s to trigger pod recreation", wl)
+			restartAnnotation := generateRestartAnnotationPatch(wl.GetPodTemplate().Annotations)
+			if err = wl.Patch(ctx, types.JSONPatchType, []byte(restartAnnotation)); err != nil {
+				return false, fmt.Errorf("unable to patch %s: %v", wl, err)
+			}
+			clog.Debugf(ctx, "Successfully patched %s", wl)
+		}
+		return true, nil
+	}
+
+	// Original behavior: try direct eviction first
 	err = evictPod(ctx, pod)
 	if err == nil {
 		return false, nil

--- a/cmd/traffic/cmd/manager/mutator/eviction_test.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction_test.go
@@ -1,0 +1,38 @@
+package mutator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateRestartAnnotationPatch(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantContains string
+	}{
+		{
+			name:         "no existing annotations",
+			annotations:  map[string]string{},
+			wantContains: "telepresence.getambassador.io/restartedAt",
+		},
+		{
+			name:         "existing restartedAt annotation",
+			annotations:  map[string]string{"telepresence.getambassador.io/restartedAt": "old-value"},
+			wantContains: "replace",
+		},
+		{
+			name:         "other annotations present",
+			annotations:  map[string]string{"other-key": "other-value"},
+			wantContains: "telepresence.getambassador.io/restartedAt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch := generateRestartAnnotationPatch(tt.annotations)
+			require.Contains(t, patch, tt.wantContains)
+		})
+	}
+}


### PR DESCRIPTION
## Description

**Change Summary**

This PR modifies how pods are replaced by introducing an option to use Kubernetes rolling updates instead of direct eviction.

**❗ Problem (Previous Behavior)**

Previously, the system attempted direct pod eviction first:

Called evictPod to immediately delete pods
If eviction succeeded, it returned early
Rolling updates were only used as a fallback when eviction failed (e.g., due to PodDisruptionBudget)
⚠️ Issue

This approach could terminate all pods at once before new ones (with traffic agents) were ready, leading to service disruption and downtime.

**✅ Solution (New Behavior)**

This change introduces a configurable option to always use Kubernetes rolling updates instead of direct eviction.

Pods are replaced gradually, not all at once
Respects deployment settings like:
maxSurge
maxUnavailable
Ensures continuous availability during updates

**How to Enable:**
Via Helm
agent:
  rolloutInsteadOfEvict:
    enabled: true

**Via Environment Variable:**
AGENT_ROLLOUT_INSTEAD_OF_EVICT=true

🔄 Default Behavior
Default remains false
Existing deployments will continue using direct eviction
This ensures backward compatibility
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml`
- [x] I made sure to add any documentation changes required for my change.
- [x] My change is adequately tested.
- [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
- [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the CNCF Slack.