### PR TITLE
Honor the client's DNS deadline in traffic-agent lookups

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -259,6 +259,16 @@ items:
           <code>kubectl describe pod</code>, instead of a confusing Helm rollback
           error. It also aborts as soon as a terminal failure is detected rather
           than waiting for the timeout.
+      - type: bugfix
+        title: Traffic-agent DNS lookups honor the client's DNS lookup timeout
+        body: >-
+          The traffic-agent imposed a hard-coded 250 millisecond timeout on the
+          DNS lookups it performs on behalf of a connected client. A resolution
+          that needs search-path expansion, or that passes through a service-mesh
+          DNS proxy such as Istio's, can easily take longer, causing spurious
+          <code>NXDOMAIN</code> answers on the workstation. The agent now honors
+          the deadline of the calling client, which is governed by the
+          <code>dns.lookupTimeout</code> client setting.
   - version: 2.28.0
     date: 2026-05-11
     notes:

--- a/cmd/traffic/cmd/agent/server.go
+++ b/cmd/traffic/cmd/agent/server.go
@@ -40,8 +40,16 @@ func (s *state) Lookup(ctx context.Context, request *rpc.LookupRequest) (*rpc.Lo
 	}
 	var ips []netip.Addr
 	response := &rpc.LookupResponse{}
-	ctx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
-	defer cancel()
+	// The caller's gRPC deadline (the client bounds every cluster lookup with its
+	// dns.lookupTimeout) governs the lookup. A resolution that needs search-path
+	// expansion, or that passes through a service-mesh DNS proxy such as Istio's,
+	// can easily take longer than a fraction of a second, so no shorter timeout is
+	// imposed here. The fallback only guards against a caller without a deadline.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 4*time.Second)
+		defer cancel()
+	}
 	ips, err := net.DefaultResolver.LookupNetIP(ctx, "ip", name[:nl-1])
 	if err != nil {
 		_, err = dnsproxy.MakeDNSError(err)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -134,6 +134,12 @@ Clients now reject <code>--mapped-namespaces</code> values that are outside the 
 When <code>telepresence helm install</code> or <code>telepresence helm upgrade</code> waits for the traffic-manager and its pod cannot become ready (a bad image, insufficient resources, or an unschedulable pod), the command now reports the underlying Kubernetes reason (for example <code>ImagePullBackOff</code>) and points at <code>kubectl describe pod</code>, instead of a confusing Helm rollback error. It also aborts as soon as a terminal failure is detected rather than waiting for the timeout.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Traffic-agent DNS lookups honor the client's DNS lookup timeout</div></div>
+<div style="margin-left: 15px">
+
+The traffic-agent imposed a hard-coded 250 millisecond timeout on the DNS lookups it performs on behalf of a connected client. A resolution that needs search-path expansion, or that passes through a service-mesh DNS proxy such as Istio's, can easily take longer, causing spurious <code>NXDOMAIN</code> answers on the workstation. The agent now honors the deadline of the calling client, which is governed by the <code>dns.lookupTimeout</code> client setting.
+</div>
+
 ## Version 2.28.0 <span style="font-size: 16px;">(May 11)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Intercept workloads in mapped namespaces](reference/engagements/cli)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -140,6 +140,12 @@ Clients now reject <code>--mapped-namespaces</code> values that are outside the 
 When <code>telepresence helm install</code> or <code>telepresence helm upgrade</code> waits for the traffic-manager and its pod cannot become ready (a bad image, insufficient resources, or an unschedulable pod), the command now reports the underlying Kubernetes reason (for example <code>ImagePullBackOff</code>) and points at <code>kubectl describe pod</code>, instead of a confusing Helm rollback error. It also aborts as soon as a terminal failure is detected rather than waiting for the timeout.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Traffic-agent DNS lookups honor the client's DNS lookup timeout</Title>
+	<Body>
+The traffic-agent imposed a hard-coded 250 millisecond timeout on the DNS lookups it performs on behalf of a connected client. A resolution that needs search-path expansion, or that passes through a service-mesh DNS proxy such as Istio's, can easily take longer, causing spurious <code>NXDOMAIN</code> answers on the workstation. The agent now honors the deadline of the calling client, which is governed by the <code>dns.lookupTimeout</code> client setting.
+  </Body>
+</Note>
 ## Version 2.28.0 <span style={{fontSize:'16px'}}>(May 11)</span>
 <Note>
 	<Title type="feature" docs="reference/engagements/cli">Intercept workloads in mapped namespaces</Title>


### PR DESCRIPTION
The traffic-agent imposes a hard-coded **250 ms** timeout on the DNS lookups it performs on behalf of a connected client (`cmd/traffic/cmd/agent/server.go`). A resolution that needs search-path expansion — the agent resolves relative names against the pod's `resolv.conf` with `ndots:5`, so a short name walks 3-4 search domains sequentially — or that passes through a service-mesh DNS proxy such as Istio's, can easily take longer. The lookup is then cut off, the client receives a spurious `NXDOMAIN`, and the workstation caches the negative answer.

The client already bounds every cluster lookup with its `dns.lookupTimeout` setting (default 4 s, `pkg/client/rootd/dns/server.go`), and that deadline propagates over gRPC. The agent now relies on the caller's deadline instead of imposing a shorter one of its own. A 4-second fallback guards against callers without a deadline.