### PR TITLE
Mount and subnet stability fixes

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -284,6 +284,24 @@ items:
           the deadline of the calling client, which is governed by the
           <code>dns.lookupTimeout</code> client setting.
       - type: bugfix
+        title: Remote mounts retry their initial connection to the traffic-agent
+        body: >-
+          When a remote mount was initiated immediately after its pod was
+          created, the first connection to the traffic-agent could lose a race
+          against the routing of the pod's new IP address. The failure was
+          treated as permanent, leaving the local mount directory empty for the
+          remainder of the engagement. The connection is now retried until the
+          intercept timeout expires.
+      - type: bugfix
+        title: Pods using the highest address of a routed subnet are now reachable
+        body: >-
+          When a subnet was routed through the virtual network interface, the
+          kernel derived a broadcast entry for the subnet's highest address and
+          refused unicast connections to it. A CNI will happily assign that
+          address to a pod, rendering the pod unreachable from the workstation.
+          Link-level broadcast has no meaning on the L3 interface, so the entry
+          is now removed, making every address in a routed subnet reachable.
+      - type: bugfix
         title: Application traffic no longer bypasses the service mesh in engaged pods
         body: >-
           The traffic-agent's own traffic is exempted from service-mesh

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -146,6 +146,18 @@ Names that only a service mesh can resolve — such as Istio <code>ServiceEntry<
 The traffic-agent imposed a hard-coded 250 millisecond timeout on the DNS lookups it performs on behalf of a connected client. A resolution that needs search-path expansion, or that passes through a service-mesh DNS proxy such as Istio's, can easily take longer, causing spurious <code>NXDOMAIN</code> answers on the workstation. The agent now honors the deadline of the calling client, which is governed by the <code>dns.lookupTimeout</code> client setting.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Remote mounts retry their initial connection to the traffic-agent</div></div>
+<div style="margin-left: 15px">
+
+When a remote mount was initiated immediately after its pod was created, the first connection to the traffic-agent could lose a race against the routing of the pod's new IP address. The failure was treated as permanent, leaving the local mount directory empty for the remainder of the engagement. The connection is now retried until the intercept timeout expires.
+</div>
+
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Pods using the highest address of a routed subnet are now reachable</div></div>
+<div style="margin-left: 15px">
+
+When a subnet was routed through the virtual network interface, the kernel derived a broadcast entry for the subnet's highest address and refused unicast connections to it. A CNI will happily assign that address to a pod, rendering the pod unreachable from the workstation. Link-level broadcast has no meaning on the L3 interface, so the entry is now removed, making every address in a routed subnet reachable.
+</div>
+
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Application traffic no longer bypasses the service mesh in engaged pods](howtos/istio)</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -153,6 +153,18 @@ The traffic-agent imposed a hard-coded 250 millisecond timeout on the DNS lookup
   </Body>
 </Note>
 <Note>
+	<Title type="bugfix">Remote mounts retry their initial connection to the traffic-agent</Title>
+	<Body>
+When a remote mount was initiated immediately after its pod was created, the first connection to the traffic-agent could lose a race against the routing of the pod's new IP address. The failure was treated as permanent, leaving the local mount directory empty for the remainder of the engagement. The connection is now retried until the intercept timeout expires.
+  </Body>
+</Note>
+<Note>
+	<Title type="bugfix">Pods using the highest address of a routed subnet are now reachable</Title>
+	<Body>
+When a subnet was routed through the virtual network interface, the kernel derived a broadcast entry for the subnet's highest address and refused unicast connections to it. A CNI will happily assign that address to a pod, rendering the pod unreachable from the workstation. Link-level broadcast has no meaning on the L3 interface, so the entry is now removed, making every address in a routed subnet reachable.
+  </Body>
+</Note>
+<Note>
 	<Title type="bugfix" docs="howtos/istio">Application traffic no longer bypasses the service mesh in engaged pods</Title>
 	<Body>
 The traffic-agent's own traffic is exempted from service-mesh processing using an iptables owner match, but the match was based on the agent's UID, which is inherited from the app container's securityContext (or defaults to root). An application sharing that UID had its outbound traffic silently bypass the mesh sidecar — no mTLS, telemetry, or policy enforcement. The agent container is now assigned a distinct primary group (default <code>7439</code>, overridable with <code>agent.securityContext.runAsGroup</code>) and the owner matches are group-based, so application traffic always traverses the mesh.

--- a/integration_test/large_files_test.go
+++ b/integration_test/large_files_test.go
@@ -171,7 +171,16 @@ func (s *largeFilesSuite) createIntercepts(ctx context.Context) {
 		}(i)
 	}
 	wg.Wait()
