### PR TITLE
Give a clearer error when the cluster cannot be reached

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -110,6 +110,16 @@ items:
           Only Telepresence's own telemount-managed volumes are now removed,
           matching the behavior of <code>docker compose down</code>.
       - type: bugfix
+        title: Clearer error when the cluster cannot be reached
+        body: >-
+          When the initial cluster check fails, Telepresence now reports, in
+          plain language, that it could not reach the cluster — naming the
+          kubeconfig context and API server, classifying the cause (host
+          could not be resolved, connection refused, timed out, TLS or
+          authentication failure), and suggesting to verify the kubeconfig
+          context with <code>kubectl cluster-info</code> instead of surfacing
+          a raw networking error.
+      - type: bugfix
         title: Reliably inject agents into simultaneously created workloads
         body: >-
           The agent-injector resolved a pod's owner workload from the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -44,6 +44,12 @@ The <code>ingest</code> command now accepts <code>--namespace</code> to select t
 Tearing down a Compose project that engaged a service with replace or intercept previously removed named volumes even when <code>-v</code>/<code>--volumes</code> was not given, because the connection teardown ran <code>docker compose down --volumes</code>. Only Telepresence's own telemount-managed volumes are now removed, matching the behavior of <code>docker compose down</code>.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Clearer error when the cluster cannot be reached</div></div>
+<div style="margin-left: 15px">
+
+When the initial cluster check fails, Telepresence now reports, in plain language, that it could not reach the cluster — naming the kubeconfig context and API server, classifying the cause (host could not be resolved, connection refused, timed out, TLS or authentication failure), and suggesting to verify the kubeconfig context with <code>kubectl cluster-info</code> instead of surfacing a raw networking error.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Reliably inject agents into simultaneously created workloads</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -51,6 +51,12 @@ Tearing down a Compose project that engaged a service with replace or intercept 
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Clearer error when the cluster cannot be reached</Title>
+	<Body>
+When the initial cluster check fails, Telepresence now reports, in plain language, that it could not reach the cluster — naming the kubeconfig context and API server, classifying the cause (host could not be resolved, connection refused, timed out, TLS or authentication failure), and suggesting to verify the kubeconfig context with <code>kubectl cluster-info</code> instead of surfacing a raw networking error.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix">Reliably inject agents into simultaneously created workloads</Title>
 	<Body>
 The agent-injector resolved a pod's owner workload from the traffic-manager's informer cache. When many workloads were created at once, that cache could lag behind the API server, and pods whose owner had not yet been observed were admitted without a traffic-agent and never reconciled. The injector now confirms a cache miss with a direct API call, so bursts of simultaneously created workloads all receive their agent.

--- a/pkg/client/k8s/cluster.go
+++ b/pkg/client/k8s/cluster.go
@@ -2,9 +2,11 @@ package k8s
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/netip"
 	"slices"
@@ -81,7 +83,7 @@ func (kc *Cluster) check(c context.Context) error {
 		return err
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(400*time.Millisecond), 4), c))
 	if err != nil {
-		return fmt.Errorf("initial cluster check failed: %w", client.RunError(err))
+		return kc.unreachableError(c, err)
 	}
 	// Validate that the kubernetes server version is supported
 	clog.Infof(c, "Server version %s", info.GitVersion)
@@ -97,6 +99,66 @@ func (kc *Cluster) check(c context.Context) error {
 		return fmt.Errorf("kubernetes server versions older than %s are not supported, using %s", supportedKubeAPIVersion, info.GitVersion)
 	}
 	return nil
