### PR TITLE
Set GOEXPERIMENT=jsonv2 in dependency submission workflow

### DIFF
--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: write
 
+# The build target imports encoding/json/v2, which is gated behind this
+# experiment; without it `go list -deps` excludes those files and fails.
+env:
+  GOEXPERIMENT: jsonv2
+
 jobs:
   go-action-detection:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

PR #4135 removed the `fuseftp.bits` embed, which unblocked the Go Dependency Submission workflow's `go list -deps cmd/telepresence/main.go` past its original `pattern fuseftp.bits: no matching files found` failure. The run then surfaced a pre-existing, previously-masked problem:

```
imports encoding/json/jsontext: build constraints exclude all Go files in .../encoding/json/jsontext
imports encoding/json/v2:       build constraints exclude all Go files in .../encoding/json/v2
```

The build target transitively imports `encoding/json/v2` / `encoding/json/jsontext`, which are gated behind `GOEXPERIMENT=jsonv2`. The rest of the build sets this (`build-aux/main.mk` exports it; the image Dockerfiles set `ENV GOEXPERIMENT=jsonv2`), but this workflow ran the action's bare `go list` without it.

## Fix

Set `GOEXPERIMENT: jsonv2` at the job env level so the action's `go list` matches the rest of the build.

## Verification

Reproduced locally with the experiment forced off, and confirmed the fix:

```
GOENV=off GOEXPERIMENT=none go list -deps cmd/telepresence/main.go   # FAILS
GOEXPERIMENT=jsonv2          go list -deps cmd/telepresence/main.go   # OK
```