-	time.Sleep(7 * time.Second)
+
+	// The intercept command returns when the remote mount has been initiated, not when it
+	// is established, so wait until the mounted directories materialize.
+	for i := 0; i < s.ServiceCount(); i++ {
+		dir := filepath.Join(s.mountPoint[i], "home", "scratch")
+		s.Require().Eventually(func() bool {
+			_, err := os.Stat(dir)
+			return err == nil
+		}, 30*time.Second, time.Second, "mount %s did not materialize", dir)
+	}
 }
 
 func (s *largeFilesSuite) leaveIntercepts(ctx context.Context) {

--- a/pkg/client/remotefs/fuseftp_linked.go
+++ b/pkg/client/remotefs/fuseftp_linked.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/telepresenceio/clog"
 	"github.com/telepresenceio/go-fuseftp/pkg/fs"
 	"github.com/telepresenceio/go-fuseftp/rpc"
@@ -53,12 +55,27 @@ func (m *ftpMounter) Start(ctx context.Context, workload, container, clientMount
 		clog.Infof(ctx, "Mounting FTP file system for container %s[%s] (address %s)%s at %q", workload, container, podAddrPort, roTxt, clientMountPoint)
 		// FTPs remote mount is already relative to the agentconfig.ExportsMountPoint
 		rmp := strings.TrimPrefix(mountPoint, agentconfig.ExportsMountPoint)
-		ftpClient, err := fs.NewFTPClient(ctx.Done(), podAddrPort, rmp, ro, cfg.Timeouts().Get(client.TimeoutFtpReadWrite))
+
+		// The dial may lose a race against the routing of a just-created pod's IP, so
+		// dial errors are retried until the intercept timeout expires.
+		var ftpClient fs.FTPClient
+		bc := backoff.NewExponentialBackOff()
+		bc.InitialInterval = 100 * time.Millisecond
+		bc.MaxInterval = 3 * time.Second
+		bc.MaxElapsedTime = cfg.Timeouts().Get(client.TimeoutIntercept)
+		err := backoff.Retry(func() error {
+			var err error
+			ftpClient, err = fs.NewFTPClient(ctx.Done(), podAddrPort, rmp, ro, cfg.Timeouts().Get(client.TimeoutFtpReadWrite))
+			if err != nil {
+				clog.Debugf(ctx, "FTP connection to %s failed (%v), retrying", podAddrPort, err)
+			}
+			return err
+		}, backoff.WithContext(bc, ctx))
 		if err != nil {
 			return err
 		}
 		host := fs.NewHost(ftpClient, clientMountPoint)
-		if err = host.Start(ctx, 5*time.Second); err != nil {
+		if err := host.Start(ctx, 5*time.Second); err != nil {
 			return err
 		}
 

--- a/pkg/vif/device_linux.go
+++ b/pkg/vif/device_linux.go
@@ -3,6 +3,8 @@ package vif
 import (
 	"context"
 	cryptoRand "crypto/rand"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -98,7 +100,36 @@ func (d *device) addSubnet(_ context.Context, pfx netip.Prefix) error {
 	if err := netlink.AddrAdd(link, addr); err != nil {
 		return fmt.Errorf("failed to add address %s to interface %s: %w", pfx, d.name, err)
 	}
+	// The kernel derives a broadcast entry for the subnet's highest address from the
+	// address assignment and refuses unicast connects to that address, but the address
+	// is a perfectly valid pod IP. Link-level broadcast has no meaning on an L3 TUN
+	// device, so the entry is removed.
+	if bc, ok := subnetBroadcast(pfx); ok {
+		err := netlink.RouteDel(&netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Table:     unix.RT_TABLE_LOCAL,
+			Type:      unix.RTN_BROADCAST,
+			Scope:     netlink.SCOPE_LINK,
+			Dst:       subnet.PrefixToIPNet(netip.PrefixFrom(bc, bc.BitLen())),
+		})
+		if err != nil && !errors.Is(err, unix.ESRCH) {
+			return fmt.Errorf("failed to remove broadcast entry %s from interface %s: %w", bc, d.name, err)
+		}
+	}
 	return nil
+}
+
+// subnetBroadcast returns the broadcast address that the kernel derives when the given
+// prefix is assigned to an interface. The second return value is false when no broadcast
+// entry is created for the prefix.
+func subnetBroadcast(pfx netip.Prefix) (netip.Addr, bool) {
+	if !pfx.Addr().Is4() || pfx.Bits() >= 31 {
+		return netip.Addr{}, false
+	}
+	bc := pfx.Masked().Addr().As4()
+	v := binary.BigEndian.Uint32(bc[:]) | (uint32(1)<<(32-pfx.Bits()) - 1)
+	binary.BigEndian.PutUint32(bc[:], v)
+	return netip.AddrFrom4(bc), true
 }
 
 func (d *device) removeSubnet(_ context.Context, pfx netip.Prefix) error {


### PR DESCRIPTION
Two client-side fixes found while chasing the flaky `Test_LargeFileIntercepts_fuseftp` (stacked on #4159).

## Pods using the highest address of a routed subnet were unreachable

When a subnet is assigned to the TUN device, the kernel derives a broadcast entry for the subnet's highest address in the local routing table and refuses unicast connections to it (`connect: network is unreachable`). A CNI will happily assign that address to a pod — in the failing run, a pod received `10.244.0.255` within the routed `10.244.0.0/24` and became undialable from the workstation. Link-level broadcast has no meaning on an L3 TUN device, so the entry is now removed right after the address assignment.

The address assignment itself is untouched: plumbing the subnets as explicit routes instead was tried and rejected, because the kernel's address-derived routes insert ahead of conflicting same-prefix routes — the very mechanism that makes `allowConflictingSubnets` win over a conflicting local route.

## Remote mounts retry their initial connection

A remote mount initiated right after its pod is created can lose a race against the routing of the pod's new IP. The fuseftp mounter treated the resulting dial error as permanent, leaving the local mount directory empty for the remainder of the engagement. The connection is now retried with exponential backoff until the intercept timeout expires.

The LargeFiles suite no longer sleeps for an arbitrary period after creating its intercepts; it waits for the mounted directories to materialize instead.