### PR TITLE
Keep local DNS reachable when its IP is in a routed subnet

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -36,6 +36,18 @@ items:
           or ingest now fails immediately with an explanatory error instead of
           appearing to start and then never delivering traffic.
         docs: reference/config
+      - type: bugfix
+        title: Keep a local DNS server reachable when its IP is in a routed subnet
+        body: >-
+          When a cluster subnet routed through Telepresence covers the
+          workstation's DNS server address (for example an EKS node whose
+          resolver lives at <code>172.31.0.2</code> while the pod subnet is
+          <code>172.31.0.0/18</code>), queries to that server were captured by
+          the TUN-device and tunnelled into the cluster, breaking name
+          resolution for everything that isn't a cluster name. Telepresence now
+          detects such DNS servers and adds a host route for them to the
+          never-proxy set, keeping them reachable on their original interface.
+        docs: reference/vpn
       - type: feature
         title: Make the agent-injector webhook reachable from outside the cluster
         body: >-

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -92,11 +92,11 @@ does not support this for anonymous users, hence the default tags.
 
 The `client.dns` configuration offers options for configuring the DNS resolution behavior in a client application or system. Here is a summary of the available fields:
 
-The fields for `client.dns` are: `localIP`, `excludeSuffixes`, `includeSuffixes`, and `lookupTimeout`.
+The fields for `client.dns` are: `localAddresses`, `excludeSuffixes`, `includeSuffixes`, and `lookupTimeout`.
 
 | Field              | Description                                                                                                                                                         | Type                                        | Default                                            |
 |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|----------------------------------------------------|
-| `localIP`          | The address of the local DNS server.  This entry is only used on Linux systems that are not configured to use systemd-resolved.                                     | IP address [string][yaml-str]               | first `nameserver` mentioned in `/etc/resolv.conf` |
+| `localAddresses`   | Addresses of local DNS servers. This entry is only used on Linux systems that are not configured to use systemd-resolved.                                          | [sequence][yaml-seq] of address:port values | first `nameserver` mentioned in `/etc/resolv.conf` |
 | `excludeSuffixes`  | Suffixes for which the DNS resolver will always fail (or fallback in case of the overriding resolver). Can be globally configured in the Helm chart.                | [sequence][yaml-seq] of [strings][yaml-str] | `[".arpa", ".com", ".io", ".net", ".org", ".ru"]`  |
 | `includeSuffixes`  | Suffixes for which the DNS resolver will always attempt to do a lookup.  Includes have higher priority than excludes. Can be globally configured in the Helm chart. | [sequence][yaml-seq] of [strings][yaml-str] | `[]`                                               |
 | `excludes`         | Names to be excluded by the DNS resolver                                                                                                                            | `[]`                                        |                                                    |
@@ -111,7 +111,7 @@ client:
   dns:
     includeSuffixes: [.private]
     excludeSuffixes: [.se, .com, .io, .net, .org, .ru]
