### PR TITLE
Client Stability: Bounded Intercept Dials

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -95,6 +95,14 @@ items:
           connect to the application through the pod IP reach the expected
           redirect and DNAT rules, avoiding missed routing when the pod IP does
           not use the loopback interface.
+      - type: bugfix
+        title: Bound selected-intercept dial responders
+        body: >-
+          Selected-intercept dial responders are now capped so bursty workloads
+          cannot make the client daemon fan out unbounded goroutines and gRPC
+          tunnels. VIF open failures also return a plain nil device and tolerate
+          partially initialized Linux devices during cleanup, making failed setup
+          paths safer.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -38,10 +38,22 @@ Injected traffic-agent configs now use a fully-qualified traffic-manager service
 Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>appProtocol</code> values such as <code>http</code> and <code>kubernetes.io/http</code>. This skips unnecessary TLS and HTTP/2 probing for known HTTP/1 services, avoiding request latency when those probes cannot connect through the inactive proxy port.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Add /usr/sbin to systemd root daemon path</div></div>
+<div style="margin-left: 15px">
+
+Ensures /usr/sbin is in the PATH used by the root daemon when it is run by systemd.  This ensures iptables can be found by the daemon.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Handle pod IP output traffic in agent init</div></div>
 <div style="margin-left: 15px">
 
 Injected init containers now route pod IP output traffic through the same traffic-agent iptables chains used for loopback traffic. This lets service mesh sidecars and traffic-agent forwarding paths that connect to the application through the pod IP reach the expected redirect and DNAT rules, avoiding missed routing when the pod IP does not use the loopback interface.
+</div>
+
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Bound selected-intercept dial responders</div></div>
+<div style="margin-left: 15px">
+
+Selected-intercept dial responders are now capped so bursty workloads cannot make the client daemon fan out unbounded goroutines and gRPC tunnels. VIF open failures also return a plain nil device and tolerate partially initialized Linux devices during cleanup, making failed setup paths safer.
 </div>
 
 ## Version 2.27.5

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -45,9 +45,21 @@ Traffic-agents now recognize common cleartext HTTP/1 Kubernetes Service <code>ap
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Add /usr/sbin to systemd root daemon path</Title>
+	<Body>
+Ensures /usr/sbin is in the PATH used by the root daemon when it is run by systemd.  This ensures iptables can be found by the daemon.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix">Handle pod IP output traffic in agent init</Title>
 	<Body>
 Injected init containers now route pod IP output traffic through the same traffic-agent iptables chains used for loopback traffic. This lets service mesh sidecars and traffic-agent forwarding paths that connect to the application through the pod IP reach the expected redirect and DNAT rules, avoiding missed routing when the pod IP does not use the loopback interface.
+  </Body>
+</Note>
+<Note>
+	<Title type="bugfix">Bound selected-intercept dial responders</Title>
+	<Body>
+Selected-intercept dial responders are now capped so bursty workloads cannot make the client daemon fan out unbounded goroutines and gRPC tunnels. VIF open failures also return a plain nil device and tolerate partially initialized Linux devices during cleanup, making failed setup paths safer.
   </Body>
 </Note>
 ## Version 2.27.5

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -32,6 +32,10 @@ const (
 	localDialTimeout = 2 * time.Second
 )
 
