### PR TITLE
Give a helpful error message on the client if you try to connect to an unmanaged namespace

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -208,6 +208,15 @@ items:
           ReplicaSets, StatefulSets, and Argo Rollouts are now generated from the
           corresponding <code>workloads.*.enabled</code> settings. Disabling a workload
           kind no longer grants get, list, watch, or patch permissions for that kind.
+      - type: bugfix
+        title: Reject unmanaged mapped namespaces
+        body: >-
+          Clients now reject <code>--mapped-namespaces</code> values that are outside
+          the namespace set managed by a namespace-limited traffic-manager. Invalid
+          mapped namespace requests now fail during connect with a helpful error
+          instead of leaving the client connected with namespaces that cannot be
+          handled by the in-cluster manager or traffic-agents.
+        docs: reference/engagements/cli
   - version: 2.28.0
     date: 2026-05-11
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -104,6 +104,12 @@ The <code>agentInjector.webhook.objectSelector</code> Helm chart value accepts a
 Traffic-manager cluster- and namespace-scoped RBAC rules for Deployments, ReplicaSets, StatefulSets, and Argo Rollouts are now generated from the corresponding <code>workloads.*.enabled</code> settings. Disabling a workload kind no longer grants get, list, watch, or patch permissions for that kind.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Reject unmanaged mapped namespaces](reference/engagements/cli)</div></div>
+<div style="margin-left: 15px">
+
+Clients now reject <code>--mapped-namespaces</code> values that are outside the namespace set managed by a namespace-limited traffic-manager. Invalid mapped namespace requests now fail during connect with a helpful error instead of leaving the client connected with namespaces that cannot be handled by the in-cluster manager or traffic-agents.
+</div>
+
 ## Version 2.28.0 <span style="font-size: 16px;">(May 11)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Intercept workloads in mapped namespaces](reference/engagements/cli)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -110,6 +110,12 @@ The <code>agentInjector.webhook.objectSelector</code> Helm chart value accepts a
 Traffic-manager cluster- and namespace-scoped RBAC rules for Deployments, ReplicaSets, StatefulSets, and Argo Rollouts are now generated from the corresponding <code>workloads.*.enabled</code> settings. Disabling a workload kind no longer grants get, list, watch, or patch permissions for that kind.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix" docs="reference/engagements/cli">Reject unmanaged mapped namespaces</Title>
+	<Body>
+Clients now reject <code>--mapped-namespaces</code> values that are outside the namespace set managed by a namespace-limited traffic-manager. Invalid mapped namespace requests now fail during connect with a helpful error instead of leaving the client connected with namespaces that cannot be handled by the in-cluster manager or traffic-agents.
+  </Body>
+</Note>
 ## Version 2.28.0 <span style={{fontSize:'16px'}}>(May 11)</span>
 <Note>
 	<Title type="feature" docs="reference/engagements/cli">Intercept workloads in mapped namespaces</Title>

--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -118,7 +118,7 @@ func (s *multipleServicesSuite) Test_List() {
 	}
 }
 
