### PR TITLE
Capture logs from all matching pods in integration tests

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -55,6 +55,16 @@ items:
           SAN requirements, and <code>failurePolicy</code> tradeoffs.
         docs: troubleshooting#eks-calico-and-traffic-agent-injection-timeouts
       - type: bugfix
+        title: Reliably re-establish intercept mounts after a pod restart
+        body: >-
+          When an intercepted pod was restarted, the user daemon waits for the
+          root daemon to learn the new pod's IP before remounting its volumes.
+          If the first connection attempt to the freshly started agent lost a
+          race and failed, the daemon gave up instead of retrying, leaving the
+          intercept's volume mounts permanently unavailable until the intercept
+          was recreated. The daemon now keeps retrying until the agent becomes
+          reachable, so the mounts come back on their own.
+      - type: bugfix
         title: Flush the DNS cache when the agent set changes
         body: >-
           The root daemon caches cluster DNS resolutions for up to a minute. If

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,12 @@ The Helm chart can now expose the agent-injector mutating webhook to an API serv
 When an intercept times out waiting for the traffic-agent to arrive and the pods were created without a sidecar, the traffic-manager now explains that the Kubernetes API server is likely unable to reach the agent-injector webhook and points to the EKS/Calico remedies (<code>hostNetwork=true</code> or an externally exposed webhook). The troubleshooting guide gained a full decision path covering host networking, NodePort/LoadBalancer exposure, access restriction, TLS SAN requirements, and <code>failurePolicy</code> tradeoffs.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Reliably re-establish intercept mounts after a pod restart</div></div>
+<div style="margin-left: 15px">
+
+When an intercepted pod was restarted, the user daemon waits for the root daemon to learn the new pod's IP before remounting its volumes. If the first connection attempt to the freshly started agent lost a race and failed, the daemon gave up instead of retrying, leaving the intercept's volume mounts permanently unavailable until the intercept was recreated. The daemon now keeps retrying until the agent becomes reachable, so the mounts come back on their own.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Flush the DNS cache when the agent set changes</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -21,6 +21,12 @@ When an intercept times out waiting for the traffic-agent to arrive and the pods
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Reliably re-establish intercept mounts after a pod restart</Title>
+	<Body>
+When an intercepted pod was restarted, the user daemon waits for the root daemon to learn the new pod's IP before remounting its volumes. If the first connection attempt to the freshly started agent lost a race and failed, the daemon gave up instead of retrying, leaving the intercept's volume mounts permanently unavailable until the intercept was recreated. The daemon now keeps retrying until the agent becomes reachable, so the mounts come back on their own.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix">Flush the DNS cache when the agent set changes</Title>
 	<Body>
 The root daemon caches cluster DNS resolutions for up to a minute. If a workload and its Service were deleted and recreated, the Service could get a new ClusterIP while the daemon kept resolving the name to the old, now-defunct address, so traffic to it was silently dropped until the cache entry expired. The daemon now flushes the DNS cache whenever the set of traffic-agents changes, so a recreated workload's new ClusterIP is picked up immediately.

--- a/integration_test/container_test.go
+++ b/integration_test/container_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json/v2"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -131,7 +130,10 @@ func (s *connectedSuite) Test_InterceptsContainerAndReplace() {
 	require.NoErrorf(err, "unable to read %s", dataFile)
 	s.Equal("Hello from echo\n", string(content))
 
