### PR TITLE
Don't let a failed agent injection block pod creation

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -45,8 +45,11 @@ items:
           <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation
           value, the ReplicaSet controller then retried the creation indefinitely
           and the workload's rollout stalled. Such errors now admit the pod without
-          an agent and surface the reason as an admission warning, while transient
-          errors still deny the request so the injection is retried.
+          an agent and surface the reason as an admission warning. Transient errors,
+          such as the agent configuration not being generatable yet because the
+          traffic-manager just started, are now retried within the admission call so
+          the agent is injected without denying the pod, and the config generation no
+          longer holds a per-namespace lock that serialized simultaneous injections.
       - type: feature
         title: Ingest workloads in mapped namespaces
         body: >-

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -37,6 +37,16 @@ items:
           until the cache entry expired. The daemon now flushes the DNS cache
           whenever the set of traffic-agents changes, so a recreated workload's
           new ClusterIP is picked up immediately.
+      - type: bugfix
+        title: A failed agent injection no longer blocks pod creation
+        body: >-
+          When the agent-injector webhook returned an error, it denied the pod's
+          creation. For an unfixable error, such as an invalid
+          <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation
+          value, the ReplicaSet controller then retried the creation indefinitely
+          and the workload's rollout stalled. Such errors now admit the pod without
+          an agent and surface the reason as an admission warning, while transient
+          errors still deny the request so the injection is retried.
       - type: feature
         title: Ingest workloads in mapped namespaces
         body: >-

--- a/cmd/traffic/cmd/manager/mutator/agent_injector.go
+++ b/cmd/traffic/cmd/manager/mutator/agent_injector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
@@ -163,7 +164,10 @@ func (a *agentInjector) Inject(ctx context.Context, req *admission.AdmissionRequ
 			return nil, nil
 		}
 	default:
-		return nil, fmt.Errorf("invalid value %q for annotation %s", ia, annotation.InjectTrafficAgent)
+		// A bad annotation value is a user error that retrying cannot fix, so categorize it as such.
+		// The webhook admits the pod (without an agent) and surfaces this as a warning rather than
+		// denying the pod and wedging the workload's rollout indefinitely.
+		return nil, errcat.User.Newf("invalid value %q for annotation %s", ia, annotation.InjectTrafficAgent)
 	}
 
 	podTpl := &core.PodTemplateSpec{ObjectMeta: pod.ObjectMeta}

--- a/cmd/traffic/cmd/manager/mutator/service.go
+++ b/cmd/traffic/cmd/manager/mutator/service.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 )
 
@@ -318,13 +319,8 @@ func serveMutatingFunc(ctx context.Context, r *http.Request, mf mutatorFunc) ([]
 	}
 
 	if err != nil {
-		// If the handler returned an error, still allow the object creation, and incorporate
-		// the error message into the response
 		clog.Errorf(ctx, "mutating function error: %v", err)
-		response.Allowed = false
-		response.Result = &meta.Status{
-			Message: err.Error(),
-		}
+		applyMutatorError(&response, err)
 	} else if patchOps != nil {
 		// Otherwise, encode the patch operations to JSON and return a positive response.
 		patchBytes, err := json.Marshal(patchOps, jsonv1.OmitEmptyWithLegacySemantics(true), json.FormatNilSliceAsNull(true))
@@ -342,4 +338,25 @@ func serveMutatingFunc(ctx context.Context, r *http.Request, mf mutatorFunc) ([]
 		return nil, http.StatusInternalServerError, fmt.Errorf("marshaling response: %v", err)
 	}
 	return b, http.StatusOK, nil
+}
+
+// applyMutatorError records a failed mutation on the admission response. The handling depends on
+// whether the error is terminal:
+//
+//   - A User error is the caller's mistake (for example an invalid annotation value) that retrying
+//     cannot fix. Denying the request would make the ReplicaSet controller retry the pod creation
+//     indefinitely and wedge the workload's rollout. The pod is therefore admitted (without an
+//     agent) and the reason is surfaced as a warning.
+//   - Any other error is treated as transient (for example the agent config could not be generated
+//     yet because the traffic-manager just started). The request is denied so that the pod creation
+//     is retried and the agent is injected once the condition clears.
+func applyMutatorError(response *admission.AdmissionResponse, err error) {
+	if errcat.GetCategory(err) == errcat.User {
+		response.Warnings = append(response.Warnings, err.Error())
+		return
+	}
+	response.Allowed = false
+	response.Result = &meta.Status{
+		Message: err.Error(),
+	}
 }

