### PR TITLE
Run dependency submission action on Node.js 24

### DIFF
--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -12,6 +12,10 @@ permissions:
 # experiment; without it `go list -deps` excludes those files and fails.
 env:
   GOEXPERIMENT: jsonv2
+  # actions/go-dependency-submission@v2 still declares Node.js 20, which the
+  # runner deprecates. There is no Node.js 24 release of it yet, so opt its
+  # JavaScript into the runner's Node.js 24 to silence the warning.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   go-action-detection:


### PR DESCRIPTION
## Summary

The Go Dependency Submission workflow now succeeds, but every run emits a deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/go-dependency-submission@v2`.

The latest release of that action (`v2.0.3`, March 2025) still declares Node.js 20 in its metadata, and there is no Node.js 24 release yet, so bumping the version cannot resolve it.

## Fix

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the job env level — the opt-in GitHub documents for exactly this situation. It runs the action's JavaScript on the runner's Node.js 24 and clears the warning. `actions/checkout@v6` and `actions/setup-go@v6` are already Node.js 24, so this action is the only one affected.