### PR TITLE
Show ingress URLs for intercepted service ports

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -363,6 +363,16 @@ items:
           the owner matches are group-based, so application traffic always
           traverses the mesh.
         docs: howtos/istio
+      - type: feature
+        title: Show ingress URLs for intercepted service ports
+        body: >-
+          The output of <code>telepresence intercept</code> and
+          <code>telepresence list</code> now shows the ingress URLs through
+          which an intercepted service port can be reached. When the intercept
+          uses HTTP header filters, a ready-to-paste <code>curl</code> example
+          with the matching <code>-H</code> flags is included, making it easy
+          to send a request that is routed to the intercept handler on the
+          workstation.
   - version: 2.28.0
     date: 2026-05-11
     notes:

--- a/charts/telepresence-oss/templates/trafficManagerRbac/cluster-scope.yaml
+++ b/charts/telepresence-oss/templates/trafficManagerRbac/cluster-scope.yaml
@@ -57,9 +57,12 @@ rules:
 - apiGroups:
     - "networking.k8s.io"
   resources:
+    - ingresses
     - servicecidrs
   verbs:
+    - get
     - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/telepresence-oss/templates/trafficManagerRbac/namespace-scope.yaml
+++ b/charts/telepresence-oss/templates/trafficManagerRbac/namespace-scope.yaml
@@ -144,9 +144,12 @@ rules:
   - apiGroups:
       - "networking.k8s.io"
     resources:
+      - ingresses
       - servicecidrs
     verbs:
+      - get
       - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 	"google.golang.org/protobuf/types/known/durationpb"
 	core "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
@@ -275,6 +276,7 @@ func (c *configWatcher) startInformers(ctx context.Context, ns string) (iwc *inf
 		}
 	}
 	c.startPods(ctx, ns)
+	c.startIngresses(ctx, ns)
 	kf := informer.GetK8sFactory(ctx, ns)
 	kf.Start(ctx.Done())
 	kf.WaitForCacheSync(ctx.Done())
@@ -437,6 +439,22 @@ func (c *configWatcher) startPods(ctx context.Context, ns string) cache.SharedIn
 		clog.Errorf(ctx, "Watcher for pods %s: %v", whereWeWatch(ns), err)
 	})
 	return ix
+}
+
+func (c *configWatcher) startIngresses(ctx context.Context, ns string) {
+	f := informer.GetK8sFactory(ctx, ns)
+	ix := f.Networking().V1().Ingresses().Informer()
+	_ = ix.SetTransform(func(o any) (any, error) {
+		if ing, ok := o.(*netv1.Ingress); ok {
+			ing.ManagedFields = nil
+			ing.Finalizers = nil
+			ing.OwnerReferences = nil
+		}
+		return o, nil
+	})
+	_ = ix.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		clog.Errorf(ctx, "Watcher for ingresses %s: %v", whereWeWatch(ns), err)
+	})
 }
 
 func (c *configWatcher) Start(ctx context.Context) {

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -616,7 +616,9 @@ func (s *State) restoreAppContainer(ctx context.Context, ii *rpc.InterceptInfo, 
 			cn, _, err = icept.FindIntercept(sc, spec)
 		}
 		if err != nil || cn.Replace == desiredPolicy {
-			return nil, nil
+			// No change is needed. Return the unchanged config rather than nil, because
+			// a nil return value would delete the config from the map.
+			return sc, nil
 		}
 		cn.Replace = desiredPolicy
 

--- a/cmd/traffic/cmd/manager/state/workload_exposure.go
+++ b/cmd/traffic/cmd/manager/state/workload_exposure.go
@@ -211,17 +211,39 @@ func attachRoutesForIngress(ingress *netv1.Ingress, services map[string]*rpc.Ser
 		}
 	}
 
+	addresses := ingressAddresses(ingress)
 	for key, aggregate := range aggregates {
 		key.service.Routes = append(key.service.Routes, &rpc.RouteAssociation{
-			Type:     "Ingress",
-			Name:     ingress.Name,
-			Hosts:    sortedKeys(aggregate.hosts),
-			Paths:    sortedKeys(aggregate.paths),
-			Tls:      ingressUsesTLS(ingress),
-			PortName: key.portName,
-			Port:     key.port,
+			Type:      "Ingress",
+			Name:      ingress.Name,
+			Hosts:     sortedKeys(aggregate.hosts),
+			Paths:     sortedKeys(aggregate.paths),
+			Tls:       ingressUsesTLS(ingress),
+			PortName:  key.portName,
+			Port:      key.port,
+			Addresses: addresses,
 		})
 	}