--- a/cmd/traffic/cmd/manager/mutator/service_test.go
+++ b/cmd/traffic/cmd/manager/mutator/service_test.go
@@ -1,0 +1,44 @@
+package mutator
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admission "k8s.io/api/admission/v1"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+)
+
+func TestApplyMutatorError(t *testing.T) {
+	t.Run("user error is admitted with a warning", func(t *testing.T) {
+		// A User error must not deny the pod, otherwise the ReplicaSet controller retries the
+		// creation indefinitely and wedges the workload's rollout.
+		resp := &admission.AdmissionResponse{Allowed: true}
+		err := errcat.User.Newf("invalid value %q for annotation %s", "bogus", "telepresence.getambassador.io/inject-traffic-agent")
+		applyMutatorError(resp, err)
+		assert.True(t, resp.Allowed, "pod creation must still be allowed for a user error")
+		assert.Nil(t, resp.Result)
+		assert.Equal(t, []string{err.Error()}, resp.Warnings)
+	})
+
+	t.Run("wrapped user error is still recognized", func(t *testing.T) {
+		resp := &admission.AdmissionResponse{Allowed: true}
+		err := fmt.Errorf("context: %w", errcat.User.New("nested user error"))
+		applyMutatorError(resp, err)
+		assert.True(t, resp.Allowed)
+		assert.Len(t, resp.Warnings, 1)
+	})
+
+	t.Run("transient error denies so the create is retried", func(t *testing.T) {
+		resp := &admission.AdmissionResponse{Allowed: true}
+		err := errors.New("unable to get or generate agent config for workload echo.demo")
+		applyMutatorError(resp, err)
+		assert.False(t, resp.Allowed, "a transient error must deny so the pod creation is retried")
+		assert.Nil(t, resp.Warnings)
+		if assert.NotNil(t, resp.Result) {
+			assert.Equal(t, err.Error(), resp.Result.Message)
+		}
+	})
+}

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/puzpuzpuz/xsync/v4"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -21,6 +22,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
@@ -341,32 +343,57 @@ func (c *configWatcher) Get(key, ns string) (ac *agentconfig.Sidecar) {
 	return ac
 }
 