-func (s *multipleServicesSuite) Test_ListOnlyMapped() {
+func (s *multipleServicesSuite) Test_RejectsUnmanagedMappedNamespace() {
 	ctx := itest.WithUser(s.Context(), "default")
 	require := s.Require()
 	itest.TelepresenceDisconnectOk(ctx)
@@ -127,13 +127,19 @@ func (s *multipleServicesSuite) Test_ListOnlyMapped() {
 		itest.TelepresenceDisconnectOk(ctx)
 		itest.TelepresenceOk(s.Context(), "connect", "--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace())
 	}()
-	s.TelepresenceConnect(ctx, "--mapped-namespaces", "default")
 
-	stdout := itest.TelepresenceOk(ctx, "list")
-	require.Contains(stdout, "No Workloads")
+	// This suite's traffic-manager only manages the app namespace. Mapping a namespace that it does
+	// not manage (here "default") must be rejected during connect, rather than leaving the client
+	// connected to namespaces that the manager and its traffic-agents cannot serve.
+	stdout, stderr, err := itest.Telepresence(ctx, "connect",
+		"--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace(),
+		"--mapped-namespaces", "default")
+	require.Error(err)
+	require.Contains(stdout+stderr, "are not managed by this traffic-manager")
 
+	// "all" resolves to the managed namespaces, so the connection succeeds and the workloads in the
+	// managed namespace are listed.
 	s.TelepresenceConnect(ctx, "--mapped-namespaces", "all")
-
 	stdout = itest.TelepresenceOk(ctx, "list")
 	require.NotContains(stdout, "No Workloads")
 }

--- a/integration_test/namespaces_test.go
+++ b/integration_test/namespaces_test.go
@@ -301,6 +301,14 @@ func (s *nsSuite) Test_NamespacesStatic() {
 	rq.Error(err)
 	rq.Contains(se, "beta is not managed")
 
+	_, se, err = itest.Telepresence(ctx,
+		"connect",
+		"--manager-namespace", s.managerNamespace(),
+		"--namespace", "alpha",
+		"--mapped-namespaces", "alpha,beta")
+	rq.Error(err)
+	rq.Contains(se, `mapped namespaces ["beta"] are not managed by this traffic-manager`)
+
 	// Switch to just using both alpha and beta
 	ctx = itest.WithNamespaces(s.Context(), &itest.Namespaces{
 		Namespace: s.managerNamespace(),

--- a/pkg/client/userd/trafficmgr/mapped_namespaces.go
+++ b/pkg/client/userd/trafficmgr/mapped_namespaces.go
@@ -1,0 +1,72 @@
+package trafficmgr
+
+import (
+	"slices"
+	"sort"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+)
+
+func normalizeMappedNamespaces(namespaces []string) ([]string, bool) {
+	if mappedNamespacesAll(namespaces) {
+		return nil, true
+	}
+	namespaces = slices.Clone(namespaces)
+	sort.Strings(namespaces)
+	return slices.Compact(namespaces), false
+}
+
+func mappedNamespacesAll(namespaces []string) bool {
+	return len(namespaces) == 1 && namespaces[0] == "all"
+}
+
+func effectiveMappedNamespaces(requestedNamespaces, clientNamespaces, managerNamespaces []string) ([]string, error) {
+	requestedNamespaces, requestedAll := normalizeMappedNamespaces(requestedNamespaces)
+	clientNamespaces, clientAll := normalizeMappedNamespaces(clientNamespaces)
+	managerNamespaces, _ = normalizeMappedNamespaces(managerNamespaces)
+
+	var namespaces []string
+	switch {
+	case requestedAll:
+		return managerNamespaces, nil
+	case len(requestedNamespaces) > 0:
+		namespaces = requestedNamespaces
+	case clientAll:
+		return managerNamespaces, nil
+	case len(clientNamespaces) > 0:
+		namespaces = clientNamespaces
+	case len(managerNamespaces) > 0:
+		return managerNamespaces, nil
+	}
+	if err := ensureMappedNamespacesManaged(namespaces, managerNamespaces); err != nil {
+		return nil, err
+	}
+	return namespaces, nil
+}
+
+func ensureMappedNamespacesManaged(requestedNamespaces, managerNamespaces []string) error {
+	if len(requestedNamespaces) == 0 || len(managerNamespaces) == 0 {
+		return nil
+	}
+
+	managed := make(map[string]struct{}, len(managerNamespaces))
+	for _, namespace := range managerNamespaces {
+		managed[namespace] = struct{}{}
+	}
+
+	var unmanaged []string
+	for _, namespace := range requestedNamespaces {
+		if _, ok := managed[namespace]; !ok {
+			unmanaged = append(unmanaged, namespace)
+		}
+	}
+	if len(unmanaged) == 0 {
+		return nil
+	}
+
+	return errcat.User.Newf(
+		"mapped namespaces %q are not managed by this traffic-manager; managed namespaces are %q. "+
+			"Reconnect with --mapped-namespaces limited to managed namespaces, or reconfigure the traffic-manager to also manage %q",
+		unmanaged, managerNamespaces, unmanaged,
+	)
+}

--- a/pkg/client/userd/trafficmgr/mapped_namespaces_test.go
+++ b/pkg/client/userd/trafficmgr/mapped_namespaces_test.go
@@ -1,0 +1,54 @@
+package trafficmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveMappedNamespacesRejectsUnmanagedRequestedNamespace(t *testing.T) {
+	namespaces, err := effectiveMappedNamespaces(
+		[]string{"alpha", "beta"},
+		nil,
+		[]string{"alpha"},
+	)
+
+	require.Error(t, err)
+	require.Nil(t, namespaces)
+	require.Contains(t, err.Error(), `mapped namespaces ["beta"] are not managed by this traffic-manager`)
+	require.Contains(t, err.Error(), `managed namespaces are ["alpha"]`)
+}
+
+func TestEffectiveMappedNamespacesRejectsUnmanagedClientConfigNamespace(t *testing.T) {
+	namespaces, err := effectiveMappedNamespaces(
+		nil,
+		[]string{"beta"},
+		[]string{"alpha"},
+	)
+
+	require.Error(t, err)
+	require.Nil(t, namespaces)
+	require.Contains(t, err.Error(), `mapped namespaces ["beta"] are not managed by this traffic-manager`)
+}
+
+func TestEffectiveMappedNamespacesUsesManagerNamespacesWhenAllRequested(t *testing.T) {
+	namespaces, err := effectiveMappedNamespaces(
+		[]string{"all"},
+		[]string{"beta"},
+		[]string{"alpha", "gamma"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "gamma"}, namespaces)
+}
+
+func TestEffectiveMappedNamespacesAllowsGlobalManager(t *testing.T) {
+	namespaces, err := effectiveMappedNamespaces(
+		[]string{"beta"},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"beta"}, namespaces)
+}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -212,7 +212,11 @@ func NewSession(
 		return nil, nil,
 			fmt.Errorf("traffic manager version %s is too old. Minimum supported version is 2.21.0, please upgrade", tmgr.managerVersion)
 	}
-	tmgr.updateClientConfig(ctx, cr.MappedNamespaces)
+	if err = tmgr.updateClientConfig(ctx, cr.MappedNamespaces); err != nil {
+		tmgr.depart(ctx)
+		tmgr.managerConn.Close()
+		return nil, nil, err
+	}
 
 	oi := tmgr.getNetworkInfo(cr)
 	if !service.RootSessionInProcess() {
@@ -584,6 +588,16 @@ func (s *session) SessionInfo() *manager.SessionInfo {
 	return s.sessionInfo
 }
 
+func (s *session) depart(ctx context.Context) {
+	c, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
+	defer cancel()
+	if _, err := s.ManagerClient().Depart(c, s.SessionInfo()); err != nil {
+		clog.Debugf(c, "failed to depart from manager after connect error: %v", err)
+	} else if err = deleteSessionInfoFromUserCache(c, s.daemonID); err != nil {
+		clog.Debugf(c, "failed to delete session from user cache after connect error: %v", err)
+	}
+}
+
 // getInfosForWorkloads returns a list of workloads found in the given namespace that fulfils the given filter criteria.
 func (s *session) getInfosForWorkloads(
 	namespaces []string,
@@ -844,7 +858,9 @@ func (s *session) UpdateStatus(ctx context.Context, cr *rpc.ConnectRequest) (*rp
 	if err != nil {
 		return nil, err
 	}
-	s.updateClientConfig(ctx, cr.MappedNamespaces)
+	if err := s.updateClientConfig(ctx, cr.MappedNamespaces); err != nil {
+		return nil, err
+	}
 	return s.Status(ctx)
 }
 
@@ -852,7 +868,7 @@ func (s *session) Status(ctx context.Context) (*rpc.ConnectInfo, error) {
 	return s.status(ctx, false)
 }
 
-func (s *session) updateClientConfig(ctx context.Context, namespaces []string) {
+func (s *session) updateClientConfig(ctx context.Context, namespaces []string) error {
 	var tmCfg client.Config
 	cliCfg, err := s.ManagerClient().GetClientConfig(ctx, &empty.Empty{})
 	if err != nil {
@@ -875,15 +891,9 @@ func (s *session) updateClientConfig(ctx context.Context, namespaces []string) {
 
 		// We do not want to override the local config with the traffic-manager's config even if the local config is empty.
 		cfg.Cluster().MappedNamespaces = clientMappedNamespaces
-		switch {
-		case len(namespaces) > 0:
-			// Use the namespaces specified by the user.
-		case len(clientMappedNamespaces) > 0:
-			// Use the namespaces specified by the client configuration.
-			namespaces = clientMappedNamespaces
-		case len(tmMappedNamespaces) > 0:
-			// Use the namespaces specified by the traffic-manager.
-			namespaces = tmMappedNamespaces
+		namespaces, err = effectiveMappedNamespaces(namespaces, clientMappedNamespaces, tmMappedNamespaces)
+		if err != nil {
+			return err
 		}
 		if s.SetMappedNamespaces(namespaces) {
 			if len(namespaces) == 0 {
@@ -910,6 +920,7 @@ func (s *session) updateClientConfig(ctx context.Context, namespaces []string) {
 			clog.Debug(s, sc.Text())
 		}
 	}
+	return nil
 }
 
 func (s *session) status(ctx context.Context, initial bool) (*rpc.ConnectInfo, error) {


### PR DESCRIPTION
## Description

We run a lot of namespace, so our traffic-manager is scoped to a subset. Sometimes, teammates will accidentally try to use a namespace traffic-manger is not currently managing. This results in cryptic/non-clear errors (timeouts usually). Instead, explicitly error out so folks know what's happening. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [x] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.