+// Limit selected-intercept dial responders so bursty workloads cannot create
+// unbounded goroutines and gRPC tunnels in the client daemon.
+const maxConcurrentDialResponders = 256
+
 const (
 	notConnected = int32(iota)
 	connecting
@@ -439,10 +443,22 @@ func DialWaitLoop(
 	// create ctx to clean up leftover dialRespond if waitloop dies
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	dialResponders := make(chan struct{}, maxConcurrentDialResponders)
 	for ctx.Err() == nil {
 		dr, err := dialStream.Recv()
 		if err == nil {
-			go dialRespond(ctx, tag, tunnelProvider, dr, sessionID)
+			select {
+			case dialResponders <- struct{}{}:
+			case <-ctx.Done():
+				return nil
+			}
+			dr := dr
+			go func() {
+				defer func() {
+					<-dialResponders
+				}()
+				dialRespond(ctx, tag, tunnelProvider, dr, sessionID)
+			}()
 			continue
 		}
 		if ctx.Err() != nil {

--- a/pkg/tunnel/dialer_test.go
+++ b/pkg/tunnel/dialer_test.go
@@ -1,0 +1,101 @@
+package tunnel
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+type blockingTunnelProvider struct {
+	active int32
+	max    int32
+	ready  chan struct{}
+	once   sync.Once
+}
+
+func newBlockingTunnelProvider() *blockingTunnelProvider {
+	return &blockingTunnelProvider{
+		ready: make(chan struct{}),
+	}
+}
+
+func (p *blockingTunnelProvider) Tunnel(ctx context.Context, _ ...grpc.CallOption) (Client, error) {
+	active := atomic.AddInt32(&p.active, 1)
+	for {
+		maxActive := atomic.LoadInt32(&p.max)
+		if active <= maxActive || atomic.CompareAndSwapInt32(&p.max, maxActive, active) {
+			break
+		}
+	}
+	if active == maxConcurrentDialResponders {
+		p.once.Do(func() {
+			close(p.ready)
+		})
+	}
+	defer atomic.AddInt32(&p.active, -1)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type dialRequestStream struct {
+	grpc.ClientStream
+	requests  <-chan *rpc.DialRequest
+	recvCount int32
+}
+
+func (s *dialRequestStream) Recv() (*rpc.DialRequest, error) {
+	atomic.AddInt32(&s.recvCount, 1)
+	dr, ok := <-s.requests
+	if !ok {
+		return nil, io.EOF
+	}
+	return dr, nil
+}
+
+func TestDialWaitLoopLimitsConcurrentDialResponders(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requests := make(chan *rpc.DialRequest, maxConcurrentDialResponders+10)
+	for i := 0; i < cap(requests); i++ {
+		requests <- &rpc.DialRequest{ConnId: []byte(NewZeroID())}
+	}
+
+	stream := &dialRequestStream{requests: requests}
+	provider := newBlockingTunnelProvider()
+	done := make(chan error, 1)
+	go func() {
+		done <- DialWaitLoop(ctx, AgentToClient, provider, stream, "session")
+	}()
+
+	select {
+	case <-provider.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %d active dial responders; got %d", maxConcurrentDialResponders, atomic.LoadInt32(&provider.max))
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&provider.max); got != maxConcurrentDialResponders {
+		t.Fatalf("max active dial responders = %d, want %d", got, maxConcurrentDialResponders)
+	}
+	if got := atomic.LoadInt32(&stream.recvCount); got > maxConcurrentDialResponders+1 {
+		t.Fatalf("DialWaitLoop read %d requests while responders were saturated, want at most %d", got, maxConcurrentDialResponders+1)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("DialWaitLoop returned error after cancellation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for DialWaitLoop to exit")
+	}
+}

--- a/pkg/vif/device.go
+++ b/pkg/vif/device.go
@@ -22,7 +22,14 @@ var _ Device = (*device)(nil)
 
 // OpenTun creates a new TUN device and ensures that it is up and running.
 func OpenTun(ctx context.Context) (Device, error) {
-	return openTun(ctx)
+	return deviceResult(openTun(ctx))
+}
+
+func deviceResult(dev *device, err error) (Device, error) {
+	if err != nil {
+		return nil, err
+	}
+	return dev, nil
 }
 
 // AddSubnet adds a subnet to this TUN device and creates a route for that subnet which

--- a/pkg/vif/device_linux.go
+++ b/pkg/vif/device_linux.go
@@ -138,8 +138,12 @@ func (d *device) createLinkEndpoint() (stack.LinkEndpoint, error) {
 }
 
 func (d *device) Close() {
-	d.endPoint.Close()
-	_ = unix.Close(d.fd)
+	if d.endPoint != nil {
+		d.endPoint.Close()
+	}
+	if d.fd >= 0 {
+		_ = unix.Close(d.fd)
+	}
 }
 
 func (d *device) WaitForDevice() {

--- a/pkg/vif/device_test.go
+++ b/pkg/vif/device_test.go
@@ -1,0 +1,16 @@
+package vif
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDeviceResultReturnsNilInterfaceOnError(t *testing.T) {
+	dev, err := deviceResult(nil, errors.New("open tun failed"))
+	if err == nil {
+		t.Fatal("deviceResult returned nil error")
+	}
+	if dev != nil {
+		t.Fatalf("deviceResult returned non-nil device on error: %#v", dev)
+	}
+}


### PR DESCRIPTION
## Description

Sometimes when using intercepts with web sites (especially things like vite + HMR) - the website would loads _thousands_ of resources at once (sigh, I know) and that could cause telepresence to die. 

After some back and forth - I think this is the right fix: Limit selected-intercept dial responders so bursty workloads cannot make the client daemon fan out without bound. Let me know if you want to change this number, for now it's hard coded. This seems to work for us, and now the super bursty traffic doesn't make telepresence die. 

Also make VIF open failures return a plain nil device and tolerate partially initialized Linux devices during cleanup. 

Tests cover the concurrency cap and nil-device error path.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.