### PR TITLE
Drop Node.js 24 force flag from dependency submission

### DIFF
--- a/.github/workflows/go-dependency-submission.yaml
+++ b/.github/workflows/go-dependency-submission.yaml
@@ -12,10 +12,6 @@ permissions:
 # experiment; without it `go list -deps` excludes those files and fails.
 env:
   GOEXPERIMENT: jsonv2
-  # actions/go-dependency-submission@v2 still declares Node.js 20, which the
-  # runner deprecates. There is no Node.js 24 release of it yet, so opt its
-  # JavaScript into the runner's Node.js 24 to silence the warning.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   go-action-detection:


### PR DESCRIPTION
## Summary

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` (added in #4137) did make the action run on Node.js 24, but it only swapped one deprecation warning for another:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/go-dependency-submission@v2`.

The warning fires off the action's *metadata* (`using: 'node20'`), so no env flag can suppress it — only a tagged release built on Node.js 24 will.

Upstream `main` already declares `using: 'node24'`, so a future release will resolve this on its own. Rather than carry a workaround that doesn't actually remove the warning, drop the force flag and rely on the eventual release.

The `GOEXPERIMENT: jsonv2` env (from #4136) stays — it's still required.