+}
+
+// unreachableError converts a failed cluster discovery call into a message that names the kubeconfig
+// context and server and explains, in plain language, why the cluster could not be reached. It is
+// categorized as a Config error so that the user is pointed at their kubeconfig rather than at the
+// daemon logs. The original error is logged for support purposes.
+func (kc *Cluster) unreachableError(c context.Context, err error) error {
+	clog.Debugf(c, "cluster check failed: %v", err)
+	target := "the Kubernetes cluster"
+	switch {
+	case kc.KubeContext != "" && kc.Server != "":
+		target = fmt.Sprintf("%s for context %q at %s", target, kc.KubeContext, kc.Server)
+	case kc.Server != "":
+		target = fmt.Sprintf("%s at %s", target, kc.Server)
+	case kc.KubeContext != "":
+		target = fmt.Sprintf("%s for context %q", target, kc.KubeContext)
+	}
+	hint := "Verify that the cluster still exists and that your current kubeconfig context points at it (try `kubectl cluster-info`)."
+	if kc.KubeContext != "" {
+		hint = fmt.Sprintf("Verify that the cluster still exists and that your kubeconfig context %q points at it (try `kubectl --context %s cluster-info`).",
+			kc.KubeContext, kc.KubeContext)
+	}
+	return errcat.Config.Newf("unable to reach %s: %s. %s", target, classifyUnreachable(err), hint)
+}
+
+// classifyUnreachable returns a plain-language reason for a failed connection to the cluster's API
+// server. It falls back to the raw error text for causes it doesn't recognize.
+func classifyUnreachable(err error) string {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "the API server host could not be resolved; the cluster may have been deleted, or you may be offline or not connected to the required network or VPN"
+	}
+	var (
+		x509Unknown  x509.UnknownAuthorityError
+		x509Hostname x509.HostnameError
+		x509Invalid  x509.CertificateInvalidError
+	)
+	if errors.As(err, &x509Unknown) || errors.As(err, &x509Hostname) || errors.As(err, &x509Invalid) {
+		return "the API server's TLS certificate could not be verified"
+	}
+	switch {
+	case k8serrors.IsUnauthorized(err):
+		return "authentication was rejected; your cluster credentials may have expired"
+	case k8serrors.IsForbidden(err):
+		return "access was forbidden; your cluster credentials may lack the necessary permissions"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "connection refused"):
+		return "the API server refused the connection"
+	case strings.Contains(msg, "i/o timeout"),
+		strings.Contains(msg, "context deadline exceeded"),
+		strings.Contains(msg, "Client.Timeout"),
+		strings.Contains(msg, "TLS handshake timeout"):
+		return "the connection to the API server timed out"
+	case strings.Contains(msg, "no route to host"):
+		return "there is no network route to the API server"
+	default:
+		return msg
+	}
 }
 
 func (kc *Cluster) CheckTrafficManagerService(ctx context.Context, namespace string) error {

--- a/pkg/client/k8s/cluster_test.go
+++ b/pkg/client/k8s/cluster_test.go
@@ -1,0 +1,70 @@
+package k8s
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestClassifyUnreachable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "dns lookup failure",
+			err:  fmt.Errorf(`Get "https://x.example:443/version": dial tcp: %w`, &net.DNSError{Err: "no such host", Name: "x.example", IsNotFound: true}),
+			want: "could not be resolved",
+		},
+		{
+			name: "unknown certificate authority",
+			err:  fmt.Errorf("tls: %w", x509.UnknownAuthorityError{}),
+			want: "TLS certificate could not be verified",
+		},
+		{
+			name: "unauthorized",
+			err:  k8serrors.NewUnauthorized("token expired"),
+			want: "authentication was rejected",
+		},
+		{
+			name: "forbidden",
+			err:  k8serrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", errors.New("nope")),
+			want: "access was forbidden",
+		},
+		{
+			name: "connection refused",
+			err:  errors.New(`Get "https://x:443/version": dial tcp 10.0.0.1:443: connect: connection refused`),
+			want: "refused the connection",
+		},
+		{
+			name: "timeout",
+			err:  errors.New(`Get "https://x:443/version": net/http: request canceled (Client.Timeout exceeded while awaiting headers)`),
+			want: "timed out",
+		},
+		{
+			name: "no route to host",
+			err:  errors.New(`dial tcp 10.0.0.1:443: connect: no route to host`),
+			want: "no network route",
+		},
+		{
+			name: "unrecognized falls back to raw error",
+			err:  errors.New("something entirely unexpected"),
+			want: "something entirely unexpected",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyUnreachable(tt.err)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("classifyUnreachable() = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The initial cluster check produced an unhelpful generic "initial cluster check failed" message, leaving users to guess whether the cause was DNS, TLS, authentication, authorization, or connectivity. Fixes #3182.

`classifyUnreachable` now inspects the underlying error and produces a categorized, actionable message for the common cases: DNS resolution failure, x509 certificate problems, unauthorized/forbidden (RBAC), connection refused, timeout, and no route to host. The error is categorized as `errcat.Config` so the CLI presents it as a user-facing configuration error rather than an internal failure.