-// GetOrGenerate returns the Sidecar configuration for the given workload. If no configuration is found, it blocks the entry from access while
-// it generates a new one using the given generator.
-func (c *configWatcher) GetOrGenerate(ctx context.Context, wl k8sapi.Workload) (ac *agentconfig.Sidecar, err error) {
+// GetOrGenerate returns the Sidecar configuration for the given workload, generating and caching a
+// new one if none exists yet.
+//
+// Generation runs outside the per-namespace lock so that simultaneous injections of different
+// workloads in the same namespace don't serialize on one another, and it is retried for a short
+// while on transient errors. The traffic-manager's informer caches can briefly lag the API server,
+// in particular right after startup or a burst of workload creations; retrying lets the config be
+// produced within this single admission call instead of denying the pod, which would otherwise
+// trigger ReplicaSet back-off and stall the workload's rollout.
+//
+// Only errors categorized as User errors (such as a malformed annotation) are terminal and skipped
+// by the retry. Service-discovery failures are deliberately left retryable: a manifest may apply a
+// referenced Service together with the workload, so a Service that is missing at admission time may
+// simply not have been created yet and is expected to appear within the retry window.
+func (c *configWatcher) GetOrGenerate(ctx context.Context, wl k8sapi.Workload) (*agentconfig.Sidecar, error) {
+	if ac := c.Get(wl.GetName(), wl.GetNamespace()); ac != nil {
+		return ac, nil
+	}
+
+	gc, err := managerutil.GetEnv(ctx).GeneratorConfig(managerutil.GetAgentImage(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	clog.Debugf(ctx, "GetOrGenerate generates config for workload %s.%s", wl.GetName(), wl.GetNamespace())
+	var ac *agentconfig.Sidecar
+	err = backoff.Retry(func() error {
+		var genErr error
+		ac, genErr = gc.Generate(ctx, wl, nil)
+		if genErr != nil && errcat.GetCategory(genErr) == errcat.User {
+			return backoff.Permanent(genErr)
+		}
+		return genErr
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the generated config, unless another goroutine generated it concurrently.
 	c.agentConfigs.Compute(wl.GetNamespace(), func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if loaded {
-			ac = scMap[wl.GetName()]
+		if !loaded {
+			return map[string]*agentconfig.Sidecar{wl.GetName(): ac}, xsync.UpdateOp
 		}
-		op := xsync.CancelOp
-		if ac == nil {
-			var gc *agentmap.GeneratorConfig
-			gc, err = managerutil.GetEnv(ctx).GeneratorConfig(managerutil.GetAgentImage(ctx))
-			if err == nil {
-				clog.Debugf(ctx, "GetOrGenerate generates config for workload %s.%s", wl.GetName(), wl.GetNamespace())
-				ac, err = gc.Generate(ctx, wl, nil)
-				if err == nil {
-					if scMap == nil {
-						scMap = make(map[string]*agentconfig.Sidecar)
-						op = xsync.UpdateOp
-					}
-					scMap[wl.GetName()] = ac
-				}
-			}
+		if existing := scMap[wl.GetName()]; existing != nil {
+			ac = existing
+			return scMap, xsync.CancelOp
 		}
-		return scMap, op
+		scMap[wl.GetName()] = ac
+		return scMap, xsync.UpdateOp
 	})
-	return ac, err
+	return ac, nil
 }
 
 func whereWeWatch(ns string) string {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,7 +11,7 @@ The root daemon caches cluster DNS resolutions for up to a minute. If a workload
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">A failed agent injection no longer blocks pod creation</div></div>
 <div style="margin-left: 15px">
 
-When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning, while transient errors still deny the request so the injection is retried.
+When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning. Transient errors, such as the agent configuration not being generatable yet because the traffic-manager just started, are now retried within the admission call so the agent is injected without denying the pod, and the config generation no longer holds a per-namespace lock that serialized simultaneous injections.
 </div>
 
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Ingest workloads in mapped namespaces](reference/engagements/cli)</div></div>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 The root daemon caches cluster DNS resolutions for up to a minute. If a workload and its Service were deleted and recreated, the Service could get a new ClusterIP while the daemon kept resolving the name to the old, now-defunct address, so traffic to it was silently dropped until the cache entry expired. The daemon now flushes the DNS cache whenever the set of traffic-agents changes, so a recreated workload's new ClusterIP is picked up immediately.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">A failed agent injection no longer blocks pod creation</div></div>
+<div style="margin-left: 15px">
+
+When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning, while transient errors still deny the request so the injection is retried.
+</div>
+
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Ingest workloads in mapped namespaces](reference/engagements/cli)</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -17,7 +17,7 @@ The root daemon caches cluster DNS resolutions for up to a minute. If a workload
 <Note>
 	<Title type="bugfix">A failed agent injection no longer blocks pod creation</Title>
 	<Body>
-When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning, while transient errors still deny the request so the injection is retried.
+When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning. Transient errors, such as the agent configuration not being generatable yet because the traffic-manager just started, are now retried within the admission call so the agent is injected without denying the pod, and the config generation no longer holds a per-namespace lock that serialized simultaneous injections.
   </Body>
 </Note>
 <Note>

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -15,6 +15,12 @@ The root daemon caches cluster DNS resolutions for up to a minute. If a workload
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">A failed agent injection no longer blocks pod creation</Title>
+	<Body>
+When the agent-injector webhook returned an error, it denied the pod's creation. For an unfixable error, such as an invalid <code>telepresence.getambassador.io/inject-traffic-agent</code> annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. Such errors now admit the pod without an agent and surface the reason as an admission warning, while transient errors still deny the request so the injection is retried.
+  </Body>
+</Note>
+<Note>
 	<Title type="feature" docs="reference/engagements/cli">Ingest workloads in mapped namespaces</Title>
 	<Body>
 The <code>ingest</code> command now accepts <code>--namespace</code> to select the workload namespace for that engagement without changing the namespace used by <code>telepresence connect</code>. This allows a single connection with multiple mapped namespaces to run simultaneous ingests in different namespaces, while preserving the connected namespace as the default when no engagement namespace is specified. Mirrors the multi-namespace support added for <code>intercept</code>, <code>wiretap</code>, and <code>replace</code> in 2.28.0. The <code>leave</code> command also accepts <code>--namespace</code> to disambiguate ingests with the same workload name across mapped namespaces.

--- a/integration_test/ignored_mounts_test.go
+++ b/integration_test/ignored_mounts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
@@ -75,13 +76,16 @@ func (s *mountsSuite) Test_IgnoredMounts() {
 			require.NoError(json.Unmarshal([]byte(stdout), &iInfo))
 			s.CapturePodLogs(ctx, "hello", "traffic-agent", s.AppNamespace())
 			mountPoint := iInfo.Mount.LocalDir
+			// The intercept command returns before the FUSE/sftp mount is necessarily populated, so
+			// wait for each expected path to appear rather than stat-ing it immediately.
 			for _, desired := range tt.expected {
-				st, err := os.Stat(filepath.Join(mountPoint, desired))
-				if !s.NoErrorf(err, "mount of %s should be successful", desired) {
-					s.T().FailNow()
-				}
-				require.True(st.IsDir())
+				require.Eventuallyf(func() bool {
+					st, err := os.Stat(filepath.Join(mountPoint, desired))
+					return err == nil && st.IsDir()
+				}, 30*time.Second, 2*time.Second, "mount of %s should be successful", desired)
 			}
+			// The expected mounts are present, so the mount is established and the ignored volumes,
+			// which are never mounted, must be absent.
 			for _, notDesired := range tt.notExpected {
 				st, err := os.Stat(filepath.Join(mountPoint, notDesired))
 				if !s.Errorf(err, "mount of %s should not be successful", notDesired) {

--- a/pkg/agentmap/generator.go
+++ b/pkg/agentmap/generator.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
+	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
@@ -78,7 +79,8 @@ func portsFromAnnotationValue(wl k8sapi.Workload, annotation, value string) (por
 	for i, cp := range cps {
 		pi := types.PortIdentifier(cp)
 		if err = pi.Validate(); err != nil {
-			return nil, fmt.Errorf("unable to parse annotation %s of %s: %w", annotation, wl, err)
+			// A malformed annotation value won't be fixed by retrying.
+			return nil, errcat.User.Newf("unable to parse annotation %s of %s: %w", annotation, wl, err)
 		}
 		ports[i] = pi
 	}
@@ -91,7 +93,7 @@ func (cfg *GeneratorConfig) Generate(
 	existingConfig *agentconfig.Sidecar,
 ) (*agentconfig.Sidecar, error) {
 	if TrafficManagerSelector.Matches(labels.Set(wl.GetLabels())) {
-		return nil, fmt.Errorf("%s is the Telepresence Traffic Manager. It can not have a traffic-agent", wl)
+		return nil, errcat.User.Newf("%s is the Telepresence Traffic Manager. It can not have a traffic-agent", wl)
 	}
 
 	pod := wl.GetPodTemplate()
@@ -105,7 +107,7 @@ func (cfg *GeneratorConfig) Generate(
 		ports := cn.Ports
 		for pi := range ports {
 			if ports[pi].ContainerPort == int32(cfg.AgentPort) {
-				return nil, fmt.Errorf(
+				return nil, errcat.User.Newf(
 					"the %s.%s pod container %s is exposing the same port (%d) as the %s sidecar",
 					pod.Name, pod.Namespace, cn.Name, cfg.AgentPort, agentconfig.ContainerName)
 			}
@@ -139,7 +141,8 @@ func (cfg *GeneratorConfig) Generate(
 	}
 	cfg.MountPolicies, err = cfg.MountPolicies.AddAnnotations(ctx, pod.Annotations)
 	if err != nil {
-		return nil, err
+		// An invalid mount-policy annotation value won't be fixed by retrying.
+		return nil, errcat.User.New(err)
 	}
 	var ccs []*agentconfig.Container
 	for _, svc := range svcs {
@@ -325,8 +328,9 @@ nextContainerPort:
 			// The port is not explicitly declared as a container port, so if possible, we synthesize one.
 			proto, name, num := p.ProtoAndNameOrNumber()
 			if name != "" {
-				// We can only synthesize given a numeric port.
-				return nil, fmt.Errorf("found no container port that matches port annotation %s", p)
+				// We can only synthesize given a numeric port. A named port that matches no container
+				// port is a configuration error that won't be fixed by retrying.
+				return nil, errcat.User.Newf("found no container port that matches port annotation %s", p)
 			}
 			appPort = &core.ContainerPort{
 				Name:          fmt.Sprintf("port-%s", Base26(anonNameIndex)),


### PR DESCRIPTION
When the agent-injector webhook returned an error it denied the pod's creation. For an error that retrying cannot fix, such as an invalid `telepresence.getambassador.io/inject-traffic-agent` annotation value, the ReplicaSet controller then retried the creation indefinitely and the workload's rollout stalled. `failurePolicy: Ignore` does not help, because the webhook returned an explicit denial rather than failing to be called.

Handler errors are now classified. A User error is the caller's mistake that retrying cannot fix (a malformed inject-traffic-agent, inject-service-ports, inject-container-ports, or mount-policy annotation, an agent-port collision, or trying to inject the traffic-manager itself); the pod is admitted without an agent and the reason is surfaced as an admission warning. Any other error is treated as transient and still denies the request so the injection is retried.

To make transient errors clear quickly, the agent config is now generated outside the per-namespace lock, which also stops simultaneous injections of different workloads in a namespace from serializing on one another, and generation is retried for a short while. This lets a cold informer cache, or a referenced Service that a manifest applies together with the workload, resolve within the single admission call instead of denying the pod. Service-discovery failures are deliberately left retryable, since a missing Service at admission time may simply not have been created yet.