-	// Verify that the container is replaced.
+	// Verify that the container is replaced. The --replace intercept triggers a rollout, so wait
+	// for it to complete before inspecting the pods; otherwise the pod from the previous
+	// ReplicaSet, which still carries the original "echo" container, may still be present.
+	require.NoError(s.RolloutStatusWait(ctx, "deploy/"+svc))
 	stdout, err = s.KubectlOut(ctx, "get", "pod", "-l", "app="+svc, "-o", "json")
 	require.NoError(err)
 	items := struct {
@@ -139,25 +141,17 @@ func (s *connectedSuite) Test_InterceptsContainerAndReplace() {
 		Items      []core.Pod `json:"items"`
 	}{}
 	require.NoError(json.Unmarshal([]byte(stdout), &items))
-	pods := items.Items
 	var echoContainer *core.Container
-	for pi := range pods {
-		cns := pods[pi].Spec.Containers
+	for pi := range items.Items {
+		cns := items.Items[pi].Spec.Containers
 		for ci := range cns {
-			container := &cns[ci]
-			if container.Name == "echo" {
-				echoContainer = container
+			if cns[ci].Name == "echo" {
+				echoContainer = &cns[ci]
 				break
 			}
 		}
 	}
-	if s.ManagerIsVersion(">2.21.x") {
-		require.Nil(echoContainer)
-	} else {
-		require.NotNil(echoContainer)
-		require.Equal(echoContainer.Image, "alpine:latest")
-		require.True(slices.Equal(echoContainer.Args, []string{"sleep", "infinity"}))
-	}
+	require.Nil(echoContainer)
 
 	// Intercept again, this time without the --container flag
 	itest.TelepresenceOk(ctx, "leave", svc)

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -48,7 +48,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/shellquote"
-	"github.com/telepresenceio/telepresence/v2/pkg/slice"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
 
@@ -617,19 +616,7 @@ func (s *cluster) UseLocalPathProvisioner() bool {
 func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string) string {
 	var pods []string
 	for i := 0; ; i++ {
-		runningPods := RunningPodNames(ctx, app, ns)
-		if len(runningPods) > 0 {
-			if container == "" {
-				pods = runningPods
-			} else {
-				for _, pod := range runningPods {
-					cns, err := KubectlOut(ctx, ns, "get", "pods", pod, "-o", "jsonpath={.spec.containers[*].name}")
-					if err == nil && slice.Contains(strings.Split(cns, " "), container) {
-						pods = append(pods, pod)
-					}
-				}
-			}
-		}
+		pods = matchingPods(ctx, app, container, ns)
 		if len(pods) > 0 || i == 5 {
 			break
 		}
@@ -644,20 +631,64 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 		}
 		return ""
 	}
-	present := struct{}{}
-
-	var pod string
-	for i, key := range pods {
-		if container != "" {
-			key += "/" + container
-		}
-		if _, ok := s.logCapturingPods.LoadOrStore(key, present); !ok {
-			pod = pods[i]
-			break
+	// Capture logs from every matching pod that isn't already being captured. A workload can have
+	// more than one pod - replicas, or a transient pair while a rollout or a --replace eviction swaps
+	// one pod for another - and capturing only the first would miss the pod that actually matters,
+	// such as the survivor of a replace eviction. The first captured log file is returned to preserve
+	// the previous single-pod contract for callers that read it.
+	var firstFile string
+	for _, pod := range pods {
+		if file := s.capturePodLog(ctx, pod, container, ns); file != "" && firstFile == "" {
+			firstFile = file
 		}
 	}
-	if pod == "" {
-		return "" // All pods already captured
+
+	// Keep capturing pods that appear after this call - for example the replacement created during a
+	// rollout or a --replace eviction - until the context is done. Without this, a pod that did not
+	// exist yet at the time of the call (often the one that ends up serving, or failing to serve, the
+	// intercept) would never have its logs captured.
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				for _, pod := range matchingPods(ctx, app, container, ns) {
+					s.capturePodLog(ctx, pod, container, ns)
+				}
+			}
+		}
+	}()
+	return firstFile
+}
+
+// matchingPods returns the names of the running pods for the given app, optionally restricted to
+// those that have a container with the given name.
+func matchingPods(ctx context.Context, app, container, ns string) []string {
+	var names []string
+	for _, pod := range RunningPods(ctx, app, ns) {
+		if container != "" && !slices.ContainsFunc(pod.Spec.Containers, func(c core.Container) bool {
+			return c.Name == container
+		}) {
+			continue
+		}
+		names = append(names, pod.Name)
+	}
+	return names
+}
+
+// capturePodLog streams the logs of a single pod (optionally a specific container) to a file in the
+// log directory and returns that file's name. It returns an empty string when the pod is already
+// being captured or when the capture could not be started.
+func (s *cluster) capturePodLog(ctx context.Context, pod, container, ns string) string {
+	key := pod
+	if container != "" {
+		key += "/" + container
+	}
+	if _, loaded := s.logCapturingPods.LoadOrStore(key, struct{}{}); loaded {
+		return "" // Already capturing this pod.
 	}
 
 	// Use another logger to avoid errors due to logs arriving after the tests complete.
@@ -669,7 +700,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 	logFile, err := os.Create(
 		filepath.Join(filelocation.AppUserLogDir(ctx), fmt.Sprintf("%s-%s.log", time.Now().Format("20060102T150405"), logName)))
 	if err != nil {
-		s.logCapturingPods.Delete(pod)
+		s.logCapturingPods.Delete(key)
 		clog.Errorf(ctx, "unable to create pod logfile %s: %v", logFile.Name(), err)
 		return ""
 	}
@@ -687,7 +718,7 @@ func (s *cluster) CapturePodLogs(ctx context.Context, app, container, ns string)
 	go func() {
 		defer func() {
 			_ = logFile.Close()
-			s.logCapturingPods.Delete(pod)
+			s.logCapturingPods.Delete(key)
 		}()
 		err := cmd.Start()
 		if err == nil {

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -48,6 +48,10 @@ type client struct {
 
 const dormantLingerTime = 5 * time.Second
 
+// connectRetryInterval is how long WaitForIP waits between attempts to reach an agent that the
+// watch reports as present but that isn't dialable yet.
+const connectRetryInterval = 200 * time.Millisecond
+
 func (ac *client) String() string {
 	if ac == nil {
 		return "<nil>"
@@ -292,6 +296,13 @@ type clients struct {
 	namespacesMu sync.RWMutex
 	namespaces   map[string]struct{}
 	disabled     atomic.Bool
+
+	// snapshot is the set of agent pods most recently reported by the watch, keyed by
+	// "<podName>.<namespace>". Unlike the live clients map, it is not mutated by failed dial
+	// attempts, so WaitForIP can consult it to tell whether an agent still exists and should be
+	// retried. Guarded by snapshotMu.
+	snapshotMu sync.RWMutex
+	snapshot   map[string]*manager.AgentPodInfo
 
 	// dialMetrics, when non-nil, receives a callback for every dial
 	// request accepted (or rejected) by a started dial watcher. Guarded
@@ -597,6 +608,37 @@ func (s *clients) waitWithTimeout(timeout time.Duration, waitOn <-chan struct{})
 	}
 }
 
+// snapshotInfoForIP returns the AgentPodInfo for the given namespace and pod IP from the latest
+// watch snapshot, or nil if the watch doesn't (currently) know of such an agent.
+func (s *clients) snapshotInfoForIP(namespace string, ip netip.Addr) *manager.AgentPodInfo {
+	s.snapshotMu.RLock()
+	defer s.snapshotMu.RUnlock()
+	for _, ai := range s.snapshot {
+		if podIP, ok := netip.AddrFromSlice(ai.PodIp); ok && ai.Namespace == namespace && ip == podIP {
+			return ai
+		}
+	}
+	return nil
+}
+
+// loadOrAddClient returns the live client for the given agent pod, adding it if the (delta-based)
+// agent watch has not (re)added it. A failed dial removes a client from the live set, and because
+// the watch only emits on change it may not re-add it; this lets WaitForIP retry the dial for an
+// agent that still exists in the watch snapshot.
+func (s *clients) loadOrAddClient(ai *manager.AgentPodInfo) *client {
+	k := ai.PodName + "." + ai.Namespace
+	ac, _ := s.clients.LoadOrCompute(k, func() (*client, bool) {
+		return &client{
+			Cluster: s.Cluster,
+			session: s.session,
+			remove:  func() { s.clients.Delete(k) },
+			owner:   s,
+			info:    ai,
+		}, false
+	})
+	return ac
+}
+
 func (s *clients) WaitForIP(ctx context.Context, timeout time.Duration, namespace string, ip netip.Addr) error {
 	if s.disabled.Load() {
 		return status.Error(codes.Unavailable, "")
@@ -607,42 +649,48 @@ func (s *clients) WaitForIP(ctx context.Context, timeout time.Duration, namespac
 	if !s.watchesNamespace(namespace) {
 		return status.Error(codes.Unavailable, "")
 	}
-	var cl *client
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Register an IP waiter so the agent watch wakes us promptly when the pod is reported, and so a
+	// dormant client for this IP isn't reaped while we wait (see hasWaiterFor).
 	key := ipWaitKey{namespace: namespace, ip: ip}
 	waitOn, _ := s.ipWaiters.LoadOrCompute(key, func() (chan struct{}, bool) {
-		s.clients.Range(func(k string, ac *client) bool {
-			if podIP, ok := netip.AddrFromSlice(ac.info.PodIp); ok && ac.info.Namespace == namespace && ip == podIP {
-				cl = ac
-				return false
-			}
-			return true
-		})
-		if cl != nil {
-			return nil, true
-		}
 		return make(chan struct{}), false
 	})
-	if cl != nil {
-		_, err := cl.ensureConnect(ctx)
-		return err
-	}
-	if err := s.waitWithTimeout(timeout, waitOn); err != nil {
-		return err
-	}
+	defer s.ipWaiters.Delete(key)
 
-	// Ensure that the client we're waiting for is ready.
-	s.clients.Range(func(k string, ac *client) bool {
-		if acIP, ok := netip.AddrFromSlice(ac.info.PodIp); ok && ac.info.Namespace == namespace && ip == acIP {
-			cl = ac
-			return false
+	// Retry until the agent is actually reachable or the deadline expires. The first dial to a
+	// just-restarted pod can lose a race (e.g. the route to its new IP isn't ready yet); on failure
+	// ensureConnect removes the client, and because the watch is delta-based it won't necessarily
+	// re-add it. We therefore drive retries off the watch snapshot - which a failed dial does not
+	// mutate - re-adding the live client ourselves as needed.
+	for {
+		if ai := s.snapshotInfoForIP(namespace, ip); ai != nil {
+			if _, err := s.loadOrAddClient(ai).ensureConnect(ctx); err == nil {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(connectRetryInterval):
+			}
+			continue
 		}
-		return true
-	})
-	if cl == nil {
-		return status.Error(codes.NotFound, "no client available")
+		// The agent isn't in the snapshot yet. Wait to be woken by the watch; the timer is a
+		// fallback in case the wakeup is missed.
+		select {
+		case <-waitOn:
+			// notifyWaiters closes and deletes the waiter, so re-arm it for any subsequent round.
+			waitOn, _ = s.ipWaiters.LoadOrCompute(key, func() (chan struct{}, bool) {
+				return make(chan struct{}), false
+			})
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(connectRetryInterval):
+		}
 	}
-	_, err := cl.ensureConnect(ctx)
-	return err
 }
 
 func (s *clients) WaitForWorkload(timeout time.Duration, name string) error {
@@ -690,6 +738,13 @@ func (s *clients) updateClients(ais []*manager.AgentPodInfo) error {
 			return nil
 		}
 	}
+
+	// Record the watch's view of existing agents. WaitForIP consults this rather than the live
+	// clients map, because a failed dial removes a client from the live map but the agent still
+	// exists here until the watch reports it gone.
+	s.snapshotMu.Lock()
+	s.snapshot = aim
+	s.snapshotMu.Unlock()
 
 	// changed is set when the membership of the watched agent set changes, so the DNS cache can be
 	// flushed - a recreated workload may have a recreated Service with a new ClusterIP.


### PR DESCRIPTION
CapturePodLogs only streamed logs from the first matching pod it found. When a workload has more than one pod - replicas, or a transient pair while a rollout or a `--replace` eviction swaps one pod for another - the pod that actually matters could be missed entirely, leaving its agent log absent from the test artifacts. This made several intermittent failures undiagnosable, because the captured log was from the evicted pod rather than the survivor.

CapturePodLogs now captures every matching pod at call time and keeps watching for pods that appear afterwards, until the context is done, so a replacement created during a rollout or replace is captured too. The per-pod streaming is extracted into a helper, and a pre-existing mismatch where the capture was registered under the pod/container key but deleted under the pod key is fixed.