### PR TITLE
Add Claude Code and Codex automation config

### DIFF
--- a/.agents/skills/changelog-entry/SKILL.md
+++ b/.agents/skills/changelog-entry/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: changelog-entry
+description: Add a new entry to CHANGELOG.yml under the current unreleased version, or create the version block if needed, then regenerate documentation. Use when the user says things like "add a changelog entry", "log this fix in the changelog", or "/changelog-entry".
+---
+
+# changelog-entry
+
+Adds an entry to `CHANGELOG.yml` following the schema documented in the file header, then regenerates the derived documentation.
+
+## Inputs to gather
+
+1. **type** - one of `bugfix`, `feature`, `security`, `change`. If the user describes the change but does not pick a type, infer it:
+   - "fixes/resolves/closes a bug" -> `bugfix`
+   - "adds support for / introduces / new" -> `feature`
+   - "CVE / vulnerability / hardens" -> `security`
+   - anything else affecting behavior -> `change`
+2. **title** - short, sentence-cased, no trailing period.
+3. **body** - 2-3 sentences. This field is HTML, not markdown. Use `<code>...</code>` for code and `<a href="...">...</a>` for links. Prefer YAML's `>-` folded scalar so line wrapping does not leak literal newlines.
+4. **docs** optional - path to a docs page under `docs/` if the entry deserves a "Learn more" link.
+5. **image** optional - path under the `release-notes` directory if there is a visual.
+
+## Steps
+
+1. Read the top of `CHANGELOG.yml`. The first `items:` entry is the current/upcoming version.
+2. If it has `date: (TBD)`, append the new entry to its `notes:` array.
+3. If the top item is already dated, insert a new `- version: <next>` block above it with `date: (TBD)` and the single new note. Ask the user for the next version number; do not invent it.
+4. Match existing indentation exactly. YAML is whitespace-sensitive.
+5. After saving, run `make docs-files` to regenerate `docs/release-notes.md`, `docs/release-notes.mdx`, and `docs/variables.yml`.
+6. Show the user the diff: `git diff CHANGELOG.yml docs/release-notes.md docs/release-notes.mdx docs/variables.yml`.
+
+## Schema reference
+
+```yaml
+items:
+  - version: 2.28.0
+    date: (TBD)
+    notes:
+      - type: bugfix
+        title: Short title
+        body: >-
+          Two or three sentences describing the change and why it
+          is noteworthy. This is HTML.
+        docs: optional/path
+        image: optional/path
+```
+
+## Things to avoid
+
+- Do not edit `docs/release-notes.md`, `docs/release-notes.mdx`, or `docs/variables.yml` directly. They are generated.
+- Do not include markdown syntax in `body`; it is rendered as HTML.
+- Do not set `date:` to a concrete date for upcoming versions; `make prepare-release` does that automatically for GA versions.

--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: prepare-release
+description: Create the local release commit and tags by setting TELEPRESENCE_VERSION and running make prepare-release. Stops at the local commit+tags; pushing is the ship-release skill's job. Use only when the user explicitly asks to prepare a release, RC, or test build.
+---
+
+# prepare-release
+
+Wraps the `make prepare-release` step so the local-tag-creation portion of a release is one explicit user action, not a chain of remembered commands. Stops at local tags; the `ship-release` skill takes over from there.
+
+This skill is explicit-only by design. The tags this skill creates will eventually drive a public release, so creating them must be an explicit user decision. Codex must never invoke this as a side effect of inferred intent.
+
+## Confirm before doing anything
+
+Ask the user explicitly:
+
+1. **Version string** (`TELEPRESENCE_VERSION`) - must be one of:
+   - `vX.Y.Z-test.N` - pre-release, no Homebrew, no "latest"
+   - `vX.Y.Z-rc.N` - pre-release, no Homebrew, no "latest"
+   - `vX.Y.Z` - GA, marked latest, triggers Homebrew update
+2. **Branch** - should be a release branch, typically `release/v2`. Refuse to proceed from `main`-style branches.
+3. **Working tree** - must be clean. Run `git status`; if there are uncommitted or untracked files relevant to the build, stop.
+4. **CHANGELOG.yml status** - the top entry should have a version matching `TELEPRESENCE_VERSION` without the leading `v`. If it is still `date: (TBD)`, that is expected: `make prepare-release` sets the date for GA versions.
+
+Show all four checks to the user before running anything. Wait for explicit "go".
+
+## Steps
+
+```bash
+export TELEPRESENCE_VERSION=vX.Y.Z[-suffix.N]
+make prepare-release
+```
+
+This creates:
+- An annotated tag `vX.Y.Z[-suffix.N]`
+- An annotated tag `rpc/vX.Y.Z[-suffix.N]`
+- A commit that bumps go.mod references inside the repo
+
+Verify with:
+
+```bash
+git log -1 --stat
+git tag --points-at HEAD
+```
+
+## Next: hand off to `ship-release`
+
+This skill stops here, with the local commit and the two annotated tags. **Do not push anything.** To carry the release through CI, the docs PR, the Releases workflow, and the PR merges, invoke `$ship-release` after the user manually pushes the branch and opens a PR on it.
+
+## Refuse to
+
+- Push anything: branch, commit, or tags. That is `ship-release`'s job.
+- Skip `make prepare-release` and just tag manually. The make target updates go.mod references; manual tagging skips that and ships a broken module.
+- Re-run `make prepare-release` on top of a previous attempt without first cleaning up the leftover tags. If `git tag --points-at HEAD` already lists the target tag, stop and report; the user has to decide whether to delete it.