-    localAddress: 172.12.0.53
+    localAddresses: [172.12.0.53:53]
     lookupTimeout: 30s
 ```
 
@@ -234,6 +234,10 @@ client:
 When using `neverProxySubnets` you provide a list of subnets. These will never be routed via the TUN device,
 even if they fall within the subnets (pod or service) for the cluster. Instead, whatever route they have before
 telepresence connects is the route they will keep.
+
+Telepresence also adds runtime never-proxy routes for local DNS server IPs when they fall inside a subnet that
+Telepresence is about to route. This prevents excluded DNS lookups from being sent into the cluster when the
+workstation's resolver is on a network that overlaps with a pod, service, or also-proxied subnet.
 
 Here is an example kubeconfig for the subnet `1.2.3.4/32`:
 

--- a/docs/reference/vpn.md
+++ b/docs/reference/vpn.md
@@ -215,6 +215,19 @@ The end result of this (assuming an allowlist of `/9`) will be a configuration l
 
 ![VPN Telepresence](../images/vpn-with-tele.jpg)
 
+### Local DNS servers inside a routed subnet
+
+When a routed subnet covers the IP address of the workstation's own DNS server
+(a common situation on cloud VMs, such as an EKS node whose resolver lives at
+`172.31.0.2` while the pod subnet is `172.31.0.0/18`), Telepresence would
+otherwise tunnel DNS queries to that server into the cluster and break name
+resolution for everything that isn't a cluster name. Telepresence detects this
+automatically and adds a host route for the DNS server to the never-proxy set,
+keeping it reachable on its original interface. No extra configuration is
+required, but you can still list the address explicitly under
+`routing.neverProxySubnets` if you prefer to make it visible in your
+configuration.
+
 ### Using docker
 
 Use `telepresence connect --docker` to make the Telepresence daemon containerized, which means that it has its own

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 Setting <code>cluster.agentPortForward=false</code> disables all direct communication between the client and traffic-agents, so the cluster can only be used as a VPN. An attempt to intercept, replace, or ingest now fails immediately with an explanatory error instead of appearing to start and then never delivering traffic.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Keep a local DNS server reachable when its IP is in a routed subnet](reference/vpn)</div></div>
+<div style="margin-left: 15px">
+
+When a cluster subnet routed through Telepresence covers the workstation's DNS server address (for example an EKS node whose resolver lives at <code>172.31.0.2</code> while the pod subnet is <code>172.31.0.0/18</code>), queries to that server were captured by the TUN-device and tunnelled into the cluster, breaking name resolution for everything that isn't a cluster name. Telepresence now detects such DNS servers and adds a host route for them to the never-proxy set, keeping them reachable on their original interface.
+</div>
+
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Make the agent-injector webhook reachable from outside the cluster](troubleshooting#eks-calico-and-traffic-agent-injection-timeouts)</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -15,6 +15,12 @@ Setting <code>cluster.agentPortForward=false</code> disables all direct communic
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix" docs="reference/vpn">Keep a local DNS server reachable when its IP is in a routed subnet</Title>
+	<Body>
+When a cluster subnet routed through Telepresence covers the workstation's DNS server address (for example an EKS node whose resolver lives at <code>172.31.0.2</code> while the pod subnet is <code>172.31.0.0/18</code>), queries to that server were captured by the TUN-device and tunnelled into the cluster, breaking name resolution for everything that isn't a cluster name. Telepresence now detects such DNS servers and adds a host route for them to the never-proxy set, keeping them reachable on their original interface.
+  </Body>
+</Note>
+<Note>
 	<Title type="feature" docs="troubleshooting#eks-calico-and-traffic-agent-injection-timeouts">Make the agent-injector webhook reachable from outside the cluster</Title>
 	<Body>
 The Helm chart can now expose the agent-injector mutating webhook to an API server that cannot reach an in-cluster Service, such as Amazon EKS with Calico where the control plane is outside the pod network. <code>agentInjector.service.type</code> and <code>agentInjector.service.nodePort</code> expose the injector Service (for example as a <code>NodePort</code>) independently of the chart-wide service type, <code>agentInjector.certificate.altNames</code> adds Subject Alternative Names to the webhook certificate, and <code>agentInjector.webhook.url</code> points the webhook at an external URL instead of the in-cluster Service.

--- a/integration_test/cidr_conflict_test.go
+++ b/integration_test/cidr_conflict_test.go
@@ -176,3 +176,40 @@ func (s *cidrConflictSuite) Test_AllowConflictResolution() {
 	rq.NoError(err)
 	rq.Contains(out, "dev tel0") // tel0 is OK, we only run this on linux
 }
+
+// Test_LocalDNSStaysReachable verifies that a local DNS server whose address falls
+// inside a routed (here: allow-conflicting) subnet is kept reachable on its original
+// interface instead of being tunnelled into the cluster. See issue #2429.
+func (s *cidrConflictSuite) Test_LocalDNSStaysReachable() {
+	rq := s.Require()
+
+	dnsIP := net.IP(s.subnets[0].Addr().AsSlice())
+	dnsIP[len(dnsIP)-1] = 53
+	dnsAddr, ok := netip.AddrFromSlice(dnsIP)
+	rq.True(ok)
+	dnsHostRoute := netip.PrefixFrom(dnsAddr, dnsAddr.BitLen())
+
+	ctx := itest.WithConfig(s.Context(), func(cfg client.Config) {
+		cfg.Routing().AutoResolveConflicts = false
+		cfg.Routing().AllowConflicting = s.subnets
+		cfg.DNS().LocalAddresses = []netip.AddrPort{netip.AddrPortFrom(dnsAddr, 53)}
+	})
+
+	// Before connecting, the DNS server is reachable via the conflicting veth interface.
+	out, err := itest.Output(ctx, "ip", "route", "get", dnsAddr.String())
+	rq.NoError(err)
+	rq.Contains(out, "dev brm")
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceQuitOk(ctx)
+
+	// The conflicting DNS server must be added to never-proxy automatically.
+	st := itest.TelepresenceStatusOk(ctx)
+	rq.Contains(st.RootDaemon.NeverProxy, dnsHostRoute,
+		"local DNS server %s should be added to never-proxy", dnsAddr)
+
+	// And it must remain reachable on its original interface, not via tel0.
+	out, err = itest.Output(ctx, "ip", "route", "get", dnsAddr.String())
+	rq.NoError(err)
+	rq.Contains(out, "dev brm")
+}

--- a/pkg/client/rootd/dns/resolvers_linux.go
+++ b/pkg/client/rootd/dns/resolvers_linux.go
@@ -1,0 +1,91 @@
+package dns
+
+import (
+	"bytes"
+	"context"
+	"net/netip"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/telepresenceio/clog"
+)
+
+// SystemResolvers returns the DNS server addresses configured on the host,
+// merged from /etc/resolv.conf and "resolvectl dns". It is used to detect a DNS
+// server that would otherwise be routed into the cluster because its address is
+// covered by a routed subnet.
+//
+// It is best-effort: an unreadable resolv.conf or a missing resolvectl yields no
+// addresses from that source rather than an error, since failing to discover a
+// resolver here only means the caller falls back to the explicitly configured
+// addresses.
+func SystemResolvers(ctx context.Context) []netip.AddrPort {
+	aps, err := nameserversFromResolvConf(ctx)
+	if err != nil {
+		clog.Debugf(ctx, "unable to read /etc/resolv.conf when detecting local DNS servers: %v", err)
+	}
+	aps = append(aps, resolveCtlResolvers(ctx)...)
+	slices.SortFunc(aps, compareAddrPort)
+	return slices.Compact(aps)
+}
+
+func resolveCtlResolvers(ctx context.Context) []netip.AddrPort {
+	// Bound the exec so a wedged resolvectl/systemd-resolved cannot stall the
+	// reconcile (and therefore connect). DNS discovery is best-effort; on
+	// timeout we simply fall back to the explicitly configured addresses.
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "resolvectl", "dns").Output()
+	if err != nil {
+		clog.Debugf(ctx, "unable to discover DNS servers using resolvectl dns: %v", err)
+		return nil
+	}
+	return parseResolveCtlDNS(out)
+}
+
+// parseResolveCtlDNS extracts the DNS server addresses from the output of
+// "resolvectl dns". Each server is rendered by systemd as
+// ADDRESS[:PORT][%IFACE][#SERVERNAME] (with IPv6 bracketed when a port is
+// present), framed by "Global:" and "Link N (iface):" labels. The interface and
+// server-name decorations are stripped and the remainder is parsed as an
+// address with optional port, defaulting to port 53.
+func parseResolveCtlDNS(out []byte) []netip.AddrPort {
+	var aps []netip.AddrPort
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		for _, field := range strings.Fields(string(line)) {
+			if ap, ok := parseResolveCtlServer(field); ok {
+				aps = append(aps, ap)
+			}
+		}
+	}
+	slices.SortFunc(aps, compareAddrPort)
+	return slices.Compact(aps)
+}
+
+func parseResolveCtlServer(field string) (netip.AddrPort, bool) {
+	// Drop the "Global:" / "(iface):" label colon and the #server-name and
+	// %interface decorations, leaving an address with an optional port.
+	field = strings.TrimSuffix(field, ":")
+	if i := strings.IndexByte(field, '#'); i >= 0 {
+		field = field[:i]
+	}
+	if i := strings.IndexByte(field, '%'); i >= 0 {
+		field = field[:i]
+	}
+	if ap, err := netip.ParseAddrPort(field); err == nil {
+		return ap, true
+	}
+	if addr, err := netip.ParseAddr(strings.Trim(field, "[]")); err == nil {
+		return netip.AddrPortFrom(addr, 53), true
+	}
+	return netip.AddrPort{}, false
+}
+
+func compareAddrPort(a, b netip.AddrPort) int {
+	if c := a.Addr().Compare(b.Addr()); c != 0 {
+		return c
+	}
+	return int(a.Port()) - int(b.Port())
+}

--- a/pkg/client/rootd/dns/resolvers_linux_test.go
+++ b/pkg/client/rootd/dns/resolvers_linux_test.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package dns
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseResolveCtlDNS(t *testing.T) {
+	out := []byte(`
+Global: 127.0.0.1:5300
+Link 2 (ens5): 172.31.0.2 2001:db8::53%ens5
+Link 3 (wg0): 10.0.0.1#corp.example
+Link 4 (eth1): [2001:db8::1]:53
+`)
+	got := parseResolveCtlDNS(out)
+
+	require.Equal(t, []netip.AddrPort{
+		netip.MustParseAddrPort("10.0.0.1:53"),
+		netip.MustParseAddrPort("127.0.0.1:5300"),
+		netip.MustParseAddrPort("172.31.0.2:53"),
+		netip.MustParseAddrPort("[2001:db8::1]:53"),
+		netip.MustParseAddrPort("[2001:db8::53]:53"),
+	}, got)
+}

--- a/pkg/client/rootd/dns/resolvers_other.go
+++ b/pkg/client/rootd/dns/resolvers_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package dns
+
+import (
+	"context"
+	"net/netip"
+)
+
+// SystemResolvers returns the host's configured DNS server addresses. It is only
+// implemented on linux. Other platforms rely on the explicitly configured
+// dns.localAddresses (and the runtime-resolved server addresses) instead.
+func SystemResolvers(context.Context) []netip.AddrPort {
+	return nil
+}

--- a/pkg/client/rootd/dns/server_linux.go
+++ b/pkg/client/rootd/dns/server_linux.go
@@ -47,36 +47,38 @@ func (s *Server) Worker(c context.Context, dev vif.Device, configureDNS func(net
 	return err
 }
 
-func addressFromResolvConf(c context.Context) (ap netip.AddrPort, err error) {
-	var rf *dnsproxy.ResolveFile
-	rf, err = dnsproxy.ReadResolveFile("/etc/resolv.conf")
+func nameserversFromResolvConf(c context.Context) ([]netip.AddrPort, error) {
+	rf, err := dnsproxy.ReadResolveFile("/etc/resolv.conf")
 	if err != nil {
-		return ap, err
+		return nil, err
 	}
 	clog.Debug(c, rf.String())
-	if len(rf.Nameservers) > 0 {
-		nsAddr := rf.Nameservers[0]
-		addr, err := netip.ParseAddr(nsAddr)
-		if err != nil {
-			return ap, fmt.Errorf("nameserver IP %q in /etc/resolv.conf is invalid: %v", nsAddr, err)
-		}
-		p := rf.Port
-		if p == 0 {
-			p = 53
-		}
-		ap = netip.AddrPortFrom(addr, uint16(p))
+	if len(rf.Nameservers) == 0 {
+		return nil, nil
 	}
-	return ap, nil
+	aps := make([]netip.AddrPort, len(rf.Nameservers))
+	for i, ns := range rf.Nameservers {
+		addr, err := netip.ParseAddr(ns)
+		if err != nil {
+			return nil, fmt.Errorf("nameserver IP %q in /etc/resolv.conf is invalid: %v", ns, err)
+		}
+		port := uint16(rf.Port)
+		if port == 0 {
+			port = 53
+		}
+		aps[i] = netip.AddrPortFrom(addr, port)
+	}
+	return aps, nil
 }
 
 func (s *Server) runOverridingServer(c context.Context, dev vif.Device, configureDNS func(netip.AddrPort, netip.AddrPort)) error {
 	if len(s.LocalAddresses) == 0 {
-		ap, err := addressFromResolvConf(c)
+		aps, err := nameserversFromResolvConf(c)
 		if err != nil {
 			return err
 		}
-		s.LocalAddresses = []netip.AddrPort{ap}
-		clog.Infof(c, "Automatically set dns=%s", ap)
+		s.LocalAddresses = aps
+		clog.Infof(c, "Automatically set dns=%s", aps)
 	}
 	if len(s.LocalAddresses) == 0 {
 		return errors.New("couldn't determine dns ip from /etc/resolv.conf")
@@ -178,10 +180,11 @@ func (s *Server) runContainerServer(c context.Context, dev vif.Device, configure
 	}
 	clog.Debugf(c, "Bootstrapping local DNS server on port %d", dnsResolverAddr.Port())
 
-	ap, err := addressFromResolvConf(c)
-	if err != nil {
+	aps, err := nameserversFromResolvConf(c)
+	if err != nil || len(aps) == 0 {
 		return err
 	}
+	ap := aps[0]
 	clog.Debugf(c, "Using DNS fallback=%s", ap)
 	pool, err := NewConnPool(ap, 10)
 	if err != nil {

--- a/pkg/client/rootd/local_dns_test.go
+++ b/pkg/client/rootd/local_dns_test.go
@@ -1,0 +1,77 @@
+package rootd
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+)
+
+func mustAddrs(t *testing.T, ss ...string) []netip.Addr {
+	t.Helper()
+	addrs := make([]netip.Addr, len(ss))
+	for i, s := range ss {
+		addrs[i] = netip.MustParseAddr(s)
+	}
+	return addrs
+}
+
+func TestAppendLocalDNSNeverProxy(t *testing.T) {
+	tests := []struct {
+		name       string
+		neverProxy []netip.Prefix
+		subnets    []netip.Prefix
+		dnsServers []netip.Addr
+		want       []netip.Prefix
+	}{
+		{
+			name:       "adds host route for DNS server inside a routed subnet",
+			subnets:    []netip.Prefix{netip.MustParsePrefix("172.31.0.0/18")},
+			dnsServers: mustAddrs(t, "172.31.0.2"),
+			want:       []netip.Prefix{netip.MustParsePrefix("172.31.0.2/32")},
+		},
+		{
+			name:       "ignores DNS server outside every routed subnet",
+			subnets:    []netip.Prefix{netip.MustParsePrefix("172.31.0.0/18")},
+			dnsServers: mustAddrs(t, "10.0.0.2"),
+			want:       nil,
+		},
+		{
+			name:       "skips loopback and unspecified servers",
+			subnets:    []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8"), netip.MustParsePrefix("0.0.0.0/1")},
+			dnsServers: mustAddrs(t, "127.0.0.53", "0.0.0.0"),
+			want:       nil,
+		},
+		{
+			name:       "does not duplicate an already configured never-proxy entry",
+			neverProxy: []netip.Prefix{netip.MustParsePrefix("172.31.0.2/32")},
+			subnets:    []netip.Prefix{netip.MustParsePrefix("172.31.0.0/18")},
+			dnsServers: mustAddrs(t, "172.31.0.2"),
+			want:       []netip.Prefix{netip.MustParsePrefix("172.31.0.2/32")},
+		},
+		{
+			name:       "deduplicates repeated DNS server addresses",
+			subnets:    []netip.Prefix{netip.MustParsePrefix("172.31.0.0/18")},
+			dnsServers: mustAddrs(t, "172.31.0.2", "172.31.0.2"),
+			want:       []netip.Prefix{netip.MustParsePrefix("172.31.0.2/32")},
+		},
+		{
+			name:       "handles an IPv6 DNS server",
+			subnets:    []netip.Prefix{netip.MustParsePrefix("fd00::/48")},
+			dnsServers: mustAddrs(t, "fd00::53"),
+			want:       []netip.Prefix{netip.MustParsePrefix("fd00::53/128")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := appendLocalDNSNeverProxy(context.Background(), tt.neverProxy, tt.subnets, tt.dnsServers)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -918,7 +918,8 @@ func (s *session) reconcileSubnets(mgrInfo *manager.ClusterInfo, subnets []netip
 		}
 	}
 
-	proxy, neverProxy, neverProxyOverrides := computeNeverProxyOverrides(s, subnets, s.neverProxySubnets)
+	neverProxySubnets, localDNSRoutes := s.neverProxyWithLocalDNS(subnets)
+	proxy, neverProxy, neverProxyOverrides := computeNeverProxyOverrides(s, subnets, neverProxySubnets)
 	s.effectiveNeverProxy = neverProxy
 	if s.tunVif == nil {
 		return nil
@@ -926,6 +927,7 @@ func (s *session) reconcileSubnets(mgrInfo *manager.ClusterInfo, subnets []netip
 	rt := s.tunVif.Router
 	clog.Debugf(s, "allowConflicting is set to %v", s.allowConflictingSubnets)
 	rt.UpdateWhitelist(s.allowConflictingSubnets)
+	rt.SetLocalDNSRoutes(localDNSRoutes)
 
 	err := rt.ValidateRoutes(s, proxy)
 	if err != nil {
@@ -996,6 +998,59 @@ func computeNeverProxyOverrides(ctx context.Context, subnets, nvp []netip.Prefix
 		return true
 	})
 	return subnet.Unique(proxy), neverProxy, neverProxyOverrides
+}
+
+// neverProxyWithLocalDNS returns the configured never-proxy subnets extended with
+// host routes for any local DNS server whose address is covered by one of the
+// subnets that we are about to route. Without this, DNS queries sent to such a
+// server would be captured by the TUN-device and tunnelled into the cluster
+// instead of reaching the real resolver, breaking name resolution for everything
+// that isn't a cluster name. See issue #2429.
+func (s *session) neverProxyWithLocalDNS(subnets []netip.Prefix) (neverProxy, dnsRoutes []netip.Prefix) {
+	cfg := client.GetConfig(s).DNS()
+
+	// Collect the DNS server addresses from every source we know of: the user
+	// configuration, the addresses the DNS server actually settled on at runtime
+	// (e.g. resolved from /etc/resolv.conf), and the host's system resolvers.
+	dnsServers := make([]netip.Addr, 0, len(cfg.LocalAddresses)+len(s.dnsServer.LocalAddresses))
+	for _, ap := range cfg.LocalAddresses {
+		dnsServers = append(dnsServers, ap.Addr())
+	}
+	for _, ap := range s.dnsServer.LocalAddresses {
+		dnsServers = append(dnsServers, ap.Addr())
+	}
+	for _, ap := range dns.SystemResolvers(s) {
+		dnsServers = append(dnsServers, ap.Addr())
+	}
+
+	return appendLocalDNSNeverProxy(s, s.neverProxySubnets, subnets, dnsServers)
+}
+
+// appendLocalDNSNeverProxy adds a host route (/32 or /128) to neverProxy for each
+// DNS server address that is covered by one of the routed subnets and not already
+// covered by a never-proxy entry. It also returns the host routes for those DNS
+// servers (dnsRoutes), so the router can route just these via their real path
+// while leaving every other never-proxy entry on the default route.
+func appendLocalDNSNeverProxy(ctx context.Context, neverProxy, subnets []netip.Prefix, dnsServers []netip.Addr) (allNeverProxy, dnsRoutes []netip.Prefix) {
+	nvp := slices.Clone(neverProxy)
+	for _, dnsIP := range slice.AppendUnique([]netip.Addr{}, dnsServers...) {
+		if !dnsIP.IsValid() || dnsIP.IsLoopback() || dnsIP.IsUnspecified() {
+			continue
+		}
+		for _, sn := range subnets {
+			if !sn.Contains(dnsIP) {
+				continue
+			}
+			hostRoute := netip.PrefixFrom(dnsIP, dnsIP.BitLen())
+			dnsRoutes = append(dnsRoutes, hostRoute)
+			if !slices.Contains(nvp, hostRoute) {
+				clog.Infof(ctx, "Adding local DNS server %s to never-proxy because it is covered by routed subnet %s", dnsIP, sn)
+				nvp = append(nvp, hostRoute)
+			}
+			break
+		}
+	}
+	return subnet.Unique(nvp), dnsRoutes
 }
 
 func validateSubnets(name string, ns []netip.Prefix, allowLoopback func() bool) ([]netip.Prefix, error) {

--- a/pkg/vif/router.go
+++ b/pkg/vif/router.go
@@ -26,6 +26,11 @@ type Router struct {
 	routedSubnets []netip.Prefix
 	// The subnets that are allowed to be routed even in the presence of conflicting routes
 	whitelistedSubnets []netip.Prefix
+	// Host routes for local DNS servers that fall inside a routed subnet. These must
+	// follow their real path (e.g. a second NIC or VPN) instead of the default route,
+	// so they are routed via the existing best path. Every other never-proxy subnet
+	// keeps the historical default-route behavior. See issue #2429.
+	localDNSRoutes []netip.Prefix
 }
 
 func NewRouter(device Device, table routing.Table) *Router {
@@ -42,6 +47,15 @@ func (rt *Router) GetRoutedSubnets() []netip.Prefix {
 func (rt *Router) UpdateWhitelist(whitelist []netip.Prefix) {
 	rt.Lock()
 	rt.whitelistedSubnets = whitelist
+	rt.Unlock()
+}
+
+// SetLocalDNSRoutes records the never-proxy host routes that target a local DNS
+// server inside a routed subnet. Only these are routed via their existing best
+// path; all other never-proxy subnets continue to use the default route.
+func (rt *Router) SetLocalDNSRoutes(routes []netip.Prefix) {
+	rt.Lock()
+	rt.localDNSRoutes = routes
 	rt.Unlock()
 }
 
@@ -182,10 +196,19 @@ func (rt *Router) UpdateRoutes(ctx context.Context, pleaseProxy, dontProxy, dont
 		return err
 	}
 
-	// All subnets in neverProxy have been verified as being routed by the TUN-device, so we
-	// route them through the same interface and next hop as the default route.
+	// All subnets in neverProxy have been verified as being routed by the TUN-device.
+	// Local DNS server host routes must follow their real path — the resolver may be
+	// reachable through a more specific route on another interface (a second NIC, a
+	// VPN, or the integration test's veth pair) — so they are routed via the existing
+	// best path. Every other never-proxy subnet keeps the historical behavior of being
+	// routed via the default route, to avoid changing how established never-proxy
+	// entries are routed.
 	for _, sn := range dontProxy {
-		staticRoutes = append(staticRoutes, routeViaDefault(sn, dr))
+		if slices.Contains(rt.localDNSRoutes, sn) {
+			staticRoutes = append(staticRoutes, rt.routeViaExisting(ctx, sn, dr, ourIdx, ourName))
+		} else {
+			staticRoutes = append(staticRoutes, routeViaDefault(sn, dr))
+		}
 	}
 
 	// ... except for the never proxy overrides, which will be routed to our device.
@@ -210,13 +233,79 @@ func (rt *Router) UpdateRoutes(ctx context.Context, pleaseProxy, dontProxy, dont
 	return nil
 }
 
-func routeViaDefault(sn netip.Prefix, dr *routing.Route) routing.Route {
-	r := routing.NewRoute(sn, dr.InterfaceIndex, dr.InterfaceName)
-	if sameAddrFamily(sn.Addr(), dr.Gateway) {
-		r.Gateway = dr.Gateway
+// routeViaExisting builds a never-proxy route for sn that follows the
+// destination's real path. It first asks the OS which route would be used. If
+// that route points at our own device, then Telepresence has already made the
+// destination look routed and we fall back to scanning the routing table for the
+// best non-Telepresence match. The second table scan is intentional: GetRoute
+// answers "what wins now", while existingRoute finds the route we are trying to
+// preserve beneath our own route.
+func (rt *Router) routeViaExisting(ctx context.Context, sn netip.Prefix, dr *routing.Route, ourIdx int, ourName string) routing.Route {
+	if existing := rt.osRoute(ctx, sn, ourIdx, ourName); existing != nil {
+		return routeVia(sn, existing)
 	}
-	if sameAddrFamily(sn.Addr(), dr.LocalIP) {
-		r.LocalIP = dr.LocalIP
+	if existing := rt.existingRoute(ctx, sn.Addr(), ourName); existing != nil {
+		return routeVia(sn, existing)
+	}
+	return routeViaDefault(sn, dr)
+}
+
+func (rt *Router) osRoute(ctx context.Context, sn netip.Prefix, ourIdx int, ourName string) *routing.Route {
+	existing, err := routing.GetRoute(ctx, sn)
+	if err != nil {
+		clog.Debugf(ctx, "unable to discover current route for never-proxy %s: %v", sn, err)
+		return nil
+	}
+	if existing.InterfaceIndex == ourIdx || existing.InterfaceName == ourName {
+		return nil
+	}
+	return existing
+}
+
+// existingRoute returns the most specific non-default route to addr that isn't on
+// our own device, or nil if no such route exists (in which case the default route
+// should be used).
+func (rt *Router) existingRoute(ctx context.Context, addr netip.Addr, ourName string) *routing.Route {
+	table, err := routing.GetRoutingTable(ctx)
+	if err != nil {
+		clog.Errorf(ctx, "failed to read routing table while resolving never-proxy route for %s: %v", addr, err)
+		return nil
+	}
+	return mostSpecificRoute(table, addr, ourName)
+}
+
+// mostSpecificRoute returns the most specific route in table that contains addr,
+// ignoring the default route, the OpenVPN half-of-default routes, and any route on
+// the ourName interface. Routes on our own device are ignored because they are
+// exactly the ones we're trying to bypass for never-proxy destinations. It returns
+// nil when no such route exists, signalling that the default route should be used.
+func mostSpecificRoute(table []*routing.Route, addr netip.Addr, ourName string) *routing.Route {
+	var best *routing.Route
+	for _, r := range table {
+		if r.Default || subnet.IsHalfOfDefault(r.RoutedNet) || r.InterfaceName == ourName {
+			continue
+		}
+		if !r.RoutedNet.Contains(addr) {
+			continue
+		}
+		if best == nil || r.RoutedNet.Bits() > best.RoutedNet.Bits() {
+			best = r
+		}
+	}
+	return best
+}
+
+func routeViaDefault(sn netip.Prefix, dr *routing.Route) routing.Route {
+	return routeVia(sn, dr)
+}
+
+func routeVia(sn netip.Prefix, base *routing.Route) routing.Route {
+	r := routing.NewRoute(sn, base.InterfaceIndex, base.InterfaceName)
+	if sameAddrFamily(sn.Addr(), base.Gateway) {
+		r.Gateway = base.Gateway
+	}
+	if sameAddrFamily(sn.Addr(), base.LocalIP) {
+		r.LocalIP = base.LocalIP
 	}
 	return r
 }

--- a/pkg/vif/router_unit_test.go
+++ b/pkg/vif/router_unit_test.go
@@ -51,3 +51,69 @@ func TestRouteViaDefaultDoesNotMixAddressFamilies(t *testing.T) {
 		t.Fatalf("LocalIP = %s, want %s", r.LocalIP, netip.IPv6Unspecified())
 	}
 }
+
+func TestRouteViaPreservesNonDefaultRoute(t *testing.T) {
+	sn := netip.MustParsePrefix("10.96.0.37/32")
+	br := routing.NewRoute(netip.MustParsePrefix("10.96.0.0/16"), 11, "brm")
+	br.LocalIP = netip.MustParseAddr("10.96.0.1")
+
+	r := routeVia(sn, &br)
+
+	if r.RoutedNet != sn {
+		t.Fatalf("RoutedNet = %s, want %s", r.RoutedNet, sn)
+	}
+	if r.InterfaceIndex != br.InterfaceIndex {
+		t.Fatalf("InterfaceIndex = %d, want %d", r.InterfaceIndex, br.InterfaceIndex)
+	}
+	if r.InterfaceName != br.InterfaceName {
+		t.Fatalf("InterfaceName = %q, want %q", r.InterfaceName, br.InterfaceName)
+	}
+	if r.LocalIP != br.LocalIP {
+		t.Fatalf("LocalIP = %s, want %s", r.LocalIP, br.LocalIP)
+	}
+}
+
+func TestMostSpecificRoute(t *testing.T) {
+	defaultRoute := routing.NewRoute(netip.MustParsePrefix("0.0.0.0/0"), 2, "enp1s0")
+	defaultRoute.Default = true
+	tunRoute := routing.NewRoute(netip.MustParsePrefix("172.31.0.0/18"), 5, "tel0")
+	vethRoute := routing.NewRoute(netip.MustParsePrefix("172.31.0.0/18"), 7, "brm")
+	narrowRoute := routing.NewRoute(netip.MustParsePrefix("172.31.0.0/24"), 8, "brm")
+
+	addr := netip.MustParseAddr("172.31.0.2")
+
+	tests := []struct {
+		name  string
+		table []*routing.Route
+		want  *routing.Route
+	}{
+		{
+			name:  "prefers a non-tunnel route over the default route",
+			table: []*routing.Route{&defaultRoute, &tunRoute, &vethRoute},
+			want:  &vethRoute,
+		},
+		{
+			name:  "ignores routes on our own device",
+			table: []*routing.Route{&defaultRoute, &tunRoute},
+			want:  nil,
+		},
+		{
+			name:  "picks the most specific matching route",
+			table: []*routing.Route{&defaultRoute, &vethRoute, &narrowRoute},
+			want:  &narrowRoute,
+		},
+		{
+			name:  "returns nil when only the default route matches",
+			table: []*routing.Route{&defaultRoute},
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mostSpecificRoute(tt.table, addr, "tel0")
+			if got != tt.want {
+				t.Fatalf("mostSpecificRoute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When `telepresence connect` maps a cluster subnet (pod or service CIDR) onto the TUN device and the workstation's DNS server has an IP that falls *inside* one of those routed subnets, every packet to that resolver is captured by the VIF and tunnelled into the cluster instead of reaching the real DNS server. The canonical report is an EKS node whose VPC resolver lives at `172.31.0.2` while the pod subnet is `172.31.0.0/18`. Names that Telepresence is supposed to resolve locally can no longer be resolved, so general network connectivity breaks for the duration of the connection. The same situation is reachable on purpose with `routing.allowConflictingSubnets`.

Fixes #2429.

## Change

**Discover local DNS servers.** Candidate resolver IPs are collected from `dns.localAddresses`, the runtime-resolved server addresses, and the host's system resolvers. On Linux the system resolvers are read from both `/etc/resolv.conf` and `resolvectl dns`, so systemd-resolved hosts (where `resolv.conf` only points at the `127.0.0.53` stub) still expose the real upstream resolver. Other platforms rely on the explicitly configured/runtime addresses.

**Protect them.** For every candidate that is valid, non-loopback, non-unspecified, and contained in a subnet about to be routed, a host route (`/32` or `/128`) is added to the never-proxy set.

**Follow the real path.** Never-proxy host routes no longer always go via the default route. The OS is queried for the active route first; if that already points at the Telepresence device, the routing table is scanned for the best non-Telepresence match before falling back to the default route. This keeps a resolver that is reachable through a non-default interface (a second NIC, a VPN, or the integration test's veth pair) reachable.

## Tests

- Unit: never-proxy augmentation logic, `resolvectl dns` parsing, and the route-selection helpers (`mostSpecificRoute`, `routeVia`).
- Integration (`CIDRConflict`, linux-only): connects with a conflicting subnet allowed and a `dns.localAddresses` inside it, asserts the IP appears in `RootDaemon.NeverProxy` and that `ip route get` stays on the original interface rather than flipping to `tel0`.

`make lint-go` passes with 0 issues.