### PR TITLE
Stability improvements for intercepts

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -111,6 +111,15 @@ items:
           tunnels. VIF open failures also return a plain nil device and tolerate
           partially initialized Linux devices during cleanup, making failed setup
           paths safer.
+      - type: bugfix
+        title: Improve selected-intercept tunnel stability
+        body: >-
+          Selected-intercept tunnels now reconnect agent dial watchers with
+          backoff, clean up pending forward state more carefully, and use
+          dedicated timeouts for traffic-agent connects and intercepted endpoint
+          dials. Telepresence also rejects queued dial requests when responder
+          capacity is saturated, giving busy intercepts a clearer failure mode
+          instead of letting work grow without limit.
   - version: 2.27.5
     date: (TBD)
     notes:

--- a/cmd/traffic/cmd/agent/fwd/http.go
+++ b/cmd/traffic/cmd/agent/fwd/http.go
@@ -11,6 +11,9 @@ import (
 	"net/http/httputil"
 	"net/netip"
 	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/go-json-experiment/json"
 	"golang.org/x/net/http2"
@@ -21,6 +24,71 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
+
+const (
+	httpInterceptSlowAfter = 2 * time.Second
+	httpInterceptVerySlow  = 10 * time.Second
+
+	httpInterceptMaxIdleConns        = 512
+	httpInterceptMaxIdleConnsPerHost = 128
+	httpInterceptMaxConnsPerHost     = 128
+)
+
+type observedResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	bytes      int64
+}
+
+func (w *observedResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *observedResponseWriter) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *observedResponseWriter) Write(p []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes += int64(n)
+	return n, err
+}
+
+func (w *observedResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+type httpInterceptDialContextKey struct{}
+
+type httpInterceptDialContext struct {
+	src       netip.AddrPort
+	ii        *manager.InterceptInfo
+	requestID uint64
+}
+
+type httpInterceptTransport struct {
+	key       string
+	targetURL *url.URL
+	transport *http.Transport
+}
+
+type metricsReportingConn struct {
+	net.Conn
+	once   sync.Once
+	report func()
+}
+
+func (c *metricsReportingConn) Close() error {
+	err := c.Conn.Close()
+	c.once.Do(c.report)
+	return err
+}
 
 func (f *tcp) protocols(ctx context.Context, plainText bool) *http.Protocols {
 	pr := new(http.Protocols)
@@ -185,6 +253,9 @@ func (f *tcp) configureUpstreamTransport(ctx context.Context, plaintext bool) *h
 	tm := f.tlsManager
 	tp := f.Target().Port()
 	trn := f.configureTransport(ctx, plaintext)
+	trn.MaxIdleConns = max(trn.MaxIdleConns, httpInterceptMaxIdleConns)
+	trn.MaxIdleConnsPerHost = max(trn.MaxIdleConnsPerHost, httpInterceptMaxIdleConnsPerHost)
+	trn.MaxConnsPerHost = max(trn.MaxConnsPerHost, httpInterceptMaxConnsPerHost)
 	if plaintext {
 		return trn
 	}
@@ -203,6 +274,107 @@ func (f *tcp) configureUpstreamTransport(ctx context.Context, plaintext bool) *h
 	return trn
 }
 
+func httpInterceptTransportKey(ii *manager.InterceptInfo) string {
+	if ii == nil || ii.Spec == nil || ii.ClientSession == nil {
+		return ""
+	}
+	spec := ii.Spec
+	return fmt.Sprintf("%s|%s|%s|%d|%t", ii.Id, ii.ClientSession.SessionId, spec.TargetHost, spec.TargetPort, spec.Plaintext)
+}
+
+func (f *tcp) getHTTPInterceptTransport(ctx context.Context, ii *manager.InterceptInfo) *httpInterceptTransport {
+	key := httpInterceptTransportKey(ii)
+	if cached, ok := f.httpTransportCache.Load(key); ok {
+		return cached.(*httpInterceptTransport)
+	}
+
+	spec := ii.Spec
+	trn := f.configureUpstreamTransport(ctx, spec.Plaintext)
+	trn.DialContext = func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+		di, ok := dialCtx.Value(httpInterceptDialContextKey{}).(*httpInterceptDialContext)
+		if !ok {
+			return nil, fmt.Errorf("missing HTTP selected intercept dial context for intercept %s", ii.Id)
+		}
+
+		f.mu.Lock()
+		sp := f.streamProvider
+		f.mu.Unlock()
+
+		metricsEnabled := sp != nil && sp.MetricsEnabled()
+		var ingressBytes, egressBytes *tunnel.CounterProbe
+		if metricsEnabled {
+			ingressBytes = tunnel.NewCounterProbe("FromClientBytes")
+			egressBytes = tunnel.NewCounterProbe("ToClientBytes")
+		}
+
+		s, err := f.createStream(dialCtx, di.src, di.ii)
+		if err != nil {
+			return nil, err
+		}
+		// Ingress and egress swap places here because this is a connection where the stream is attached to a connection *to* the client, not *from* the client.
+		conn := tunnel.NewStreamConn(dialCtx, s, egressBytes, ingressBytes)
+		if !metricsEnabled {
+			return conn, nil
+		}
+		return &metricsReportingConn{
+			Conn: conn,
+			report: func() {
+				sp.ReportMetrics(f.lCtx, &manager.TunnelMetrics{
+					ClientSessionId: di.ii.ClientSession.SessionId,
+					IngressBytes:    ingressBytes.GetValue(),
+					EgressBytes:     egressBytes.GetValue(),
+				})
+			},
+		}, nil
+	}
+
+	scheme := "http"
+	if trn.Protocols.HTTP2() {
+		scheme = "https"
+	}
+	hit := &httpInterceptTransport{
+		key:       key,
+		targetURL: &url.URL{Scheme: scheme, Host: iputil.JoinHostPort(spec.TargetHost, uint16(spec.TargetPort))},
+		transport: trn,
+	}
+	actual, loaded := f.httpTransportCache.LoadOrStore(key, hit)
+	if loaded {
+		trn.CloseIdleConnections()
+		return actual.(*httpInterceptTransport)
+	}
+	return hit
+}
+
+func (f *tcp) pruneHTTPInterceptTransports(intercepts []*manager.InterceptInfo) {
+	if len(intercepts) == 0 {
+		f.httpTransportCache.Range(func(key, value any) bool {
+			if hit, ok := value.(*httpInterceptTransport); ok {
+				hit.transport.CloseIdleConnections()
+			}
+			f.httpTransportCache.Delete(key)
+			return true
+		})
+		return
+	}
+
+	active := make(map[string]struct{}, len(intercepts))
+	for _, ii := range intercepts {
+		if key := httpInterceptTransportKey(ii); key != "" {
+			active[key] = struct{}{}
+		}
+	}
+	f.httpTransportCache.Range(func(key, value any) bool {
+		if _, ok := active[key.(string)]; ok {
+			return true
+		}
+		if hit, ok := value.(*httpInterceptTransport); ok {
+			hit.transport.CloseIdleConnections()
+		}
+		f.httpTransportCache.Delete(key)
+		return true
+	})
+}
+
 func (f *tcp) serveHTTPIntercept(
 	ctx context.Context,
 	src netip.AddrPort,
@@ -212,66 +384,93 @@ func (f *tcp) serveHTTPIntercept(
 	defaultHandler http.Handler,
 ) {
 	spec := ii.Spec
-	f.mu.Lock()
-	sp := f.streamProvider
-	f.mu.Unlock()
-
-	metricsEnabled := sp != nil && sp.MetricsEnabled()
-	var ingressBytes, egressBytes *tunnel.CounterProbe
-	if metricsEnabled {
-		ingressBytes = tunnel.NewCounterProbe("FromClientBytes")
-		egressBytes = tunnel.NewCounterProbe("ToClientBytes")
+	requestID := f.httpRequestID.Add(1)
+	requestStart := time.Now()
+	method := request.Method
+	path := request.URL.RequestURI()
+	if path == "" {
+		path = request.URL.Path
 	}
-	trn := f.configureUpstreamTransport(ctx, spec.Plaintext)
-	trn.DialContext = func(context.Context, string, string) (net.Conn, error) {
-		s, err := f.createStream(ctx, src, ii)
-		if err != nil {
-			return nil, err
-		}
-		// Ingress and egress swap places here because this is a connection where the stream is attached to a connection *to* the client, not *from* the client.
-		return tunnel.NewStreamConn(ctx, s, egressBytes, ingressBytes), nil
-	}
+	host := request.Host
+	var slowLogged atomic.Bool
+	slowTimer := time.AfterFunc(httpInterceptSlowAfter, func() {
+		slowLogged.Store(true)
+		clog.Warnf(
+			ctx,
+			"HTTP selected intercept request still active after %s: request=%d intercept=%s clientSession=%s method=%s host=%q path=%q src=%s target=%s:%d",
+			time.Since(requestStart).Round(time.Millisecond),
+			requestID,
+			ii.Id,
+			ii.ClientSession.SessionId,
+			method,
+			host,
+			path,
+			src,
+			spec.TargetHost,
+			spec.TargetPort,
+		)
+	})
+	defer slowTimer.Stop()
 
-	scheme := "http"
-	if trn.Protocols.HTTP2() {
-		scheme = "https"
-	}
-	trg := &url.URL{Scheme: scheme, Host: iputil.JoinHostPort(spec.TargetHost, uint16(spec.TargetPort))}
-
-	if tlsConfig := trn.TLSClientConfig; tlsConfig != nil {
+	hit := f.getHTTPInterceptTransport(ctx, ii)
+	if tlsConfig := hit.transport.TLSClientConfig; tlsConfig != nil {
 		if len(tlsConfig.Certificates) > 0 {
-			clog.Debugf(ctx, "Using a client certificate when connecting to %s", trg)
+			clog.Debugf(ctx, "Using a client certificate when connecting to %s", hit.targetURL)
 		} else {
-			clog.Debugf(ctx, "Not using a client certificate when connecting to %s", trg)
+			clog.Debugf(ctx, "Not using a client certificate when connecting to %s", hit.targetURL)
 		}
 		if tlsConfig.InsecureSkipVerify {
-			clog.Warnf(ctx, "Skipping verification of server's certificate chain and host name when connecting to %s", trg)
+			clog.Warnf(ctx, "Skipping verification of server's certificate chain and host name when connecting to %s", hit.targetURL)
 		}
 	} else {
-		clog.Debugf(ctx, "No TLS config used when connecting to %s", trg)
+		clog.Debugf(ctx, "No TLS config used when connecting to %s", hit.targetURL)
 	}
-	targetProxy := httputil.NewSingleHostReverseProxy(trg)
+	targetProxy := httputil.NewSingleHostReverseProxy(hit.targetURL)
 	targetProxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
 		if errors.Is(err, errClientStream) {
-			clog.Warnf(ctx, "Intercept tunnel unavailable for %s %s; failing open to app container: %v", req.Method, req.URL.Path, err)
+			clog.Warnf(ctx, "HTTP selected intercept tunnel unavailable for request=%d %s %s; failing open to app container: %v", requestID, req.Method, req.URL.Path, err)
 			defaultHandler.ServeHTTP(rw, req)
 			return
 		}
+		clog.Warnf(ctx, "HTTP selected intercept proxy error for request=%d %s %s: %v", requestID, req.Method, req.URL.Path, err)
 		proxyErrorHandler(rw, req, err)
 	}
-	targetProxy.Transport = trn
-	targetProxy.ServeHTTP(writer, request)
+	targetProxy.Transport = hit.transport
+	observedWriter := &observedResponseWriter{ResponseWriter: writer}
+	request = request.WithContext(context.WithValue(request.Context(), httpInterceptDialContextKey{}, &httpInterceptDialContext{
+		src:       src,
+		ii:        ii,
+		requestID: requestID,
+	}))
+	targetProxy.ServeHTTP(observedWriter, request)
 
-	if metricsEnabled {
-		clog.Debugf(ctx, "Connection to %s ended. IngressBytes: %d, egressBytes: %d", trg, ingressBytes.GetValue(), egressBytes.GetValue())
-		sp.ReportMetrics(f.lCtx, &manager.TunnelMetrics{
-			ClientSessionId: ii.ClientSession.SessionId,
-			IngressBytes:    ingressBytes.GetValue(),
-			EgressBytes:     egressBytes.GetValue(),
-		})
-	} else {
-		clog.Debugf(ctx, "Connection to %s ended", trg)
+	duration := time.Since(requestStart)
+	statusCode := observedWriter.statusCode
+	if statusCode == 0 {
+		statusCode = -1
 	}
+	if slowLogged.Load() || duration > httpInterceptSlowAfter || statusCode == -1 {
+		logFn := clog.Infof
+		if duration > httpInterceptVerySlow || statusCode == -1 {
+			logFn = clog.Warnf
+		}
+		logFn(
+			ctx,
+			"HTTP selected intercept request finished after %s: request=%d intercept=%s clientSession=%s method=%s host=%q path=%q src=%s target=%s status=%d responseBytes=%d",
+			duration.Round(time.Millisecond),
+			requestID,
+			ii.Id,
+			ii.ClientSession.SessionId,
+			method,
+			host,
+			path,
+			src,
+			hit.targetURL,
+			statusCode,
+			observedWriter.bytes,
+		)
+	}
+	clog.Debugf(ctx, "Request to %s ended", hit.targetURL)
 }
 
 func proxyErrorHandler(rw http.ResponseWriter, _ *http.Request, err error) {

--- a/cmd/traffic/cmd/agent/fwd/tcp.go
+++ b/cmd/traffic/cmd/agent/fwd/tcp.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/telepresenceio/clog"
@@ -22,8 +23,10 @@ var errClientStream = errors.New("failed to create client stream")
 
 type tcp struct {
 	*interceptor
-	tlsManager     tls.Manager
-	listenerSwitch ListenerSwitch
+	tlsManager         tls.Manager
+	listenerSwitch     ListenerSwitch
+	httpRequestID      atomic.Uint64
+	httpTransportCache sync.Map
 }
 
 func NewTCPInterceptor(ctx context.Context, listenPort types.PortAndProto, tag tunnel.Tag, tlsManager tls.Manager, target netip.AddrPort) Interceptor {
@@ -40,6 +43,7 @@ func (f *tcp) IsHTTP() bool {
 // SetIntercepting overrides the base implementation to handle HTTP intercepts.
 func (f *tcp) SetIntercepting(intercepts []*manager.InterceptInfo) {
 	f.interceptor.SetIntercepting(intercepts)
+	f.pruneHTTPInterceptTransports(intercepts)
 	f.setListenerSwitch()
 }
 
@@ -191,9 +195,37 @@ func (f *tcp) createStream(ctx context.Context, src netip.AddrPort, ii *manager.
 	f.mu.Lock()
 	sp := f.streamProvider
 	f.mu.Unlock()
+	start := time.Now()
 	s, err := sp.CreateClientStream(ctx, tunnel.AgentToClient, clientSession, id, latency, timeout)
 	if err != nil {
+		clog.Warnf(
+			ctx,
+			"failed to create agent-to-client intercept stream after %s: intercept=%s clientSession=%s conn=%s src=%s dst=%s target=%s:%d error=%v",
+			time.Since(start).Round(time.Millisecond),
+			ii.Id,
+			clientSession,
+			id,
+			src,
+			dst,
+			spec.TargetHost,
+			spec.TargetPort,
+			err,
+		)
 		return nil, fmt.Errorf("%w: %w", errClientStream, err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		clog.Warnf(
+			ctx,
+			"created agent-to-client intercept stream slowly after %s: intercept=%s clientSession=%s conn=%s src=%s dst=%s target=%s:%d",
+			elapsed.Round(time.Millisecond),
+			ii.Id,
+			clientSession,
+			id,
+			src,
+			dst,
+			spec.TargetHost,
+			spec.TargetPort,
+		)
 	}
 	return s, nil
 }

--- a/cmd/traffic/cmd/agent/fwd/tcp_test.go
+++ b/cmd/traffic/cmd/agent/fwd/tcp_test.go
@@ -3,11 +3,14 @@ package fwd
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
 
 func TestTCPDispatch_HTTPMechanism_Handled(t *testing.T) {
@@ -56,4 +59,35 @@ func TestTCPDispatch_NoMechanism_NotHandled(t *testing.T) {
 	f.SetIntercepting([]*manager.InterceptInfo{intercept})
 	handled = f.IsHTTP()
 	require.False(t, handled)
+}
+
+func TestHTTPInterceptTransportReusedAndPruned(t *testing.T) {
+	f := NewTCPInterceptor(
+		context.Background(),
+		types.PortAndProto{Port: 3000, Proto: types.ProtoTCP},
+		tunnel.AgentToClient,
+		nil,
+		netip.MustParseAddrPort("127.0.0.1:3000"),
+	).(*tcp)
+	ii := &manager.InterceptInfo{
+		Id:            "intercept-id",
+		ClientSession: &manager.SessionInfo{SessionId: "client-session"},
+		Spec: &manager.InterceptSpec{
+			TargetHost:    "127.0.0.1",
+			TargetPort:    3000,
+			HeaderFilters: map[string]string{"X-Test": "value"},
+		},
+	}
+
+	first := f.getHTTPInterceptTransport(context.Background(), ii)
+	second := f.getHTTPInterceptTransport(context.Background(), ii)
+	require.Same(t, first, second)
+
+	key := httpInterceptTransportKey(ii)
+	_, ok := f.httpTransportCache.Load(key)
+	require.True(t, ok)
+
+	f.SetIntercepting(nil)
+	_, ok = f.httpTransportCache.Load(key)
+	require.False(t, ok)
 }

--- a/cmd/traffic/cmd/agent/server.go
+++ b/cmd/traffic/cmd/agent/server.go
@@ -27,6 +27,11 @@ type awaitingForward struct {
 	doneCh   <-chan struct{}
 }
 
+const (
+	clientTunnelSlowAfter       = time.Second
+	clientTunnelStillWaitingLog = 5 * time.Second
+)
+
 func (s *state) Version(context.Context, *emptypb.Empty) (*rpc.VersionInfo2, error) {
 	return &rpc.VersionInfo2{Name: DisplayName, Version: version.Version}, nil
 }
@@ -65,10 +70,14 @@ func (s *state) Tunnel(server agent.Agent_TunnelServer) error {
 	if err != nil {
 		return errors.FromError(err, codes.FailedPrecondition, err.Error())
 	}
+	tunnelStart := time.Now()
 	if awc, ok := s.awaitingForwards.Load(stream.SessionID()); ok {
 		if awf, ok := awc.LoadAndDelete(stream.ID()); ok {
 			awf.streamCh <- stream
 			<-awf.doneCh
+			if elapsed := time.Since(tunnelStart); elapsed > clientTunnelSlowAfter {
+				clog.Debugf(ctx, "agent tunnel for awaited client stream stayed open for %s: session=%s conn=%s", elapsed.Round(time.Millisecond), stream.SessionID(), stream.ID())
+			}
 			return nil
 		}
 	}
@@ -82,6 +91,9 @@ func (s *state) Tunnel(server agent.Agent_TunnelServer) error {
 	endPoint := tunnel.NewDialer(stream, func() {}, ingressBytes, egressBytes)
 	endPoint.Start(ctx)
 	<-endPoint.Done()
+	if elapsed := time.Since(tunnelStart); elapsed > clientTunnelSlowAfter {
+		clog.Debugf(ctx, "agent tunnel endpoint stayed open for %s: session=%s conn=%s", elapsed.Round(time.Millisecond), stream.SessionID(), stream.ID())
+	}
 
 	if reporting {
 		s.ReportMetrics(ctx, &rpc.TunnelMetrics{
@@ -95,13 +107,21 @@ func (s *state) Tunnel(server agent.Agent_TunnelServer) error {
 
 func (s *state) WatchDial(session *rpc.SessionInfo, server agent.Agent_WatchDialServer) error {
 	ctx := server.Context()
-	clog.Debugf(ctx, "WatchDial called from client %s", session.SessionId)
-	defer clog.Debugf(ctx, "WatchDial ended from client %s", session.SessionId)
+	started := time.Now()
+	clog.Infof(ctx, "WatchDial called from client %s", session.SessionId)
+	defer func() {
+		clog.Infof(ctx, "WatchDial ended from client %s after %s: context=%v", session.SessionId, time.Since(started).Round(time.Millisecond), ctx.Err())
+	}()
 	drCh := make(chan *rpc.DialRequest)
 	sid := tunnel.SessionID(session.SessionId)
 	s.dialWatchers.Store(sid, drCh)
 	defer func() {
-		s.dialWatchers.Delete(sid)
+		s.dialWatchers.Compute(sid, func(current chan *rpc.DialRequest, loaded bool) (chan *rpc.DialRequest, xsync.ComputeOp) {
+			if loaded && current == drCh {
+				return nil, xsync.DeleteOp
+			}
+			return current, xsync.CancelOp
+		})
 	}()
 
 	for {
@@ -123,7 +143,10 @@ func (s *state) WatchDial(session *rpc.SessionInfo, server agent.Agent_WatchDial
 func (s *state) CreateClientStream(ctx context.Context, _ tunnel.Tag, sessionID tunnel.SessionID, id tunnel.ConnID, roundTripLatency, dialTimeout time.Duration,
 ) (tunnel.Stream, error) {
 	clog.Debugf(ctx, "Creating tunnel to client %s for id %s", sessionID, id)
+	createStart := time.Now()
 	var drCh chan<- *rpc.DialRequest
+	var awc *xsync.Map[tunnel.ConnID, *awaitingForward]
+	var aw *awaitingForward
 	var stCh <-chan tunnel.Stream
 
 	// A retry is needed here because what actually happens is that the dial watcher channel drCh is inserted when the
@@ -133,10 +156,10 @@ func (s *state) CreateClientStream(ctx context.Context, _ tunnel.Tag, sessionID 
 		var ok bool
 		drCh, ok = s.dialWatchers.Load(sessionID)
 		if ok {
-			awc, _ := s.awaitingForwards.LoadOrCompute(sessionID, func() (*xsync.Map[tunnel.ConnID, *awaitingForward], bool) {
+			awc, _ = s.awaitingForwards.LoadOrCompute(sessionID, func() (*xsync.Map[tunnel.ConnID, *awaitingForward], bool) {
 				return xsync.NewMap[tunnel.ConnID, *awaitingForward](), false
 			})
-			aw, _ := awc.LoadOrCompute(id, func() (*awaitingForward, bool) {
+			aw, _ = awc.LoadOrCompute(id, func() (*awaitingForward, bool) {
 				return &awaitingForward{
 					streamCh: make(chan tunnel.Stream),
 					doneCh:   ctx.Done(),
@@ -148,18 +171,57 @@ func (s *state) CreateClientStream(ctx context.Context, _ tunnel.Tag, sessionID 
 		return fmt.Errorf("unable to create tunnel to client %s for id %s: no dial watcher", sessionID, id)
 	}, backoff.WithContext(backoff.NewConstantBackOff(20*time.Millisecond), ctx))
 	if err != nil {
+		clog.Warnf(ctx, "unable to create tunnel to client %s for id %s after %s: %v", sessionID, id, time.Since(createStart).Round(time.Millisecond), err)
 		return nil, err
 	}
+	defer func() {
+		if awc != nil && aw != nil {
+			awc.Compute(id, func(current *awaitingForward, loaded bool) (*awaitingForward, xsync.ComputeOp) {
+				if loaded && current == aw {
+					return nil, xsync.DeleteOp
+				}
+				return current, xsync.CancelOp
+			})
+		}
+	}()
 
-	drCh <- &rpc.DialRequest{ConnId: []byte(id), DialTimeout: int64(dialTimeout), RoundtripLatency: int64(roundTripLatency)}
-
+	requestStart := time.Now()
 	select {
 	case <-ctx.Done():
-		clog.Errorf(ctx, "unable to create tunnel to client %s for id %s: %v", sessionID, id, ctx.Done())
+		clog.Errorf(ctx, "unable to send DialRequest to client %s for id %s: %v", sessionID, id, ctx.Err())
 		return nil, ctx.Err()
-	case stream := <-stCh:
-		clog.Debugf(ctx, "Created tunnel to client %s for id %s", sessionID, id)
-		return stream, nil
+	case drCh <- &rpc.DialRequest{ConnId: []byte(id), DialTimeout: int64(dialTimeout), RoundtripLatency: int64(roundTripLatency)}:
+		if sendDuration := time.Since(requestStart); sendDuration > 100*time.Millisecond {
+			clog.Debugf(ctx, "Sent DialRequest to client %s for id %s after %s", sessionID, id, sendDuration)
+		}
+	}
+
+	waitLog := time.NewTimer(clientTunnelSlowAfter)
+	defer waitLog.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			clog.Errorf(ctx, "unable to create tunnel to client %s for id %s after %s: %v", sessionID, id, time.Since(requestStart).Round(time.Millisecond), ctx.Err())
+			return nil, ctx.Err()
+		case stream := <-stCh:
+			if elapsed := time.Since(requestStart); elapsed > clientTunnelSlowAfter {
+				clog.Warnf(ctx, "created tunnel to client %s for id %s slowly in %s", sessionID, id, elapsed.Round(time.Millisecond))
+			} else {
+				clog.Debugf(ctx, "Created tunnel to client %s for id %s in %s", sessionID, id, elapsed)
+			}
+			return stream, nil
+		case <-waitLog.C:
+			clog.Warnf(
+				ctx,
+				"still waiting for client tunnel after %s: clientSession=%s conn=%s dialTimeout=%s roundtripLatency=%s",
+				time.Since(requestStart).Round(time.Millisecond),
+				sessionID,
+				id,
+				dialTimeout,
+				roundTripLatency,
+			)
+			waitLog.Reset(clientTunnelStillWaitingLog)
+		}
 	}
 }
 

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -704,10 +704,14 @@ func (s *State) Tunnel(ctx context.Context, stream tunnel.Stream) error {
 }
 
 func (s *State) clientTunnel(ctx context.Context, client *ClientSession, stream tunnel.Stream) error {
+	start := time.Now()
 	scm := client.ConsumptionMetrics()
 	endPoint := tunnel.NewDialer(stream, func() {}, scm.FromClientBytes, scm.ToClientBytes)
 	endPoint.Start(ctx)
 	<-endPoint.Done()
+	if elapsed := time.Since(start); elapsed > time.Second {
+		clog.Debugf(ctx, "manager client tunnel stayed open for %s: session=%s conn=%s", elapsed.Round(time.Millisecond), stream.SessionID(), stream.ID())
+	}
 	return nil
 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -62,6 +62,12 @@ Injected init containers now route pod IP output traffic through the same traffi
 Selected-intercept dial responders are now capped so bursty workloads cannot make the client daemon fan out unbounded goroutines and gRPC tunnels. VIF open failures also return a plain nil device and tolerate partially initialized Linux devices during cleanup, making failed setup paths safer.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Improve selected-intercept tunnel stability</div></div>
+<div style="margin-left: 15px">
+
+Selected-intercept tunnels now reconnect agent dial watchers with backoff, clean up pending forward state more carefully, and use dedicated timeouts for traffic-agent connects and intercepted endpoint dials. Telepresence also rejects queued dial requests when responder capacity is saturated, giving busy intercepts a clearer failure mode instead of letting work grow without limit.
+</div>
+
 ## Version 2.27.5
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Clear agent intercept snapshot on reconnect to prevent stale intercepts](https://github.com/telepresenceio/telepresence/issues/4095)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -68,6 +68,12 @@ Injected init containers now route pod IP output traffic through the same traffi
 Selected-intercept dial responders are now capped so bursty workloads cannot make the client daemon fan out unbounded goroutines and gRPC tunnels. VIF open failures also return a plain nil device and tolerate partially initialized Linux devices during cleanup, making failed setup paths safer.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Improve selected-intercept tunnel stability</Title>
+	<Body>
+Selected-intercept tunnels now reconnect agent dial watchers with backoff, clean up pending forward state more carefully, and use dedicated timeouts for traffic-agent connects and intercepted endpoint dials. Telepresence also rejects queued dial requests when responder capacity is saturated, giving busy intercepts a clearer failure mode instead of letting work grow without limit.
+  </Body>
+</Note>
 ## Version 2.27.5
 <Note>
 	<Title type="bugfix" docs="https://github.com/telepresenceio/telepresence/issues/4095">Clear agent intercept snapshot on reconnect to prevent stale intercepts</Title>

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/puzpuzpuz/xsync/v4"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -40,12 +41,17 @@ type client struct {
 	remove          func()
 	cancelClient    context.CancelFunc
 	cancelDialWatch context.CancelFunc
-	connectErr      error
+	dialWatchID     uint64
 	tunnelCount     int32
 	lastActive      int64
 }
 
-const dormantLingerTime = 5 * time.Second
+const (
+	dormantLingerTime             = 5 * time.Second
+	dialWatcherReconnectInitial   = 250 * time.Millisecond
+	dialWatcherReconnectMax       = 5 * time.Second
+	dialWatcherReconnectResetTime = 30 * time.Second
+)
 
 func (ac *client) String() string {
 	if ac == nil {
@@ -60,11 +66,16 @@ func (ac *client) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tunnel.C
 	if err != nil {
 		return nil, err
 	}
+	start := time.Now()
 	clog.Tracef(ctx, "%s(%s) creating Tunnel over gRPC", ac, net.IP(ac.info.PodIp))
 	tc, err := cli.Tunnel(ctx, opts...)
+	elapsed := time.Since(start)
 	if err != nil {
-		clog.Tracef(ctx, "%s(%s) failed to create Tunnel over gRPC: %v", ac, net.IP(ac.info.PodIp), err)
+		clog.Warnf(ctx, "%s(%s) failed to create Tunnel over gRPC after %s: %v", ac, net.IP(ac.info.PodIp), elapsed.Round(time.Millisecond), err)
 		return nil, err
+	}
+	if elapsed > time.Second {
+		clog.Warnf(ctx, "%s(%s) created Tunnel over gRPC slowly in %s", ac, net.IP(ac.info.PodIp), elapsed.Round(time.Millisecond))
 	}
 	atomic.AddInt32(&ac.tunnelCount, 1)
 	clog.Tracef(ctx, "%s(%s) have %d active tunnels", ac, net.IP(ac.info.PodIp), atomic.LoadInt32(&ac.tunnelCount))
@@ -86,18 +97,21 @@ func (ac *client) ensureConnect(ctx context.Context) (agent.AgentClient, error) 
 }
 
 func (ac *client) ensureConnectLocked(ctx context.Context) (agent.AgentClient, error) {
-	if ac.connectErr != nil {
-		return nil, ac.connectErr
+	if ac.info.Intercepted {
+		ac.startDialWatcherLocked()
 	}
 
 	if ac.cli == nil {
-		dialCtx, dialCancel := context.WithTimeout(ctx, 5*time.Second)
+		tos := tpClient.GetConfig(ac).Timeouts()
+		dialCtx, dialCancel := tos.TimeoutContext(ctx, tpClient.TimeoutTrafficAgentConnect)
 		defer dialCancel()
 
 		ai := ac.info
 		conn, cli, _, err := ac.ConnectToAgent(dialCtx, ai.Namespace, ai.PodName, uint16(ai.ApiPort), types.UID(ai.PodId))
 		if err != nil {
-			ac.connectErr = err
+			if ac.info.Intercepted {
+				return nil, err
+			}
 
 			// There's a risk for deadlock here, because of the Range iteration of the map that performs cancel. This cancel will block
 			// because we're holding the lock now, and since the Range iteration holds a lock for the entry that we're about to delete,
@@ -122,12 +136,6 @@ func (ac *client) ensureConnectLocked(ctx context.Context) (agent.AgentClient, e
 		}
 	}
 
-	if ac.info.Intercepted {
-		err := ac.startDialWatcherLocked()
-		if err != nil {
-			return nil, err
-		}
-	}
 	atomic.StoreInt64(&ac.lastActive, time.Now().UnixNano())
 	return ac.cli, nil
 }
@@ -211,45 +219,118 @@ func (ac *client) refresh(ai *manager.AgentPodInfo) {
 	}
 }
 
-func (ac *client) startDialWatcherLocked() error {
+func (ac *client) startDialWatcherLocked() {
 	if ac.cancelDialWatch != nil {
 		// Already started
-		return nil
+		return
 	}
 	ctx, cancel := context.WithCancel(ac)
-
-	// Create the dial watcher
-	clog.Debugf(ctx, "watching dials from agent pod %s", ac)
-	dialStream, err := ac.cli.WatchDial(ctx, ac.session)
-	if err != nil {
-		cancel()
-		return err
-	}
-
+	ac.dialWatchID++
+	watchID := ac.dialWatchID
 	ac.cancelDialWatch = func() {
 		ac.Lock()
-		ac.info.Intercepted = false
-		ac.cancelDialWatch = nil
+		if ac.dialWatchID == watchID {
+			ac.cancelDialWatch = nil
+		}
 		ac.Unlock()
 		cancel()
 	}
 
-	go func() {
-		err := tunnel.DialWaitLoop(ctx, tunnel.AgentToClient, tunnel.AgentProvider(ac.cli), dialStream, tunnel.SessionID(ac.session.SessionId))
-		if err != nil {
-			// The traffic-agent closed the dial wait loop, which means that it's terminating.
-			clog.Error(ctx, err)
+	go ac.runDialWatcher(ctx, watchID)
+}
+
+func (ac *client) resetAgentClient() {
+	ac.Lock()
+	cancelClient := ac.cancelClient
+	ac.cancelClient = nil
+	ac.cli = nil
+	atomic.StoreInt32(&ac.tunnelCount, 0)
+	ac.Unlock()
+	if cancelClient != nil {
+		cancelClient()
+	}
+}
+
+func (ac *client) runDialWatcher(ctx context.Context, watchID uint64) {
+	started := time.Now()
+	clog.Debugf(ctx, "dial watcher %d starting for %s", watchID, ac)
+	defer func() {
+		ac.Lock()
+		if ac.dialWatchID == watchID {
+			ac.cancelDialWatch = nil
 		}
-		ai := ac.info
-		clog.Debugf(ctx, "DialWaitLoop ended for %s.%s", ai.PodName, ai.Namespace)
-		ac.RLock()
-		dwCancel := ac.cancelDialWatch
-		ac.RUnlock()
-		if dwCancel != nil {
-			dwCancel()
-		}
+		ac.Unlock()
+		clog.Debugf(
+			ctx,
+			"dial watcher %d stopped for %s after %s: context=%v cause=%v activeTunnels=%d intercepted=%t",
+			watchID,
+			ac,
+			time.Since(started).Round(time.Millisecond),
+			ctx.Err(),
+			context.Cause(ctx),
+			atomic.LoadInt32(&ac.tunnelCount),
+			ac.intercepted(),
+		)
 	}()
-	return nil
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = dialWatcherReconnectInitial
+	bo.MaxInterval = dialWatcherReconnectMax
+	bo.MaxElapsedTime = 0
+	bo.Reset()
+	lastConnected := time.Now()
+
+	for ctx.Err() == nil {
+		cli, err := ac.ensureConnect(ctx)
+		if err == nil {
+			ac.RLock()
+			session := ac.session
+			ai := ac.info
+			ac.RUnlock()
+
+			clog.Debugf(ctx, "watching dials from agent pod %s(%s)", ai.PodName, net.IP(ai.PodIp))
+			watchStarted := time.Now()
+			dialStream, watchErr := cli.WatchDial(ctx, session)
+			if watchErr == nil {
+				if time.Since(lastConnected) > dialWatcherReconnectResetTime {
+					bo.Reset()
+				}
+				lastConnected = time.Now()
+				watchErr = tunnel.DialWaitLoop(ctx, tunnel.AgentToClient, tunnel.AgentProvider(cli), dialStream, tunnel.SessionID(session.SessionId))
+			}
+			if watchErr != nil {
+				clog.Warnf(
+					ctx,
+					"dial watcher %d stream for %s ended after %s: %v activeTunnels=%d",
+					watchID,
+					ac,
+					time.Since(watchStarted).Round(time.Millisecond),
+					watchErr,
+					atomic.LoadInt32(&ac.tunnelCount),
+				)
+			}
+			err = watchErr
+		}
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err != nil {
+			clog.Warnf(ctx, "dial watcher for %s ended; reconnecting: %v", ac, err)
+			ac.resetAgentClient()
+		} else {
+			clog.Warnf(ctx, "dial watcher for %s ended unexpectedly; reconnecting", ac)
+		}
+
+		delay := bo.NextBackOff()
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
 }
 
 type Clients interface {
@@ -453,7 +534,7 @@ func (s *clients) WatchAgentPods(rmc manager.ManagerClient) error {
 			}
 			return true
 		})
-		clog.Debugf(s, "WatchAgentPods ending with %d clients still active", activeCount)
+		clog.Infof(s, "WatchAgentPods ending with %d clients still active", activeCount)
 		s.disabled.Store(true)
 	}()
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -323,8 +323,10 @@ type Timeouts struct {
 	PrivateEndpointDial          time.Duration `json:"endpointDial,format:units"`
 	PrivateHelm                  time.Duration `json:"helm,format:units"`
 	PrivateIntercept             time.Duration `json:"intercept,format:units"`
+	PrivateInterceptEndpointDial time.Duration `json:"interceptEndpointDial,format:units"`
 	PrivateRoundtripLatency      time.Duration `json:"roundtripLatency,format:units"`
 	PrivateProxyDial             time.Duration `json:"proxyDial,format:units"`
+	PrivateTrafficAgentConnect   time.Duration `json:"trafficAgentConnect,format:units"`
 	PrivateTrafficManagerAPI     time.Duration `json:"trafficManagerAPI,format:units"`
 	PrivateTrafficManagerConnect time.Duration `json:"trafficManagerConnect,format:units"`
 	PrivateTrafficAgentArrival   time.Duration `json:"trafficAgentArrival,format:units"` // Deprecated.
@@ -351,11 +353,17 @@ const (
 	// TimeoutIntercept is the time to wait for an intercept after the agents has been installed.
 	TimeoutIntercept
 
+	// TimeoutInterceptEndpointDial is how long an intercepted agent should wait for the client to dial the local endpoint.
+	TimeoutInterceptEndpointDial
+
 	// TimeoutProxyDial is how long to wait for the proxy to establish an outbound connection.
 	TimeoutProxyDial
 
 	// TimeoutRoundtripLatency is how much to add to the EndpointDial timeout when establishing a remote connection.
 	TimeoutRoundtripLatency
+
+	// TimeoutTrafficAgentConnect is how long to wait for a direct connection to an agent pod.
+	TimeoutTrafficAgentConnect
 
 	// TimeoutTrafficManagerAPI is how long to wait for the traffic-manager API to connect.
 	TimeoutTrafficManagerAPI
@@ -405,10 +413,14 @@ func (t *Timeouts) Get(timeoutID TimeoutID) time.Duration {
 		timeoutVal = t.PrivateHelm
 	case TimeoutIntercept:
 		timeoutVal = t.PrivateIntercept
+	case TimeoutInterceptEndpointDial:
+		timeoutVal = t.PrivateInterceptEndpointDial
 	case TimeoutProxyDial:
 		timeoutVal = t.PrivateProxyDial
 	case TimeoutRoundtripLatency:
 		timeoutVal = t.PrivateRoundtripLatency
+	case TimeoutTrafficAgentConnect:
+		timeoutVal = t.PrivateTrafficAgentConnect
 	case TimeoutTrafficManagerAPI:
 		timeoutVal = t.PrivateTrafficManagerAPI
 	case TimeoutTrafficManagerConnect:
@@ -466,12 +478,18 @@ func (e timeoutError) Error() string {
 	case TimeoutIntercept:
 		yamlName = "intercept"
 		humanName = "intercept"
+	case TimeoutInterceptEndpointDial:
+		yamlName = "interceptEndpointDial"
+		humanName = "intercept local endpoint dial"
 	case TimeoutProxyDial:
 		yamlName = "proxyDial"
 		humanName = "proxy dial"
 	case TimeoutRoundtripLatency:
 		yamlName = "roundtripDelay"
 		humanName = "additional delay for tunnel roundtrip"
+	case TimeoutTrafficAgentConnect:
+		yamlName = "trafficAgentConnect"
+		humanName = "port-forward connection to a traffic agent"
 	case TimeoutTrafficManagerAPI:
 		yamlName = "trafficManagerAPI"
 		humanName = "traffic manager gRPC API"
@@ -508,11 +526,13 @@ func CheckTimeout(ctx context.Context, err error) error {
 const (
 	defaultTimeoutsClusterConnect        = 20 * time.Second
 	defaultTimeoutsConnectivityCheck     = 500 * time.Millisecond
-	defaultTimeoutsEndpointDial          = 3 * time.Second
+	defaultTimeoutsEndpointDial          = 15 * time.Second
 	defaultTimeoutsHelm                  = 30 * time.Second
 	defaultTimeoutsIntercept             = 30 * time.Second
+	defaultTimeoutsInterceptEndpointDial = 15 * time.Second
 	defaultTimeoutsProxyDial             = 5 * time.Second
 	defaultTimeoutsRoundtripLatency      = 2 * time.Second
+	defaultTimeoutsTrafficAgentConnect   = 15 * time.Second
 	defaultTimeoutsTrafficManagerAPI     = 15 * time.Second
 	defaultTimeoutsTrafficManagerConnect = 60 * time.Second
 	defaultTimeoutsFtpReadWrite          = 1 * time.Minute
@@ -527,8 +547,10 @@ var defaultTimeouts = Timeouts{ //nolint:gochecknoglobals // constant
 	PrivateEndpointDial:          defaultTimeoutsEndpointDial,
 	PrivateHelm:                  defaultTimeoutsHelm,
 	PrivateIntercept:             defaultTimeoutsIntercept,
+	PrivateInterceptEndpointDial: defaultTimeoutsInterceptEndpointDial,
 	PrivateProxyDial:             defaultTimeoutsProxyDial,
 	PrivateRoundtripLatency:      defaultTimeoutsRoundtripLatency,
+	PrivateTrafficAgentConnect:   defaultTimeoutsTrafficAgentConnect,
 	PrivateTrafficManagerAPI:     defaultTimeoutsTrafficManagerAPI,
 	PrivateTrafficManagerConnect: defaultTimeoutsTrafficManagerConnect,
 	PrivateFtpReadWrite:          defaultTimeoutsFtpReadWrite,

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -23,6 +23,8 @@ func TestGetConfig(t *testing.T) {
 timeouts:
   clusterConnect: 25s
   proxyDial: 17s
+  trafficAgentConnect: 19s
+  interceptEndpointDial: 21s
 logLevels:
   rootDaemon: trace
 dns:
@@ -55,8 +57,10 @@ routing:
 
 	cfg = GetConfig(c)
 	to := cfg.Timeouts()
-	assert.Equal(t, 25*time.Second, to.PrivateClusterConnect)    // from user
-	assert.Equal(t, 17*time.Second, to.PrivateProxyDial)         // from user
+	assert.Equal(t, 25*time.Second, to.PrivateClusterConnect) // from user
+	assert.Equal(t, 17*time.Second, to.PrivateProxyDial)      // from user
+	assert.Equal(t, 19*time.Second, to.PrivateTrafficAgentConnect)
+	assert.Equal(t, 21*time.Second, to.PrivateInterceptEndpointDial)
 	assert.Equal(t, clog.LevelTrace, cfg.LogLevels().RootDaemon) // from user
 
 	assert.Equal(t, "testregistry.io", cfg.Images().PrivateRegistry)                             // from user

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -2,6 +2,8 @@ package rootd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -89,11 +91,11 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 		return nil, err
 	}
 
-	sessionCtx, sessionCancel := context.WithCancel(s)
+	sessionCtx, sessionCancel := context.WithCancelCause(s)
 	var sn *session
 	sn, err = createSession(client.WithConfig(sessionCtx, cfg), ctx, info, s.activity, dns.CleanupRouting)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to create root daemon session: %w", err))
 		return nil, err
 	}
 	if !s.managed {
@@ -107,7 +109,7 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 	sessionRunning := make(chan struct{})
 	go func() {
 		defer func() {
-			sessionCancel()
+			sessionCancel(context.Canceled)
 			if !s.managed {
 				// Restore log level from service config after session ends.
 				client.ReloadLogLevel(s)
@@ -123,18 +125,24 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 		return nil, status.Error(codes.Canceled, "session canceled")
 	case <-ctx.Done():
 		// gRPC context was canceled, probably by the caller.
-		sessionCancel()
+		sessionCancel(errors.New("root daemon Connect call canceled"))
 		return nil, status.Error(codes.Canceled, "connect call canceled")
 	case err = <-initErrCh:
 		if err != nil {
 			// Session failed to initialize.
-			sessionCancel()
+			sessionCancel(fmt.Errorf("root daemon session initialization failed: %w", err))
 			return nil, err
 		}
 		// Session initialized successfully.
 	}
 	s.session = sn
-	s.sessionCancel = sessionCancel
+	s.sessionCancel = func(cause error) {
+		if cause == nil {
+			cause = context.Canceled
+		}
+		clog.Infof(sn, "canceling root daemon session: %v", cause)
+		sessionCancel(cause)
+	}
 	s.sessionRunning = sessionRunning
 	return reply, nil
 }
@@ -157,7 +165,7 @@ func (s *service) cancelSession(ctx context.Context) {
 	// We must use a shared read lock when cancelling to avoid a deadlock.
 	var oldSession *session
 	err := s.withSession(ctx, func(_ context.Context, session *session) error {
-		s.sessionCancel()
+		s.sessionCancel(errors.New("root daemon Disconnect request"))
 		oldSession = session
 		return nil
 	})

--- a/pkg/client/rootd/service.go
+++ b/pkg/client/rootd/service.go
@@ -52,7 +52,7 @@ type service struct {
 	// sessionLock protects the session, sessionCancel, and sessionRunning fields.
 	sessionLock   sync.RWMutex
 	session       *session
-	sessionCancel context.CancelFunc
+	sessionCancel func(error)
 
 	// sessionRunning is closed when the session is done running.
 	sessionRunning chan struct{}
@@ -248,7 +248,7 @@ func runAliveAndCancellation(g log.Group, daemonPort uint16, cancel context.Canc
 		return il.WatchInfos(func(ctx context.Context) error {
 			ok, err := il.InfoExists(daemon.InfoFileName)
 			if err == nil && !ok {
-				clog.Debugf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemon.InfoFileName)
+				clog.Warnf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemon.InfoFileName)
 				cancel()
 			}
 			return err

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -1149,6 +1149,7 @@ func (s *session) hasPodConnectivity(info *manager.ClusterInfo) bool {
 }
 
 func (s *session) run(initErrs chan<- error) {
+	started := time.Now()
 	defer func() {
 		clog.Info(s, "-- session ended")
 	}()
@@ -1160,8 +1161,14 @@ func (s *session) run(initErrs chan<- error) {
 	}
 	close(initErrs)
 	err := g.Wait()
-	if err != nil {
-		clog.Errorf(s, "session ended with error: %v", err)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	switch {
+	case err != nil:
+		clog.Errorf(s, "session ended after %s with error: %v context=%v cause=%v", elapsed, err, s.Err(), context.Cause(s))
+	case s.Err() != nil:
+		clog.Infof(s, "session context ended after %s: context=%v cause=%v", elapsed, s.Err(), context.Cause(s))
+	default:
+		clog.Infof(s, "session services stopped cleanly after %s", elapsed)
 	}
 }
 

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -93,10 +93,10 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 	// Obtain the kubeconfig from the request parameters so that we can determine
 	// what kubernetes context that will be used.
 	var kubeConfig *k8s.Kubeconfig
-	sessionCtx, sessionCancel := context.WithCancel(s.Context)
+	sessionCtx, sessionCancel := context.WithCancelCause(s.Context)
 	kubeConfig, err = k8s.DaemonKubeconfig(client.WithConfig(sessionCtx, cfg), cr)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to obtain kubeconfig: %w", err))
 		if s.rootSessionInProc {
 			s.quit(true)
 		}
@@ -124,7 +124,7 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 	var session userd.Session
 	session, result, err = trafficmgr.NewSession(s, server.NewCombinedContext(s, ctx), cr, kubeConfig, wg)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to create user daemon session: %w", err))
 		if s.rootSessionInProc {
 			// Simplified session management. The daemon handles one session, then exits.
 			s.quit(true)
@@ -132,11 +132,15 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 		return nil, err
 	}
 	client.ReloadLogLevel(session)
-	s.sessionCancel = func() {
+	s.sessionCancel = func(cause error) {
+		if cause == nil {
+			cause = context.Canceled
+		}
+		clog.Infof(session, "canceling user daemon session: %v", cause)
 		if err := session.ClearIngestsAndIntercepts(); err != nil {
 			clog.Errorf(ctx, "failed to clear intercepts: %v", err)
 		}
-		sessionCancel()
+		sessionCancel(cause)
 	}
 	sessionRunning := make(chan struct{})
 	s.session = session
@@ -155,7 +159,10 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 		s.clearSession(session)
 	}()
 	if s.rootSessionInProc {
-		go runAliveAndCancellationSession(session, s.sessionCancel, daemonID, wg)
+		cancelUserSession := s.sessionCancel
+		go runAliveAndCancellationSession(session, func() {
+			cancelUserSession(errors.New("session daemon info file disappeared"))
+		}, daemonID, wg)
 	}
 	return result, err
 }
@@ -169,7 +176,7 @@ func (s *service) cancelSession(ctx context.Context, disconnectRoot bool) {
 	var oldSession userd.Session
 	err := s.withSession(ctx, func(_ context.Context, session userd.Session) error {
 		oldSession = session
-		s.sessionCancel()
+		s.sessionCancel(errors.New("connector Disconnect request"))
 		return nil
 	})
 	if err == nil && s.clearSession(oldSession) && disconnectRoot {

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -59,7 +59,7 @@ type service struct {
 
 	sessionLock    sync.RWMutex
 	session        userd.Session
-	sessionCancel  context.CancelFunc
+	sessionCancel  func(error)
 	sessionRunning chan struct{}
 
 	fuseFtpMgr remotefs.FuseFTPManager
@@ -213,7 +213,7 @@ func runAliveAndCancellation(g log.Group, cancel context.CancelFunc, daemonInfoF
 		return il.WatchInfos(func(ctx context.Context) error {
 			ok, err := il.InfoExists(daemonInfoFile)
 			if err == nil && !ok {
-				clog.Debugf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemonInfoFile)
+				clog.Warnf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemonInfoFile)
 				cancel()
 			}
 			return err

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -630,7 +630,7 @@ func (s *session) AddIntercept(ctx context.Context, ir *rpc.CreateInterceptReque
 	clog.Debugf(s, "creating intercept %s", spec.Name)
 	tos := client.GetConfig(ctx).Timeouts()
 	spec.RoundtripLatency = int64(tos.Get(client.TimeoutRoundtripLatency)) * 2 // Account for extra hop
-	spec.DialTimeout = int64(tos.Get(client.TimeoutEndpointDial))
+	spec.DialTimeout = int64(tos.Get(client.TimeoutInterceptEndpointDial))
 	c, cancel := tos.TimeoutContext(ctx, client.TimeoutIntercept)
 	defer cancel()
 

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -246,6 +246,7 @@ func (s *session) GetService() userd.Service {
 //     Services, and
 //   - (4) mount the appropriate remote volumes.
 func (s *session) Run() {
+	started := time.Now()
 	g := log.NewGroup(s)
 	defer func() {
 		_ = s.WithRootClient(context.WithoutCancel(s), func(ctx context.Context, rd rootdRpc.DaemonClient) error {
@@ -257,8 +258,14 @@ func (s *session) Run() {
 	}()
 	s.startServices(g)
 	err := g.Wait()
-	if err != nil {
-		clog.Errorf(s, "session ended with error: %v", err)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	switch {
+	case err != nil:
+		clog.Errorf(s, "session ended after %s with error: %v context=%v cause=%v", elapsed, err, s.Err(), context.Cause(s))
+	case s.Err() != nil:
+		clog.Infof(s, "session context ended after %s: context=%v cause=%v", elapsed, s.Err(), context.Cause(s))
+	default:
+		clog.Infof(s, "session services stopped cleanly after %s", elapsed)
 	}
 }
 

--- a/pkg/log/group.go
+++ b/pkg/log/group.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -35,5 +36,22 @@ func NewGroup(ctx context.Context) Group {
 
 // Go runs the given function in a goroutine where the context logger uses the given name as a group prefix.
 func (g group) Go(name string, f func(context.Context) error) {
-	g.Group.Go(func() error { return f(clog.WithGroup(g.Context, name)) })
+	g.Group.Go(func() (err error) {
+		ctx := clog.WithGroup(g.Context, name)
+		started := time.Now()
+		defer func() {
+			elapsed := time.Since(started).Round(time.Millisecond)
+			ctxErr := ctx.Err()
+			cause := context.Cause(ctx)
+			switch {
+			case err != nil:
+				clog.Errorf(ctx, "service goroutine ended after %s: err=%v context=%v cause=%v", elapsed, err, ctxErr, cause)
+			case ctxErr != nil:
+				clog.Debugf(ctx, "service goroutine stopped after %s: context=%v cause=%v", elapsed, ctxErr, cause)
+			default:
+				clog.Debugf(ctx, "service goroutine completed after %s", elapsed)
+			}
+		}()
+		return f(ctx)
+	})
 }

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -30,11 +30,17 @@ const (
 	tcpConnTTL       = 2 * time.Hour // Default tcp_keepalive_time on Linux
 	udpConnTTL       = 2 * time.Second
 	localDialTimeout = 2 * time.Second
+	slowDialResponse = 2 * time.Second
 )
 
 // Limit selected-intercept dial responders so bursty workloads cannot create
 // unbounded goroutines and gRPC tunnels in the client daemon.
-const maxConcurrentDialResponders = 256
+const (
+	maxConcurrentDialResponders = 256
+	maxConcurrentDialRejecters  = 16
+	minDialRequestTimeout       = time.Second
+	maxDialRejectTimeout        = 5 * time.Second
+)
 
 const (
 	notConnected = int32(iota)
@@ -156,7 +162,7 @@ func (h *dialer) Start(ctx context.Context) {
 			if dstAddr.Is6() {
 				addr, err := sr.Resolve(dstAddr)
 				if err != nil {
-					clog.Errorf(ctx, "!> %s %s, failed to establish connection: %v", tag, id, err)
+					clog.Errorf(ctx, "!> %s %s session=%s timeout=%s, failed to establish connection: %v", tag, id, h.stream.SessionID(), dto, err)
 					h.connected = notConnected
 					return
 				}
@@ -169,6 +175,7 @@ func (h *dialer) Start(ctx context.Context) {
 				}
 			}
 			clog.Debugf(ctx, "   %s %s, dialing", tag, id)
+			dialStart := time.Now()
 			d := GetDialer(ctx)
 			dtoCtx, cancel := context.WithTimeout(ctx, dto)
 			defer cancel()
@@ -187,7 +194,7 @@ func (h *dialer) Start(ctx context.Context) {
 				return err
 			}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), dtoCtx))
 			if err != nil {
-				clog.Errorf(ctx, "!> %s %s, failed to establish connection: %v", tag, id, err)
+				clog.Errorf(ctx, "!> %s %s session=%s timeout=%s, failed to establish connection after %s: %v", tag, id, h.stream.SessionID(), dto, time.Since(dialStart), err)
 				if err = h.stream.Send(ctx, NewMessage(DialReject, nil)); err != nil {
 					clog.Errorf(ctx, "!> %s %s, failed to send DialReject: %v", tag, id, err)
 				}
@@ -202,7 +209,12 @@ func (h *dialer) Start(ctx context.Context) {
 				clog.Errorf(ctx, "!> %s %s, failed to send DialOK: %v", tag, id, err)
 				return
 			}
-			clog.Debugf(ctx, "<- %s %s, dial answered", tag, id)
+			dialDuration := time.Since(dialStart)
+			if dialDuration > time.Second {
+				clog.Warnf(ctx, "<- %s %s, slow dial answered in %s (timeout %s)", tag, id, dialDuration, dto)
+			} else {
+				clog.Debugf(ctx, "<- %s %s, dial answered in %s", tag, id, dialDuration)
+			}
 			h.conn = conn
 
 		case connecting:
@@ -444,13 +456,42 @@ func DialWaitLoop(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	dialResponders := make(chan struct{}, maxConcurrentDialResponders)
+	dialRejecters := make(chan struct{}, maxConcurrentDialRejecters)
 	for ctx.Err() == nil {
 		dr, err := dialStream.Recv()
 		if err == nil {
+			queueStart := time.Now()
+			queueTimer := time.NewTimer(dialRequestTimeout(dr))
 			select {
 			case dialResponders <- struct{}{}:
+				if !queueTimer.Stop() {
+					select {
+					case <-queueTimer.C:
+					default:
+					}
+				}
+				if queueWait := time.Since(queueStart); queueWait > 100*time.Millisecond {
+					clog.Debugf(ctx, "   %s %s, dial responder queued for %s", tag, ConnID(dr.ConnId), queueWait)
+				}
 			case <-ctx.Done():
+				queueTimer.Stop()
 				return nil
+			case <-queueTimer.C:
+				id := ConnID(dr.ConnId)
+				clog.Errorf(ctx, "!! %s %s, dial responder queue saturated for %s; rejecting", tag, id, time.Since(queueStart))
+				select {
+				case dialRejecters <- struct{}{}:
+					dr := dr
+					go func() {
+						defer func() {
+							<-dialRejecters
+						}()
+						dialReject(ctx, tag, tunnelProvider, dr, sessionID)
+					}()
+				default:
+					clog.Errorf(ctx, "!! %s %s, dial reject queue saturated; dropping request", tag, id)
+				}
+				continue
 			}
 			dr := dr
 			go func() {
@@ -476,22 +517,97 @@ func DialWaitLoop(
 	return nil
 }
 
-func dialRespond(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.DialRequest, sessionID SessionID) {
+func dialRequestTimeout(dr *rpc.DialRequest) time.Duration {
+	timeout := time.Duration(dr.DialTimeout) + time.Duration(dr.RoundtripLatency)
+	if timeout < minDialRequestTimeout {
+		return minDialRequestTimeout
+	}
+	return timeout
+}
+
+func dialRejectTimeout(dr *rpc.DialRequest) time.Duration {
+	timeout := dialRequestTimeout(dr)
+	if timeout > maxDialRejectTimeout {
+		return maxDialRejectTimeout
+	}
+	return timeout
+}
+
+func dialReject(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.DialRequest, sessionID SessionID) {
 	id := ConnID(dr.ConnId)
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, dialRejectTimeout(dr))
+	defer cancel()
 	mt, err := tunnelProvider.Tunnel(ctx)
 	if err != nil {
-		clog.Errorf(ctx, "!! %s %s, call to manager Tunnel failed: %v", tag, id, err)
+		clog.Errorf(ctx, "!! %s %s, failed to create reject tunnel: %v", tag, id, err)
+		return
+	}
+	s, err := NewClientStream(ctx, tag, mt, id, sessionID, time.Duration(dr.RoundtripLatency), time.Duration(dr.DialTimeout))
+	if err != nil {
+		clog.Errorf(ctx, "!! %s %s, failed to create reject stream: %v", tag, id, err)
+		return
+	}
+	if err = s.Send(ctx, NewMessage(DialReject, nil)); err != nil {
+		clog.Errorf(ctx, "!! %s %s, failed to send DialReject: %v", tag, id, err)
+	}
+	if err = s.CloseSend(ctx); err != nil {
+		clog.Errorf(ctx, "!! %s %s, reject stream CloseSend failed: %v", tag, id, err)
+	}
+}
+
+func dialRespond(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.DialRequest, sessionID SessionID) {
+	id := ConnID(dr.ConnId)
+	respondStart := time.Now()
+	var slowLogged atomic.Bool
+	slowTimer := time.AfterFunc(slowDialResponse, func() {
+		slowLogged.Store(true)
+		clog.Warnf(ctx, "!! %s %s, dial response still active after %s for session %s", tag, id, time.Since(respondStart).Round(time.Millisecond), sessionID)
+	})
+	defer slowTimer.Stop()
+	ctx, cancel := context.WithCancel(ctx)
+	tunnelStart := time.Now()
+	mt, err := tunnelProvider.Tunnel(ctx)
+	if err != nil {
+		clog.Errorf(ctx, "!! %s %s, call to Tunnel failed: %v", tag, id, err)
 		cancel()
 		return
 	}
+	tunnelDuration := time.Since(tunnelStart)
+	if tunnelDuration > time.Second {
+		clog.Warnf(ctx, "   %s %s, Tunnel stream established slowly in %s", tag, id, tunnelDuration.Round(time.Millisecond))
+	} else if tunnelDuration > 100*time.Millisecond {
+		clog.Debugf(ctx, "   %s %s, Tunnel stream established in %s", tag, id, tunnelDuration)
+	}
+	streamStart := time.Now()
 	s, err := NewClientStream(ctx, tag, mt, id, sessionID, time.Duration(dr.RoundtripLatency), time.Duration(dr.DialTimeout))
 	if err != nil {
 		clog.Error(ctx, err)
 		cancel()
 		return
 	}
-	d := NewDialer(s, cancel, nil, nil)
+	streamDuration := time.Since(streamStart)
+	if streamDuration > time.Second {
+		clog.Warnf(ctx, "   %s %s, client stream handshake completed slowly in %s", tag, id, streamDuration.Round(time.Millisecond))
+	} else if streamDuration > 100*time.Millisecond {
+		clog.Debugf(ctx, "   %s %s, client stream handshake completed in %s", tag, id, streamDuration)
+	}
+	ingressBytes := NewCounterProbe("FromClientBytes")
+	egressBytes := NewCounterProbe("ToClientBytes")
+	d := NewDialer(s, cancel, ingressBytes, egressBytes)
 	d.Start(ctx)
 	<-d.Done()
+	if elapsed := time.Since(respondStart); slowLogged.Load() || elapsed > slowDialResponse {
+		clog.Warnf(
+			ctx,
+			"!! %s %s, dial response ended after %s for session %s: ingressBytes=%d egressBytes=%d context=%v cause=%v",
+			tag,
+			id,
+			elapsed.Round(time.Millisecond),
+			sessionID,
+			ingressBytes.GetValue(),
+			egressBytes.GetValue(),
+			ctx.Err(),
+			context.Cause(ctx),
+		)
+	}
 }


### PR DESCRIPTION
**Still a draft. I want to see if I can simplify this further. Reviews/feedback welcome. I can also split this if needed in to some (partly) smaller change sets.** 

Selected intercepts have a few sharp edges when a watch stream drops, a local endpoint is slow to answer, or traffic arrives in a burst. This makes that path steadier without making quiet sessions noisier.

Reconnect agent dial watchers with backoff, clear stale agent clients before retrying, reuse HTTP intercept transports, and clean up pending forwards more carefully so old work cannot step on newer state.

Also add dedicated timeout knobs for traffic-agent connects and intercepted endpoint dials, cap dial responder and rejecter work, and log the slow or flappy paths with enough context to diagnose real stalls.

Update the 2.28.0 release notes for the stability work.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [ ] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.