--- a/.agents/skills/prepare-release/agents/openai.yaml
+++ b/.agents/skills/prepare-release/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/ship-release/SKILL.md
+++ b/.agents/skills/ship-release/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ship-release
+description: Drive a Telepresence release from a prepared branch through CI, docs, the Releases workflow, and PR merges. Assumes make prepare-release has already been run locally and the branch with that commit was pushed and a PR opened. Use only when the user says "ship the release", "complete the release", or "/ship-release".
+---
+
+# ship-release
+
+End-to-end driver for releasing Telepresence. Picks up where `prepare-release` left off and carries the change through:
+
+1. Telepresence release PR: CI green, `ok to test`, and `build_and_test` green
+2. Docs PR in `../telepresence.io`
+3. Tag push, Releases workflow, merge of both PRs
+
+This skill is explicit-only. A release is publicly visible and partially irreversible. Codex must never invoke this as a side effect of inferred intent.
+
+## Preconditions
+
+Run each check and stop with a clear message if any fails:
+
+1. **CWD is the telepresence repo.** `git rev-parse --show-toplevel` ends in `telepresence`.
+2. **`make prepare-release` has been run.** The current HEAD must carry both `vX.Y.Z` and `rpc/vX.Y.Z` annotated tags locally:
+   ```bash
+   git tag --points-at HEAD | sort
+   ```
+3. **Branch is pushed.** Capture `tp_branch=$(git branch --show-current)`, then run:
+   ```bash
+   git ls-remote --exit-code origin "refs/heads/$tp_branch"
+   ```
+4. **PR exists.** `gh pr view "$tp_branch" --json number,state,url,headRefName`
+5. **Sibling docs repo present.** `test -d ../telepresence.io && test -d ../telepresence.io/.git`
+
+Capture once and reuse:
+- `tp_branch` - prepare-release branch
+- `tp_version` - non-`rpc/` tag from `git tag --points-at HEAD`, such as `v2.28.0`
+- `docs_version` - `echo "$tp_version" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/'`, such as `2.28`
+- `pr_number` - from `gh pr view`
+
+## Phase 1: Drive the Telepresence release PR
+
+### Wait for non-build_and_test checks
+
+Use:
+
+```bash
+gh pr checks "$tp_branch" --json name,state,conclusion
+```
+
+Filter out the row whose name matches `build_and_test`; the label triggers it later. For every remaining row:
+
+- `state == "COMPLETED"` and `conclusion == "SUCCESS"` -> green
+- `conclusion` in `FAILURE`, `CANCELLED`, `TIMED_OUT`, or `ACTION_REQUIRED` -> stop and report the failing check name plus a short excerpt from `gh run view <run-id> --log-failed`
+- Anything else -> keep waiting
+
+Poll every 180 seconds while checks are still running.
+
+### Trigger build_and_test
+
+Once every non-`build_and_test` check is green:
+
+```bash
+gh pr edit "$tp_branch" --add-label "ok to test"
+gh pr view "$tp_branch" --json labels
+```
+
+### Wait for build_and_test
+
+This job can take up to two hours. Poll `gh pr checks "$tp_branch" --json name,state,conclusion` every 1200-1800 seconds, looking specifically at `build_and_test`.
+
+- Success -> continue to Phase 2
+- Failure or cancellation -> stop and report, including `gh run view <run-id> --log-failed`
+- Still running after about 2.5 hours -> tell the user and stop
+
+## Phase 2: Create the docs PR
+
+Run this in sibling repo `../telepresence.io`.
+
+1. Pull master:
+   ```bash
+   git checkout master
+   git pull
+   ```
+2. Create a branch with the same name as the Telepresence PR branch:
+   ```bash
+   git checkout -b "$tp_branch"
+   ```
+   If that branch already exists locally, stop and ask whether to reuse, reset, or rename.
+3. Export variables:
+   ```bash
+   export DOCS_VERSION="$docs_version"
+   export DOCS_BRANCH="$tp_branch"
+   ```
+4. Generate:
+   ```bash
+   make generate-version
+   ```
+5. Verify output:
+   ```bash
+   ls versioned_docs/version-"$DOCS_VERSION"
+   git status
+   ```
+   Expect `versioned_docs/version-$DOCS_VERSION/` to exist and `git status` to show useful changes.
+6. Create the PR. Add only files that actually changed:
+   ```bash
+   git add versioned_docs/version-"$DOCS_VERSION" versioned_sidebars docusaurus.config.js versions.json
+   git commit -s -S -m "Generate docs for telepresence $tp_version"
+   git push -u origin "$tp_branch"
+   gh pr create --base master --head "$tp_branch" \
+     --title "Generate docs for telepresence $tp_version" \
+     --body "Generated with \`make generate-version\` DOCS_VERSION=$docs_version DOCS_BRANCH=$tp_branch."
+   ```
+7. Monitor docs PR checks with `gh pr checks "$tp_branch" --json name,state,conclusion`. Stop and report if anything fails.
+
+Do not include `Co-Authored-By` or generated-tool trailers in commit messages or PR bodies.
+
+## Phase 3: Release
+
+### Push the release tags
+
+Back in the telepresence repo:
+
+```bash
+git push origin "$tp_version" "rpc/$tp_version"
+```
+
+This triggers `.github/workflows/release.yaml`. The release PR is still unmerged at this point intentionally; merging now would create a new commit and move the branch tip away from the tagged commit.
+
+### Monitor the Releases workflow
+
+```bash
+gh run list --workflow=release.yaml --limit 1 --json databaseId,status,conclusion,url
+gh run view <id> --json jobs
+```
+
+The workflow requires manual approval of the protected `macos-signing` environment. Wait for this up to 24 hours and surface the workflow URL early so the user can chase the approver.
+
+- If the workflow completes successfully -> continue
+- If a job other than `build-macos-pkg` fails -> stop and report
+- If `build-macos-pkg` is never approved within 24 hours -> tell the user; per `CLAUDE.md`, the release still ships without `.pkg` installers and the user decides whether to proceed
+
+### Merge both PRs
+
+Both PRs must use merge commits, never squash or rebase:
+
+```bash
+gh pr merge "$tp_branch" --merge
+```
+
+Then in `../telepresence.io`:
+
+```bash
+gh pr merge "$tp_branch" --merge
+```
+
+Verify each merged with `gh pr view "$tp_branch" --json state`.
+
+## Stop and report
+
+Do not advance to the next step. Surface the failed step, check/run names, run URLs, and a short excerpt from `gh run view <id> --log-failed`. Do not retry automatically.
+
+## Never do
+
+- Run `make prepare-release`; that is a separate skill and decision.
+- Push tags before all required PR checks are green.
+- Merge PRs as squash or rebase.
+- Skip `ok to test`.
+- Approve the `macos-signing` environment programmatically.
+- Force-push or delete the release branch.

