### PR TITLE
Report why the traffic-manager pod isn't ready during helm install

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -248,6 +248,17 @@ items:
           instead of leaving the client connected with namespaces that cannot be
           handled by the in-cluster manager or traffic-agents.
         docs: reference/engagements/cli
+      - type: feature
+        title: Report why the traffic-manager pod isn't ready during helm install
+        body: >-
+          When <code>telepresence helm install</code> or
+          <code>telepresence helm upgrade</code> waits for the traffic-manager and
+          its pod cannot become ready (a bad image, insufficient resources, or an
+          unschedulable pod), the command now reports the underlying Kubernetes
+          reason (for example <code>ImagePullBackOff</code>) and points at
+          <code>kubectl describe pod</code>, instead of a confusing Helm rollback
+          error. It also aborts as soon as a terminal failure is detected rather
+          than waiting for the timeout.
   - version: 2.28.0
     date: 2026-05-11
     notes:

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -17,8 +17,6 @@ import (
 	core "k8s.io/api/core/v1"
 	events "k8s.io/api/events/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
@@ -30,6 +28,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
 	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+	"github.com/telepresenceio/telepresence/v2/pkg/eventwatch"
 	grpcErrors "github.com/telepresenceio/telepresence/v2/pkg/grpc/errors"
 	"github.com/telepresenceio/telepresence/v2/pkg/icept"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
@@ -514,7 +513,7 @@ func (s *State) ensureAgent(parentCtx context.Context, wl k8sapi.Workload, exten
 	ctx, cancel := context.WithTimeout(parentCtx, managerutil.GetEnv(parentCtx).AgentArrivalTimeout)
 	defer cancel()
 
-	failedCreateCh, err := watchFailedInjectionEvents(ctx, wl.GetName(), wl.GetNamespace())
+	failedCreateCh, err := eventwatch.WatchWarnings(ctx, k8sapi.GetK8sInterface(ctx), wl.GetNamespace(), wl.GetName())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -720,47 +719,6 @@ func checkInterceptAnnotations(ctx context.Context, wl k8sapi.Workload) (bool, e
 	return true, nil
 }
 
-func watchFailedInjectionEvents(ctx context.Context, name, namespace string) (<-chan *events.Event, error) {
-	// A timestamp with second granularity is needed here, because that's what the event creation time uses.
-	// Finer granularity will result in relevant events seemingly being created before this timestamp because
-	// they have the fraction of seconds trimmed off (which is odd, given that the type used is a MicroTime).
-	start := time.Unix(time.Now().Unix(), 0)
-
-	ei := k8sapi.GetK8sInterface(ctx).EventsV1().Events(namespace)
-	w, err := ei.Watch(ctx, meta.ListOptions{
-		FieldSelector: fields.OneTermNotEqualSelector("type", "Normal").String(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	nd := name + "-"
-	ec := make(chan *events.Event)
-	go func() {
-		defer w.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case eo, ok := <-w.ResultChan():
-				if !ok {
-					return
-				}
-				// Using negated Before when comparing the timestamps here is relevant. They will often be equal and still relevant
-				if e, ok := eo.Object.(*events.Event); ok &&
-					!e.CreationTimestamp.Time.Before(start) &&
-					!strings.HasPrefix(e.Note, "(combined from similar events):") {
-					n := e.Regarding.Name
-					if strings.HasPrefix(n, nd) || n == name {
-						clog.Infof(ctx, "%s %s %s", e.Type, e.Reason, e.Note)
-						ec <- e
-					}
-				}
-			}
-		}
-	}()
-	return ec, nil
-}
-
 func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, failedCreateCh <-chan *events.Event) ([]*AgentSession, error) {
 	name := ac.AgentName
 	namespace := ac.Namespace
@@ -780,9 +738,16 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 			if !ok {
 				return nil, errors.New("failed create channel closed")
 			}
+			if !eventwatch.IsTerminal(fe) {
+				// Something went wrong, but it might not be fatal. There are several events logged that are
+				// just warnings where the action will be retried and eventually succeed. Collect them for
+				// the timeout message and keep waiting.
+				fes = append(fes, fe)
+				continue
+			}
+			// A terminal event was encountered. Surface it now with agent-specific context, rather than
+			// making the user wait for a timeout.
 			msg := fe.Note
-			// Terminate directly on known fatal events. No need for the user to wait for a timeout
-			// when one of those is encountered.
 			switch fe.Reason {
 			case "BackOff":
 				// The traffic-agent container was injected, but it fails to start
@@ -806,22 +771,9 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 				msg = fmt.Sprintf("%s\nThe logs of %s %s might provide more details", msg, fe.Regarding.Kind, fe.Regarding.Name)
 			case "Failed", "FailedCreate", "FailedScheduling":
 				// The injection of the traffic-agent failed for some reason, most likely due to resource quota restrictions.
-				if fe.Type == "Warning" && (strings.Contains(msg, "waiting for ephemeral volume") ||
-					strings.Contains(msg, "unbound immediate PersistentVolumeClaims") ||
-					strings.Contains(msg, "skip schedule deleting pod") ||
-					strings.Contains(msg, "nodes are available")) {
-					// This isn't fatal.
-					fes = append(fes, fe)
-					continue
-				}
 				msg = fmt.Sprintf(
 					"%s\nHint: if the error mentions resource quota, the traffic-agent's requested resources can be configured by providing values to telepresence helm install",
 					msg)
-			default:
-				// Something went wrong, but it might not be fatal. There are several events logged that are just
-				// warnings where the action will be retried and eventually succeed.
-				fes = append(fes, fe)
-				continue
 			}
 			return nil, errcat.User.New(msg)
 		case delta, ok := <-deltaCh:
@@ -855,7 +807,7 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 			ioutil.Printf(bf, "request %s while waiting for agent %s.%s to arrive", v, name, namespace)
 			if len(fes) > 0 {
 				bf.WriteString(": Events that may be relevant:\n")
-				writeEventList(bf, fes)
+				eventwatch.WriteList(bf, fes)
 			} else if ctx.Err() == context.DeadlineExceeded {
 				// No injection failures were observed, yet no agent arrived. This is the typical
 				// signature of the API server being unable to reach the agent-injector webhook
@@ -868,39 +820,5 @@ func (s *State) waitForAgents(ctx context.Context, ac *agentconfig.Sidecar, fail
 			}
 			return nil, errcat.User.New(bf.String())
 		}
-	}
-}
-
-func writeEventList(bf *strings.Builder, es []*events.Event) {
-	now := time.Now()
-	age := func(e *events.Event) string {
-		return now.Sub(e.CreationTimestamp.Time).Truncate(time.Second).String()
-	}
-	object := func(e *events.Event) string {
-		or := e.Regarding
-		return strings.ToLower(or.Kind) + "/" + or.Name
-	}
-	ageLen, typeLen, reasonLen, objectLen := len("AGE"), len("TYPE"), len("REASON"), len("OBJECT")
-	for _, e := range es {
-		if l := len(age(e)); l > ageLen {
-			ageLen = l
-		}
-		if l := len(e.Type); l > typeLen {
-			typeLen = l
-		}
-		if l := len(e.Reason); l > reasonLen {
-			reasonLen = l
-		}
-		if l := len(object(e)); l > objectLen {
-			objectLen = l
-		}
-	}
-	ageLen += 3
-	typeLen += 3
-	reasonLen += 3
-	objectLen += 3
-	ioutil.Printf(bf, "%-*s%-*s%-*s%-*s%s\n", ageLen, "AGE", typeLen, "TYPE", reasonLen, "REASON", objectLen, "OBJECT", "MESSAGE")
-	for _, e := range es {
-		ioutil.Printf(bf, "%-*s%-*s%-*s%-*s%s\n", ageLen, age(e), typeLen, e.Type, reasonLen, e.Reason, objectLen, object(e), e.Note)
 	}
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -128,6 +128,12 @@ Traffic-manager cluster- and namespace-scoped RBAC rules for Deployments, Replic
 Clients now reject <code>--mapped-namespaces</code> values that are outside the namespace set managed by a namespace-limited traffic-manager. Invalid mapped namespace requests now fail during connect with a helpful error instead of leaving the client connected with namespaces that cannot be handled by the in-cluster manager or traffic-agents.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Report why the traffic-manager pod isn't ready during helm install</div></div>
+<div style="margin-left: 15px">
+
+When <code>telepresence helm install</code> or <code>telepresence helm upgrade</code> waits for the traffic-manager and its pod cannot become ready (a bad image, insufficient resources, or an unschedulable pod), the command now reports the underlying Kubernetes reason (for example <code>ImagePullBackOff</code>) and points at <code>kubectl describe pod</code>, instead of a confusing Helm rollback error. It also aborts as soon as a terminal failure is detected rather than waiting for the timeout.
+</div>
+
 ## Version 2.28.0 <span style="font-size: 16px;">(May 11)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Intercept workloads in mapped namespaces](reference/engagements/cli)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -134,6 +134,12 @@ Traffic-manager cluster- and namespace-scoped RBAC rules for Deployments, Replic
 Clients now reject <code>--mapped-namespaces</code> values that are outside the namespace set managed by a namespace-limited traffic-manager. Invalid mapped namespace requests now fail during connect with a helpful error instead of leaving the client connected with namespaces that cannot be handled by the in-cluster manager or traffic-agents.
   </Body>
 </Note>
+<Note>
+	<Title type="feature">Report why the traffic-manager pod isn't ready during helm install</Title>
+	<Body>
+When <code>telepresence helm install</code> or <code>telepresence helm upgrade</code> waits for the traffic-manager and its pod cannot become ready (a bad image, insufficient resources, or an unschedulable pod), the command now reports the underlying Kubernetes reason (for example <code>ImagePullBackOff</code>) and points at <code>kubectl describe pod</code>, instead of a confusing Helm rollback error. It also aborts as soon as a terminal failure is detected rather than waiting for the timeout.
+  </Body>
+</Note>
 ## Version 2.28.0 <span style={{fontSize:'16px'}}>(May 11)</span>
 <Note>
 	<Title type="feature" docs="reference/engagements/cli">Intercept workloads in mapped namespaces</Title>

--- a/integration_test/helm_test.go
+++ b/integration_test/helm_test.go
@@ -154,3 +154,35 @@ func (s *helmSuite) Test_CollidingInstalls() {
 	_, err := s.TelepresenceHelmInstall(ctx, false)
 	s.Error(err)
 }
+
+// Test_HelmInstallReportsPodFailureReason verifies that when the traffic-manager
+// pod cannot become ready (here: an image that can't be pulled), the install
+// error names the pod's not-ready reason instead of the opaque Helm rollback
+// error. See issue #2305.
+func (s *helmSuite) Test_HelmInstallReportsPodFailureReason() {
+	ctx := s.Context()
+	rq := s.Require()
+	mgrNs := s.ManagerNamespace() + "-badimg"
+	// With a local registry images are pulled (Always); when loaded directly they are not (Never).
+	pullPolicy := "Always"
+	if s.ManagerRegistry() == "local" {
+		pullPolicy = "Never"
+	}
+	defer func() {
+		_, _, _ = itest.Telepresence(ctx, "helm", "uninstall", "--manager-namespace", mgrNs) //nolint:dogsled // best-effort cleanup
+		itest.DeleteNamespaces(ctx, mgrNs)
+	}()
+
+	_, stderr, err := itest.Telepresence(ctx, "helm", "install",
+		"--manager-namespace", mgrNs,
+		"--create-namespace",
+		// Scope to its own namespace so it doesn't collide with the suite's manager.
+		"--set", "namespaces={"+mgrNs+"}",
+		"--set", "image.registry="+s.ManagerRegistry(),
+		"--set", "image.tag=9.9.9", // a valid version that does not exist as an image
+		"--set", "image.pullPolicy="+pullPolicy,
+	)
+	rq.Error(err)
+	rq.Contains(stderr, "traffic-manager pod is not ready",
+		"the install error should name the pod failure reason; got: %s", stderr)
+}

--- a/pkg/client/cli/helm/install.go
+++ b/pkg/client/cli/helm/install.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -16,7 +17,9 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/release"
+	events "k8s.io/api/events/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/telepresence/rpc/v2/connector"
@@ -25,6 +28,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
 	"github.com/telepresenceio/telepresence/v2/pkg/dos"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
+	"github.com/telepresenceio/telepresence/v2/pkg/eventwatch"
 	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/version"
 )
@@ -211,6 +215,7 @@ func timedRun(ctx context.Context, run func(time.Duration) error) error {
 
 func installNew(
 	ctx context.Context,
+	ki kubernetes.Interface,
 	chrt *chart.Chart,
 	helmConfig *action.Configuration,
 	releaseName, namespace string,
@@ -227,15 +232,16 @@ func installNew(
 	install.DisableHooks = req.NoHooks
 	install.KubeVersion = req.KubeVersion
 	install.Version = chrt.Metadata.Version
-	return timedRun(ctx, func(timeout time.Duration) error {
+	return runManagerHelm(ctx, ki, namespace, releaseName, func(c context.Context, timeout time.Duration) error {
 		install.Timeout = timeout
-		_, err := install.Run(chrt, values)
+		_, err := install.RunWithContext(c, chrt, values)
 		return err
 	})
 }
 
 func upgradeExisting(
 	ctx context.Context,
+	ki kubernetes.Interface,
 	existingVer string,
 	chrt *chart.Chart,
 	helmConfig *action.Configuration,
@@ -252,11 +258,85 @@ func upgradeExisting(
 	upgrade.ReuseValues = req.ReuseValues
 	upgrade.DisableHooks = req.NoHooks
 	upgrade.Version = chrt.Metadata.Version
-	return timedRun(ctx, func(timeout time.Duration) error {
+	return runManagerHelm(ctx, ki, ns, releaseName, func(c context.Context, timeout time.Duration) error {
 		upgrade.Timeout = timeout
-		_, err := upgrade.Run(releaseName, chrt, values)
+		_, err := upgrade.RunWithContext(c, releaseName, chrt, values)
 		return err
 	})
+}
+
+// runManagerHelm runs a traffic-manager install/upgrade under a TimeoutHelm
+// context while watching the manager namespace for Warning events. If the
+// traffic-manager pod hits a terminal failure (ImagePullBackOff,
+// FailedScheduling, ...), the operation is canceled — so Helm aborts the wait and
+// rolls back immediately instead of waiting out the timeout — and the returned
+// error names that reason rather than the opaque rollback error. If ki is nil
+// (no usable cluster client) the watch is skipped and the raw error is returned.
+func runManagerHelm(
+	ctx context.Context,
+	ki kubernetes.Interface,
+	namespace, releaseName string,
+	run func(context.Context, time.Duration) error,
+) error {
+	timeouts := client.GetConfig(ctx).Timeouts()
+	ctx, cancel := timeouts.TimeoutContext(ctx, client.TimeoutHelm)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		fes      []*events.Event
+		terminal *events.Event
+	)
+	if ki != nil {
+		if ec, err := eventwatch.WatchWarnings(ctx, ki, namespace, releaseName); err != nil {
+			clog.Debugf(ctx, "unable to watch %s events in %s: %v", releaseName, namespace, err)
+		} else {
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case e, ok := <-ec:
+						if !ok {
+							return
+						}
+						mu.Lock()
+						fes = append(fes, e)
+						abort := terminal == nil && eventwatch.IsTerminal(e)
+						if abort {
+							terminal = e
+						}
+						mu.Unlock()
+						if abort {
+							clog.Infof(ctx, "Aborting helm operation; traffic-manager pod %s: %s", e.Reason, e.Note)
+							cancel()
+						}
+					}
+				}
+			}()
+		}
+	}
+
+	err := run(ctx, timeouts.Get(client.TimeoutHelm))
+	if err == nil {
+		return nil
+	}
+	err = client.CheckTimeout(ctx, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if terminal != nil {
+		return errcat.User.Newf(
+			"traffic-manager pod is not ready: %s: %s\nFor more detail, run: kubectl describe pod -n %s -l app=traffic-manager",
+			terminal.Reason, terminal.Note, namespace)
+	}
+	if len(fes) > 0 {
+		bf := &strings.Builder{}
+		fmt.Fprintf(bf, "%s\nEvents that may be relevant:\n", err.Error())
+		eventwatch.WriteList(bf, fes)
+		return errcat.User.New(bf.String())
+	}
+	return err
 }
 
 func uninstallExisting(ctx context.Context, helmConfig *action.Configuration, releaseName, namespace string, req *Request) error {
@@ -372,16 +452,29 @@ func ensureIsInstalled(
 		return err
 	}
 
+	// Build a cluster client so that, if the traffic-manager pod fails to become ready, we can report
+	// the Kubernetes reason (ImagePullBackOff, FailedScheduling, ...) instead of an opaque Helm timeout.
+	// Best-effort: a failure here just disables that diagnostic.
+	var ki kubernetes.Interface
+	if cfg, cErr := clientGetter.ToRESTConfig(); cErr == nil {
+		if ki, cErr = kubernetes.NewForConfig(cfg); cErr != nil {
+			clog.Debugf(ctx, "traffic-manager event diagnostics disabled: %v", cErr)
+			ki = nil
+		}
+	} else {
+		clog.Debugf(ctx, "traffic-manager event diagnostics disabled: %v", cErr)
+	}
+
 	switch {
 	case existing == nil && req.Type == Upgrade: // fresh install
 		err = fmt.Errorf("%s is not installed, use 'telepresence helm install' to install it", releaseName)
 	case existing == nil:
 		clog.Infof(ctx, "ensureIsInstalled(namespace=%q): performing fresh install...", namespace)
-		err = installNew(ctx, chrt, helmConfig, releaseName, namespace, req, vals)
+		err = installNew(ctx, ki, chrt, helmConfig, releaseName, namespace, req, vals)
 	case req.Type == Upgrade: // replace existing install
 		clog.Infof(ctx, "ensureIsInstalled(namespace=%q): replacing %s from %q to %q...",
 			namespace, releaseName, releaseVer(existing), chrt.Metadata.AppVersion)
-		err = upgradeExisting(ctx, releaseVer(existing), chrt, helmConfig, releaseName, namespace, req, vals)
+		err = upgradeExisting(ctx, ki, releaseVer(existing), chrt, helmConfig, releaseName, namespace, req, vals)
 	default:
 		err = fmt.Errorf(
 			"%s version %q is already installed, use 'telepresence helm upgrade' instead to replace it",

--- a/pkg/eventwatch/eventwatch.go
+++ b/pkg/eventwatch/eventwatch.go
@@ -1,0 +1,137 @@
+// Package eventwatch streams and classifies Kubernetes Warning events for a
+// named workload (and the pods it owns), so callers can surface why a pod failed
+// to become ready — ImagePullBackOff, FailedScheduling, and so on — instead of
+// waiting out a timeout and reporting a generic error.
+package eventwatch
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	events "k8s.io/api/events/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/v2/pkg/ioutil"
+)
+
+// WatchWarnings streams Warning events (type != "Normal") for the object named
+// name, or any pod it owns (matched by the "name-" prefix), in namespace. Only
+// events created at or after the call are delivered. The returned channel stops
+// receiving when ctx is done or the underlying watch ends.
+//
+// The kubernetes.Interface is passed explicitly so the watcher works both in the
+// traffic-manager (in-cluster) and in the client (against the user's kubeconfig).
+func WatchWarnings(ctx context.Context, ki kubernetes.Interface, namespace, name string) (<-chan *events.Event, error) {
+	// A timestamp with second granularity is needed here, because that's what the event creation time uses.
+	// Finer granularity will result in relevant events seemingly being created before this timestamp because
+	// they have the fraction of seconds trimmed off (which is odd, given that the type used is a MicroTime).
+	start := time.Unix(time.Now().Unix(), 0)
+
+	ei := ki.EventsV1().Events(namespace)
+	w, err := ei.Watch(ctx, meta.ListOptions{
+		FieldSelector: fields.OneTermNotEqualSelector("type", "Normal").String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	nd := name + "-"
+	ec := make(chan *events.Event)
+	go func() {
+		defer w.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case eo, ok := <-w.ResultChan():
+				if !ok {
+					return
+				}
+				// Using negated Before when comparing the timestamps here is relevant. They will often be equal and still relevant
+				if e, ok := eo.Object.(*events.Event); ok &&
+					!e.CreationTimestamp.Time.Before(start) &&
+					!strings.HasPrefix(e.Note, "(combined from similar events):") {
+					n := e.Regarding.Name
+					if strings.HasPrefix(n, nd) || n == name {
+						clog.Infof(ctx, "%s %s %s", e.Type, e.Reason, e.Note)
+						ec <- e
+					}
+				}
+			}
+		}
+	}()
+	return ec, nil
+}
+
+// transientNotes are substrings in an event's note that indicate a retryable
+// condition — the action will be retried and may still succeed — so the event is
+// not treated as terminal.
+var transientNotes = []string{ //nolint:gochecknoglobals // effectively a constant
+	"waiting for ephemeral volume",
+	"unbound immediate PersistentVolumeClaims",
+	"skip schedule deleting pod",
+	"nodes are available",
+}
+
+// IsTerminal reports whether a Warning event names a failure that will not
+// resolve on its own, so a caller can stop waiting and report it immediately
+// rather than waiting for a timeout.
+func IsTerminal(e *events.Event) bool {
+	switch e.Reason {
+	case "BackOff":
+		// A container was created but fails to start (image pull back-off, crash loop).
+		return true
+	case "Failed", "FailedCreate", "FailedScheduling":
+		// Usually fatal (bad image, resource quota, unschedulable), but some of
+		// these are retried and may still succeed.
+		if e.Type == "Warning" {
+			for _, t := range transientNotes {
+				if strings.Contains(e.Note, t) {
+					return false
+				}
+			}
+		}
+		return true
+	default:
+		// Other warnings are often retried and eventually succeed.
+		return false
+	}
+}
+
+// WriteList renders es as a kubectl-style AGE/TYPE/REASON/OBJECT/MESSAGE table.
+func WriteList(bf *strings.Builder, es []*events.Event) {
+	now := time.Now()
+	age := func(e *events.Event) string {
+		return now.Sub(e.CreationTimestamp.Time).Truncate(time.Second).String()
+	}
+	object := func(e *events.Event) string {
+		or := e.Regarding
+		return strings.ToLower(or.Kind) + "/" + or.Name
+	}
+	ageLen, typeLen, reasonLen, objectLen := len("AGE"), len("TYPE"), len("REASON"), len("OBJECT")
+	for _, e := range es {
+		if l := len(age(e)); l > ageLen {
+			ageLen = l
+		}
+		if l := len(e.Type); l > typeLen {
+			typeLen = l
+		}
+		if l := len(e.Reason); l > reasonLen {
+			reasonLen = l
+		}
+		if l := len(object(e)); l > objectLen {
+			objectLen = l
+		}
+	}
+	ageLen += 3
+	typeLen += 3
+	reasonLen += 3
+	objectLen += 3
+	ioutil.Printf(bf, "%-*s%-*s%-*s%-*s%s\n", ageLen, "AGE", typeLen, "TYPE", reasonLen, "REASON", objectLen, "OBJECT", "MESSAGE")
+	for _, e := range es {
+		ioutil.Printf(bf, "%-*s%-*s%-*s%-*s%s\n", ageLen, age(e), typeLen, e.Type, reasonLen, e.Reason, objectLen, object(e), e.Note)
+	}
+}

--- a/pkg/eventwatch/eventwatch_test.go
+++ b/pkg/eventwatch/eventwatch_test.go
@@ -1,0 +1,62 @@
+package eventwatch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+	events "k8s.io/api/events/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsTerminal(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		etype  string
+		note   string
+		want   bool
+	}{
+		{"backoff is terminal", "BackOff", "Warning", "Back-off restarting failed container", true},
+		{"image pull failure is terminal", "Failed", "Warning", `Failed to pull image "tel2:9.9.9": not found`, true},
+		{"failed create is terminal", "FailedCreate", "Warning", "create Pod failed: forbidden", true},
+		{"unschedulable on resources is terminal", "FailedScheduling", "Warning", "0/3 nodes are available: Insufficient cpu", false},
+		{"ephemeral volume wait is transient", "Failed", "Warning", "waiting for ephemeral volume controller to create the persistentvolumeclaim", false},
+		{"unbound pvc is transient", "FailedScheduling", "Warning", "0/1 nodes: unbound immediate PersistentVolumeClaims", false},
+		{"skip schedule deleting pod is transient", "FailedScheduling", "Warning", "skip schedule deleting pod: ns/p", false},
+		{"nodes are available is transient", "FailedScheduling", "Warning", "0/3 nodes are available", false},
+		{"unknown reason is not terminal", "SomethingElse", "Warning", "whatever", false},
+		{"non-warning transient note is still terminal", "Failed", "Normal", "nodes are available", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &events.Event{Reason: tt.reason, Type: tt.etype, Note: tt.note}
+			assert.Equal(t, tt.want, IsTerminal(e))
+		})
+	}
+}
+
+func TestWriteList(t *testing.T) {
+	now := meta.Now()
+	es := []*events.Event{
+		{
+			ObjectMeta: meta.ObjectMeta{CreationTimestamp: now},
+			Regarding:  core.ObjectReference{Kind: "Pod", Name: "traffic-manager-abc"},
+			Type:       "Warning",
+			Reason:     "Failed",
+			Note:       `Failed to pull image "tel2:9.9.9"`,
+		},
+	}
+	bf := &strings.Builder{}
+	WriteList(bf, es)
+	out := bf.String()
+
+	require.Contains(t, out, "AGE")
+	require.Contains(t, out, "REASON")
+	require.Contains(t, out, "OBJECT")
+	require.Contains(t, out, "Failed")
+	require.Contains(t, out, "pod/traffic-manager-abc")
+	require.Contains(t, out, `Failed to pull image "tel2:9.9.9"`)
+}


### PR DESCRIPTION
## Problem

When `telepresence helm install` / `telepresence helm upgrade` waits for the traffic-manager and its pod cannot become ready — a bad image (`ImagePullBackOff`), insufficient resources, an unschedulable pod — Helm's atomic rollback produces a confusing secondary error that buries the real cause and deletes the pod before it can be inspected. Measured on minikube: ~38s wait, then `an error occurred while uninstalling the release. original install error: services "traffic-manager" not found ...`.

(`telepresence connect` no longer performs an implicit `helm install`, so the only place this waited-and-showed-useless-info behavior remained was the explicit `helm` command, which this PR fixes.)

Closes #2305.

## Change

While Helm waits, watch the manager namespace for Warning events. On the first **terminal** event (`ImagePullBackOff`, `FailedScheduling`, ...) cancel the operation so Helm aborts and rolls back immediately instead of waiting out `timeouts.helm`, and return an error that names the reason and points at `kubectl describe pod`:

```
traffic-manager pod is not ready: Failed: Error: ErrImageNeverPull
For more detail, run: kubectl describe pod -n NS -l app=traffic-manager
```

- **`Atomic` is preserved** — a failed install still leaves no half-installed release behind.
- **Best-effort** — if no cluster client is available, it falls back to the original Helm error.

The event watching, terminal-event classification, and event formatting are extracted into a new `pkg/eventwatch`, generalized from the logic the traffic-manager already used when waiting for a traffic-agent to be injected. The manager now calls the shared package; its agent-specific handling (failed-container log retrieval, resource-quota and EKS webhook hints) stays local, and behavior on the agent-injection path is unchanged.

## Validation

- Unit tests for `pkg/eventwatch` (`IsTerminal`, `WriteList`); manager `state` tests; `make check-unit` green; `make lint-go` clean.
- On minikube: the `SingleService` intercept suite passes (no agent-injection regression), and a new integration test `Test_HelmInstallReportsPodFailureReason` asserts the install error names the pod's not-ready reason. Manual check: the bad-image install now reports the reason in ~10s with the rollback intact.