+}
+
+// ingressAddresses returns the load-balancer addresses of the given ingress,
+// preferring hostnames over IPs.
+func ingressAddresses(ingress *netv1.Ingress) []string {
+	lbs := ingress.Status.LoadBalancer.Ingress
+	if len(lbs) == 0 {
+		return nil
+	}
+	addresses := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		switch {
+		case lb.Hostname != "":
+			addresses = append(addresses, lb.Hostname)
+		case lb.IP != "":
+			addresses = append(addresses, lb.IP)
+		}
+	}
+	sort.Strings(addresses)
+	return addresses
 }
 
 func ingressBackendMatch(

--- a/cmd/traffic/cmd/manager/state/workload_exposure.go
+++ b/cmd/traffic/cmd/manager/state/workload_exposure.go
@@ -1,0 +1,321 @@
+package state
+
+import (
+	"context"
+	"maps"
+	"sort"
+
+	netv1 "k8s.io/api/networking/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/telepresenceio/clog"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+)
+
+type workloadExposure struct {
+	desiredReplicas int32
+	readyReplicas   int32
+	services        []*rpc.ServiceAssociation
+	routes          []*rpc.RouteAssociation
+}
+
+type serviceRouteKey struct {
+	name      string
+	namespace string
+	portName  string
+	port      int32
+}
+
+func describeWorkloadExposure(ctx context.Context, wl k8sapi.Workload) workloadExposure {
+	services := serviceAssociationsForWorkload(ctx, wl)
+	return workloadExposure{
+		desiredReplicas: k8sapi.DesiredReplicas(wl),
+		readyReplicas:   k8sapi.ReadyReplicas(wl),
+		services:        services,
+		routes:          routeAssociationsForServices(ctx, wl.GetNamespace(), serviceRouteIndex(services)),
+	}
+}
+
+func serviceAssociationsForWorkload(ctx context.Context, wl k8sapi.Workload) []*rpc.ServiceAssociation {
+	podTemplate := wl.GetPodTemplate().DeepCopy()
+	if podTemplate.Namespace == "" {
+		podTemplate.Namespace = wl.GetNamespace()
+	}
+
+	objects, err := agentmap.FindServicesForPod(ctx, podTemplate, "")
+	if err != nil {
+		clog.Warnf(ctx, "unable to discover services for %s %s.%s: %v", wl.GetKind(), wl.GetName(), wl.GetNamespace(), err)
+		return nil
+	}
+
+	services := make([]*rpc.ServiceAssociation, 0, len(objects))
+	for _, object := range objects {
+		service, ok := k8sapi.ServiceImpl(object)
+		if !ok {
+			continue
+		}
+
+		ports := make([]*rpc.ServicePort, 0, len(service.Spec.Ports))
+		for _, port := range service.Spec.Ports {
+			ports = append(ports, &rpc.ServicePort{
+				Name:       port.Name,
+				Port:       port.Port,
+				TargetPort: port.TargetPort.String(),
+			})
+		}
+		sort.Slice(ports, func(i, j int) bool {
+			if ports[i].GetPort() != ports[j].GetPort() {
+				return ports[i].GetPort() < ports[j].GetPort()
+			}
+			return ports[i].GetName() < ports[j].GetName()
+		})
+
+		services = append(services, &rpc.ServiceAssociation{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+			Ports:     ports,
+		})
+	}
+
+	sort.Slice(services, func(i, j int) bool {
+		if services[i].GetNamespace() != services[j].GetNamespace() {
+			return services[i].GetNamespace() < services[j].GetNamespace()
+		}
+		return services[i].GetName() < services[j].GetName()
+	})
+	clog.Debugf(ctx, "discovered %d services for %s %s.%s using pod labels %v", len(services), wl.GetKind(), wl.GetName(), wl.GetNamespace(), podTemplate.Labels)
+	return services
+}
+
+func routeAssociationsForServices(ctx context.Context, namespace string, services map[string]*rpc.ServiceAssociation) []*rpc.RouteAssociation {
+	if len(services) == 0 {
+		clog.Debugf(ctx, "discovered 0 routes in namespace %s because no matching services were found", namespace)
+		return nil
+	}
+
+	ingresses, err := listIngresses(ctx, namespace)
+	if err != nil {
+		clog.Warnf(ctx, "unable to discover ingresses in namespace %s: %v", namespace, err)
+		return nil
+	}
+
+	routes := make([]*rpc.RouteAssociation, 0, len(ingresses))
+	for _, ingress := range ingresses {
+		routes = append(routes, routeAssociationsForIngress(ingress, services)...)
+	}
+
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].GetNamespace() != routes[j].GetNamespace() {
+			return routes[i].GetNamespace() < routes[j].GetNamespace()
+		}
+		if routes[i].GetServiceNamespace() != routes[j].GetServiceNamespace() {
+			return routes[i].GetServiceNamespace() < routes[j].GetServiceNamespace()
+		}
+		if routes[i].GetServiceName() != routes[j].GetServiceName() {
+			return routes[i].GetServiceName() < routes[j].GetServiceName()
+		}
+		if routes[i].GetServicePort() != routes[j].GetServicePort() {
+			return routes[i].GetServicePort() < routes[j].GetServicePort()
+		}
+		if routes[i].GetServicePortName() != routes[j].GetServicePortName() {
+			return routes[i].GetServicePortName() < routes[j].GetServicePortName()
+		}
+		return routes[i].GetName() < routes[j].GetName()
+	})
+	clog.Debugf(ctx, "discovered %d routes in namespace %s for services %v", len(routes), namespace, maps.Keys(services))
+	return routes
+}
+
+func listIngresses(ctx context.Context, namespace string) ([]*netv1.Ingress, error) {
+	if factory := informer.GetK8sFactory(ctx, namespace); factory != nil {
+		ingresses, err := factory.Networking().V1().Ingresses().Lister().Ingresses(namespace).List(labels.Everything())
+		if err == nil && len(ingresses) > 0 {
+			return ingresses, nil
+		}
+		if err != nil {
+			clog.Debugf(ctx, "namespace ingress lister lookup failed for %s, falling back to direct client: %v", namespace, err)
+		}
+	}
+
+	list, err := k8sapi.GetK8sInterface(ctx).NetworkingV1().Ingresses(namespace).List(ctx, meta.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	ingresses := make([]*netv1.Ingress, 0, len(list.Items))
+	for i := range list.Items {
+		ingresses = append(ingresses, &list.Items[i])
+	}
+	return ingresses, nil
+}
+
+func routeAssociationsForIngress(ingress *netv1.Ingress, services map[string]*rpc.ServiceAssociation) []*rpc.RouteAssociation {
+	if ingress == nil {
+		return nil
+	}
+
+	type routeAggregate struct {
+		key   serviceRouteKey
+		hosts map[string]struct{}
+		paths map[string]struct{}
+	}
+
+	aggregates := map[serviceRouteKey]*routeAggregate{}
+
+	appendMatch := func(service *rpc.ServiceAssociation, portName string, port int32, host string, path string) {
+		if service == nil || service.GetName() == "" {
+			return
+		}
+		key := serviceRouteKey{
+			name:      service.GetName(),
+			namespace: service.GetNamespace(),
+			portName:  portName,
+			port:      port,
+		}
+		aggregate := aggregates[key]
+		if aggregate == nil {
+			aggregate = &routeAggregate{
+				key:   key,
+				hosts: map[string]struct{}{},
+				paths: map[string]struct{}{},
+			}
+			aggregates[key] = aggregate
+		}
+		if host != "" {
+			aggregate.hosts[host] = struct{}{}
+		}
+		if path != "" {
+			aggregate.paths[path] = struct{}{}
+		}
+	}
+
+	if service, portName, port, ok := ingressBackendMatch(ingress.Spec.DefaultBackend, services); ok {
+		appendMatch(service, portName, port, "", "/")
+	}
+
+	for _, rule := range ingress.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			service, portName, port, ok := ingressBackendMatch(&path.Backend, services)
+			if !ok {
+				continue
+			}
+			appendMatch(service, portName, port, rule.Host, path.Path)
+		}
+	}
+
+	if len(aggregates) == 0 {
+		return nil
+	}
+
+	routes := make([]*rpc.RouteAssociation, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		routes = append(routes, &rpc.RouteAssociation{
+			Type:             "Ingress",
+			Name:             ingress.Name,
+			Namespace:        ingress.Namespace,
+			Hosts:            sortedKeys(aggregate.hosts),
+			Paths:            sortedKeys(aggregate.paths),
+			Tls:              ingressUsesTLS(ingress),
+			ServiceName:      aggregate.key.name,
+			ServiceNamespace: aggregate.key.namespace,
+			ServicePortName:  aggregate.key.portName,
+			ServicePort:      aggregate.key.port,
+		})
+	}
+	return routes
+}
+
+func ingressBackendMatch(
+	backend *netv1.IngressBackend,
+	services map[string]*rpc.ServiceAssociation,
+) (*rpc.ServiceAssociation, string, int32, bool) {
+	if backend == nil || backend.Service == nil {
+		return nil, "", 0, false
+	}
+	service, ok := services[backend.Service.Name]
+	if !ok || service == nil {
+		return nil, "", 0, false
+	}
+
+	portName := backend.Service.Port.Name
+	portNumber := backend.Service.Port.Number
+	if portName == "" && portNumber == 0 && len(service.Ports) == 1 {
+		portName = service.Ports[0].GetName()
+		portNumber = service.Ports[0].GetPort()
+	}
+	if portName != "" {
+		for _, port := range service.Ports {
+			if port != nil && port.GetName() == portName {
+				return service, portName, port.GetPort(), true
+			}
+		}
+	}
+	if portNumber != 0 {
+		for _, port := range service.Ports {
+			if port != nil && port.GetPort() == portNumber {
+				return service, port.GetName(), portNumber, true
+			}
+		}
+	}
+	return service, portName, portNumber, true
+}
+
+func ingressUsesTLS(ingress *netv1.Ingress) bool {
+	if ingress == nil {
+		return false
+	}
+	if len(ingress.Spec.TLS) > 0 {
+		return true
+	}
+
+	annotations := ingress.GetAnnotations()
+	if len(annotations) == 0 {
+		return false
+	}
+
+	for _, key := range []string{
+		"networking.gke.io/managed-certificates",
+		"ingress.gcp.kubernetes.io/pre-shared-cert",
+		"ingress.kubernetes.io/https-forwarding-rule",
+		"ingress.kubernetes.io/https-target-proxy",
+		"ingress.kubernetes.io/ssl-cert",
+	} {
+		if annotations[key] != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func serviceRouteIndex(services []*rpc.ServiceAssociation) map[string]*rpc.ServiceAssociation {
+	if len(services) == 0 {
+		return nil
+	}
+	index := make(map[string]*rpc.ServiceAssociation, len(services))
+	for _, service := range services {
+		if service == nil || service.GetName() == "" {
+			continue
+		}
+		index[service.GetName()] = service
+	}
+	return index
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cmd/traffic/cmd/manager/state/workload_exposure.go
+++ b/cmd/traffic/cmd/manager/state/workload_exposure.go
@@ -2,8 +2,8 @@ package state
 
 import (
 	"context"
-	"maps"
 	"sort"
+	"strconv"
 
 	netv1 "k8s.io/api/networking/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +11,8 @@ import (
 
 	"github.com/telepresenceio/clog"
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
-	"github.com/telepresenceio/telepresence/v2/pkg/agentmap"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
@@ -20,127 +21,122 @@ type workloadExposure struct {
 	desiredReplicas int32
 	readyReplicas   int32
 	services        []*rpc.ServiceAssociation
-	routes          []*rpc.RouteAssociation
-}
-
-type serviceRouteKey struct {
-	name      string
-	namespace string
-	portName  string
-	port      int32
 }
 
 func describeWorkloadExposure(ctx context.Context, wl k8sapi.Workload) workloadExposure {
-	services := serviceAssociationsForWorkload(ctx, wl)
-	return workloadExposure{
+	exposure := workloadExposure{
 		desiredReplicas: k8sapi.DesiredReplicas(wl),
 		readyReplicas:   k8sapi.ReadyReplicas(wl),
-		services:        services,
-		routes:          routeAssociationsForServices(ctx, wl.GetNamespace(), serviceRouteIndex(services)),
 	}
+	if sc := mutator.GetMap(ctx).Get(wl.GetName(), wl.GetNamespace()); sc != nil {
+		exposure.services = serviceAssociationsForSidecar(sc)
+		attachRouteAssociations(ctx, sc.Namespace, exposure.services)
+	}
+	return exposure
 }
 
-func serviceAssociationsForWorkload(ctx context.Context, wl k8sapi.Workload) []*rpc.ServiceAssociation {
-	podTemplate := wl.GetPodTemplate().DeepCopy()
-	if podTemplate.Namespace == "" {
-		podTemplate.Namespace = wl.GetNamespace()
+func serviceAssociationsForSidecar(sc *agentconfig.Sidecar) []*rpc.ServiceAssociation {
+	type servicePortKey struct {
+		name     string
+		portName string
+		port     int32
 	}
+	svcMap := map[string]*rpc.ServiceAssociation{}
+	seen := map[servicePortKey]struct{}{}
+	for _, cn := range sc.Containers {
+		for _, ic := range cn.Intercepts {
+			if ic.ServiceName == "" {
+				continue
+			}
+			key := servicePortKey{
+				name:     ic.ServiceName,
+				portName: ic.ServicePortName,
+				port:     int32(ic.ServicePort),
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
 
-	objects, err := agentmap.FindServicesForPod(ctx, podTemplate, "")
-	if err != nil {
-		clog.Warnf(ctx, "unable to discover services for %s %s.%s: %v", wl.GetKind(), wl.GetName(), wl.GetNamespace(), err)
+			targetPort := ic.ContainerPortName
+			if ic.TargetPortNumeric {
+				targetPort = strconv.Itoa(int(ic.ContainerPort))
+			}
+			service := svcMap[ic.ServiceName]
+			if service == nil {
+				service = &rpc.ServiceAssociation{
+					Name: ic.ServiceName,
+				}
+				svcMap[ic.ServiceName] = service
+			}
+			service.Ports = append(service.Ports, &rpc.ServicePort{
+				Name:       ic.ServicePortName,
+				Port:       int32(ic.ServicePort),
+				TargetPort: targetPort,
+			})
+		}
+	}
+	if len(svcMap) == 0 {
 		return nil
 	}
 
-	services := make([]*rpc.ServiceAssociation, 0, len(objects))
-	for _, object := range objects {
-		service, ok := k8sapi.ServiceImpl(object)
-		if !ok {
-			continue
-		}
-
-		ports := make([]*rpc.ServicePort, 0, len(service.Spec.Ports))
-		for _, port := range service.Spec.Ports {
-			ports = append(ports, &rpc.ServicePort{
-				Name:       port.Name,
-				Port:       port.Port,
-				TargetPort: port.TargetPort.String(),
-			})
-		}
-		sort.Slice(ports, func(i, j int) bool {
-			if ports[i].GetPort() != ports[j].GetPort() {
-				return ports[i].GetPort() < ports[j].GetPort()
+	services := make([]*rpc.ServiceAssociation, 0, len(svcMap))
+	for _, service := range svcMap {
+		sort.Slice(service.Ports, func(i, j int) bool {
+			if service.Ports[i].GetPort() != service.Ports[j].GetPort() {
+				return service.Ports[i].GetPort() < service.Ports[j].GetPort()
 			}
-			return ports[i].GetName() < ports[j].GetName()
+			return service.Ports[i].GetName() < service.Ports[j].GetName()
 		})
-
-		services = append(services, &rpc.ServiceAssociation{
-			Name:      service.Name,
-			Namespace: service.Namespace,
-			Ports:     ports,
-		})
+		services = append(services, service)
 	}
-
 	sort.Slice(services, func(i, j int) bool {
-		if services[i].GetNamespace() != services[j].GetNamespace() {
-			return services[i].GetNamespace() < services[j].GetNamespace()
-		}
 		return services[i].GetName() < services[j].GetName()
 	})
-	clog.Debugf(ctx, "discovered %d services for %s %s.%s using pod labels %v", len(services), wl.GetKind(), wl.GetName(), wl.GetNamespace(), podTemplate.Labels)
 	return services
 }
 
-func routeAssociationsForServices(ctx context.Context, namespace string, services map[string]*rpc.ServiceAssociation) []*rpc.RouteAssociation {
+// attachRouteAssociations finds all routes in the given namespace that target one of
+// the given services and attaches them to the service they target.
+func attachRouteAssociations(ctx context.Context, namespace string, services []*rpc.ServiceAssociation) {
 	if len(services) == 0 {
-		clog.Debugf(ctx, "discovered 0 routes in namespace %s because no matching services were found", namespace)
-		return nil
+		return
 	}
 
 	ingresses, err := listIngresses(ctx, namespace)
 	if err != nil {
 		clog.Warnf(ctx, "unable to discover ingresses in namespace %s: %v", namespace, err)
-		return nil
+		return
 	}
 
-	routes := make([]*rpc.RouteAssociation, 0, len(ingresses))
+	index := serviceIndex(services)
 	for _, ingress := range ingresses {
-		routes = append(routes, routeAssociationsForIngress(ingress, services)...)
+		attachRoutesForIngress(ingress, index)
 	}
 
-	sort.Slice(routes, func(i, j int) bool {
-		if routes[i].GetNamespace() != routes[j].GetNamespace() {
-			return routes[i].GetNamespace() < routes[j].GetNamespace()
-		}
-		if routes[i].GetServiceNamespace() != routes[j].GetServiceNamespace() {
-			return routes[i].GetServiceNamespace() < routes[j].GetServiceNamespace()
-		}
-		if routes[i].GetServiceName() != routes[j].GetServiceName() {
-			return routes[i].GetServiceName() < routes[j].GetServiceName()
-		}
-		if routes[i].GetServicePort() != routes[j].GetServicePort() {
-			return routes[i].GetServicePort() < routes[j].GetServicePort()
-		}
-		if routes[i].GetServicePortName() != routes[j].GetServicePortName() {
-			return routes[i].GetServicePortName() < routes[j].GetServicePortName()
-		}
-		return routes[i].GetName() < routes[j].GetName()
-	})
-	clog.Debugf(ctx, "discovered %d routes in namespace %s for services %v", len(routes), namespace, maps.Keys(services))
-	return routes
+	count := 0
+	for _, service := range services {
+		sort.Slice(service.Routes, func(i, j int) bool {
+			if service.Routes[i].GetName() != service.Routes[j].GetName() {
+				return service.Routes[i].GetName() < service.Routes[j].GetName()
+			}
+			if service.Routes[i].GetPort() != service.Routes[j].GetPort() {
+				return service.Routes[i].GetPort() < service.Routes[j].GetPort()
+			}
+			return service.Routes[i].GetPortName() < service.Routes[j].GetPortName()
+		})
+		count += len(service.Routes)
+	}
+	clog.Debugf(ctx, "discovered %d routes in namespace %s for %d services", count, namespace, len(services))
 }
 
 func listIngresses(ctx context.Context, namespace string) ([]*netv1.Ingress, error) {
 	if factory := informer.GetK8sFactory(ctx, namespace); factory != nil {
-		ingresses, err := factory.Networking().V1().Ingresses().Lister().Ingresses(namespace).List(labels.Everything())
-		if err == nil && len(ingresses) > 0 {
-			return ingresses, nil
-		}
-		if err != nil {
-			clog.Debugf(ctx, "namespace ingress lister lookup failed for %s, falling back to direct client: %v", namespace, err)
-		}
+		return factory.Networking().V1().Ingresses().Lister().Ingresses(namespace).List(labels.Everything())
 	}
 
+	// This shouldn't happen really.
+	clog.Debugf(ctx, "listing ingresses in namespace %s using direct API call", namespace)
 	list, err := k8sapi.GetK8sInterface(ctx).NetworkingV1().Ingresses(namespace).List(ctx, meta.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -153,33 +149,38 @@ func listIngresses(ctx context.Context, namespace string) ([]*netv1.Ingress, err
 	return ingresses, nil
 }
 
-func routeAssociationsForIngress(ingress *netv1.Ingress, services map[string]*rpc.ServiceAssociation) []*rpc.RouteAssociation {
+// attachRoutesForIngress appends a route to each service port that the given ingress
+// routes traffic to. The hosts and paths of all ingress rules targeting the same
+// service port are aggregated into one single route.
+func attachRoutesForIngress(ingress *netv1.Ingress, services map[string]*rpc.ServiceAssociation) {
 	if ingress == nil {
-		return nil
+		return
 	}
 
+	type routeKey struct {
+		service  *rpc.ServiceAssociation
+		portName string
+		port     int32
+	}
 	type routeAggregate struct {
-		key   serviceRouteKey
 		hosts map[string]struct{}
 		paths map[string]struct{}
 	}
 
-	aggregates := map[serviceRouteKey]*routeAggregate{}
+	aggregates := map[routeKey]*routeAggregate{}
 
 	appendMatch := func(service *rpc.ServiceAssociation, portName string, port int32, host string, path string) {
 		if service == nil || service.GetName() == "" {
 			return
 		}
-		key := serviceRouteKey{
-			name:      service.GetName(),
-			namespace: service.GetNamespace(),
-			portName:  portName,
-			port:      port,
+		key := routeKey{
+			service:  service,
+			portName: portName,
+			port:     port,
 		}
 		aggregate := aggregates[key]
 		if aggregate == nil {
 			aggregate = &routeAggregate{
-				key:   key,
 				hosts: map[string]struct{}{},
 				paths: map[string]struct{}{},
 			}
@@ -210,26 +211,17 @@ func routeAssociationsForIngress(ingress *netv1.Ingress, services map[string]*rp
 		}
 	}
 
-	if len(aggregates) == 0 {
-		return nil
-	}
-
-	routes := make([]*rpc.RouteAssociation, 0, len(aggregates))
-	for _, aggregate := range aggregates {
-		routes = append(routes, &rpc.RouteAssociation{
-			Type:             "Ingress",
-			Name:             ingress.Name,
-			Namespace:        ingress.Namespace,
-			Hosts:            sortedKeys(aggregate.hosts),
-			Paths:            sortedKeys(aggregate.paths),
-			Tls:              ingressUsesTLS(ingress),
-			ServiceName:      aggregate.key.name,
-			ServiceNamespace: aggregate.key.namespace,
-			ServicePortName:  aggregate.key.portName,
-			ServicePort:      aggregate.key.port,
+	for key, aggregate := range aggregates {
+		key.service.Routes = append(key.service.Routes, &rpc.RouteAssociation{
+			Type:     "Ingress",
+			Name:     ingress.Name,
+			Hosts:    sortedKeys(aggregate.hosts),
+			Paths:    sortedKeys(aggregate.paths),
+			Tls:      ingressUsesTLS(ingress),
+			PortName: key.portName,
+			Port:     key.port,
 		})
 	}
-	return routes
 }
 
 func ingressBackendMatch(
@@ -294,10 +286,7 @@ func ingressUsesTLS(ingress *netv1.Ingress) bool {
 	return false
 }
 
-func serviceRouteIndex(services []*rpc.ServiceAssociation) map[string]*rpc.ServiceAssociation {
-	if len(services) == 0 {
-		return nil
-	}
+func serviceIndex(services []*rpc.ServiceAssociation) map[string]*rpc.ServiceAssociation {
 	index := make(map[string]*rpc.ServiceAssociation, len(services))
 	for _, service := range services {
 		if service == nil || service.GetName() == "" {

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -172,12 +172,17 @@ func rpcWorkloadState(s workload.State) (state rpc.WorkloadInfo_State) {
 	return state
 }
 
-func rpcWorkload(wl k8sapi.Workload, as rpc.WorkloadInfo_AgentState, iClients []*rpc.WorkloadInfo_Intercept) *rpc.WorkloadInfo {
+func rpcWorkload(ctx context.Context, wl k8sapi.Workload, as rpc.WorkloadInfo_AgentState, iClients []*rpc.WorkloadInfo_Intercept) *rpc.WorkloadInfo {
+	exposure := describeWorkloadExposure(ctx, wl)
 	return &rpc.WorkloadInfo{
 		Kind:             workload.RpcKind(wl.GetKind()),
 		Name:             wl.GetName(),
 		Namespace:        wl.GetNamespace(),
 		Uid:              string(wl.GetUID()),
+		DesiredReplicas:  exposure.desiredReplicas,
+		ReadyReplicas:    exposure.readyReplicas,
+		Services:         exposure.services,
+		Routes:           exposure.routes,
 		State:            rpcWorkloadState(workload.GetWorkloadState(wl)),
 		AgentState:       as,
 		InterceptClients: iClients,
@@ -220,7 +225,7 @@ func (wf *workloadInfoWatcher) handleWorkloadEvents(ctx context.Context, wes []E
 				}
 				w = &rpc.WorkloadEvent{
 					Type:     rpc.WorkloadEvent_Type(we.Type),
-					Workload: rpcWorkload(wl, as, iClients),
+					Workload: rpcWorkload(ctx, wl, as, iClients),
 				}
 			}
 			clog.Tracef(ctx, "WorkloadInfoEvent: Workload %s %s %s %s", we.Type, wl, as, w.Workload.State)
@@ -256,7 +261,7 @@ func (wf *workloadInfoWatcher) handleAgentDelta(ctx context.Context, delta cache
 				}
 				w = &rpc.WorkloadEvent{
 					Type:     rpc.WorkloadEvent_MODIFIED,
-					Workload: rpcWorkload(wl, as, nil),
+					Workload: rpcWorkload(ctx, wl, as, nil),
 				}
 			}
 			clog.Tracef(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, w.Workload.State)
@@ -300,7 +305,7 @@ func (wf *workloadInfoWatcher) handleAgentDelta(ctx context.Context, delta cache
 				}
 				w = &rpc.WorkloadEvent{
 					Type:     rpc.WorkloadEvent_ADDED_UNSPECIFIED,
-					Workload: rpcWorkload(wl, as, iClients),
+					Workload: rpcWorkload(ctx, wl, as, iClients),
 				}
 			}
 			clog.Tracef(ctx, "WorkloadInfoEvent: AgentInfo %s(%s).%s %s %s", a.PodName, a.PodIp, a.Namespace, as, w.Workload.State)
@@ -363,7 +368,7 @@ func (wf *workloadInfoWatcher) handleInterceptDelta(ctx context.Context, delta c
 				}
 				w = &rpc.WorkloadEvent{
 					Type:     rpc.WorkloadEvent_Type(EventTypeUpdate),
-					Workload: rpcWorkload(wl, as, iClients),
+					Workload: rpcWorkload(ctx, wl, as, iClients),
 				}
 			}
 			clog.Tracef(ctx, "WorkloadInfoEvent: InterceptInfo %s %s %s", name, as, w.Workload.State)
@@ -400,7 +405,7 @@ func (wf *workloadInfoWatcher) handleInterceptDelta(ctx context.Context, delta c
 				}
 				w = &rpc.WorkloadEvent{
 					Type:     rpc.WorkloadEvent_Type(EventTypeUpdate),
-					Workload: rpcWorkload(wl, as, iClients),
+					Workload: rpcWorkload(ctx, wl, as, iClients),
 				}
 			}
 			clog.Tracef(ctx, "WorkloadInfoEvent: InterceptInfo %s.%s %s %s", w.Workload.Name, w.Workload.Namespace, as, w.Workload.State)

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -182,7 +182,6 @@ func rpcWorkload(ctx context.Context, wl k8sapi.Workload, as rpc.WorkloadInfo_Ag
 		DesiredReplicas:  exposure.desiredReplicas,
 		ReadyReplicas:    exposure.readyReplicas,
 		Services:         exposure.services,
-		Routes:           exposure.routes,
 		State:            rpcWorkloadState(workload.GetWorkloadState(wl)),
 		AgentState:       as,
 		InterceptClients: iClients,

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -182,6 +182,12 @@ When a subnet was routed through the virtual network interface, the kernel deriv
 The traffic-agent's own traffic is exempted from service-mesh processing using an iptables owner match, but the match was based on the agent's UID, which is inherited from the app container's securityContext (or defaults to root). An application sharing that UID had its outbound traffic silently bypass the mesh sidecar — no mTLS, telemetry, or policy enforcement. The agent container is now assigned a distinct primary group (default <code>7439</code>, overridable with <code>agent.securityContext.runAsGroup</code>) and the owner matches are group-based, so application traffic always traverses the mesh.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Show ingress URLs for intercepted service ports</div></div>
+<div style="margin-left: 15px">
+
+The output of <code>telepresence intercept</code> and <code>telepresence list</code> now shows the ingress URLs through which an intercepted service port can be reached. When the intercept uses HTTP header filters, a ready-to-paste <code>curl</code> example with the matching <code>-H</code> flags is included, making it easy to send a request that is routed to the intercept handler on the workstation.
+</div>
+
 ## Version 2.28.0 <span style="font-size: 16px;">(May 11)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Intercept workloads in mapped namespaces](reference/engagements/cli)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -188,6 +188,12 @@ When a subnet was routed through the virtual network interface, the kernel deriv
 The traffic-agent's own traffic is exempted from service-mesh processing using an iptables owner match, but the match was based on the agent's UID, which is inherited from the app container's securityContext (or defaults to root). An application sharing that UID had its outbound traffic silently bypass the mesh sidecar — no mTLS, telemetry, or policy enforcement. The agent container is now assigned a distinct primary group (default <code>7439</code>, overridable with <code>agent.securityContext.runAsGroup</code>) and the owner matches are group-based, so application traffic always traverses the mesh.
   </Body>
 </Note>
+<Note>
+	<Title type="feature">Show ingress URLs for intercepted service ports</Title>
+	<Body>
+The output of <code>telepresence intercept</code> and <code>telepresence list</code> now shows the ingress URLs through which an intercepted service port can be reached. When the intercept uses HTTP header filters, a ready-to-paste <code>curl</code> example with the matching <code>-H</code> flags is included, making it easy to send a request that is routed to the intercept handler on the workstation.
+  </Body>
+</Note>
 ## Version 2.28.0 <span style={{fontSize:'16px'}}>(May 11)</span>
 <Note>
 	<Title type="feature" docs="reference/engagements/cli">Intercept workloads in mapped namespaces</Title>

--- a/pkg/client/cli/cmd/list.go
+++ b/pkg/client/cli/cmd/list.go
@@ -193,7 +193,7 @@ func (s *listCommand) printList(ctx context.Context, workloads []*connector.Work
 
 	state := func(workload *connector.WorkloadInfo) string {
 		if iis, igs := workload.InterceptInfo, workload.IngestInfo; len(iis)+len(igs) > 0 {
-			return intercept.DescribeIntercepts(ctx, iis, igs, nil, s.debug)
+			return intercept.DescribeIntercepts(ctx, iis, igs, workload.Services, nil, s.debug)
 		}
 		if workload.NotInterceptableReason == "Progressing" {
 			return "progressing..."

--- a/pkg/client/cli/intercept/describe_intercepts.go
+++ b/pkg/client/cli/intercept/describe_intercepts.go
@@ -9,7 +9,14 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ingest"
 )
 
-func DescribeIntercepts(ctx context.Context, iis []*manager.InterceptInfo, igs []*rpc.IngestInfo, volumeMountsPrevented error, debug bool) string {
+func DescribeIntercepts(
+	ctx context.Context,
+	iis []*manager.InterceptInfo,
+	igs []*rpc.IngestInfo,
+	services []*manager.ServiceAssociation,
+	volumeMountsPrevented error,
+	debug bool,
+) string {
 	sb := strings.Builder{}
 	if len(iis) > 0 {
 		var nis, ris, wts []*manager.InterceptInfo
@@ -27,21 +34,21 @@ func DescribeIntercepts(ctx context.Context, iis []*manager.InterceptInfo, igs [
 			sb.WriteString("replaced")
 			for _, ii := range ris {
 				sb.WriteByte('\n')
-				describeIntercept(ctx, ii, volumeMountsPrevented, debug, &sb)
+				describeIntercept(ctx, ii, services, volumeMountsPrevented, debug, &sb)
 			}
 		}
 		if len(nis) > 0 {
 			sb.WriteString("intercepted")
 			for _, ii := range nis {
 				sb.WriteByte('\n')
-				describeIntercept(ctx, ii, volumeMountsPrevented, debug, &sb)
+				describeIntercept(ctx, ii, services, volumeMountsPrevented, debug, &sb)
 			}
 		}
 		if len(wts) > 0 {
 			sb.WriteString("wiretapped")
 			for _, ii := range wts {
 				sb.WriteByte('\n')
-				describeIntercept(ctx, ii, volumeMountsPrevented, debug, &sb)
+				describeIntercept(ctx, ii, services, volumeMountsPrevented, debug, &sb)
 			}
 		}
 	}
@@ -55,9 +62,17 @@ func DescribeIntercepts(ctx context.Context, iis []*manager.InterceptInfo, igs [
 	return sb.String()
 }
 
-func describeIntercept(ctx context.Context, ii *manager.InterceptInfo, volumeMountsPrevented error, debug bool, sb *strings.Builder) {
+func describeIntercept(
+	ctx context.Context,
+	ii *manager.InterceptInfo,
+	services []*manager.ServiceAssociation,
+	volumeMountsPrevented error,
+	debug bool,
+	sb *strings.Builder,
+) {
 	info := NewInfo(ctx, ii, false, volumeMountsPrevented)
 	info.debug = debug
+	info.AccessURLs = routeURLs(routesForService(ii.Spec, services))
 	_, _ = info.WriteTo(sb)
 }
 

--- a/pkg/client/cli/intercept/info.go
+++ b/pkg/client/cli/intercept/info.go
@@ -19,13 +19,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
 
-type Ingress struct {
-	Host   string `json:"host,omitempty"    yaml:"host,omitempty"`
-	Port   int32  `json:"port,omitempty"    yaml:"port,omitempty"`
-	UseTLS bool   `json:"use_tls,omitempty" yaml:"use_tls,omitempty"`
-	L5Host string `json:"l5host,omitempty"  yaml:"l5host,omitempty"`
-}
-
 type Info struct {
 	ID            string            `json:"id,omitempty"              yaml:"id,omitempty"`
 	Name          string            `json:"name,omitempty"            yaml:"name,omitempty"`
@@ -47,6 +40,7 @@ type Info struct {
 	Metadata      map[string]string `json:"metadata,omitempty"        yaml:"metadata,omitempty"`
 	HeaderFilters map[string]string `json:"header_filters,omitempty"  yaml:"header_filters,omitempty"`
 	PathFilters   []string          `json:"path_filters,omitempty"    yaml:"path_filters,omitempty"`
+	AccessURLs    []string          `json:"access_urls,omitempty"     yaml:"access_urls,omitempty"`
 	Global        bool              `json:"global,omitempty"          yaml:"global,omitempty"`
 	Replace       bool              `json:"replace,omitempty"         yaml:"replace,omitempty"`
 	Wiretap       bool              `json:"wiretap,omitempty"         yaml:"wiretap,omitempty"`
@@ -168,6 +162,16 @@ func (ii *Info) WriteTo(w io.Writer) (int64, error) {
 			}
 			return matcher.NewRequest(ii.PathFilters, ii.HeaderFilters).String()
 		}())
+	}
+
+	if len(ii.AccessURLs) > 0 {
+		v := strings.Join(ii.AccessURLs, "\n")
+		if len(ii.HeaderFilters) > 0 {
+			if ce := curlExample(ii.AccessURLs[0], ii.HeaderFilters); ce != "" {
+				v += "\n  " + ce
+			}
+		}
+		kvf.Add("Reachable via", v)
 	}
 
 	if m := ii.Mount; m != nil {

--- a/pkg/client/cli/intercept/routes.go
+++ b/pkg/client/cli/intercept/routes.go
@@ -1,0 +1,92 @@
+package intercept
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+// routesForSpec returns the route associations for the service port that the
+// given intercept spec targets.
+func routesForSpec(spec *manager.InterceptSpec, workloads []*connector.WorkloadInfo) []*manager.RouteAssociation {
+	for _, wl := range workloads {
+		if wl.GetName() == spec.Agent && wl.GetNamespace() == spec.Namespace {
+			return routesForService(spec, wl.GetServices())
+		}
+	}
+	return nil
+}
+
+// routesForService returns the routes of the service named by the given intercept
+// spec that target the service port that the spec identifies.
+func routesForService(spec *manager.InterceptSpec, services []*manager.ServiceAssociation) []*manager.RouteAssociation {
+	if spec.ServiceName == "" {
+		return nil
+	}
+	for _, svc := range services {
+		if svc.GetName() != spec.ServiceName {
+			continue
+		}
+		var routes []*manager.RouteAssociation
+		for _, route := range svc.GetRoutes() {
+			if spec.ServicePort != 0 && route.GetPort() == spec.ServicePort ||
+				spec.ServicePortName != "" && route.GetPortName() == spec.ServicePortName {
+				routes = append(routes, route)
+			}
+		}
+		return routes
+	}
+	return nil
+}
+
+// routeURLs builds one URL per host (or load-balancer address when the route
+// declares no hosts) using the route's first path. The returned slice is sorted
+// and free from duplicates.
+func routeURLs(routes []*manager.RouteAssociation) []string {
+	urls := make(map[string]struct{})
+	for _, route := range routes {
+		scheme := "http://"
+		if route.GetTls() {
+			scheme = "https://"
+		}
+		path := ""
+		if paths := route.GetPaths(); len(paths) > 0 {
+			path = paths[0]
+		}
+		if path == "/" {
+			path = ""
+		}
+		hosts := route.GetHosts()
+		if len(hosts) == 0 {
+			hosts = route.GetAddresses()
+		}
+		for _, host := range hosts {
+			urls[scheme+host+path] = struct{}{}
+		}
+	}
+	if len(urls) == 0 {
+		return nil
+	}
+	return slices.Sorted(maps.Keys(urls))
+}
+
+// curlExample returns a curl command that reaches the given URL with one -H flag
+// for each of the given headers, or an empty string when the URL contains a
+// wildcard host.
+func curlExample(url string, headers map[string]string) string {
+	if url == "" || strings.Contains(url, "*") {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString("curl")
+	for _, k := range slices.Sorted(maps.Keys(headers)) {
+		fmt.Fprintf(&sb, " -H '%s: %s'", k, headers[k])
+	}
+	sb.WriteByte(' ')
+	sb.WriteString(url)
+	return sb.String()
+}

--- a/pkg/client/cli/intercept/routes_test.go
+++ b/pkg/client/cli/intercept/routes_test.go
@@ -1,0 +1,125 @@
+package intercept
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/connector"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+func testServices() []*manager.ServiceAssociation {
+	return []*manager.ServiceAssociation{
+		{
+			Name: "echo",
+			Ports: []*manager.ServicePort{
+				{Name: "http", Port: 80, TargetPort: "8080"},
+				{Name: "grpc", Port: 8081, TargetPort: "grpc"},
+			},
+			Routes: []*manager.RouteAssociation{
+				{
+					Type:     "Ingress",
+					Name:     "echo-ing",
+					Hosts:    []string{"api.example.com"},
+					Paths:    []string{"/api"},
+					Tls:      true,
+					PortName: "http",
+					Port:     80,
+				},
+				{
+					Type:     "Ingress",
+					Name:     "echo-grpc-ing",
+					Hosts:    []string{"grpc.example.com"},
+					Tls:      false,
+					PortName: "grpc",
+					Port:     8081,
+				},
+			},
+		},
+		{
+			Name: "other",
+			Routes: []*manager.RouteAssociation{
+				{Type: "Ingress", Name: "other-ing", Hosts: []string{"other.example.com"}, Port: 80},
+			},
+		},
+	}
+}
+
+func TestRoutesForService(t *testing.T) {
+	services := testServices()
+
+	// Match by port number.
+	routes := routesForService(&manager.InterceptSpec{ServiceName: "echo", ServicePort: 80}, services)
+	assert.Len(t, routes, 1)
+	assert.Equal(t, "echo-ing", routes[0].GetName())
+
+	// Match by port name only.
+	routes = routesForService(&manager.InterceptSpec{ServiceName: "echo", ServicePortName: "grpc"}, services)
+	assert.Len(t, routes, 1)
+	assert.Equal(t, "echo-grpc-ing", routes[0].GetName())
+
+	// No service name.
+	assert.Nil(t, routesForService(&manager.InterceptSpec{ServicePort: 80}, services))
+
+	// Unknown service.
+	assert.Nil(t, routesForService(&manager.InterceptSpec{ServiceName: "nope", ServicePort: 80}, services))
+
+	// Known service, no matching port.
+	assert.Nil(t, routesForService(&manager.InterceptSpec{ServiceName: "echo", ServicePort: 9999}, services))
+}
+
+func TestRoutesForSpec(t *testing.T) {
+	workloads := []*connector.WorkloadInfo{
+		{Name: "echo", Namespace: "default", Services: testServices()},
+	}
+	spec := &manager.InterceptSpec{Agent: "echo", Namespace: "default", ServiceName: "echo", ServicePort: 80}
+	routes := routesForSpec(spec, workloads)
+	assert.Len(t, routes, 1)
+
+	// Wrong namespace.
+	spec = &manager.InterceptSpec{Agent: "echo", Namespace: "other", ServiceName: "echo", ServicePort: 80}
+	assert.Nil(t, routesForSpec(spec, workloads))
+}
+
+func TestRouteURLs(t *testing.T) {
+	// TLS scheme, path appended.
+	urls := routeURLs([]*manager.RouteAssociation{
+		{Hosts: []string{"api.example.com"}, Paths: []string{"/api"}, Tls: true},
+	})
+	assert.Equal(t, []string{"https://api.example.com/api"}, urls)
+
+	// Plain scheme, root path omitted.
+	urls = routeURLs([]*manager.RouteAssociation{
+		{Hosts: []string{"api.example.com"}, Paths: []string{"/"}},
+	})
+	assert.Equal(t, []string{"http://api.example.com"}, urls)
+
+	// Host-less route falls back to load-balancer addresses.
+	urls = routeURLs([]*manager.RouteAssociation{
+		{Addresses: []string{"192.168.1.1"}, Paths: []string{"/api"}},
+	})
+	assert.Equal(t, []string{"http://192.168.1.1/api"}, urls)
+
+	// Multiple hosts, sorted and de-duplicated.
+	urls = routeURLs([]*manager.RouteAssociation{
+		{Hosts: []string{"b.example.com", "a.example.com"}},
+		{Hosts: []string{"a.example.com"}},
+	})
+	assert.Equal(t, []string{"http://a.example.com", "http://b.example.com"}, urls)
+
+	// No hosts and no addresses yields nothing.
+	assert.Nil(t, routeURLs([]*manager.RouteAssociation{{Paths: []string{"/api"}}}))
+	assert.Nil(t, routeURLs(nil))
+}
+
+func TestCurlExample(t *testing.T) {
+	assert.Equal(t,
+		"curl -H 'a: b' -H 'x: y' https://api.example.com/api",
+		curlExample("https://api.example.com/api", map[string]string{"x": "y", "a": "b"}))
+	assert.Equal(t, "curl http://api.example.com", curlExample("http://api.example.com", nil))
+
+	// Wildcard hosts are not pasteable.
+	assert.Equal(t, "", curlExample("https://*.example.com", map[string]string{"x": "y"}))
+	assert.Equal(t, "", curlExample("", map[string]string{"x": "y"}))
+}

--- a/pkg/client/cli/intercept/state.go
+++ b/pkg/client/cli/intercept/state.go
@@ -260,6 +260,13 @@ func (s *state) create(ctx context.Context) (acquired bool, err error) {
 	}
 
 	s.info = NewInfo(ctx, intercept, s.MountFlags.ReadOnly, s.mountError)
+	if spec := intercept.Spec; spec.ServiceName != "" {
+		if r, err := ud.List(ctx, &connector.ListRequest{Namespace: spec.Namespace}); err != nil {
+			clog.Debugf(ctx, "failed to list workloads for route discovery: %v", err)
+		} else {
+			s.info.AccessURLs = routeURLs(routesForSpec(spec, r.Workloads))
+		}
+	}
 	detailedOutput := s.DetailedOutput && s.FormattedOutput
 	if detailedOutput {
 		output.Object(ctx, s.info, true)

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -616,6 +616,10 @@ func (s *session) AddIntercept(ctx context.Context, ir *rpc.CreateInterceptReque
 		spec.Mechanism = "tcp"
 	}
 
+	// Start the workload info watcher early so that the workload snapshot is up to
+	// date with this intercept's workload by the time this call returns.
+	go s.ensureWatchers([]string{spec.Namespace})
+
 	mgrClient := s.ManagerClient()
 
 	// iInfo.preparedIntercept == nil means that we're using an older traffic-manager, incapable
@@ -646,6 +650,7 @@ func (s *session) AddIntercept(ctx context.Context, ir *rpc.CreateInterceptReque
 		spec.TargetPort = pi.ContainerPort
 	}
 
+	spec.ServiceName = pi.ServiceName
 	spec.ServiceUid = pi.ServiceUid
 	spec.ServiceName = pi.ServiceName
 	spec.ServiceIps = pi.ServiceIps
@@ -727,6 +732,17 @@ func (s *session) AddIntercept(ctx context.Context, ir *rpc.CreateInterceptReque
 				return nil, client.CheckTimeout(c, err)
 			}
 			success = true // Prevent removal in deferred function
+
+			// Wait for the workload info update that reflects this intercept, so
+			// that a subsequent fetch of the workload snapshot includes the service
+			// and route associations of this intercept's workload.
+			wc, cancelWait := context.WithTimeout(c, 5*time.Second)
+			defer cancelWait()
+			if !s.waitForWorkloadUpdate(wc, spec.Namespace, spec.Agent, func(wi workloadInfo) bool {
+				return wi.agentState == manager.WorkloadInfo_INTERCEPTED
+			}) {
+				clog.Debugf(c, "timed out waiting for workload info update of %s.%s", spec.Agent, spec.Namespace)
+			}
 			return ii, nil
 		}
 	}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -685,21 +685,55 @@ func cloneServiceAssociations(services []*manager.ServiceAssociation) []*manager
 	return cloned
 }
 
-func (s *session) WatchWorkloads(wr *rpc.WatchWorkloadsRequest, stream userd.WatchWorkloadsStream) error {
+// subscribeWorkloadsChange returns a channel that is signaled every time the
+// workloads map is updated, and a function that cancels the subscription. The
+// channel is buffered, so a signal arriving when the subscriber isn't actively
+// receiving is never lost; consecutive signals are coalesced into one.
+func (s *session) subscribeWorkloadsChange() (<-chan struct{}, func()) {
 	id := uuid.New()
-	ch := make(chan struct{})
+	ch := make(chan struct{}, 1)
 	s.workloadsLock.Lock()
 	if s.workloadSubscribers == nil {
 		s.workloadSubscribers = make(map[uuid.UUID]chan struct{})
 	}
 	s.workloadSubscribers[id] = ch
 	s.workloadsLock.Unlock()
-
-	defer func() {
+	return ch, func() {
 		s.workloadsLock.Lock()
 		delete(s.workloadSubscribers, id)
 		s.workloadsLock.Unlock()
-	}()
+	}
+}
+
+// waitForWorkloadUpdate waits until the workload info for the named workload in
+// the given namespace satisfies the given predicate. It returns false if the
+// context is done before that happens.
+func (s *session) waitForWorkloadUpdate(ctx context.Context, namespace, name string, predicate func(workloadInfo) bool) bool {
+	ch, unsubscribe := s.subscribeWorkloadsChange()
+	defer unsubscribe()
+	check := func() bool {
+		s.workloadsLock.Lock()
+		defer s.workloadsLock.Unlock()
+		for key, info := range s.workloads[namespace] {
+			if key.name == name && predicate(info) {
+				return true
+			}
+		}
+		return false
+	}
+	for !check() {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ch:
+		}
+	}
+	return true
+}
+
+func (s *session) WatchWorkloads(wr *rpc.WatchWorkloadsRequest, stream userd.WatchWorkloadsStream) error {
+	ch, unsubscribe := s.subscribeWorkloadsChange()
+	defer unsubscribe()
 
 	send := func() error {
 		ws, err := s.WorkloadInfoSnapshot(wr.Namespaces, rpc.ListRequest_UNSPECIFIED)

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -75,6 +75,10 @@ type workloadInfo struct {
 	state            workload.State
 	agentState       manager.WorkloadInfo_AgentState
 	interceptClients []string
+	desiredReplicas  int32
+	readyReplicas    int32
+	services         []*manager.ServiceAssociation
+	routes           []*manager.RouteAssociation
 }
 
 type session struct {
@@ -609,11 +613,16 @@ func (s *session) getInfosForWorkloads(
 	wiMap := make(map[string]*rpc.WorkloadInfo)
 	s.eachWorkload(namespaces, func(wlKind manager.WorkloadInfo_Kind, name, namespace string, info workloadInfo) {
 		kind := wlKind.String()
+		clog.Debugf(s, "snapshot workload %s/%s.%s services=%d routes=%d", wlKind, name, namespace, len(info.services), len(info.routes))
 		wlInfo := &rpc.WorkloadInfo{
 			Name:                 name,
 			Namespace:            namespace,
 			WorkloadResourceType: kind,
 			Uid:                  string(info.uid),
+			DesiredReplicas:      info.desiredReplicas,
+			ReadyReplicas:        info.readyReplicas,
+			Services:             cloneServiceAssociations(info.services),
+			Routes:               cloneRouteAssociations(info.routes),
 		}
 		if info.state != workload.StateAvailable {
 			wlInfo.NotInterceptableReason = info.state.String()
@@ -663,6 +672,62 @@ func (s *session) getInfosForWorkloads(
 	}
 	sort.Slice(wiz, func(i, j int) bool { return wiz[i].Name < wiz[j].Name })
 	return wiz
+}
+
+func cloneServiceAssociations(services []*manager.ServiceAssociation) []*manager.ServiceAssociation {
+	if len(services) == 0 {
+		return nil
+	}
+
+	cloned := make([]*manager.ServiceAssociation, 0, len(services))
+	for _, service := range services {
+		if service == nil {
+			continue
+		}
+		ports := make([]*manager.ServicePort, 0, len(service.Ports))
+		for _, port := range service.Ports {
+			if port == nil {
+				continue
+			}
+			ports = append(ports, &manager.ServicePort{
+				Name:       port.Name,
+				Port:       port.Port,
+				TargetPort: port.TargetPort,
+			})
+		}
+		cloned = append(cloned, &manager.ServiceAssociation{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+			Ports:     ports,
+		})
+	}
+	return cloned
+}
+
+func cloneRouteAssociations(routes []*manager.RouteAssociation) []*manager.RouteAssociation {
+	if len(routes) == 0 {
+		return nil
+	}
+
+	cloned := make([]*manager.RouteAssociation, 0, len(routes))
+	for _, route := range routes {
+		if route == nil {
+			continue
+		}
+		cloned = append(cloned, &manager.RouteAssociation{
+			Type:             route.Type,
+			Name:             route.Name,
+			Namespace:        route.Namespace,
+			Hosts:            append([]string(nil), route.Hosts...),
+			Paths:            append([]string(nil), route.Paths...),
+			Tls:              route.Tls,
+			ServiceName:      route.ServiceName,
+			ServiceNamespace: route.ServiceNamespace,
+			ServicePortName:  route.ServicePortName,
+			ServicePort:      route.ServicePort,
+		})
+	}
+	return cloned
 }
 
 func (s *session) WatchWorkloads(wr *rpc.WatchWorkloadsRequest, stream userd.WatchWorkloadsStream) error {
@@ -1242,11 +1307,16 @@ func (s *session) workloadsWatcher(namespace string, synced *sync.WaitGroup) err
 					}
 					state := workload.StateFromRPC(w.State)
 					clog.Debugf(s, "Adding workload %s/%s.%s %s %s %s", key.kind, key.name, namespace, state, w.AgentState, clients)
+					clog.Debugf(s, "workload event payload %s/%s.%s services=%d routes=%d", key.kind, key.name, namespace, len(w.Services), len(w.Routes))
 					workloads[key] = workloadInfo{
 						uid:              k8sTypes.UID(w.Uid),
 						state:            state,
 						agentState:       w.AgentState,
 						interceptClients: clients,
+						desiredReplicas:  w.DesiredReplicas,
+						readyReplicas:    w.ReadyReplicas,
+						services:         cloneServiceAssociations(w.Services),
+						routes:           cloneRouteAssociations(w.Routes),
 					}
 				}
 			}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -78,7 +78,6 @@ type workloadInfo struct {
 	desiredReplicas  int32
 	readyReplicas    int32
 	services         []*manager.ServiceAssociation
-	routes           []*manager.RouteAssociation
 }
 
 type session struct {
@@ -613,7 +612,6 @@ func (s *session) getInfosForWorkloads(
 	wiMap := make(map[string]*rpc.WorkloadInfo)
 	s.eachWorkload(namespaces, func(wlKind manager.WorkloadInfo_Kind, name, namespace string, info workloadInfo) {
 		kind := wlKind.String()
-		clog.Debugf(s, "snapshot workload %s/%s.%s services=%d routes=%d", wlKind, name, namespace, len(info.services), len(info.routes))
 		wlInfo := &rpc.WorkloadInfo{
 			Name:                 name,
 			Namespace:            namespace,
@@ -622,7 +620,6 @@ func (s *session) getInfosForWorkloads(
 			DesiredReplicas:      info.desiredReplicas,
 			ReadyReplicas:        info.readyReplicas,
 			Services:             cloneServiceAssociations(info.services),
-			Routes:               cloneRouteAssociations(info.routes),
 		}
 		if info.state != workload.StateAvailable {
 			wlInfo.NotInterceptableReason = info.state.String()
@@ -681,51 +678,9 @@ func cloneServiceAssociations(services []*manager.ServiceAssociation) []*manager
 
 	cloned := make([]*manager.ServiceAssociation, 0, len(services))
 	for _, service := range services {
-		if service == nil {
-			continue
+		if service != nil {
+			cloned = append(cloned, proto.Clone(service).(*manager.ServiceAssociation))
 		}
-		ports := make([]*manager.ServicePort, 0, len(service.Ports))
-		for _, port := range service.Ports {
-			if port == nil {
-				continue
-			}
-			ports = append(ports, &manager.ServicePort{
-				Name:       port.Name,
-				Port:       port.Port,
-				TargetPort: port.TargetPort,
-			})
-		}
-		cloned = append(cloned, &manager.ServiceAssociation{
-			Name:      service.Name,
-			Namespace: service.Namespace,
-			Ports:     ports,
-		})
-	}
-	return cloned
-}
-
-func cloneRouteAssociations(routes []*manager.RouteAssociation) []*manager.RouteAssociation {
-	if len(routes) == 0 {
-		return nil
-	}
-
-	cloned := make([]*manager.RouteAssociation, 0, len(routes))
-	for _, route := range routes {
-		if route == nil {
-			continue
-		}
-		cloned = append(cloned, &manager.RouteAssociation{
-			Type:             route.Type,
-			Name:             route.Name,
-			Namespace:        route.Namespace,
-			Hosts:            append([]string(nil), route.Hosts...),
-			Paths:            append([]string(nil), route.Paths...),
-			Tls:              route.Tls,
-			ServiceName:      route.ServiceName,
-			ServiceNamespace: route.ServiceNamespace,
-			ServicePortName:  route.ServicePortName,
-			ServicePort:      route.ServicePort,
-		})
 	}
 	return cloned
 }
@@ -1307,7 +1262,6 @@ func (s *session) workloadsWatcher(namespace string, synced *sync.WaitGroup) err
 					}
 					state := workload.StateFromRPC(w.State)
 					clog.Debugf(s, "Adding workload %s/%s.%s %s %s %s", key.kind, key.name, namespace, state, w.AgentState, clients)
-					clog.Debugf(s, "workload event payload %s/%s.%s services=%d routes=%d", key.kind, key.name, namespace, len(w.Services), len(w.Routes))
 					workloads[key] = workloadInfo{
 						uid:              k8sTypes.UID(w.Uid),
 						state:            state,
@@ -1316,7 +1270,6 @@ func (s *session) workloadsWatcher(namespace string, synced *sync.WaitGroup) err
 						desiredReplicas:  w.DesiredReplicas,
 						readyReplicas:    w.ReadyReplicas,
 						services:         cloneServiceAssociations(w.Services),
-						routes:           cloneRouteAssociations(w.Routes),
 					}
 				}
 			}

--- a/pkg/client/userd/trafficmgr/workloads_wait_test.go
+++ b/pkg/client/userd/trafficmgr/workloads_wait_test.go
@@ -1,0 +1,66 @@
+package trafficmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+func agentInstalled(wi workloadInfo) bool {
+	return wi.agentState != manager.WorkloadInfo_NO_AGENT_UNSPECIFIED
+}
+
+func (s *session) setWorkload(namespace, name string, wi workloadInfo) {
+	s.workloadsLock.Lock()
+	nm := s.workloads[namespace]
+	if nm == nil {
+		nm = make(map[workloadInfoKey]workloadInfo)
+		s.workloads[namespace] = nm
+	}
+	nm[workloadInfoKey{kind: manager.WorkloadInfo_DEPLOYMENT, name: name}] = wi
+	for _, subscriber := range s.workloadSubscribers {
+		select {
+		case subscriber <- struct{}{}:
+		default:
+		}
+	}
+	s.workloadsLock.Unlock()
+}
+
+func TestWaitForWorkloadUpdate(t *testing.T) {
+	newSession := func() *session {
+		return &session{workloads: make(map[string]map[workloadInfoKey]workloadInfo)}
+	}
+
+	t.Run("predicate already satisfied", func(t *testing.T) {
+		s := newSession()
+		s.setWorkload("default", "echo", workloadInfo{agentState: manager.WorkloadInfo_INSTALLED})
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.True(t, s.waitForWorkloadUpdate(ctx, "default", "echo", agentInstalled))
+	})
+
+	t.Run("predicate satisfied after update", func(t *testing.T) {
+		s := newSession()
+		s.setWorkload("default", "echo", workloadInfo{agentState: manager.WorkloadInfo_NO_AGENT_UNSPECIFIED})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			s.setWorkload("default", "echo", workloadInfo{agentState: manager.WorkloadInfo_INSTALLED})
+		}()
+		assert.True(t, s.waitForWorkloadUpdate(ctx, "default", "echo", agentInstalled))
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		s := newSession()
+		s.setWorkload("default", "echo", workloadInfo{agentState: manager.WorkloadInfo_NO_AGENT_UNSPECIFIED})
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		assert.False(t, s.waitForWorkloadUpdate(ctx, "default", "echo", agentInstalled))
+	})
+}

--- a/pkg/k8sapi/workload.go
+++ b/pkg/k8sapi/workload.go
@@ -32,6 +32,48 @@ func (u UnsupportedWorkloadKindError) Error() string {
 	return fmt.Sprintf("unsupported workload kind: %q", string(u))
 }
 
+func DesiredReplicas(w Workload) int32 {
+	switch w := w.(type) {
+	case *deployment:
+		if w.Spec.Replicas != nil {
+			return *w.Spec.Replicas
+		}
+		return w.Status.Replicas
+	case *rollout:
+		if w.Spec.Replicas != nil {
+			return *w.Spec.Replicas
+		}
+		return w.Status.Replicas
+	case *replicaSet:
+		if w.Spec.Replicas != nil {
+			return *w.Spec.Replicas
+		}
+		return w.Status.Replicas
+	case *statefulSet:
+		if w.Spec.Replicas != nil {
+			return *w.Spec.Replicas
+		}
+		return w.Status.Replicas
+	default:
+		return int32(w.Replicas())
+	}
+}
+
+func ReadyReplicas(w Workload) int32 {
+	switch w := w.(type) {
+	case *deployment:
+		return w.Status.ReadyReplicas
+	case *rollout:
+		return w.Status.ReadyReplicas
+	case *replicaSet:
+		return w.Status.ReadyReplicas
+	case *statefulSet:
+		return w.Status.ReadyReplicas
+	default:
+		return 0
+	}
+}
+
 // GetWorkload returns a workload for the given name, namespace, and workloadKind. The workloadKind
 // is optional. A search is performed in the following order if it is empty:
 //

--- a/rpc/connector/connector.pb.go
+++ b/rpc/connector/connector.pb.go
@@ -1095,9 +1095,13 @@ type WorkloadInfo struct {
 	// IngestInfo reported from the traffic manager in case the workload is currently intercepted
 	IngestInfo []*IngestInfo `protobuf:"bytes,5,rep,name=ingest_info,json=ingestInfo,proto3" json:"ingest_info,omitempty"`
 	// Workload Resource type (e.g. Deployment, ReplicaSet, StatefulSet, Rollout)
-	WorkloadResourceType string `protobuf:"bytes,6,opt,name=workload_resource_type,json=workloadResourceType,proto3" json:"workload_resource_type,omitempty"`
-	Uid                  string `protobuf:"bytes,7,opt,name=uid,proto3" json:"uid,omitempty"`
-	AgentVersion         string `protobuf:"bytes,8,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
+	WorkloadResourceType string                        `protobuf:"bytes,6,opt,name=workload_resource_type,json=workloadResourceType,proto3" json:"workload_resource_type,omitempty"`
+	Uid                  string                        `protobuf:"bytes,7,opt,name=uid,proto3" json:"uid,omitempty"`
+	AgentVersion         string                        `protobuf:"bytes,8,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
+	DesiredReplicas      int32                         `protobuf:"varint,9,opt,name=desired_replicas,json=desiredReplicas,proto3" json:"desired_replicas,omitempty"`
+	ReadyReplicas        int32                         `protobuf:"varint,10,opt,name=ready_replicas,json=readyReplicas,proto3" json:"ready_replicas,omitempty"`
+	Services             []*manager.ServiceAssociation `protobuf:"bytes,11,rep,name=services,proto3" json:"services,omitempty"`
+	Routes               []*manager.RouteAssociation   `protobuf:"bytes,12,rep,name=routes,proto3" json:"routes,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -1186,6 +1190,34 @@ func (x *WorkloadInfo) GetAgentVersion() string {
 		return x.AgentVersion
 	}
 	return ""
+}
+
+func (x *WorkloadInfo) GetDesiredReplicas() int32 {
+	if x != nil {
+		return x.DesiredReplicas
+	}
+	return 0
+}
+
+func (x *WorkloadInfo) GetReadyReplicas() int32 {
+	if x != nil {
+		return x.ReadyReplicas
+	}
+	return 0
+}
+
+func (x *WorkloadInfo) GetServices() []*manager.ServiceAssociation {
+	if x != nil {
+		return x.Services
+	}
+	return nil
+}
+
+func (x *WorkloadInfo) GetRoutes() []*manager.RouteAssociation {
+	if x != nil {
+		return x.Routes
+	}
+	return nil
 }
 
 type WorkloadInfoSnapshot struct {
@@ -1899,7 +1931,7 @@ const file_connector_connector_proto_rawDesc = "" +
 	"\x15WatchWorkloadsRequest\x12\x1e\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\tR\n" +
-	"namespaces\"\xf8\x02\n" +
+	"namespaces\"\xd0\x04\n" +
 	"\fWorkloadInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x128\n" +
@@ -1909,7 +1941,12 @@ const file_connector_connector_proto_rawDesc = "" +
 	"ingestInfo\x124\n" +
 	"\x16workload_resource_type\x18\x06 \x01(\tR\x14workloadResourceType\x12\x10\n" +
 	"\x03uid\x18\a \x01(\tR\x03uid\x12#\n" +
-	"\ragent_version\x18\b \x01(\tR\fagentVersion\"Z\n" +
+	"\ragent_version\x18\b \x01(\tR\fagentVersion\x12)\n" +
+	"\x10desired_replicas\x18\t \x01(\x05R\x0fdesiredReplicas\x12%\n" +
+	"\x0eready_replicas\x18\n" +
+	" \x01(\x05R\rreadyReplicas\x12D\n" +
+	"\bservices\x18\v \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\x12>\n" +
+	"\x06routes\x18\f \x03(\v2&.telepresence.manager.RouteAssociationR\x06routes\"Z\n" +
 	"\x14WorkloadInfoSnapshot\x12B\n" +
 	"\tworkloads\x18\x01 \x03(\v2$.telepresence.connector.WorkloadInfoR\tworkloads\"\xe5\x01\n" +
 	"\x0fLogLevelRequest\x12\x1b\n" +
@@ -2051,23 +2088,25 @@ var file_connector_connector_proto_goTypes = []any{
 	(*daemon.DaemonStatus)(nil),             // 36: telepresence.daemon.DaemonStatus
 	(*manager.InterceptSpec)(nil),           // 37: telepresence.manager.InterceptSpec
 	(*manager.InterceptInfo)(nil),           // 38: telepresence.manager.InterceptInfo
-	(*durationpb.Duration)(nil),             // 39: google.protobuf.Duration
-	(*manager.IPNet)(nil),                   // 40: telepresence.manager.IPNet
-	(*emptypb.Empty)(nil),                   // 41: google.protobuf.Empty
-	(*manager.GetInterceptRequest)(nil),     // 42: telepresence.manager.GetInterceptRequest
-	(*manager.RemoveInterceptRequest2)(nil), // 43: telepresence.manager.RemoveInterceptRequest2
-	(*daemon.SetDNSExcludesRequest)(nil),    // 44: telepresence.daemon.SetDNSExcludesRequest
-	(*daemon.SetDNSMappingsRequest)(nil),    // 45: telepresence.daemon.SetDNSMappingsRequest
-	(*manager.AgentConfigRequest)(nil),      // 46: telepresence.manager.AgentConfigRequest
-	(*daemon.LookupIPRequest)(nil),          // 47: telepresence.daemon.LookupIPRequest
-	(*daemon.ResolvePortRequest)(nil),       // 48: telepresence.daemon.ResolvePortRequest
-	(*daemon.ReroutePortRequest)(nil),       // 49: telepresence.daemon.ReroutePortRequest
-	(*manager.AgentImageFQN)(nil),           // 50: telepresence.manager.AgentImageFQN
-	(*daemon.QuitResponse)(nil),             // 51: telepresence.daemon.QuitResponse
-	(*manager.KnownWorkloadKinds)(nil),      // 52: telepresence.manager.KnownWorkloadKinds
-	(*manager.AgentConfigResponse)(nil),     // 53: telepresence.manager.AgentConfigResponse
-	(*daemon.LookupIPResponse)(nil),         // 54: telepresence.daemon.LookupIPResponse
-	(*daemon.ResolvePortResponse)(nil),      // 55: telepresence.daemon.ResolvePortResponse
+	(*manager.ServiceAssociation)(nil),      // 39: telepresence.manager.ServiceAssociation
+	(*manager.RouteAssociation)(nil),        // 40: telepresence.manager.RouteAssociation
+	(*durationpb.Duration)(nil),             // 41: google.protobuf.Duration
+	(*manager.IPNet)(nil),                   // 42: telepresence.manager.IPNet
+	(*emptypb.Empty)(nil),                   // 43: google.protobuf.Empty
+	(*manager.GetInterceptRequest)(nil),     // 44: telepresence.manager.GetInterceptRequest
+	(*manager.RemoveInterceptRequest2)(nil), // 45: telepresence.manager.RemoveInterceptRequest2
+	(*daemon.SetDNSExcludesRequest)(nil),    // 46: telepresence.daemon.SetDNSExcludesRequest
+	(*daemon.SetDNSMappingsRequest)(nil),    // 47: telepresence.daemon.SetDNSMappingsRequest
+	(*manager.AgentConfigRequest)(nil),      // 48: telepresence.manager.AgentConfigRequest
+	(*daemon.LookupIPRequest)(nil),          // 49: telepresence.daemon.LookupIPRequest
+	(*daemon.ResolvePortRequest)(nil),       // 50: telepresence.daemon.ResolvePortRequest
+	(*daemon.ReroutePortRequest)(nil),       // 51: telepresence.daemon.ReroutePortRequest
+	(*manager.AgentImageFQN)(nil),           // 52: telepresence.manager.AgentImageFQN
+	(*daemon.QuitResponse)(nil),             // 53: telepresence.daemon.QuitResponse
+	(*manager.KnownWorkloadKinds)(nil),      // 54: telepresence.manager.KnownWorkloadKinds
+	(*manager.AgentConfigResponse)(nil),     // 55: telepresence.manager.AgentConfigResponse
+	(*daemon.LookupIPResponse)(nil),         // 56: telepresence.daemon.LookupIPResponse
+	(*daemon.ResolvePortResponse)(nil),      // 57: telepresence.daemon.ResolvePortResponse
 }
 var file_connector_connector_proto_depIdxs = []int32{
 	25, // 0: telepresence.connector.ConnectRequest.kube_flags:type_name -> telepresence.connector.ConnectRequest.KubeFlagsEntry
@@ -2089,89 +2128,91 @@ var file_connector_connector_proto_depIdxs = []int32{
 	29, // 16: telepresence.connector.IngestInfo.mounts:type_name -> telepresence.connector.IngestInfo.MountsEntry
 	38, // 17: telepresence.connector.WorkloadInfo.intercept_info:type_name -> telepresence.manager.InterceptInfo
 	11, // 18: telepresence.connector.WorkloadInfo.ingest_info:type_name -> telepresence.connector.IngestInfo
-	13, // 19: telepresence.connector.WorkloadInfoSnapshot.workloads:type_name -> telepresence.connector.WorkloadInfo
-	39, // 20: telepresence.connector.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	2,  // 21: telepresence.connector.LogLevelRequest.scope:type_name -> telepresence.connector.LogLevelRequest.Scope
-	30, // 22: telepresence.connector.LogsResponse.pod_info:type_name -> telepresence.connector.LogsResponse.PodInfoEntry
-	40, // 23: telepresence.connector.ClusterSubnets.pod_subnets:type_name -> telepresence.manager.IPNet
-	40, // 24: telepresence.connector.ClusterSubnets.svc_subnets:type_name -> telepresence.manager.IPNet
-	41, // 25: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
-	41, // 26: telepresence.connector.Connector.RootDaemonVersion:input_type -> google.protobuf.Empty
-	41, // 27: telepresence.connector.Connector.TrafficManagerVersion:input_type -> google.protobuf.Empty
-	41, // 28: telepresence.connector.Connector.AgentImageFQN:input_type -> google.protobuf.Empty
-	42, // 29: telepresence.connector.Connector.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	4,  // 30: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
-	41, // 31: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
-	41, // 32: telepresence.connector.Connector.GetClusterSubnets:input_type -> google.protobuf.Empty
-	41, // 33: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
-	7,  // 34: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	10, // 35: telepresence.connector.Connector.Ingest:input_type -> telepresence.connector.IngestRequest
-	9,  // 36: telepresence.connector.Connector.GetIngest:input_type -> telepresence.connector.IngestIdentifier
-	9,  // 37: telepresence.connector.Connector.LeaveIngest:input_type -> telepresence.connector.IngestIdentifier
-	7,  // 38: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	43, // 39: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	24, // 40: telepresence.connector.Connector.RevokeIntercept:input_type -> telepresence.connector.RevokeInterceptRequest
-	6,  // 41: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
-	8,  // 42: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
-	12, // 43: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
-	15, // 44: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.connector.LogLevelRequest
-	41, // 45: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
-	16, // 46: telepresence.connector.Connector.GatherLogs:input_type -> telepresence.connector.LogsRequest
-	3,  // 47: telepresence.connector.Connector.AddInterceptor:input_type -> telepresence.connector.Interceptor
-	3,  // 48: telepresence.connector.Connector.RemoveInterceptor:input_type -> telepresence.connector.Interceptor
-	18, // 49: telepresence.connector.Connector.GetNamespaces:input_type -> telepresence.connector.GetNamespacesRequest
-	41, // 50: telepresence.connector.Connector.GetKnownWorkloadKinds:input_type -> google.protobuf.Empty
-	41, // 51: telepresence.connector.Connector.RemoteMountAvailability:input_type -> google.protobuf.Empty
-	41, // 52: telepresence.connector.Connector.GetConfig:input_type -> google.protobuf.Empty
-	44, // 53: telepresence.connector.Connector.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
-	45, // 54: telepresence.connector.Connector.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
-	46, // 55: telepresence.connector.Connector.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	22, // 56: telepresence.connector.Connector.ResolveSyntheticIP:input_type -> telepresence.connector.ResolveSyntheticRequest
-	47, // 57: telepresence.connector.Connector.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
-	48, // 58: telepresence.connector.Connector.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
-	49, // 59: telepresence.connector.Connector.RerouteLocalPort:input_type -> telepresence.daemon.ReroutePortRequest
-	49, // 60: telepresence.connector.Connector.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
-	32, // 61: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
-	32, // 62: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
-	32, // 63: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
-	50, // 64: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	38, // 65: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	5,  // 66: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
-	41, // 67: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
-	21, // 68: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
-	5,  // 69: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
-	41, // 70: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
-	11, // 71: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
-	11, // 72: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
-	11, // 73: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
-	38, // 74: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	41, // 75: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
-	41, // 76: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
-	41, // 77: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
-	14, // 78: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	14, // 79: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	41, // 80: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
-	51, // 81: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
-	17, // 82: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
-	41, // 83: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
-	41, // 84: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
-	19, // 85: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
-	52, // 86: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	41, // 87: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
-	20, // 88: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
-	41, // 89: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
-	41, // 90: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
-	53, // 91: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	23, // 92: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
-	54, // 93: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
-	55, // 94: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
-	41, // 95: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
-	41, // 96: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
-	61, // [61:97] is the sub-list for method output_type
-	25, // [25:61] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	39, // 19: telepresence.connector.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
+	40, // 20: telepresence.connector.WorkloadInfo.routes:type_name -> telepresence.manager.RouteAssociation
+	13, // 21: telepresence.connector.WorkloadInfoSnapshot.workloads:type_name -> telepresence.connector.WorkloadInfo
+	41, // 22: telepresence.connector.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	2,  // 23: telepresence.connector.LogLevelRequest.scope:type_name -> telepresence.connector.LogLevelRequest.Scope
+	30, // 24: telepresence.connector.LogsResponse.pod_info:type_name -> telepresence.connector.LogsResponse.PodInfoEntry
+	42, // 25: telepresence.connector.ClusterSubnets.pod_subnets:type_name -> telepresence.manager.IPNet
+	42, // 26: telepresence.connector.ClusterSubnets.svc_subnets:type_name -> telepresence.manager.IPNet
+	43, // 27: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
+	43, // 28: telepresence.connector.Connector.RootDaemonVersion:input_type -> google.protobuf.Empty
+	43, // 29: telepresence.connector.Connector.TrafficManagerVersion:input_type -> google.protobuf.Empty
+	43, // 30: telepresence.connector.Connector.AgentImageFQN:input_type -> google.protobuf.Empty
+	44, // 31: telepresence.connector.Connector.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	4,  // 32: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
+	43, // 33: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
+	43, // 34: telepresence.connector.Connector.GetClusterSubnets:input_type -> google.protobuf.Empty
+	43, // 35: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
+	7,  // 36: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	10, // 37: telepresence.connector.Connector.Ingest:input_type -> telepresence.connector.IngestRequest
+	9,  // 38: telepresence.connector.Connector.GetIngest:input_type -> telepresence.connector.IngestIdentifier
+	9,  // 39: telepresence.connector.Connector.LeaveIngest:input_type -> telepresence.connector.IngestIdentifier
+	7,  // 40: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	45, // 41: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	24, // 42: telepresence.connector.Connector.RevokeIntercept:input_type -> telepresence.connector.RevokeInterceptRequest
+	6,  // 43: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
+	8,  // 44: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
+	12, // 45: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
+	15, // 46: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.connector.LogLevelRequest
+	43, // 47: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
+	16, // 48: telepresence.connector.Connector.GatherLogs:input_type -> telepresence.connector.LogsRequest
+	3,  // 49: telepresence.connector.Connector.AddInterceptor:input_type -> telepresence.connector.Interceptor
+	3,  // 50: telepresence.connector.Connector.RemoveInterceptor:input_type -> telepresence.connector.Interceptor
+	18, // 51: telepresence.connector.Connector.GetNamespaces:input_type -> telepresence.connector.GetNamespacesRequest
+	43, // 52: telepresence.connector.Connector.GetKnownWorkloadKinds:input_type -> google.protobuf.Empty
+	43, // 53: telepresence.connector.Connector.RemoteMountAvailability:input_type -> google.protobuf.Empty
+	43, // 54: telepresence.connector.Connector.GetConfig:input_type -> google.protobuf.Empty
+	46, // 55: telepresence.connector.Connector.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
+	47, // 56: telepresence.connector.Connector.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
+	48, // 57: telepresence.connector.Connector.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	22, // 58: telepresence.connector.Connector.ResolveSyntheticIP:input_type -> telepresence.connector.ResolveSyntheticRequest
+	49, // 59: telepresence.connector.Connector.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
+	50, // 60: telepresence.connector.Connector.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
+	51, // 61: telepresence.connector.Connector.RerouteLocalPort:input_type -> telepresence.daemon.ReroutePortRequest
+	51, // 62: telepresence.connector.Connector.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
+	32, // 63: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
+	32, // 64: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
+	32, // 65: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
+	52, // 66: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	38, // 67: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	5,  // 68: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
+	43, // 69: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
+	21, // 70: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
+	5,  // 71: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
+	43, // 72: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
+	11, // 73: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
+	11, // 74: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
+	11, // 75: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
+	38, // 76: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	43, // 77: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
+	43, // 78: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
+	43, // 79: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
+	14, // 80: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	14, // 81: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	43, // 82: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
+	53, // 83: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
+	17, // 84: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
+	43, // 85: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
+	43, // 86: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
+	19, // 87: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
+	54, // 88: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	43, // 89: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
+	20, // 90: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
+	43, // 91: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
+	43, // 92: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
+	55, // 93: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	23, // 94: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
+	56, // 95: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
+	57, // 96: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
+	43, // 97: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
+	43, // 98: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
+	63, // [63:99] is the sub-list for method output_type
+	27, // [27:63] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_connector_connector_proto_init() }

--- a/rpc/connector/connector.pb.go
+++ b/rpc/connector/connector.pb.go
@@ -1101,7 +1101,6 @@ type WorkloadInfo struct {
 	DesiredReplicas      int32                         `protobuf:"varint,9,opt,name=desired_replicas,json=desiredReplicas,proto3" json:"desired_replicas,omitempty"`
 	ReadyReplicas        int32                         `protobuf:"varint,10,opt,name=ready_replicas,json=readyReplicas,proto3" json:"ready_replicas,omitempty"`
 	Services             []*manager.ServiceAssociation `protobuf:"bytes,11,rep,name=services,proto3" json:"services,omitempty"`
-	Routes               []*manager.RouteAssociation   `protobuf:"bytes,12,rep,name=routes,proto3" json:"routes,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -1209,13 +1208,6 @@ func (x *WorkloadInfo) GetReadyReplicas() int32 {
 func (x *WorkloadInfo) GetServices() []*manager.ServiceAssociation {
 	if x != nil {
 		return x.Services
-	}
-	return nil
-}
-
-func (x *WorkloadInfo) GetRoutes() []*manager.RouteAssociation {
-	if x != nil {
-		return x.Routes
 	}
 	return nil
 }
@@ -1931,7 +1923,7 @@ const file_connector_connector_proto_rawDesc = "" +
 	"\x15WatchWorkloadsRequest\x12\x1e\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\tR\n" +
-	"namespaces\"\xd0\x04\n" +
+	"namespaces\"\x90\x04\n" +
 	"\fWorkloadInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x128\n" +
@@ -1945,8 +1937,7 @@ const file_connector_connector_proto_rawDesc = "" +
 	"\x10desired_replicas\x18\t \x01(\x05R\x0fdesiredReplicas\x12%\n" +
 	"\x0eready_replicas\x18\n" +
 	" \x01(\x05R\rreadyReplicas\x12D\n" +
-	"\bservices\x18\v \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\x12>\n" +
-	"\x06routes\x18\f \x03(\v2&.telepresence.manager.RouteAssociationR\x06routes\"Z\n" +
+	"\bservices\x18\v \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\"Z\n" +
 	"\x14WorkloadInfoSnapshot\x12B\n" +
 	"\tworkloads\x18\x01 \x03(\v2$.telepresence.connector.WorkloadInfoR\tworkloads\"\xe5\x01\n" +
 	"\x0fLogLevelRequest\x12\x1b\n" +
@@ -2089,24 +2080,23 @@ var file_connector_connector_proto_goTypes = []any{
 	(*manager.InterceptSpec)(nil),           // 37: telepresence.manager.InterceptSpec
 	(*manager.InterceptInfo)(nil),           // 38: telepresence.manager.InterceptInfo
 	(*manager.ServiceAssociation)(nil),      // 39: telepresence.manager.ServiceAssociation
-	(*manager.RouteAssociation)(nil),        // 40: telepresence.manager.RouteAssociation
-	(*durationpb.Duration)(nil),             // 41: google.protobuf.Duration
-	(*manager.IPNet)(nil),                   // 42: telepresence.manager.IPNet
-	(*emptypb.Empty)(nil),                   // 43: google.protobuf.Empty
-	(*manager.GetInterceptRequest)(nil),     // 44: telepresence.manager.GetInterceptRequest
-	(*manager.RemoveInterceptRequest2)(nil), // 45: telepresence.manager.RemoveInterceptRequest2
-	(*daemon.SetDNSExcludesRequest)(nil),    // 46: telepresence.daemon.SetDNSExcludesRequest
-	(*daemon.SetDNSMappingsRequest)(nil),    // 47: telepresence.daemon.SetDNSMappingsRequest
-	(*manager.AgentConfigRequest)(nil),      // 48: telepresence.manager.AgentConfigRequest
-	(*daemon.LookupIPRequest)(nil),          // 49: telepresence.daemon.LookupIPRequest
-	(*daemon.ResolvePortRequest)(nil),       // 50: telepresence.daemon.ResolvePortRequest
-	(*daemon.ReroutePortRequest)(nil),       // 51: telepresence.daemon.ReroutePortRequest
-	(*manager.AgentImageFQN)(nil),           // 52: telepresence.manager.AgentImageFQN
-	(*daemon.QuitResponse)(nil),             // 53: telepresence.daemon.QuitResponse
-	(*manager.KnownWorkloadKinds)(nil),      // 54: telepresence.manager.KnownWorkloadKinds
-	(*manager.AgentConfigResponse)(nil),     // 55: telepresence.manager.AgentConfigResponse
-	(*daemon.LookupIPResponse)(nil),         // 56: telepresence.daemon.LookupIPResponse
-	(*daemon.ResolvePortResponse)(nil),      // 57: telepresence.daemon.ResolvePortResponse
+	(*durationpb.Duration)(nil),             // 40: google.protobuf.Duration
+	(*manager.IPNet)(nil),                   // 41: telepresence.manager.IPNet
+	(*emptypb.Empty)(nil),                   // 42: google.protobuf.Empty
+	(*manager.GetInterceptRequest)(nil),     // 43: telepresence.manager.GetInterceptRequest
+	(*manager.RemoveInterceptRequest2)(nil), // 44: telepresence.manager.RemoveInterceptRequest2
+	(*daemon.SetDNSExcludesRequest)(nil),    // 45: telepresence.daemon.SetDNSExcludesRequest
+	(*daemon.SetDNSMappingsRequest)(nil),    // 46: telepresence.daemon.SetDNSMappingsRequest
+	(*manager.AgentConfigRequest)(nil),      // 47: telepresence.manager.AgentConfigRequest
+	(*daemon.LookupIPRequest)(nil),          // 48: telepresence.daemon.LookupIPRequest
+	(*daemon.ResolvePortRequest)(nil),       // 49: telepresence.daemon.ResolvePortRequest
+	(*daemon.ReroutePortRequest)(nil),       // 50: telepresence.daemon.ReroutePortRequest
+	(*manager.AgentImageFQN)(nil),           // 51: telepresence.manager.AgentImageFQN
+	(*daemon.QuitResponse)(nil),             // 52: telepresence.daemon.QuitResponse
+	(*manager.KnownWorkloadKinds)(nil),      // 53: telepresence.manager.KnownWorkloadKinds
+	(*manager.AgentConfigResponse)(nil),     // 54: telepresence.manager.AgentConfigResponse
+	(*daemon.LookupIPResponse)(nil),         // 55: telepresence.daemon.LookupIPResponse
+	(*daemon.ResolvePortResponse)(nil),      // 56: telepresence.daemon.ResolvePortResponse
 }
 var file_connector_connector_proto_depIdxs = []int32{
 	25, // 0: telepresence.connector.ConnectRequest.kube_flags:type_name -> telepresence.connector.ConnectRequest.KubeFlagsEntry
@@ -2129,90 +2119,89 @@ var file_connector_connector_proto_depIdxs = []int32{
 	38, // 17: telepresence.connector.WorkloadInfo.intercept_info:type_name -> telepresence.manager.InterceptInfo
 	11, // 18: telepresence.connector.WorkloadInfo.ingest_info:type_name -> telepresence.connector.IngestInfo
 	39, // 19: telepresence.connector.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
-	40, // 20: telepresence.connector.WorkloadInfo.routes:type_name -> telepresence.manager.RouteAssociation
-	13, // 21: telepresence.connector.WorkloadInfoSnapshot.workloads:type_name -> telepresence.connector.WorkloadInfo
-	41, // 22: telepresence.connector.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	2,  // 23: telepresence.connector.LogLevelRequest.scope:type_name -> telepresence.connector.LogLevelRequest.Scope
-	30, // 24: telepresence.connector.LogsResponse.pod_info:type_name -> telepresence.connector.LogsResponse.PodInfoEntry
-	42, // 25: telepresence.connector.ClusterSubnets.pod_subnets:type_name -> telepresence.manager.IPNet
-	42, // 26: telepresence.connector.ClusterSubnets.svc_subnets:type_name -> telepresence.manager.IPNet
-	43, // 27: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
-	43, // 28: telepresence.connector.Connector.RootDaemonVersion:input_type -> google.protobuf.Empty
-	43, // 29: telepresence.connector.Connector.TrafficManagerVersion:input_type -> google.protobuf.Empty
-	43, // 30: telepresence.connector.Connector.AgentImageFQN:input_type -> google.protobuf.Empty
-	44, // 31: telepresence.connector.Connector.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	4,  // 32: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
-	43, // 33: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
-	43, // 34: telepresence.connector.Connector.GetClusterSubnets:input_type -> google.protobuf.Empty
-	43, // 35: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
-	7,  // 36: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	10, // 37: telepresence.connector.Connector.Ingest:input_type -> telepresence.connector.IngestRequest
-	9,  // 38: telepresence.connector.Connector.GetIngest:input_type -> telepresence.connector.IngestIdentifier
-	9,  // 39: telepresence.connector.Connector.LeaveIngest:input_type -> telepresence.connector.IngestIdentifier
-	7,  // 40: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
-	45, // 41: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	24, // 42: telepresence.connector.Connector.RevokeIntercept:input_type -> telepresence.connector.RevokeInterceptRequest
-	6,  // 43: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
-	8,  // 44: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
-	12, // 45: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
-	15, // 46: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.connector.LogLevelRequest
-	43, // 47: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
-	16, // 48: telepresence.connector.Connector.GatherLogs:input_type -> telepresence.connector.LogsRequest
-	3,  // 49: telepresence.connector.Connector.AddInterceptor:input_type -> telepresence.connector.Interceptor
-	3,  // 50: telepresence.connector.Connector.RemoveInterceptor:input_type -> telepresence.connector.Interceptor
-	18, // 51: telepresence.connector.Connector.GetNamespaces:input_type -> telepresence.connector.GetNamespacesRequest
-	43, // 52: telepresence.connector.Connector.GetKnownWorkloadKinds:input_type -> google.protobuf.Empty
-	43, // 53: telepresence.connector.Connector.RemoteMountAvailability:input_type -> google.protobuf.Empty
-	43, // 54: telepresence.connector.Connector.GetConfig:input_type -> google.protobuf.Empty
-	46, // 55: telepresence.connector.Connector.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
-	47, // 56: telepresence.connector.Connector.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
-	48, // 57: telepresence.connector.Connector.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	22, // 58: telepresence.connector.Connector.ResolveSyntheticIP:input_type -> telepresence.connector.ResolveSyntheticRequest
-	49, // 59: telepresence.connector.Connector.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
-	50, // 60: telepresence.connector.Connector.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
-	51, // 61: telepresence.connector.Connector.RerouteLocalPort:input_type -> telepresence.daemon.ReroutePortRequest
-	51, // 62: telepresence.connector.Connector.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
-	32, // 63: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
-	32, // 64: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
-	32, // 65: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
-	52, // 66: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	38, // 67: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	5,  // 68: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
-	43, // 69: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
-	21, // 70: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
-	5,  // 71: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
-	43, // 72: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
-	11, // 73: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
-	11, // 74: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
-	11, // 75: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
-	38, // 76: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	43, // 77: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
-	43, // 78: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
-	43, // 79: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
-	14, // 80: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	14, // 81: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	43, // 82: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
-	53, // 83: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
-	17, // 84: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
-	43, // 85: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
-	43, // 86: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
-	19, // 87: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
-	54, // 88: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	43, // 89: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
-	20, // 90: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
-	43, // 91: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
-	43, // 92: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
-	55, // 93: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	23, // 94: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
-	56, // 95: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
-	57, // 96: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
-	43, // 97: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
-	43, // 98: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
-	63, // [63:99] is the sub-list for method output_type
-	27, // [27:63] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	13, // 20: telepresence.connector.WorkloadInfoSnapshot.workloads:type_name -> telepresence.connector.WorkloadInfo
+	40, // 21: telepresence.connector.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	2,  // 22: telepresence.connector.LogLevelRequest.scope:type_name -> telepresence.connector.LogLevelRequest.Scope
+	30, // 23: telepresence.connector.LogsResponse.pod_info:type_name -> telepresence.connector.LogsResponse.PodInfoEntry
+	41, // 24: telepresence.connector.ClusterSubnets.pod_subnets:type_name -> telepresence.manager.IPNet
+	41, // 25: telepresence.connector.ClusterSubnets.svc_subnets:type_name -> telepresence.manager.IPNet
+	42, // 26: telepresence.connector.Connector.Version:input_type -> google.protobuf.Empty
+	42, // 27: telepresence.connector.Connector.RootDaemonVersion:input_type -> google.protobuf.Empty
+	42, // 28: telepresence.connector.Connector.TrafficManagerVersion:input_type -> google.protobuf.Empty
+	42, // 29: telepresence.connector.Connector.AgentImageFQN:input_type -> google.protobuf.Empty
+	43, // 30: telepresence.connector.Connector.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	4,  // 31: telepresence.connector.Connector.Connect:input_type -> telepresence.connector.ConnectRequest
+	42, // 32: telepresence.connector.Connector.Disconnect:input_type -> google.protobuf.Empty
+	42, // 33: telepresence.connector.Connector.GetClusterSubnets:input_type -> google.protobuf.Empty
+	42, // 34: telepresence.connector.Connector.Status:input_type -> google.protobuf.Empty
+	7,  // 35: telepresence.connector.Connector.CanIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	10, // 36: telepresence.connector.Connector.Ingest:input_type -> telepresence.connector.IngestRequest
+	9,  // 37: telepresence.connector.Connector.GetIngest:input_type -> telepresence.connector.IngestIdentifier
+	9,  // 38: telepresence.connector.Connector.LeaveIngest:input_type -> telepresence.connector.IngestIdentifier
+	7,  // 39: telepresence.connector.Connector.CreateIntercept:input_type -> telepresence.connector.CreateInterceptRequest
+	44, // 40: telepresence.connector.Connector.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	24, // 41: telepresence.connector.Connector.RevokeIntercept:input_type -> telepresence.connector.RevokeInterceptRequest
+	6,  // 42: telepresence.connector.Connector.Uninstall:input_type -> telepresence.connector.UninstallRequest
+	8,  // 43: telepresence.connector.Connector.List:input_type -> telepresence.connector.ListRequest
+	12, // 44: telepresence.connector.Connector.WatchWorkloads:input_type -> telepresence.connector.WatchWorkloadsRequest
+	15, // 45: telepresence.connector.Connector.SetLogLevel:input_type -> telepresence.connector.LogLevelRequest
+	42, // 46: telepresence.connector.Connector.Quit:input_type -> google.protobuf.Empty
+	16, // 47: telepresence.connector.Connector.GatherLogs:input_type -> telepresence.connector.LogsRequest
+	3,  // 48: telepresence.connector.Connector.AddInterceptor:input_type -> telepresence.connector.Interceptor
+	3,  // 49: telepresence.connector.Connector.RemoveInterceptor:input_type -> telepresence.connector.Interceptor
+	18, // 50: telepresence.connector.Connector.GetNamespaces:input_type -> telepresence.connector.GetNamespacesRequest
+	42, // 51: telepresence.connector.Connector.GetKnownWorkloadKinds:input_type -> google.protobuf.Empty
+	42, // 52: telepresence.connector.Connector.RemoteMountAvailability:input_type -> google.protobuf.Empty
+	42, // 53: telepresence.connector.Connector.GetConfig:input_type -> google.protobuf.Empty
+	45, // 54: telepresence.connector.Connector.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
+	46, // 55: telepresence.connector.Connector.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
+	47, // 56: telepresence.connector.Connector.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	22, // 57: telepresence.connector.Connector.ResolveSyntheticIP:input_type -> telepresence.connector.ResolveSyntheticRequest
+	48, // 58: telepresence.connector.Connector.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
+	49, // 59: telepresence.connector.Connector.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
+	50, // 60: telepresence.connector.Connector.RerouteLocalPort:input_type -> telepresence.daemon.ReroutePortRequest
+	50, // 61: telepresence.connector.Connector.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
+	32, // 62: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
+	32, // 63: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
+	32, // 64: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
+	51, // 65: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	38, // 66: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	5,  // 67: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
+	42, // 68: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
+	21, // 69: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
+	5,  // 70: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
+	42, // 71: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
+	11, // 72: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
+	11, // 73: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
+	11, // 74: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
+	38, // 75: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	42, // 76: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
+	42, // 77: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
+	42, // 78: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
+	14, // 79: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	14, // 80: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	42, // 81: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
+	52, // 82: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
+	17, // 83: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
+	42, // 84: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
+	42, // 85: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
+	19, // 86: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
+	53, // 87: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	42, // 88: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
+	20, // 89: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
+	42, // 90: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
+	42, // 91: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
+	54, // 92: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	23, // 93: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
+	55, // 94: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
+	56, // 95: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
+	42, // 96: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
+	42, // 97: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
+	62, // [62:98] is the sub-list for method output_type
+	26, // [26:62] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_connector_connector_proto_init() }

--- a/rpc/connector/connector.proto
+++ b/rpc/connector/connector.proto
@@ -348,8 +348,6 @@ message WorkloadInfo {
   int32 ready_replicas = 10;
 
   repeated manager.ServiceAssociation services = 11;
-
-  repeated manager.RouteAssociation routes = 12;
 }
 
 message WorkloadInfoSnapshot {

--- a/rpc/connector/connector.proto
+++ b/rpc/connector/connector.proto
@@ -342,6 +342,14 @@ message WorkloadInfo {
   string uid = 7;
 
   string agent_version = 8;
+
+  int32 desired_replicas = 9;
+
+  int32 ready_replicas = 10;
+
+  repeated manager.ServiceAssociation services = 11;
+
+  repeated manager.RouteAssociation routes = 12;
 }
 
 message WorkloadInfoSnapshot {

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -169,7 +169,7 @@ func (x WorkloadInfo_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_Kind.Descriptor instead.
 func (WorkloadInfo_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48, 0}
 }
 
 type WorkloadInfo_State int32
@@ -229,7 +229,7 @@ func (x WorkloadInfo_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_State.Descriptor instead.
 func (WorkloadInfo_State) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45, 1}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48, 1}
 }
 
 type WorkloadInfo_AgentState int32
@@ -281,7 +281,7 @@ func (x WorkloadInfo_AgentState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_AgentState.Descriptor instead.
 func (WorkloadInfo_AgentState) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45, 2}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48, 2}
 }
 
 type WorkloadEvent_Type int32
@@ -330,7 +330,7 @@ func (x WorkloadEvent_Type) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadEvent_Type.Descriptor instead.
 func (WorkloadEvent_Type) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{49, 0}
 }
 
 // ClientInfo is the self-reported metadata that the on-laptop
@@ -3550,6 +3550,242 @@ func (x *KnownWorkloadKinds) GetKinds() []WorkloadInfo_Kind {
 	return nil
 }
 
+type ServicePort struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Port          int32                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	TargetPort    string                 `protobuf:"bytes,3,opt,name=target_port,json=targetPort,proto3" json:"target_port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServicePort) Reset() {
+	*x = ServicePort{}
+	mi := &file_manager_manager_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServicePort) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServicePort) ProtoMessage() {}
+
+func (x *ServicePort) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServicePort.ProtoReflect.Descriptor instead.
+func (*ServicePort) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ServicePort) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ServicePort) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *ServicePort) GetTargetPort() string {
+	if x != nil {
+		return x.TargetPort
+	}
+	return ""
+}
+
+type ServiceAssociation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace     string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Ports         []*ServicePort         `protobuf:"bytes,3,rep,name=ports,proto3" json:"ports,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServiceAssociation) Reset() {
+	*x = ServiceAssociation{}
+	mi := &file_manager_manager_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServiceAssociation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServiceAssociation) ProtoMessage() {}
+
+func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServiceAssociation.ProtoReflect.Descriptor instead.
+func (*ServiceAssociation) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ServiceAssociation) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ServiceAssociation) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ServiceAssociation) GetPorts() []*ServicePort {
+	if x != nil {
+		return x.Ports
+	}
+	return nil
+}
+
+type RouteAssociation struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Type             string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Name             string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace        string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Hosts            []string               `protobuf:"bytes,4,rep,name=hosts,proto3" json:"hosts,omitempty"`
+	Paths            []string               `protobuf:"bytes,5,rep,name=paths,proto3" json:"paths,omitempty"`
+	Tls              bool                   `protobuf:"varint,6,opt,name=tls,proto3" json:"tls,omitempty"`
+	ServiceName      string                 `protobuf:"bytes,7,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	ServiceNamespace string                 `protobuf:"bytes,8,opt,name=service_namespace,json=serviceNamespace,proto3" json:"service_namespace,omitempty"`
+	ServicePortName  string                 `protobuf:"bytes,9,opt,name=service_port_name,json=servicePortName,proto3" json:"service_port_name,omitempty"`
+	ServicePort      int32                  `protobuf:"varint,10,opt,name=service_port,json=servicePort,proto3" json:"service_port,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *RouteAssociation) Reset() {
+	*x = RouteAssociation{}
+	mi := &file_manager_manager_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RouteAssociation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RouteAssociation) ProtoMessage() {}
+
+func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RouteAssociation.ProtoReflect.Descriptor instead.
+func (*RouteAssociation) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *RouteAssociation) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetHosts() []string {
+	if x != nil {
+		return x.Hosts
+	}
+	return nil
+}
+
+func (x *RouteAssociation) GetPaths() []string {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+func (x *RouteAssociation) GetTls() bool {
+	if x != nil {
+		return x.Tls
+	}
+	return false
+}
+
+func (x *RouteAssociation) GetServiceName() string {
+	if x != nil {
+		return x.ServiceName
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetServiceNamespace() string {
+	if x != nil {
+		return x.ServiceNamespace
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetServicePortName() string {
+	if x != nil {
+		return x.ServicePortName
+	}
+	return ""
+}
+
+func (x *RouteAssociation) GetServicePort() int32 {
+	if x != nil {
+		return x.ServicePort
+	}
+	return 0
+}
+
 // WorkloadInfo contains information about a workload (typically a
 // Deployment).
 type WorkloadInfo struct {
@@ -3558,6 +3794,10 @@ type WorkloadInfo struct {
 	Name             string                    `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Namespace        string                    `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	Uid              string                    `protobuf:"bytes,7,opt,name=uid,proto3" json:"uid,omitempty"`
+	DesiredReplicas  int32                     `protobuf:"varint,8,opt,name=desired_replicas,json=desiredReplicas,proto3" json:"desired_replicas,omitempty"`
+	ReadyReplicas    int32                     `protobuf:"varint,9,opt,name=ready_replicas,json=readyReplicas,proto3" json:"ready_replicas,omitempty"`
+	Services         []*ServiceAssociation     `protobuf:"bytes,10,rep,name=services,proto3" json:"services,omitempty"`
+	Routes           []*RouteAssociation       `protobuf:"bytes,11,rep,name=routes,proto3" json:"routes,omitempty"`
 	AgentState       WorkloadInfo_AgentState   `protobuf:"varint,4,opt,name=agent_state,json=agentState,proto3,enum=telepresence.manager.WorkloadInfo_AgentState" json:"agent_state,omitempty"`
 	InterceptClients []*WorkloadInfo_Intercept `protobuf:"bytes,5,rep,name=intercept_clients,json=interceptClients,proto3" json:"intercept_clients,omitempty"`
 	State            WorkloadInfo_State        `protobuf:"varint,6,opt,name=state,proto3,enum=telepresence.manager.WorkloadInfo_State" json:"state,omitempty"`
@@ -3567,7 +3807,7 @@ type WorkloadInfo struct {
 
 func (x *WorkloadInfo) Reset() {
 	*x = WorkloadInfo{}
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3579,7 +3819,7 @@ func (x *WorkloadInfo) String() string {
 func (*WorkloadInfo) ProtoMessage() {}
 
 func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3592,7 +3832,7 @@ func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *WorkloadInfo) GetKind() WorkloadInfo_Kind {
@@ -3621,6 +3861,34 @@ func (x *WorkloadInfo) GetUid() string {
 		return x.Uid
 	}
 	return ""
+}
+
+func (x *WorkloadInfo) GetDesiredReplicas() int32 {
+	if x != nil {
+		return x.DesiredReplicas
+	}
+	return 0
+}
+
+func (x *WorkloadInfo) GetReadyReplicas() int32 {
+	if x != nil {
+		return x.ReadyReplicas
+	}
+	return 0
+}
+
+func (x *WorkloadInfo) GetServices() []*ServiceAssociation {
+	if x != nil {
+		return x.Services
+	}
+	return nil
+}
+
+func (x *WorkloadInfo) GetRoutes() []*RouteAssociation {
+	if x != nil {
+		return x.Routes
+	}
+	return nil
 }
 
 func (x *WorkloadInfo) GetAgentState() WorkloadInfo_AgentState {
@@ -3654,7 +3922,7 @@ type WorkloadEvent struct {
 
 func (x *WorkloadEvent) Reset() {
 	*x = WorkloadEvent{}
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3666,7 +3934,7 @@ func (x *WorkloadEvent) String() string {
 func (*WorkloadEvent) ProtoMessage() {}
 
 func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3679,7 +3947,7 @@ func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadEvent) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46}
+	return file_manager_manager_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *WorkloadEvent) GetType() WorkloadEvent_Type {
@@ -3711,7 +3979,7 @@ type WorkloadEventsDelta struct {
 
 func (x *WorkloadEventsDelta) Reset() {
 	*x = WorkloadEventsDelta{}
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3723,7 +3991,7 @@ func (x *WorkloadEventsDelta) String() string {
 func (*WorkloadEventsDelta) ProtoMessage() {}
 
 func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3736,7 +4004,7 @@ func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsDelta.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+	return file_manager_manager_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *WorkloadEventsDelta) GetSince() *timestamppb.Timestamp {
@@ -3770,7 +4038,7 @@ type WorkloadEventsRequest struct {
 
 func (x *WorkloadEventsRequest) Reset() {
 	*x = WorkloadEventsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3782,7 +4050,7 @@ func (x *WorkloadEventsRequest) String() string {
 func (*WorkloadEventsRequest) ProtoMessage() {}
 
 func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3795,7 +4063,7 @@ func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsRequest.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{48}
+	return file_manager_manager_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *WorkloadEventsRequest) GetSessionInfo() *SessionInfo {
@@ -3832,7 +4100,7 @@ type UninstallAgentsRequest struct {
 
 func (x *UninstallAgentsRequest) Reset() {
 	*x = UninstallAgentsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3844,7 +4112,7 @@ func (x *UninstallAgentsRequest) String() string {
 func (*UninstallAgentsRequest) ProtoMessage() {}
 
 func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3857,7 +4125,7 @@ func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UninstallAgentsRequest.ProtoReflect.Descriptor instead.
 func (*UninstallAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{49}
+	return file_manager_manager_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *UninstallAgentsRequest) GetSessionInfo() *SessionInfo {
@@ -3896,7 +4164,7 @@ type AgentInfo_Mechanism struct {
 
 func (x *AgentInfo_Mechanism) Reset() {
 	*x = AgentInfo_Mechanism{}
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3908,7 +4176,7 @@ func (x *AgentInfo_Mechanism) String() string {
 func (*AgentInfo_Mechanism) ProtoMessage() {}
 
 func (x *AgentInfo_Mechanism) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3959,7 +4227,7 @@ type AgentInfo_ContainerInfo struct {
 
 func (x *AgentInfo_ContainerInfo) Reset() {
 	*x = AgentInfo_ContainerInfo{}
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3971,7 +4239,7 @@ func (x *AgentInfo_ContainerInfo) String() string {
 func (*AgentInfo_ContainerInfo) ProtoMessage() {}
 
 func (x *AgentInfo_ContainerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4018,7 +4286,7 @@ type WorkloadInfo_Intercept struct {
 
 func (x *WorkloadInfo_Intercept) Reset() {
 	*x = WorkloadInfo_Intercept{}
-	mi := &file_manager_manager_proto_msgTypes[66]
+	mi := &file_manager_manager_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4030,7 +4298,7 @@ func (x *WorkloadInfo_Intercept) String() string {
 func (*WorkloadInfo_Intercept) ProtoMessage() {}
 
 func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[66]
+	mi := &file_manager_manager_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4043,7 +4311,7 @@ func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo_Intercept.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo_Intercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48, 0}
 }
 
 func (x *WorkloadInfo_Intercept) GetClient() string {
@@ -4376,12 +4644,38 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\ringress_bytes\x18\x02 \x01(\x04R\fingressBytes\x12!\n" +
 	"\fegress_bytes\x18\x03 \x01(\x04R\vegressBytes\"S\n" +
 	"\x12KnownWorkloadKinds\x12=\n" +
-	"\x05kinds\x18\x01 \x03(\x0e2'.telepresence.manager.WorkloadInfo.KindR\x05kinds\"\x8d\x05\n" +
+	"\x05kinds\x18\x01 \x03(\x0e2'.telepresence.manager.WorkloadInfo.KindR\x05kinds\"V\n" +
+	"\vServicePort\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1f\n" +
+	"\vtarget_port\x18\x03 \x01(\tR\n" +
+	"targetPort\"\x7f\n" +
+	"\x12ServiceAssociation\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x127\n" +
+	"\x05ports\x18\x03 \x03(\v2!.telepresence.manager.ServicePortR\x05ports\"\xb5\x02\n" +
+	"\x10RouteAssociation\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
+	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x14\n" +
+	"\x05hosts\x18\x04 \x03(\tR\x05hosts\x12\x14\n" +
+	"\x05paths\x18\x05 \x03(\tR\x05paths\x12\x10\n" +
+	"\x03tls\x18\x06 \x01(\bR\x03tls\x12!\n" +
+	"\fservice_name\x18\a \x01(\tR\vserviceName\x12+\n" +
+	"\x11service_namespace\x18\b \x01(\tR\x10serviceNamespace\x12*\n" +
+	"\x11service_port_name\x18\t \x01(\tR\x0fservicePortName\x12!\n" +
+	"\fservice_port\x18\n" +
+	" \x01(\x05R\vservicePort\"\xe5\x06\n" +
 	"\fWorkloadInfo\x12;\n" +
 	"\x04kind\x18\x01 \x01(\x0e2'.telepresence.manager.WorkloadInfo.KindR\x04kind\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x10\n" +
-	"\x03uid\x18\a \x01(\tR\x03uid\x12N\n" +
+	"\x03uid\x18\a \x01(\tR\x03uid\x12)\n" +
+	"\x10desired_replicas\x18\b \x01(\x05R\x0fdesiredReplicas\x12%\n" +
+	"\x0eready_replicas\x18\t \x01(\x05R\rreadyReplicas\x12D\n" +
+	"\bservices\x18\n" +
+	" \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\x12>\n" +
+	"\x06routes\x18\v \x03(\v2&.telepresence.manager.RouteAssociationR\x06routes\x12N\n" +
 	"\vagent_state\x18\x04 \x01(\x0e2-.telepresence.manager.WorkloadInfo.AgentStateR\n" +
 	"agentState\x12Y\n" +
 	"\x11intercept_clients\x18\x05 \x03(\v2,.telepresence.manager.WorkloadInfo.InterceptR\x10interceptClients\x12>\n" +
@@ -4485,7 +4779,7 @@ func file_manager_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_manager_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_manager_manager_proto_goTypes = []any{
 	(InterceptDispositionType)(0),   // 0: telepresence.manager.InterceptDispositionType
 	(WorkloadInfo_Kind)(0),          // 1: telepresence.manager.WorkloadInfo.Kind
@@ -4537,43 +4831,46 @@ var file_manager_manager_proto_goTypes = []any{
 	(*AgentConfigResponse)(nil),     // 47: telepresence.manager.AgentConfigResponse
 	(*TunnelMetrics)(nil),           // 48: telepresence.manager.TunnelMetrics
 	(*KnownWorkloadKinds)(nil),      // 49: telepresence.manager.KnownWorkloadKinds
-	(*WorkloadInfo)(nil),            // 50: telepresence.manager.WorkloadInfo
-	(*WorkloadEvent)(nil),           // 51: telepresence.manager.WorkloadEvent
-	(*WorkloadEventsDelta)(nil),     // 52: telepresence.manager.WorkloadEventsDelta
-	(*WorkloadEventsRequest)(nil),   // 53: telepresence.manager.WorkloadEventsRequest
-	(*UninstallAgentsRequest)(nil),  // 54: telepresence.manager.UninstallAgentsRequest
-	(*AgentInfo_Mechanism)(nil),     // 55: telepresence.manager.AgentInfo.Mechanism
-	(*AgentInfo_ContainerInfo)(nil), // 56: telepresence.manager.AgentInfo.ContainerInfo
-	nil,                             // 57: telepresence.manager.AgentInfo.ContainersEntry
-	nil,                             // 58: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	nil,                             // 59: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	nil,                             // 60: telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	nil,                             // 61: telepresence.manager.InterceptSpec.MetadataEntry
-	nil,                             // 62: telepresence.manager.InterceptInfo.EnvironmentEntry
-	nil,                             // 63: telepresence.manager.InterceptInfo.MountsEntry
-	nil,                             // 64: telepresence.manager.AgentInfoDelta.UpsertsEntry
-	nil,                             // 65: telepresence.manager.InterceptInfoDelta.UpsertsEntry
-	nil,                             // 66: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	nil,                             // 67: telepresence.manager.ReviewInterceptRequest.MountsEntry
-	nil,                             // 68: telepresence.manager.LogsResponse.PodLogsEntry
-	nil,                             // 69: telepresence.manager.LogsResponse.PodYamlEntry
-	nil,                             // 70: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
-	(*WorkloadInfo_Intercept)(nil),  // 71: telepresence.manager.WorkloadInfo.Intercept
-	(*timestamppb.Timestamp)(nil),   // 72: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),     // 73: google.protobuf.Duration
-	(*emptypb.Empty)(nil),           // 74: google.protobuf.Empty
+	(*ServicePort)(nil),             // 50: telepresence.manager.ServicePort
+	(*ServiceAssociation)(nil),      // 51: telepresence.manager.ServiceAssociation
+	(*RouteAssociation)(nil),        // 52: telepresence.manager.RouteAssociation
+	(*WorkloadInfo)(nil),            // 53: telepresence.manager.WorkloadInfo
+	(*WorkloadEvent)(nil),           // 54: telepresence.manager.WorkloadEvent
+	(*WorkloadEventsDelta)(nil),     // 55: telepresence.manager.WorkloadEventsDelta
+	(*WorkloadEventsRequest)(nil),   // 56: telepresence.manager.WorkloadEventsRequest
+	(*UninstallAgentsRequest)(nil),  // 57: telepresence.manager.UninstallAgentsRequest
+	(*AgentInfo_Mechanism)(nil),     // 58: telepresence.manager.AgentInfo.Mechanism
+	(*AgentInfo_ContainerInfo)(nil), // 59: telepresence.manager.AgentInfo.ContainerInfo
+	nil,                             // 60: telepresence.manager.AgentInfo.ContainersEntry
+	nil,                             // 61: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	nil,                             // 62: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	nil,                             // 63: telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	nil,                             // 64: telepresence.manager.InterceptSpec.MetadataEntry
+	nil,                             // 65: telepresence.manager.InterceptInfo.EnvironmentEntry
+	nil,                             // 66: telepresence.manager.InterceptInfo.MountsEntry
+	nil,                             // 67: telepresence.manager.AgentInfoDelta.UpsertsEntry
+	nil,                             // 68: telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	nil,                             // 69: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	nil,                             // 70: telepresence.manager.ReviewInterceptRequest.MountsEntry
+	nil,                             // 71: telepresence.manager.LogsResponse.PodLogsEntry
+	nil,                             // 72: telepresence.manager.LogsResponse.PodYamlEntry
+	nil,                             // 73: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	(*WorkloadInfo_Intercept)(nil),  // 74: telepresence.manager.WorkloadInfo.Intercept
+	(*timestamppb.Timestamp)(nil),   // 75: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),     // 76: google.protobuf.Duration
+	(*emptypb.Empty)(nil),           // 77: google.protobuf.Empty
 }
 var file_manager_manager_proto_depIdxs = []int32{
-	55,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
-	57,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
-	60,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	61,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
+	58,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
+	60,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
+	63,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	64,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
 	8,   // 4: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
 	12,  // 5: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
 	0,   // 6: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	62,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
-	63,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
-	72,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
+	65,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
+	66,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
+	75,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
 	12,  // 10: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
 	6,   // 11: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
 	12,  // 12: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
@@ -4582,9 +4879,9 @@ var file_manager_manager_proto_depIdxs = []int32{
 	6,   // 15: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
 	12,  // 16: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
 	6,   // 17: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
-	64,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
+	67,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
 	9,   // 19: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
-	65,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	68,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
 	12,  // 21: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
 	8,   // 22: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
 	12,  // 23: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
@@ -4592,13 +4889,13 @@ var file_manager_manager_proto_depIdxs = []int32{
 	12,  // 25: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
 	12,  // 26: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
 	0,   // 27: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	66,  // 28: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	67,  // 29: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
+	69,  // 28: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	70,  // 29: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
 	12,  // 30: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
-	72,  // 31: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
-	73,  // 32: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	68,  // 33: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
-	69,  // 34: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
+	75,  // 31: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
+	76,  // 32: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	71,  // 33: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
+	72,  // 34: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
 	12,  // 35: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
 	12,  // 36: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
 	12,  // 37: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
@@ -4612,101 +4909,104 @@ var file_manager_manager_proto_depIdxs = []int32{
 	37,  // 45: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
 	37,  // 46: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
 	43,  // 47: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
-	70,  // 48: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	73,  // 48: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
 	12,  // 49: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
 	1,   // 50: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
-	1,   // 51: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
-	3,   // 52: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
-	71,  // 53: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
-	2,   // 54: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
-	4,   // 55: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
-	50,  // 56: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
-	72,  // 57: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
-	51,  // 58: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
-	12,  // 59: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	72,  // 60: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
-	12,  // 61: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	58,  // 62: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	59,  // 63: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	56,  // 64: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
-	6,   // 65: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
-	9,   // 66: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
-	43,  // 67: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
-	74,  // 68: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
-	74,  // 69: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
-	46,  // 70: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	74,  // 71: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
-	74,  // 72: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
-	5,   // 73: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
-	10,  // 74: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
-	11,  // 75: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
-	6,   // 76: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
-	24,  // 77: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
-	12,  // 78: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
-	25,  // 79: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	26,  // 80: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
-	12,  // 81: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
-	12,  // 82: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
-	13,  // 83: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
-	12,  // 84: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
-	12,  // 85: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
-	12,  // 86: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
-	12,  // 87: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
-	53,  // 88: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
-	12,  // 89: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
-	19,  // 90: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
-	18,  // 91: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	18,  // 92: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	21,  // 93: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	22,  // 94: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	23,  // 95: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
-	12,  // 96: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
-	32,  // 97: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
-	34,  // 98: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
-	74,  // 99: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
-	30,  // 100: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
-	48,  // 101: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
-	54,  // 102: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
-	29,  // 103: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
-	42,  // 104: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	47,  // 105: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	41,  // 106: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
-	28,  // 107: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
-	12,  // 108: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
-	74,  // 109: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
-	74,  // 110: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
-	12,  // 111: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
-	74,  // 112: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
-	74,  // 113: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
-	74,  // 114: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
-	27,  // 115: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
-	44,  // 116: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
-	45,  // 117: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	45,  // 118: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	14,  // 119: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
-	15,  // 120: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
-	16,  // 121: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
-	17,  // 122: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
-	52,  // 123: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
-	38,  // 124: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
-	14,  // 125: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
-	20,  // 126: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
-	9,   // 127: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	74,  // 128: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
-	9,   // 129: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	74,  // 130: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
-	49,  // 131: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	33,  // 132: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
-	35,  // 133: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
-	25,  // 134: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
-	30,  // 135: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
-	74,  // 136: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
-	74,  // 137: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
-	103, // [103:138] is the sub-list for method output_type
-	68,  // [68:103] is the sub-list for method input_type
-	68,  // [68:68] is the sub-list for extension type_name
-	68,  // [68:68] is the sub-list for extension extendee
-	0,   // [0:68] is the sub-list for field type_name
+	50,  // 51: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
+	1,   // 52: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
+	51,  // 53: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
+	52,  // 54: telepresence.manager.WorkloadInfo.routes:type_name -> telepresence.manager.RouteAssociation
+	3,   // 55: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
+	74,  // 56: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
+	2,   // 57: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
+	4,   // 58: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
+	53,  // 59: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
+	75,  // 60: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
+	54,  // 61: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
+	12,  // 62: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	75,  // 63: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
+	12,  // 64: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	61,  // 65: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	62,  // 66: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	59,  // 67: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
+	6,   // 68: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
+	9,   // 69: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
+	43,  // 70: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	77,  // 71: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
+	77,  // 72: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
+	46,  // 73: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	77,  // 74: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
+	77,  // 75: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
+	5,   // 76: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
+	10,  // 77: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
+	11,  // 78: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
+	6,   // 79: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
+	24,  // 80: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
+	12,  // 81: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
+	25,  // 82: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	26,  // 83: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
+	12,  // 84: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
+	12,  // 85: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
+	13,  // 86: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
+	12,  // 87: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
+	12,  // 88: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
+	12,  // 89: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
+	12,  // 90: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
+	56,  // 91: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
+	12,  // 92: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
+	19,  // 93: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
+	18,  // 94: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	18,  // 95: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	21,  // 96: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	22,  // 97: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	23,  // 98: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
+	12,  // 99: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
+	32,  // 100: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
+	34,  // 101: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
+	77,  // 102: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
+	30,  // 103: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
+	48,  // 104: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
+	57,  // 105: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
+	29,  // 106: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
+	42,  // 107: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	47,  // 108: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	41,  // 109: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
+	28,  // 110: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
+	12,  // 111: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
+	77,  // 112: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
+	77,  // 113: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
+	12,  // 114: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
+	77,  // 115: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
+	77,  // 116: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
+	77,  // 117: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
+	27,  // 118: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
+	44,  // 119: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
+	45,  // 120: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	45,  // 121: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	14,  // 122: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
+	15,  // 123: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
+	16,  // 124: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
+	17,  // 125: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
+	55,  // 126: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
+	38,  // 127: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
+	14,  // 128: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
+	20,  // 129: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
+	9,   // 130: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	77,  // 131: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
+	9,   // 132: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	77,  // 133: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
+	49,  // 134: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	33,  // 135: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
+	35,  // 136: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
+	25,  // 137: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
+	30,  // 138: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
+	77,  // 139: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
+	77,  // 140: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
+	106, // [106:141] is the sub-list for method output_type
+	71,  // [71:106] is the sub-list for method input_type
+	71,  // [71:71] is the sub-list for extension type_name
+	71,  // [71:71] is the sub-list for extension extendee
+	0,   // [0:71] is the sub-list for field type_name
 }
 
 func init() { file_manager_manager_proto_init() }
@@ -4721,7 +5021,7 @@ func file_manager_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_manager_manager_proto_rawDesc), len(file_manager_manager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   67,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -3610,85 +3610,26 @@ func (x *ServicePort) GetTargetPort() string {
 	return ""
 }
 
-type ServiceAssociation struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace     string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Ports         []*ServicePort         `protobuf:"bytes,3,rep,name=ports,proto3" json:"ports,omitempty"`
+// RouteAssociation describes a route object (currently always an Ingress
+// in the service's own namespace) that routes traffic to one of the ports
+// of the service it is associated with.
+type RouteAssociation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Type  string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Name  string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Hosts []string               `protobuf:"bytes,3,rep,name=hosts,proto3" json:"hosts,omitempty"`
+	Paths []string               `protobuf:"bytes,4,rep,name=paths,proto3" json:"paths,omitempty"`
+	Tls   bool                   `protobuf:"varint,5,opt,name=tls,proto3" json:"tls,omitempty"`
+	// The service port that this route targets.
+	PortName      string `protobuf:"bytes,6,opt,name=port_name,json=portName,proto3" json:"port_name,omitempty"`
+	Port          int32  `protobuf:"varint,7,opt,name=port,proto3" json:"port,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ServiceAssociation) Reset() {
-	*x = ServiceAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[46]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ServiceAssociation) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ServiceAssociation) ProtoMessage() {}
-
-func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[46]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ServiceAssociation.ProtoReflect.Descriptor instead.
-func (*ServiceAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46}
-}
-
-func (x *ServiceAssociation) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-func (x *ServiceAssociation) GetNamespace() string {
-	if x != nil {
-		return x.Namespace
-	}
-	return ""
-}
-
-func (x *ServiceAssociation) GetPorts() []*ServicePort {
-	if x != nil {
-		return x.Ports
-	}
-	return nil
-}
-
-type RouteAssociation struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Type             string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
-	Name             string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace        string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Hosts            []string               `protobuf:"bytes,4,rep,name=hosts,proto3" json:"hosts,omitempty"`
-	Paths            []string               `protobuf:"bytes,5,rep,name=paths,proto3" json:"paths,omitempty"`
-	Tls              bool                   `protobuf:"varint,6,opt,name=tls,proto3" json:"tls,omitempty"`
-	ServiceName      string                 `protobuf:"bytes,7,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
-	ServiceNamespace string                 `protobuf:"bytes,8,opt,name=service_namespace,json=serviceNamespace,proto3" json:"service_namespace,omitempty"`
-	ServicePortName  string                 `protobuf:"bytes,9,opt,name=service_port_name,json=servicePortName,proto3" json:"service_port_name,omitempty"`
-	ServicePort      int32                  `protobuf:"varint,10,opt,name=service_port,json=servicePort,proto3" json:"service_port,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
-}
-
 func (x *RouteAssociation) Reset() {
 	*x = RouteAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3700,7 +3641,7 @@ func (x *RouteAssociation) String() string {
 func (*RouteAssociation) ProtoMessage() {}
 
 func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3713,7 +3654,7 @@ func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteAssociation.ProtoReflect.Descriptor instead.
 func (*RouteAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+	return file_manager_manager_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RouteAssociation) GetType() string {
@@ -3726,13 +3667,6 @@ func (x *RouteAssociation) GetType() string {
 func (x *RouteAssociation) GetName() string {
 	if x != nil {
 		return x.Name
-	}
-	return ""
-}
-
-func (x *RouteAssociation) GetNamespace() string {
-	if x != nil {
-		return x.Namespace
 	}
 	return ""
 }
@@ -3758,32 +3692,81 @@ func (x *RouteAssociation) GetTls() bool {
 	return false
 }
 
-func (x *RouteAssociation) GetServiceName() string {
+func (x *RouteAssociation) GetPortName() string {
 	if x != nil {
-		return x.ServiceName
+		return x.PortName
 	}
 	return ""
 }
 
-func (x *RouteAssociation) GetServiceNamespace() string {
+func (x *RouteAssociation) GetPort() int32 {
 	if x != nil {
-		return x.ServiceNamespace
-	}
-	return ""
-}
-
-func (x *RouteAssociation) GetServicePortName() string {
-	if x != nil {
-		return x.ServicePortName
-	}
-	return ""
-}
-
-func (x *RouteAssociation) GetServicePort() int32 {
-	if x != nil {
-		return x.ServicePort
+		return x.Port
 	}
 	return 0
+}
+
+// ServiceAssociation describes a service in the workload's namespace whose
+// selector matches the workload's pods, together with the routes that
+// target that service.
+type ServiceAssociation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Ports         []*ServicePort         `protobuf:"bytes,2,rep,name=ports,proto3" json:"ports,omitempty"`
+	Routes        []*RouteAssociation    `protobuf:"bytes,3,rep,name=routes,proto3" json:"routes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServiceAssociation) Reset() {
+	*x = ServiceAssociation{}
+	mi := &file_manager_manager_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServiceAssociation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServiceAssociation) ProtoMessage() {}
+
+func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServiceAssociation.ProtoReflect.Descriptor instead.
+func (*ServiceAssociation) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *ServiceAssociation) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ServiceAssociation) GetPorts() []*ServicePort {
+	if x != nil {
+		return x.Ports
+	}
+	return nil
+}
+
+func (x *ServiceAssociation) GetRoutes() []*RouteAssociation {
+	if x != nil {
+		return x.Routes
+	}
+	return nil
 }
 
 // WorkloadInfo contains information about a workload (typically a
@@ -3797,7 +3780,6 @@ type WorkloadInfo struct {
 	DesiredReplicas  int32                     `protobuf:"varint,8,opt,name=desired_replicas,json=desiredReplicas,proto3" json:"desired_replicas,omitempty"`
 	ReadyReplicas    int32                     `protobuf:"varint,9,opt,name=ready_replicas,json=readyReplicas,proto3" json:"ready_replicas,omitempty"`
 	Services         []*ServiceAssociation     `protobuf:"bytes,10,rep,name=services,proto3" json:"services,omitempty"`
-	Routes           []*RouteAssociation       `protobuf:"bytes,11,rep,name=routes,proto3" json:"routes,omitempty"`
 	AgentState       WorkloadInfo_AgentState   `protobuf:"varint,4,opt,name=agent_state,json=agentState,proto3,enum=telepresence.manager.WorkloadInfo_AgentState" json:"agent_state,omitempty"`
 	InterceptClients []*WorkloadInfo_Intercept `protobuf:"bytes,5,rep,name=intercept_clients,json=interceptClients,proto3" json:"intercept_clients,omitempty"`
 	State            WorkloadInfo_State        `protobuf:"varint,6,opt,name=state,proto3,enum=telepresence.manager.WorkloadInfo_State" json:"state,omitempty"`
@@ -3880,13 +3862,6 @@ func (x *WorkloadInfo) GetReadyReplicas() int32 {
 func (x *WorkloadInfo) GetServices() []*ServiceAssociation {
 	if x != nil {
 		return x.Services
-	}
-	return nil
-}
-
-func (x *WorkloadInfo) GetRoutes() []*RouteAssociation {
-	if x != nil {
-		return x.Routes
 	}
 	return nil
 }
@@ -4649,23 +4624,19 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1f\n" +
 	"\vtarget_port\x18\x03 \x01(\tR\n" +
-	"targetPort\"\x7f\n" +
-	"\x12ServiceAssociation\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
-	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x127\n" +
-	"\x05ports\x18\x03 \x03(\v2!.telepresence.manager.ServicePortR\x05ports\"\xb5\x02\n" +
+	"targetPort\"\xa9\x01\n" +
 	"\x10RouteAssociation\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
-	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x14\n" +
-	"\x05hosts\x18\x04 \x03(\tR\x05hosts\x12\x14\n" +
-	"\x05paths\x18\x05 \x03(\tR\x05paths\x12\x10\n" +
-	"\x03tls\x18\x06 \x01(\bR\x03tls\x12!\n" +
-	"\fservice_name\x18\a \x01(\tR\vserviceName\x12+\n" +
-	"\x11service_namespace\x18\b \x01(\tR\x10serviceNamespace\x12*\n" +
-	"\x11service_port_name\x18\t \x01(\tR\x0fservicePortName\x12!\n" +
-	"\fservice_port\x18\n" +
-	" \x01(\x05R\vservicePort\"\xe5\x06\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
+	"\x05hosts\x18\x03 \x03(\tR\x05hosts\x12\x14\n" +
+	"\x05paths\x18\x04 \x03(\tR\x05paths\x12\x10\n" +
+	"\x03tls\x18\x05 \x01(\bR\x03tls\x12\x1b\n" +
+	"\tport_name\x18\x06 \x01(\tR\bportName\x12\x12\n" +
+	"\x04port\x18\a \x01(\x05R\x04port\"\xa1\x01\n" +
+	"\x12ServiceAssociation\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x127\n" +
+	"\x05ports\x18\x02 \x03(\v2!.telepresence.manager.ServicePortR\x05ports\x12>\n" +
+	"\x06routes\x18\x03 \x03(\v2&.telepresence.manager.RouteAssociationR\x06routes\"\xa5\x06\n" +
 	"\fWorkloadInfo\x12;\n" +
 	"\x04kind\x18\x01 \x01(\x0e2'.telepresence.manager.WorkloadInfo.KindR\x04kind\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
@@ -4674,8 +4645,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x10desired_replicas\x18\b \x01(\x05R\x0fdesiredReplicas\x12%\n" +
 	"\x0eready_replicas\x18\t \x01(\x05R\rreadyReplicas\x12D\n" +
 	"\bservices\x18\n" +
-	" \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\x12>\n" +
-	"\x06routes\x18\v \x03(\v2&.telepresence.manager.RouteAssociationR\x06routes\x12N\n" +
+	" \x03(\v2(.telepresence.manager.ServiceAssociationR\bservices\x12N\n" +
 	"\vagent_state\x18\x04 \x01(\x0e2-.telepresence.manager.WorkloadInfo.AgentStateR\n" +
 	"agentState\x12Y\n" +
 	"\x11intercept_clients\x18\x05 \x03(\v2,.telepresence.manager.WorkloadInfo.InterceptR\x10interceptClients\x12>\n" +
@@ -4832,8 +4802,8 @@ var file_manager_manager_proto_goTypes = []any{
 	(*TunnelMetrics)(nil),           // 48: telepresence.manager.TunnelMetrics
 	(*KnownWorkloadKinds)(nil),      // 49: telepresence.manager.KnownWorkloadKinds
 	(*ServicePort)(nil),             // 50: telepresence.manager.ServicePort
-	(*ServiceAssociation)(nil),      // 51: telepresence.manager.ServiceAssociation
-	(*RouteAssociation)(nil),        // 52: telepresence.manager.RouteAssociation
+	(*RouteAssociation)(nil),        // 51: telepresence.manager.RouteAssociation
+	(*ServiceAssociation)(nil),      // 52: telepresence.manager.ServiceAssociation
 	(*WorkloadInfo)(nil),            // 53: telepresence.manager.WorkloadInfo
 	(*WorkloadEvent)(nil),           // 54: telepresence.manager.WorkloadEvent
 	(*WorkloadEventsDelta)(nil),     // 55: telepresence.manager.WorkloadEventsDelta
@@ -4913,9 +4883,9 @@ var file_manager_manager_proto_depIdxs = []int32{
 	12,  // 49: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
 	1,   // 50: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
 	50,  // 51: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
-	1,   // 52: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
-	51,  // 53: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
-	52,  // 54: telepresence.manager.WorkloadInfo.routes:type_name -> telepresence.manager.RouteAssociation
+	51,  // 52: telepresence.manager.ServiceAssociation.routes:type_name -> telepresence.manager.RouteAssociation
+	1,   // 53: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
+	52,  // 54: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
 	3,   // 55: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
 	74,  // 56: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
 	2,   // 57: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -3621,8 +3621,11 @@ type RouteAssociation struct {
 	Paths []string               `protobuf:"bytes,4,rep,name=paths,proto3" json:"paths,omitempty"`
 	Tls   bool                   `protobuf:"varint,5,opt,name=tls,proto3" json:"tls,omitempty"`
 	// The service port that this route targets.
-	PortName      string `protobuf:"bytes,6,opt,name=port_name,json=portName,proto3" json:"port_name,omitempty"`
-	Port          int32  `protobuf:"varint,7,opt,name=port,proto3" json:"port,omitempty"`
+	PortName string `protobuf:"bytes,6,opt,name=port_name,json=portName,proto3" json:"port_name,omitempty"`
+	Port     int32  `protobuf:"varint,7,opt,name=port,proto3" json:"port,omitempty"`
+	// Load-balancer addresses (IPs or hostnames) of the route object, used
+	// to reach the route when it declares no hosts.
+	Addresses     []string `protobuf:"bytes,8,rep,name=addresses,proto3" json:"addresses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3704,6 +3707,13 @@ func (x *RouteAssociation) GetPort() int32 {
 		return x.Port
 	}
 	return 0
+}
+
+func (x *RouteAssociation) GetAddresses() []string {
+	if x != nil {
+		return x.Addresses
+	}
+	return nil
 }
 
 // ServiceAssociation describes a service in the workload's namespace whose
@@ -4624,7 +4634,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1f\n" +
 	"\vtarget_port\x18\x03 \x01(\tR\n" +
-	"targetPort\"\xa9\x01\n" +
+	"targetPort\"\xc7\x01\n" +
 	"\x10RouteAssociation\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -4632,7 +4642,8 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x05paths\x18\x04 \x03(\tR\x05paths\x12\x10\n" +
 	"\x03tls\x18\x05 \x01(\bR\x03tls\x12\x1b\n" +
 	"\tport_name\x18\x06 \x01(\tR\bportName\x12\x12\n" +
-	"\x04port\x18\a \x01(\x05R\x04port\"\xa1\x01\n" +
+	"\x04port\x18\a \x01(\x05R\x04port\x12\x1c\n" +
+	"\taddresses\x18\b \x03(\tR\taddresses\"\xa1\x01\n" +
 	"\x12ServiceAssociation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x127\n" +
 	"\x05ports\x18\x02 \x03(\v2!.telepresence.manager.ServicePortR\x05ports\x12>\n" +

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -650,6 +650,10 @@ message RouteAssociation {
   // The service port that this route targets.
   string port_name = 6;
   int32 port = 7;
+
+  // Load-balancer addresses (IPs or hostnames) of the route object, used
+  // to reach the route when it declares no hosts.
+  repeated string addresses = 8;
 }
 
 // ServiceAssociation describes a service in the workload's namespace whose

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -637,23 +637,28 @@ message ServicePort {
   string target_port = 3;
 }
 
-message ServiceAssociation {
-  string name = 1;
-  string namespace = 2;
-  repeated ServicePort ports = 3;
-}
-
+// RouteAssociation describes a route object (currently always an Ingress
+// in the service's own namespace) that routes traffic to one of the ports
+// of the service it is associated with.
 message RouteAssociation {
   string type = 1;
   string name = 2;
-  string namespace = 3;
-  repeated string hosts = 4;
-  repeated string paths = 5;
-  bool tls = 6;
-  string service_name = 7;
-  string service_namespace = 8;
-  string service_port_name = 9;
-  int32 service_port = 10;
+  repeated string hosts = 3;
+  repeated string paths = 4;
+  bool tls = 5;
+
+  // The service port that this route targets.
+  string port_name = 6;
+  int32 port = 7;
+}
+
+// ServiceAssociation describes a service in the workload's namespace whose
+// selector matches the workload's pods, together with the routes that
+// target that service.
+message ServiceAssociation {
+  string name = 1;
+  repeated ServicePort ports = 2;
+  repeated RouteAssociation routes = 3;
 }
 
 // WorkloadInfo contains information about a workload (typically a
@@ -708,7 +713,6 @@ message WorkloadInfo {
   int32 desired_replicas = 8;
   int32 ready_replicas = 9;
   repeated ServiceAssociation services = 10;
-  repeated RouteAssociation routes = 11;
   AgentState agent_state = 4;
 
   repeated Intercept intercept_clients = 5;

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -631,6 +631,31 @@ message KnownWorkloadKinds {
   repeated WorkloadInfo.Kind kinds = 1;
 }
 
+message ServicePort {
+  string name = 1;
+  int32 port = 2;
+  string target_port = 3;
+}
+
+message ServiceAssociation {
+  string name = 1;
+  string namespace = 2;
+  repeated ServicePort ports = 3;
+}
+
+message RouteAssociation {
+  string type = 1;
+  string name = 2;
+  string namespace = 3;
+  repeated string hosts = 4;
+  repeated string paths = 5;
+  bool tls = 6;
+  string service_name = 7;
+  string service_namespace = 8;
+  string service_port_name = 9;
+  int32 service_port = 10;
+}
+
 // WorkloadInfo contains information about a workload (typically a
 // Deployment).
 message WorkloadInfo {
@@ -680,6 +705,10 @@ message WorkloadInfo {
   string name = 2;
   string namespace = 3;
   string uid = 7;
+  int32 desired_replicas = 8;
+  int32 ready_replicas = 9;
+  repeated ServiceAssociation services = 10;
+  repeated RouteAssociation routes = 11;
   AgentState agent_state = 4;
 
   repeated Intercept intercept_clients = 5;


### PR DESCRIPTION
## Summary
- derive workload service and route exposure from the traffic-agent sidecar config
- expose service-scoped ingress route data through the manager and connector snapshots
- show ingress URLs for intercepted service ports in `telepresence intercept` and `telepresence list`
- include a ready-to-paste `curl` example when an intercept uses HTTP header filters

## Testing
- `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/state ./pkg/client/userd/trafficmgr ./pkg/k8sapi`
- `GOEXPERIMENT=jsonv2 go test ./pkg/client/cli/intercept ./pkg/client/cli/cmd`