--- a/.agents/skills/ship-release/agents/openai.yaml
+++ b/.agents/skills/ship-release/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.claude/agents/integration-test-runner.md
+++ b/.claude/agents/integration-test-runner.md
@@ -1,0 +1,37 @@
+---
+name: integration-test-runner
+description: Use when the user wants to run, identify, or debug integration tests in integration_test/. Locates the relevant testify suite(s) by feature keywords, builds prerequisites if needed, runs a focused subset with -testify.m or TEST_SUITE filtering, and reports back a tight summary of pass/fail with the relevant log excerpts. Keeps the heavy go-test output out of the parent context.
+tools: Bash, Read, Grep, Glob
+---
+
+You are the integration-test specialist for the telepresence repository.
+
+## Context you should assume
+
+- Integration tests live under `integration_test/` and use testify suites. They require a working Kubernetes cluster (typically Docker Desktop's built-in cluster or kind).
+- The test harness lives in `integration_test/itest/`.
+- Test invocation patterns:
+  - Single test: `go test ./integration_test/... -v -testify.m=Test_InterceptDetailedOutput`
+  - Suite-scoped: `TEST_SUITE='^WorkloadConfiguration$' go test ./integration_test/... -v`
+- Tests rely on built images (`telepresence` client, `tel2` cluster-side). If the user changed Go code in `pkg/`, `cmd/`, or `rpc/`, images probably need rebuilding:
+  - `make build client-image tel2-image`
+  - When `DEV_CLIENT_REGISTRY=local`, tests use `pullPolicy=Never`.
+- Required environment is documented in CLAUDE.md under "Integration Test Environment Variables".
+
+## Your workflow
+
+1. **Identify the right suite/test.** Use Grep across `integration_test/` to map the user's feature description to suite or test names. Suites typically follow `<feature>_test.go` and embed `itest.NamespacePair` or similar; tests are method names starting with `Test_`.
+2. **Decide if a rebuild is needed.** Check `git status` and `git diff --name-only HEAD` (or the last commit) for changes under `pkg/`, `cmd/`, `rpc/`, or `charts/`. If yes, propose the rebuild commands; only run them if the user agreed or pre-authorized.
+3. **Run the focused subset.** Prefer narrow `-testify.m=` patterns over running everything. Always pass `-v`. If the user wants a full suite, prefer `TEST_SUITE='^<Suite>$'` over running the whole package.
+4. **Summarize.** Return: command(s) run, pass/fail counts, names of any failing tests, and the smallest log excerpt that explains each failure. Do not dump the whole test log into the parent context.
+
+## What NOT to do
+
+- Do not run the full integration suite without explicit user instruction; it is slow and resource-hungry.
+- Do not run `make clobber` or anything that destroys local images without asking.
+- Do not modify test files unless the user asked for that specifically.
+- Do not edit files matching `docs/reference/cli/**`, `DEPENDENCIES.md`, `DEPENDENCY_LICENSES.md`, or `docs/release-notes*` — those are generated.
+
+## Reporting format
+
+Keep the response to 200-400 words. Lead with: pass/fail headline, then the failing test names, then per-failure excerpts. End with the next concrete action (e.g., "run `make tel2-image` and rerun" or "inspect connector.log around 15:42:13").

--- a/.claude/agents/proto-rpc-reviewer.md
+++ b/.claude/agents/proto-rpc-reviewer.md
@@ -1,0 +1,53 @@
+---
+name: proto-rpc-reviewer
+description: Use when reviewing changes to any .proto file under rpc/ or to the Go bindings generated from them. Verifies wire-level backward compatibility, that 'make protoc' has been run, that protolint passes, and that both sides of each affected RPC are updated. Surfaces incompatibilities that would break older clients, older traffic-managers, or older traffic-agents talking to a new peer.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the gRPC contract reviewer for the telepresence repository.
+
+## Communication boundaries you must consider
+
+The repo defines four RPC surfaces; a single proto edit can ripple across them:
+
+| Boundary                               | Proto package        |
+|----------------------------------------|----------------------|
+| client/userd ↔ traffic-manager         | `rpc/manager/`       |
+| client ↔ user daemon                   | `rpc/connector/`     |
+| client ↔ root daemon                   | `rpc/daemon/`        |
+| traffic-manager ↔ traffic-agent        | `rpc/agent/`         |
+| auth                                   | `rpc/authenticator/` |
+| teleroute (docker network driver)      | `rpc/teleroute/`     |
+| shared types                           | `rpc/common/`        |
+
+Each daemon ships independently: an older client may talk to a newer traffic-manager, a newer traffic-manager may inject an older traffic-agent (mismatched manifest), and a newer agent may run alongside an older sidecar in another pod. Wire compatibility is therefore mandatory, not optional.
+
+## Checks you must run
+
+1. **Wire compatibility:**
+   - Field numbers must never be reused or repurposed.
+   - Field types must not change (e.g., int32 → int64 silently corrupts).
+   - Enum values must not be renumbered; only appended.
+   - `optional` and `repeated` are part of the wire contract; do not flip.
+   - Removing a field requires `reserved` to lock the number/name.
+2. **Generated code is in sync:** Confirm `make protoc` has been run — check that .pb.go files in the same package are touched in the same change. If not, flag and recommend running it.
+3. **Lint:** Confirm `protolint` would pass against the configured rules in `.protolint.yaml` (line length 120, ENUM_FIELD_NAMES_PREFIX disabled). Spot-check naming conventions for fields (snake_case in proto, mapped to PascalCase in Go).
+4. **Both sides updated:** For every RPC method added or changed, locate the server implementation (usually under `cmd/traffic/cmd/manager/`, `cmd/traffic/cmd/agent/`, `pkg/client/userd/`, or `pkg/client/rootd/`) AND the call site(s). If only one side is touched, flag it.
+5. **Compat shims:** If the change adds a field that older peers don't know about, confirm the server tolerates its absence and the client treats nil/zero correctly. Reject any change that requires a synchronized upgrade of both sides.
+
+## Reporting format
+
+Return a punch list, not prose. For each finding:
+
+- **Severity:** Blocker / Risk / Nit
+- **Where:** file:line
+- **Why:** one sentence
+- **Fix:** one sentence
+
+End with a one-line verdict: "Safe to merge", "Needs follow-up", or "Blocked".
+
+## What NOT to do
+
+- Do not edit any files. You are a reviewer.
+- Do not run `make protoc` yourself; report whether it appears to have been run and let the caller decide.
+- Do not chase code-style nits unrelated to the proto/RPC contract.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "path=$(jq -r '.tool_input.file_path // empty'); case \"$path\" in */docs/reference/cli/*|*/DEPENDENCIES.md|*/DEPENDENCY_LICENSES.md|*/docs/release-notes.md|*/docs/release-notes.mdx|*/docs/variables.yml) echo \"Refusing to edit generated file: $path. Modify the source (CHANGELOG.yml, Go source under pkg/client/cli/cmd/, or run 'make generate') instead.\" >&2; exit 2 ;; esac"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "path=$(jq -r '.tool_input.file_path // empty'); case \"$path\" in */CHANGELOG.yml) echo 'CHANGELOG.yml changed; regenerating docs...' >&2; make docs-files >&2 ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/changelog-entry/SKILL.md
+++ b/.claude/skills/changelog-entry/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: changelog-entry
+description: Add a new entry to CHANGELOG.yml under the current unreleased version (or create the version block if needed), then regenerate documentation. Use when the user says things like "add a changelog entry", "log this fix in the changelog", or "/changelog-entry".
+---
+
+# changelog-entry
+
+Adds an entry to `CHANGELOG.yml` following the schema documented in the file header, then regenerates the derived documentation.
+
+## Inputs to gather (in order)
+
+1. **type** — one of `bugfix`, `feature`, `security`, `change`. If the user describes the change but does not pick a type, infer it:
+   - "fixes/resolves/closes a bug" → `bugfix`
+   - "adds support for / introduces / new" → `feature`
+   - "CVE / vulnerability / hardens" → `security`
+   - anything else affecting behavior → `change`
+2. **title** — short (≤80 chars), sentence-cased, no trailing period.
+3. **body** — 2-3 sentences. **This field is HTML, not markdown.** Use `<code>...</code>` for code, `<a href="...">...</a>` for links. Prefer YAML's `>-` folded scalar so line wrapping doesn't leak literal newlines.
+4. **docs** *(optional)* — path to a docs page under `docs/` if the entry deserves a "Learn more" link.
+5. **image** *(optional)* — path under the `release-notes` directory if there's a visual.
+
+## Steps
+
+1. Read the top of `CHANGELOG.yml`. The first `items:` entry is the current/upcoming version.
+2. If it has `date: (TBD)`, append the new entry to its `notes:` array.
+3. If the top item is already dated (a shipped release), insert a NEW `- version: <next>` block above it with `date: (TBD)` and the single new note. Ask the user for the next version number — do not invent it.
+4. Match existing indentation exactly (2 spaces). YAML is whitespace-sensitive.
+5. After saving, run `make docs-files` to regenerate `docs/release-notes.md`, `docs/release-notes.mdx`, and `docs/variables.yml`. (The PostToolUse hook in `.claude/settings.json` will also try to do this; running it explicitly here makes the success/failure visible.)
+6. Show the user the diff: `git diff CHANGELOG.yml docs/release-notes.md docs/release-notes.mdx docs/variables.yml`.
+
+## Schema reference (from CHANGELOG.yml header)
+
+```yaml
+items:
+  - version: 2.28.0
+    date: (TBD)              # or YYYY-MM-DD
+    notes:
+      - type: bugfix         # bugfix | feature | security | change
+        title: Short title
+        body: >-
+          Two or three sentences describing the change and why it
+          is noteworthy.  This is HTML.
+        docs: optional/path
+        image: optional/path
+```
+
+## Things to avoid
+
+- Do not edit `docs/release-notes.md`, `docs/release-notes.mdx`, or `docs/variables.yml` directly — they are generated.
+- Do not include markdown syntax in `body`; it is rendered as HTML.
+- Do not set `date:` to a concrete date for upcoming versions; `make prepare-release` does that automatically for GA versions.

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: prepare-release
+description: Create the local release commit and tags by setting TELEPRESENCE_VERSION and running make prepare-release. Stops at the local commit+tags - pushing is the ship-release skill's job. Use when the user explicitly asks to prepare a release, RC, or test build. User-only.
+disable-model-invocation: true
+---
+
+# prepare-release
+
+Wraps the `make prepare-release` step so the local-tag-creation portion of a release is one explicit user action, not a chain of remembered commands. Stops at local tags; the `ship-release` skill takes over from there.
+
+This is **user-only** by design (`disable-model-invocation: true`). The tags this skill creates will eventually drive a public release, so creating them must be an explicit user decision — never a side-effect of Claude inferring intent.
+
+## Confirm before doing anything
+
+Ask the user explicitly:
+
+1. **Version string** (`TELEPRESENCE_VERSION`) — must be one of:
+   - `vX.Y.Z-test.N` — pre-release, no Homebrew, no "latest"
+   - `vX.Y.Z-rc.N` — pre-release, no Homebrew, no "latest"
+   - `vX.Y.Z` — GA, marked latest, triggers Homebrew update
+2. **Branch** — should be a release branch (typically `release/v2`). Refuse to proceed from `main`-style branches.
+3. **Working tree** — must be clean. Run `git status`; if there are uncommitted or untracked files relevant to the build, stop.
+4. **CHANGELOG.yml status** — the top entry should have version matching `TELEPRESENCE_VERSION` (without the leading `v`). If it's still `date: (TBD)`, that's expected: `make prepare-release` sets the date for GA versions.
+
+Show all four checks to the user before running anything. Wait for explicit "go".
+
+## Steps
+
+```bash
+export TELEPRESENCE_VERSION=vX.Y.Z[-suffix.N]
+make prepare-release
+```
+
+This creates:
+- An annotated tag `vX.Y.Z[-suffix.N]`
+- An annotated tag `rpc/vX.Y.Z[-suffix.N]`
+- A commit that bumps go.mod references inside the repo
+
+Verify with:
+
+```bash
+git log -1 --stat
+git tag --points-at HEAD
+```
+
+## Next: hand off to `ship-release`
+
+This skill stops here, with the local commit and the two annotated tags. **Do not push anything.** To carry the release through CI, the docs PR, the Releases workflow, and the PR merges, invoke `/ship-release` (after pushing the branch and opening a PR on it — that's a manual handoff step the user does between the two skills).
+
+## Refuse to
+
+- Push anything (branch, commit, or tags). That's `ship-release`'s job.
+- Skip `make prepare-release` and just tag manually. The make target updates go.mod references; manual tagging skips that and ships a broken module.
+- Re-run `make prepare-release` on top of a previous attempt without first cleaning up the leftover tags. If `git tag --points-at HEAD` already lists the target tag, stop and report — the user has to decide whether to delete it.

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: ship-release
+description: Drive a Telepresence release from a prepared branch all the way through CI, docs, the Releases workflow, and PR merges. Assumes `make prepare-release` has already been run locally and the branch with that commit was pushed and a PR opened. Use when the user says "ship the release", "complete the release", or "/ship-release". User-only.
+disable-model-invocation: true
+---
+
+# ship-release
+
+End-to-end driver for releasing Telepresence. Picks up where `prepare-release` left off and carries the change through:
+
+1. Telepresence release PR (CI green + `ok to test` + `build_and_test` green)
+2. Docs PR in `../telepresence.io`
+3. Tag push, Releases workflow, merge of both PRs.
+
+This is **user-only** (`disable-model-invocation: true`). A release is publicly visible and partially irreversible (tags push to GitHub, Homebrew updates for GA). Claude must never invoke this on its own.
+
+## Preconditions to verify before doing anything
+
+Run each check and stop with a clear message if any fails:
+
+1. **CWD is the telepresence repo.** `git rev-parse --show-toplevel` ends in `telepresence`.
+2. **`make prepare-release` has been run.** The current HEAD must carry both `vX.Y.Z` and `rpc/vX.Y.Z` annotated tags locally:
+   ```
+   git tag --points-at HEAD | sort
+   ```
+   Two entries expected. If the tag list is empty or missing the `rpc/` peer, stop — the user needs to run `make prepare-release` first.
+3. **Branch is pushed.** Capture `tp_branch=$(git branch --show-current)`, then:
+   ```
+   git ls-remote --exit-code origin "refs/heads/$tp_branch"
+   ```
+   If this fails, stop and tell the user to push the branch first.
+4. **PR exists.** `gh pr view "$tp_branch" --json number,state,url,headRefName`. If no PR, stop.
+5. **Sibling docs repo present.** `test -d ../telepresence.io && test -d ../telepresence.io/.git`. If not, stop.
+
+Capture once and reuse throughout:
+
+- `tp_branch` — name of the prepare-release branch.
+- `tp_version` — pick the non-`rpc/` tag from `git tag --points-at HEAD` (e.g. `v2.28.0`).
+- `docs_version` — `echo "$tp_version" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/'` (e.g. `2.28`).
+- `pr_number` — from `gh pr view`.
+
+## Phase 1 — Drive the Telepresence release PR
+
+### 1.1 Verify branch and PR (already done in preconditions)
+
+### 1.2 Wait for all checks except `build_and_test` to be green
+
+Use:
+
+```
+gh pr checks "$tp_branch" --json name,state,conclusion
+```
+
+Filter out the row whose name matches `build_and_test` (it has not been triggered yet — the label triggers it). For every remaining row:
+
+- `state == "COMPLETED"` and `conclusion == "SUCCESS"` → green
+- `conclusion ∈ {"FAILURE","CANCELLED","TIMED_OUT","ACTION_REQUIRED"}` → **stop**. Report the failing check name and a short excerpt from `gh run view <run-id> --log-failed`. Do not advance.
+- Anything else (`IN_PROGRESS`, `QUEUED`, `PENDING`) → keep waiting.
+
+**Polling cadence:** these checks (lint, unit tests, license, image-scan) typically finish in 5-15 min. Use `ScheduleWakeup` with `delaySeconds=180` while any check is still running. Do not tight-loop with sleeps.
+
+### 1.3 Trigger `build_and_test`
+
+Once every non-`build_and_test` check is green:
+
+```
+gh pr edit "$tp_branch" --add-label "ok to test"
+```
+
+Confirm the label is set: `gh pr view "$tp_branch" --json labels`.
+
+### 1.4 Wait for `build_and_test` to be green
+
+This job can take up to two hours. Use `ScheduleWakeup` with `delaySeconds` in the **1200-1800** range (cache miss is fine because the wait is long). Poll with the same `gh pr checks` query, looking specifically at the `build_and_test` row.
+
+- Success → continue to Phase 2.
+- Failure / cancellation → **stop and report**. Pull failed-step logs with `gh run view <run-id> --log-failed`.
+- Still running after ~2.5 hours → tell the user and stop (workflow may be stuck).
+
+## Phase 2 — Create the docs PR
+
+Done in the sibling repo `../telepresence.io`. Each shell step below is a separate Bash call (no `&&` chains), and `cd` to switch repos.
+
+### 2.1 Pull master
+
+```
+cd ../telepresence.io
+git checkout master
+git pull
+```
+
+### 2.2 Create branch with the same name as the telepresence PR branch
+
+```
+git checkout -b "$tp_branch"
+```
+
+If that branch already exists locally from a previous attempt, stop and ask whether to reuse, reset, or rename.
+
+### 2.3 + 2.4 Export variables
+
+```
+export DOCS_VERSION="$docs_version"   # e.g. 2.28 — note: no patch number
+export DOCS_BRANCH="$tp_branch"
+```
+
+(Per CLAUDE.md, `export` in its own Bash call, then use in subsequent calls. Shell state persists between calls in a session.)
+
+### 2.5 Generate
+
+```
+make generate-version
+```
+
+### 2.6 Verify output
+
+```
+ls versioned_docs/version-"$DOCS_VERSION"
+git status
+```
+
+Expectations:
+
+- **Minor release** (first time this `2.X` is generated): the directory `versioned_docs/version-$DOCS_VERSION/` appears as untracked.
+- **Bugfix release** (directory already existed): files within it are modified.
+
+If `versioned_docs/version-$DOCS_VERSION` is absent or `git status` shows no changes, **stop and report** — `make generate-version` did not do anything useful.
+
+### 2.7 Create the PR
+
+```
+git add versioned_docs/version-"$DOCS_VERSION" versioned_sidebars docusaurus.config.js versions.json
+# (Add only the files that actually changed — git status will tell you which of the
+#  above moved; for a fresh minor you'll likely see all of them, for a bugfix only some.)
+git commit -s -S -m "Generate docs for telepresence $tp_version"
+git push -u origin "$tp_branch"
+gh pr create --base master --head "$tp_branch" \
+  --title "Generate docs for telepresence $tp_version" \
+  --body "Generated with \`make generate-version\` DOCS_VERSION=$docs_version DOCS_BRANCH=$tp_branch."
+```
+
+Capture `docs_pr_number` from the `gh pr create` output URL.
+
+Do not include "Co-Authored-By" or "Generated with" trailers in the commit message or the PR body (per global preferences).
+
+### 2.8 Monitor the docs PR checks
+
+```
+gh pr checks "$tp_branch" --json name,state,conclusion
+```
+
+Same polling rules as Phase 1.2. If anything fails, **stop and report**.
+
+## Phase 3 — Release
+
+`cd` back to the telepresence repo for step 3.1 and 3.3a.
+
+### 3.1 Push the release tags
+
+```
+git push origin "$tp_version" "rpc/$tp_version"
+```
+
+This triggers the **Releases** workflow (`.github/workflows/release.yaml`). The release PR is still unmerged at this point — that is intentional. Merging now would create a new commit and move the branch tip away from the tagged commit.
+
+### 3.2 Monitor the Releases workflow
+
+```
+gh run list --workflow=release.yaml --limit 1 --json databaseId,status,conclusion,url
+gh run view <id> --json jobs
+```
+
+The workflow requires manual approval of a protected GitHub environment (`macos-signing`) containing secrets for macOS signing. Wait for this up to **24 hours**. Poll with `ScheduleWakeup` at `delaySeconds=1800` (or longer when overnight). Surface the workflow URL early so the user can chase the approver.
+
+- If the workflow completes successfully → continue to 3.3.
+- If a job other than `build-macos-pkg` fails → **stop and report**.
+- If `build-macos-pkg` itself is never approved within 24h → tell the user; per CLAUDE.md the release still ships without `.pkg` installers, and the user can decide whether to proceed to 3.3 anyway.
+
+### 3.3 Merge both PRs
+
+Order does not matter. Both must use a **merge commit** (CLAUDE.md: never squash, never rebase).
+
+```
+# telepresence PR (in telepresence repo)
+gh pr merge "$tp_branch" --merge
+
+# docs PR (in ../telepresence.io)
+cd ../telepresence.io
+gh pr merge "$tp_branch" --merge
+```
+
+Verify each merged: `gh pr view "$tp_branch" --json state` should report `MERGED`.
+
+## Long-wait strategy
+
+- Anything under 5 min → don't sleep; just poll once.
+- 5-30 min waits (Phase 1.2 non-build_and_test checks) → `ScheduleWakeup` with `delaySeconds=180`.
+- 30 min-2h waits (Phase 1.4 `build_and_test`) → `ScheduleWakeup` with `delaySeconds=1200`.
+- Hours-to-overnight (Phase 3.2 macOS signing approval) → `ScheduleWakeup` with `delaySeconds=1800` or longer.
+
+Each wake-up: re-fetch state, decide green/red/still-waiting, schedule the next wake or advance.
+
+## What "stop and report" means
+
+- Do not advance to the next numbered step.
+- Surface: the step that failed, the check/run name(s), the run URL(s), and a short excerpt from `gh run view <id> --log-failed`.
+- Do not retry automatically. Wait for the user to direct.
+- Do not delete branches, force-push, or close PRs. The user decides what to do.
+
+## What this skill must NEVER do
+
+- Run `make prepare-release` itself — that's a separate skill and a separate decision.
+- Push tags before all required PR checks are green (Phase 1 must complete first).
+- Merge PRs as squash or rebase — both repos require merge commits.
+- Skip `ok to test` and try to trigger `build_and_test` some other way.
+- Approve the `macos-signing` environment programmatically — that requires a human reviewer.
+- Force-push or delete the release branch.

--- a/.codex/agents/integration-test-runner.toml
+++ b/.codex/agents/integration-test-runner.toml
@@ -1,0 +1,30 @@
+name = "integration_test_runner"
+description = "Use when the user wants to run, identify, or debug integration tests in integration_test/. Locates relevant testify suites by feature keywords, decides whether images need rebuilding, runs a focused subset, and returns a tight pass/fail summary."
+developer_instructions = """
+You are the integration-test specialist for the telepresence repository.
+
+Context to assume:
+- Integration tests live under integration_test/ and use testify suites. They require a working Kubernetes cluster, typically Docker Desktop's built-in cluster or kind.
+- The test harness lives in integration_test/itest/.
+- Single-test invocation: go test ./integration_test/... -v -testify.m=Test_InterceptDetailedOutput
+- Suite-scoped invocation: TEST_SUITE='^WorkloadConfiguration$' go test ./integration_test/... -v
+- Tests rely on built images: telepresence client and tel2 cluster-side.
+- If the user changed Go code in pkg/, cmd/, rpc/, or charts/, images probably need rebuilding with make build client-image tel2-image.
+- When DEV_CLIENT_REGISTRY=local, tests use pullPolicy=Never.
+- Required environment is documented in CLAUDE.md under Integration Test Environment Variables.
+
+Workflow:
+1. Identify the right suite/test. Search integration_test/ to map the user's feature description to suite or test names. Suites typically follow <feature>_test.go and embed itest.NamespacePair or similar; tests are method names starting with Test_.
+2. Decide if a rebuild is needed. Check git status and git diff --name-only HEAD, or the last commit, for changes under pkg/, cmd/, rpc/, or charts/. If yes, propose the rebuild commands; only run them if the user agreed or pre-authorized.
+3. Run the focused subset. Prefer narrow -testify.m= patterns over running everything. Always pass -v. If the user wants a full suite, prefer TEST_SUITE='^<Suite>$' over running the whole package.
+4. Summarize. Return commands run, pass/fail counts, failing test names, and the smallest log excerpt that explains each failure.
+
+Do not:
+- Run the full integration suite without explicit user instruction.
+- Run make clobber or anything that destroys local images without asking.
+- Modify test files unless the user asked for that specifically.
+- Edit generated files under docs/reference/cli/**, DEPENDENCIES.md, DEPENDENCY_LICENSES.md, docs/release-notes*, or docs/variables.yml.
+
+Reporting format:
+Keep the response to 200-400 words. Lead with a pass/fail headline, then failing test names, then per-failure excerpts. End with the next concrete action.
+"""

--- a/.codex/agents/proto-rpc-reviewer.toml
+++ b/.codex/agents/proto-rpc-reviewer.toml
@@ -1,0 +1,35 @@
+name = "proto_rpc_reviewer"
+description = "Use when reviewing changes to .proto files under rpc/ or generated Go bindings. Verifies wire-level backward compatibility, generated-code sync, protolint expectations, and that both sides of affected RPCs were updated."
+sandbox_mode = "read-only"
+developer_instructions = """
+You are the gRPC contract reviewer for the telepresence repository.
+
+Communication boundaries to consider:
+- client/userd <-> traffic-manager: rpc/manager/
+- client <-> user daemon: rpc/connector/
+- client <-> root daemon: rpc/daemon/
+- traffic-manager <-> traffic-agent: rpc/agent/
+- auth: rpc/authenticator/
+- teleroute docker network driver: rpc/teleroute/
+- shared types: rpc/common/
+
+Each daemon ships independently. Older clients may talk to newer traffic-managers, newer traffic-managers may inject older traffic-agents, and newer agents may run alongside older sidecars in other pods. Wire compatibility is mandatory.
+
+Checks to run:
+1. Wire compatibility: field numbers are never reused or repurposed; field types do not change; enum values are only appended; optional/repeated are not flipped; removed fields reserve number and name.
+2. Generated code is in sync: confirm make protoc appears to have been run by checking .pb.go files in the same package are touched in the same change.
+3. Lint: confirm protolint expectations from .protolint.yaml would pass, including line length 120 and ENUM_FIELD_NAMES_PREFIX disabled.
+4. Both sides updated: for every added or changed RPC method, locate server implementation and call sites. If only one side is touched, flag it.
+5. Compat shims: if the change adds fields older peers do not know about, confirm servers tolerate absence and clients treat nil/zero correctly. Reject changes that require synchronized upgrades.
+
+Reporting format:
+Return a punch list, not prose. For each finding include:
+- Severity: Blocker / Risk / Nit
+- Where: file:line
+- Why: one sentence
+- Fix: one sentence
+
+End with one verdict: Safe to merge, Needs follow-up, or Blocked.
+
+Do not edit files, run make protoc, or chase style nits unrelated to the proto/RPC contract.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,15 @@
+[features]
+hooks = true
+codex_hooks = true
+
+[agents]
+max_threads = 6
+max_depth = 1
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.kubernetes]
+command = "npx"
+args = ["-y", "mcp-server-kubernetes"]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/generated_files.py\"",
+            "statusMessage": "Checking generated-file policy"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/generated_files.py\"",
+            "statusMessage": "Checking docs regeneration"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/generated_files.py
+++ b/.codex/hooks/generated_files.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+
+GENERATED_SUFFIXES = {
+    "DEPENDENCIES.md",
+    "DEPENDENCY_LICENSES.md",
+    "docs/release-notes.md",
+    "docs/release-notes.mdx",
+    "docs/variables.yml",
+}
+
+
+def normalize(path):
+    path = path.strip().strip('"')
+    while path.startswith("./"):
+        path = path[2:]
+    return path.replace(os.sep, "/")
+
+
+def paths_from_patch(command):
+    paths = []
+    for line in command.splitlines():
+        for marker in (
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Update File: ",
+            "*** Move to: ",
+        ):
+            if line.startswith(marker):
+                paths.append(normalize(line[len(marker) :]))
+    return paths
+
+
+def touched_paths(payload):
+    tool_input = payload.get("tool_input") or {}
+    paths = []
+
+    file_path = tool_input.get("file_path")
+    if isinstance(file_path, str):
+        paths.append(normalize(file_path))
+
+    command = tool_input.get("command")
+    if isinstance(command, str):
+        paths.extend(paths_from_patch(command))
+
+    patch = tool_input.get("patch")
+    if isinstance(patch, str):
+        paths.extend(paths_from_patch(patch))
+
+    return sorted(set(paths))
+
+
+def is_generated(path):
+    return path.startswith("docs/reference/cli/") or path in GENERATED_SUFFIXES or any(
+        path.endswith("/" + suffix) for suffix in GENERATED_SUFFIXES
+    )
+
+
+def main():
+    payload = json.load(sys.stdin)
+    paths = touched_paths(payload)
+    event = payload.get("hook_event_name")
+
+    generated = [path for path in paths if is_generated(path)]
+    if event == "PreToolUse" and generated:
+        print(
+            "Refusing to edit generated file(s): "
+            + ", ".join(generated)
+            + ". Modify the source (CHANGELOG.yml, Go source under "
+            + "pkg/client/cli/cmd/, or run 'make generate') instead.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if event == "PostToolUse" and any(path == "CHANGELOG.yml" or path.endswith("/CHANGELOG.yml") for path in paths):
+        print("CHANGELOG.yml changed; regenerating docs...", file=sys.stderr)
+        completed = subprocess.run(["make", "docs-files"], cwd=payload.get("cwd") or os.getcwd())
+        sys.exit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "kubernetes": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-kubernetes"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,1 @@
-# AGENTS.md
-
-See [CLAUDE.md](CLAUDE.md) for repository instructions.
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ Telepresence is a Kubernetes development tool that enables fast local developmen
 
 - Never commit directly to the `release/v2` branch. Always create a feature branch with a name following the pattern `username/topic` (e.g., `thallgren/fix-dns-resolution`).
 - All commits must be signed and signed-off (`git commit -s -S`).
+- Limit commit message subjects to 72 characters. Do not wrap subjects;
+  rewrite them shorter instead. Wrap commit message body lines at 72
+  characters by default unless preserving exact external text requires a
+  longer line.
 - **Always run `make lint` and fix every reported issue before pushing.** This is non-negotiable — CI runs the same linters and a push with lint errors wastes a CI cycle. If `make lint` finds problems, fix them in the appropriate commit (use `git commit --fixup=<sha>` followed by `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash --gpg-sign <base>` to fold them in) before pushing.
 - Push the branch and create a pull request for review.
 - Always merge PRs with a merge commit (never squash or rebase).


### PR DESCRIPTION
## Summary

Adds AI-assistant automation configuration for this repository, targeting both Claude Code (`.claude/`) and Codex (`.codex/`), plus shared, assistant-neutral skills under `.agents/`.

### Claude Code config (`.claude/`)
- **`settings.json`** — hooks that (a) block edits to generated files under `docs/reference/cli/`, `DEPENDENCIES.md`, `DEPENDENCY_LICENSES.md`, and the `docs/release-notes*` + `docs/variables.yml` outputs, and (b) auto-run `make docs-files` after any `CHANGELOG.yml` edit so derived docs never drift.
- **`agents/integration-test-runner.md`** — subagent that locates the right testify suite, decides whether images need rebuilding, runs a focused `-testify.m` subset, and returns a tight summary instead of dumping the full integration log into the parent context.
- **`agents/proto-rpc-reviewer.md`** — subagent that audits `.proto` and generated-binding changes for wire-level backward compatibility across the four RPC boundaries.
- **`skills/changelog-entry`**, **`skills/prepare-release`**, **`skills/ship-release`** — guided changelog and release workflows. Release skills are user-only because they push public release tags, trigger GitHub release workflows, and merge release PRs.

### Codex config (`.codex/`)
- Repo-scoped skills, custom subagents for integration-test and proto/RPC work, project MCP configuration, and lifecycle hooks that protect generated files.

### Shared
- **`.mcp.json`** — project-level MCP servers: context7 for live Go-library docs and mcp-server-kubernetes for cluster inspection during integration debugging.
- **`AGENTS.md`** is a symlink to `CLAUDE.md` so both assistant entrypoints read the same guidance.
- **`CLAUDE.md`** documents the 72-character commit subject cap and 72-character body wrap.