### PR TITLE
Allow mapping unmanaged namespaces for DNS (fix #4170)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,17 @@ items:
           When running telepresence connect, we list all interfaces and use
           <code>net.InterfaceByIndex(idx)</code> on each of them. This function
           takes ~10ms so when you have LOTS of interfaces it takes a while.
+      - type: bugfix
+        title: Allow mapping namespaces that the traffic-manager does not manage
+        body: >-
+          Restores the ability to pass namespaces that the traffic-manager does
+          not manage to <code>--mapped-namespaces</code>, so short DNS names
+          (such as <code>svc.ns</code>) resolve for them again. A 2.29.0
+          regression rejected such namespaces at connect. Mapping only affects
+          the client's DNS — names are resolved by the traffic-manager or a
+          traffic-agent, so management is not required. Targeting an unmanaged
+          namespace for an engagement remains an error, and listing one now
+          fails fast with that error instead of hanging until a timeout.
   - version: 2.29.0
     date: 2026-06-20
     notes:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 When running telepresence connect, we list all interfaces and use <code>net.InterfaceByIndex(idx)</code> on each of them. This function takes ~10ms so when you have LOTS of interfaces it takes a while.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Allow mapping namespaces that the traffic-manager does not manage</div></div>
+<div style="margin-left: 15px">
+
+Restores the ability to pass namespaces that the traffic-manager does not manage to <code>--mapped-namespaces</code>, so short DNS names (such as <code>svc.ns</code>) resolve for them again. A 2.29.0 regression rejected such namespaces at connect. Mapping only affects the client's DNS — names are resolved by the traffic-manager or a traffic-agent, so management is not required. Targeting an unmanaged namespace for an engagement remains an error, and listing one now fails fast with that error instead of hanging until a timeout.
+</div>
+
 ## Version 2.29.0 <span style="font-size: 16px;">(June 20)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Local traffic to intercepted destinations no longer round-trips through the cluster](reference/config)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 When running telepresence connect, we list all interfaces and use <code>net.InterfaceByIndex(idx)</code> on each of them. This function takes ~10ms so when you have LOTS of interfaces it takes a while.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">Allow mapping namespaces that the traffic-manager does not manage</Title>
+	<Body>
+Restores the ability to pass namespaces that the traffic-manager does not manage to <code>--mapped-namespaces</code>, so short DNS names (such as <code>svc.ns</code>) resolve for them again. A 2.29.0 regression rejected such namespaces at connect. Mapping only affects the client's DNS — names are resolved by the traffic-manager or a traffic-agent, so management is not required. Targeting an unmanaged namespace for an engagement remains an error, and listing one now fails fast with that error instead of hanging until a timeout.
+  </Body>
+</Note>
 ## Version 2.29.0 <span style={{fontSize:'16px'}}>(June 20)</span>
 <Note>
 	<Title type="feature" docs="reference/config">Local traffic to intercepted destinations no longer round-trips through the cluster</Title>

--- a/integration_test/multiple_services_test.go
+++ b/integration_test/multiple_services_test.go
@@ -118,29 +118,21 @@ func (s *multipleServicesSuite) Test_List() {
 	}
 }
 
-func (s *multipleServicesSuite) Test_RejectsUnmanagedMappedNamespace() {
-	ctx := itest.WithUser(s.Context(), "default")
+func (s *multipleServicesSuite) Test_AllowsUnmanagedMappedNamespace() {
+	ctx := s.Context()
 	require := s.Require()
-	itest.TelepresenceDisconnectOk(ctx)
+	itest.TelepresenceQuitOk(ctx)
 	defer func() {
-		ctx := s.Context()
-		itest.TelepresenceDisconnectOk(ctx)
-		itest.TelepresenceOk(s.Context(), "connect", "--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace())
+		itest.TelepresenceQuitOk(ctx)
+		s.TelepresenceConnect(s.Context())
 	}()
 
-	// This suite's traffic-manager only manages the app namespace. Mapping a namespace that it does
-	// not manage (here "default") must be rejected during connect, rather than leaving the client
-	// connected to namespaces that the manager and its traffic-agents cannot serve.
-	stdout, stderr, err := itest.Telepresence(ctx, "connect",
-		"--namespace", s.AppNamespace(), "--manager-namespace", s.ManagerNamespace(),
-		"--mapped-namespaces", "default")
-	require.Error(err)
-	require.Contains(stdout+stderr, "are not managed by this traffic-manager")
-
-	// "all" resolves to the managed namespaces, so the connection succeeds and the workloads in the
-	// managed namespace are listed.
-	s.TelepresenceConnect(ctx, "--mapped-namespaces", "all")
-	stdout = itest.TelepresenceOk(ctx, "list")
+	// This suite's traffic-manager only manages the app namespace. Mapping a namespace it does not
+	// manage (here "default") is allowed: mapping only sets up the client's short DNS, and names are
+	// resolved by the traffic-manager/agent regardless of management. connect therefore succeeds
+	// instead of being rejected, and the managed app namespace remains operational.
+	s.TelepresenceConnect(ctx, "--mapped-namespaces", s.AppNamespace()+",default")
+	stdout := itest.TelepresenceOk(ctx, "list")
 	require.NotContains(stdout, "No Workloads")
 }
 

--- a/integration_test/namespaces_test.go
+++ b/integration_test/namespaces_test.go
@@ -301,13 +301,17 @@ func (s *nsSuite) Test_NamespacesStatic() {
 	rq.Error(err)
 	rq.Contains(se, "beta is not managed")
 
-	_, se, err = itest.Telepresence(ctx,
+	// Mapping an unmanaged namespace (beta) is allowed: the default namespace
+	// (alpha) is managed, so connect succeeds instead of being rejected (the
+	// 2.29.0 regression). beta is mapped for short DNS even though it is not
+	// managed; it does not show up in the status, which lists only the
+	// namespaces the client can access.
+	itest.TelepresenceOk(ctx,
 		"connect",
 		"--manager-namespace", s.managerNamespace(),
 		"--namespace", "alpha",
 		"--mapped-namespaces", "alpha,beta")
-	rq.Error(err)
-	rq.Contains(se, `mapped namespaces ["beta"] are not managed by this traffic-manager`)
+	itest.TelepresenceDisconnectOk(ctx)
 
 	// Switch to just using both alpha and beta
 	ctx = itest.WithNamespaces(s.Context(), &itest.Namespaces{

--- a/pkg/client/userd/trafficmgr/mapped_namespaces.go
+++ b/pkg/client/userd/trafficmgr/mapped_namespaces.go
@@ -3,8 +3,6 @@ package trafficmgr
 import (
 	"slices"
 	"sort"
-
-	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 )
 
 func normalizeMappedNamespaces(namespaces []string) ([]string, bool) {
@@ -20,53 +18,27 @@ func mappedNamespacesAll(namespaces []string) bool {
 	return len(namespaces) == 1 && namespaces[0] == "all"
 }
 
-func effectiveMappedNamespaces(requestedNamespaces, clientNamespaces, managerNamespaces []string) ([]string, error) {
+// effectiveMappedNamespaces resolves the namespaces the client creates top-level
+// DNS for, by precedence: an explicit --mapped-namespaces request, then the
+// client config, then the traffic-manager's set. "all" (and an empty result)
+// means every namespace. A mapped namespace need not be managed by the
+// traffic-manager; DNS for any namespace is resolved server-side, so mapping an
+// unmanaged namespace is valid.
+func effectiveMappedNamespaces(requestedNamespaces, clientNamespaces, managerNamespaces []string) []string {
 	requestedNamespaces, requestedAll := normalizeMappedNamespaces(requestedNamespaces)
 	clientNamespaces, clientAll := normalizeMappedNamespaces(clientNamespaces)
 	managerNamespaces, _ = normalizeMappedNamespaces(managerNamespaces)
 
-	var namespaces []string
 	switch {
 	case requestedAll:
-		return managerNamespaces, nil
+		return managerNamespaces
 	case len(requestedNamespaces) > 0:
-		namespaces = requestedNamespaces
+		return requestedNamespaces
 	case clientAll:
-		return managerNamespaces, nil
+		return managerNamespaces
 	case len(clientNamespaces) > 0:
-		namespaces = clientNamespaces
-	case len(managerNamespaces) > 0:
-		return managerNamespaces, nil
+		return clientNamespaces
+	default:
+		return managerNamespaces
 	}
-	if err := ensureMappedNamespacesManaged(namespaces, managerNamespaces); err != nil {
-		return nil, err
-	}
-	return namespaces, nil
-}
-
-func ensureMappedNamespacesManaged(requestedNamespaces, managerNamespaces []string) error {
-	if len(requestedNamespaces) == 0 || len(managerNamespaces) == 0 {
-		return nil
-	}
-
-	managed := make(map[string]struct{}, len(managerNamespaces))
-	for _, namespace := range managerNamespaces {
-		managed[namespace] = struct{}{}
-	}
-
-	var unmanaged []string
-	for _, namespace := range requestedNamespaces {
-		if _, ok := managed[namespace]; !ok {
-			unmanaged = append(unmanaged, namespace)
-		}
-	}
-	if len(unmanaged) == 0 {
-		return nil
-	}
-
-	return errcat.User.Newf(
-		"mapped namespaces %q are not managed by this traffic-manager; managed namespaces are %q. "+
-			"Reconnect with --mapped-namespaces limited to managed namespaces, or reconfigure the traffic-manager to also manage %q",
-		unmanaged, managerNamespaces, unmanaged,
-	)
 }

--- a/pkg/client/userd/trafficmgr/mapped_namespaces_test.go
+++ b/pkg/client/userd/trafficmgr/mapped_namespaces_test.go
@@ -6,49 +6,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEffectiveMappedNamespacesRejectsUnmanagedRequestedNamespace(t *testing.T) {
-	namespaces, err := effectiveMappedNamespaces(
+func TestEffectiveMappedNamespacesAllowsUnmanagedRequestedNamespace(t *testing.T) {
+	// A requested namespace the traffic-manager does not manage is still mapped
+	// for DNS; mapping does not require management.
+	namespaces := effectiveMappedNamespaces(
 		[]string{"alpha", "beta"},
 		nil,
 		[]string{"alpha"},
 	)
-
-	require.Error(t, err)
-	require.Nil(t, namespaces)
-	require.Contains(t, err.Error(), `mapped namespaces ["beta"] are not managed by this traffic-manager`)
-	require.Contains(t, err.Error(), `managed namespaces are ["alpha"]`)
+	require.Equal(t, []string{"alpha", "beta"}, namespaces)
 }
 
-func TestEffectiveMappedNamespacesRejectsUnmanagedClientConfigNamespace(t *testing.T) {
-	namespaces, err := effectiveMappedNamespaces(
+func TestEffectiveMappedNamespacesAllowsUnmanagedClientConfigNamespace(t *testing.T) {
+	namespaces := effectiveMappedNamespaces(
 		nil,
 		[]string{"beta"},
 		[]string{"alpha"},
 	)
-
-	require.Error(t, err)
-	require.Nil(t, namespaces)
-	require.Contains(t, err.Error(), `mapped namespaces ["beta"] are not managed by this traffic-manager`)
+	require.Equal(t, []string{"beta"}, namespaces)
 }
 
 func TestEffectiveMappedNamespacesUsesManagerNamespacesWhenAllRequested(t *testing.T) {
-	namespaces, err := effectiveMappedNamespaces(
+	namespaces := effectiveMappedNamespaces(
 		[]string{"all"},
 		[]string{"beta"},
 		[]string{"alpha", "gamma"},
 	)
-
-	require.NoError(t, err)
 	require.Equal(t, []string{"alpha", "gamma"}, namespaces)
 }
 
 func TestEffectiveMappedNamespacesAllowsGlobalManager(t *testing.T) {
-	namespaces, err := effectiveMappedNamespaces(
+	namespaces := effectiveMappedNamespaces(
 		[]string{"beta"},
 		nil,
 		nil,
 	)
-
-	require.NoError(t, err)
 	require.Equal(t, []string{"beta"}, namespaces)
 }

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -215,11 +215,7 @@ func NewSession(
 		return nil, nil,
 			fmt.Errorf("traffic manager version %s is too old. Minimum supported version is 2.21.0, please upgrade", tmgr.managerVersion)
 	}
-	if err = tmgr.updateClientConfig(ctx, cr.MappedNamespaces); err != nil {
-		tmgr.depart(ctx)
-		tmgr.managerConn.Close()
-		return nil, nil, err
-	}
+	tmgr.updateClientConfig(ctx, cr.MappedNamespaces)
 
 	oi := tmgr.getNetworkInfo(cr)
 	if !service.RootSessionInProcess() {
@@ -591,16 +587,6 @@ func (s *session) SessionInfo() *manager.SessionInfo {
 	return s.sessionInfo
 }
 
-func (s *session) depart(ctx context.Context) {
-	c, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
-	defer cancel()
-	if _, err := s.ManagerClient().Depart(c, s.SessionInfo()); err != nil {
-		clog.Debugf(c, "failed to depart from manager after connect error: %v", err)
-	} else if err = deleteSessionInfoFromUserCache(c, s.daemonID); err != nil {
-		clog.Debugf(c, "failed to delete session from user cache after connect error: %v", err)
-	}
-}
-
 // getInfosForWorkloads returns a list of workloads found in the given namespace that fulfils the given filter criteria.
 func (s *session) getInfosForWorkloads(
 	namespaces []string,
@@ -912,9 +898,7 @@ func (s *session) UpdateStatus(ctx context.Context, cr *rpc.ConnectRequest) (*rp
 	if err != nil {
 		return nil, err
 	}
-	if err := s.updateClientConfig(ctx, cr.MappedNamespaces); err != nil {
-		return nil, err
-	}
+	s.updateClientConfig(ctx, cr.MappedNamespaces)
 	return s.Status(ctx)
 }
 
@@ -922,7 +906,7 @@ func (s *session) Status(ctx context.Context) (*rpc.ConnectInfo, error) {
 	return s.status(ctx, false)
 }
 
-func (s *session) updateClientConfig(ctx context.Context, namespaces []string) error {
+func (s *session) updateClientConfig(ctx context.Context, namespaces []string) {
 	var tmCfg client.Config
 	cliCfg, err := s.ManagerClient().GetClientConfig(ctx, &empty.Empty{})
 	if err != nil {
@@ -945,10 +929,7 @@ func (s *session) updateClientConfig(ctx context.Context, namespaces []string) e
 
 		// We do not want to override the local config with the traffic-manager's config even if the local config is empty.
 		cfg.Cluster().MappedNamespaces = clientMappedNamespaces
-		namespaces, err = effectiveMappedNamespaces(namespaces, clientMappedNamespaces, tmMappedNamespaces)
-		if err != nil {
-			return err
-		}
+		namespaces = effectiveMappedNamespaces(namespaces, clientMappedNamespaces, tmMappedNamespaces)
 		if s.SetMappedNamespaces(namespaces) {
 			if len(namespaces) == 0 {
 				if k8sapi.CanWatchNamespaces(s) {
@@ -974,7 +955,6 @@ func (s *session) updateClientConfig(ctx context.Context, namespaces []string) e
 			clog.Debug(s, sc.Text())
 		}
 	}
-	return nil
 }
 
 func (s *session) status(ctx context.Context, initial bool) (*rpc.ConnectInfo, error) {
@@ -1319,5 +1299,8 @@ func (s *session) workloadsWatcher(namespace string, synced *sync.WaitGroup) err
 				synced = nil
 			}
 			return nil
-		}, nil)
+			// A namespace that the traffic-manager does not manage yields FailedPrecondition;
+			// retrying cannot change that, so treat it as permanent and surface the error instead
+			// of spinning (which manifests as a hang when listing an unmanaged namespace).
+		}, nil, codes.FailedPrecondition)
 }

--- a/pkg/grpc/watcher/watcher.go
+++ b/pkg/grpc/watcher/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -19,6 +20,9 @@ import (
 // Errors returned by the handler will be treated as permanent and returned as-is.
 //
 // Errors returned by the stream provider and the repair will be treated as transient and retried. The backup.Permanent wrapper can be used to override this behavior.
+//
+// A gRPC status code listed in permanentCodes is treated as permanent (not retried) for errors from both the stream
+// provider and Recv. Use this for codes that retrying cannot resolve, such as FailedPrecondition.
 func WatchWithRetry[T any](
 	ctx context.Context,
 	name string,
@@ -26,6 +30,7 @@ func WatchWithRetry[T any](
 	streamProvider func(context.Context) (grpc.ServerStreamingClient[T], error),
 	handler func(*T) error,
 	repair func() error,
+	permanentCodes ...codes.Code,
 ) error {
 	retryCount := 0
 	err := backoff.Retry(func() error {
@@ -36,11 +41,14 @@ func WatchWithRetry[T any](
 		}
 		retryCount++
 		stream, err := streamProvider(ctx)
-		switch status.Code(err) {
+		switch c := status.Code(err); c {
 		case codes.OK:
 		case codes.Unimplemented:
 			return backoff.Permanent(err)
 		default:
+			if slices.Contains(permanentCodes, c) {
+				return backoff.Permanent(err)
+			}
 			return fmt.Errorf("error when calling stream provider for %s: %w", name, err)
 		}
 		defer func() {
@@ -52,7 +60,7 @@ func WatchWithRetry[T any](
 				return nil
 			default:
 				value, err := stream.Recv()
-				switch status.Code(err) {
+				switch c := status.Code(err); c {
 				case codes.OK:
 					err = handler(value)
 					if err != nil {
@@ -61,6 +69,9 @@ func WatchWithRetry[T any](
 				case codes.Unimplemented:
 					return backoff.Permanent(err)
 				default:
+					if slices.Contains(permanentCodes, c) {
+						return backoff.Permanent(err)
+					}
 					return fmt.Errorf("error when calling Recv for %s: %w", name, err)
 				}
 			}

--- a/pkg/grpc/watcher/watcher_test.go
+++ b/pkg/grpc/watcher/watcher_test.go
@@ -1,0 +1,46 @@
+package watcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// A code listed in permanentCodes must stop the retry loop and surface the error
+// rather than spinning (the cause of the "list of an unmanaged namespace hangs" timeout).
+func TestWatchWithRetry_PermanentCodeStops(t *testing.T) {
+	calls := 0
+	sp := func(context.Context) (grpc.ServerStreamingClient[emptypb.Empty], error) {
+		calls++
+		return nil, status.Error(codes.FailedPrecondition, "namespace x is not managed")
+	}
+	err := WatchWithRetry(context.Background(), "test", time.Millisecond,
+		sp, func(*emptypb.Empty) error { return nil }, nil, codes.FailedPrecondition)
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, 1, calls, "a permanent code must not be retried")
+}
+
+// Without permanentCodes the same error is treated as transient and retried.
+func TestWatchWithRetry_RetriesByDefault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	calls := 0
+	sp := func(context.Context) (grpc.ServerStreamingClient[emptypb.Empty], error) {
+		calls++
+		if calls >= 3 {
+			cancel()
+		}
+		return nil, status.Error(codes.FailedPrecondition, "transient")
+	}
+	err := WatchWithRetry(ctx, "test", time.Millisecond,
+		sp, func(*emptypb.Empty) error { return nil }, nil)
+	require.NoError(t, err) // a canceled context ends the retry with a nil error
+	require.GreaterOrEqual(t, calls, 3, "without a permanent code the error is retried")
+}


### PR DESCRIPTION
## Summary

Fixes a 2.29.0 regression (#4170): `telepresence connect --mapped-namespaces <ns>`
(and the `cluster.mappedNamespaces` config) again accept namespaces the
traffic-manager does not manage, restoring short DNS (e.g. `svc.ns`) for
namespaces a developer can reach but intentionally does not manage — such as a
shared database namespace.

## Background

#4124 added a client-side check that rejected, at connect time, any
`--mapped-namespaces` value outside the traffic-manager's managed set. That
conflated two distinct concepts:

- **mapped** — which namespaces the *client* creates short DNS for. This is
  client-side only; names are resolved by the traffic-manager or a traffic-agent,
  so a mapped namespace need not be managed.
- **managed** — namespaces the traffic-manager operates in (agent injection,
  intercepts).

Mapping is allowed to exceed the managed set; #4124's rejection broke that. The
clear "not managed" error for actually *using* an unmanaged namespace is already
enforced authoritatively by the traffic-manager (`ArriveAsClient` for connect,
`managedTargetNamespace` for engagements, `WatchWorkloads` for list) — all
predating #4124 — so removing the client-side rejection loses no helpful error.

## Changes

- Remove `ensureMappedNamespacesManaged`; `effectiveMappedNamespaces` no longer
  rejects mapping an unmanaged namespace. The default mapped set still resolves
  to the managed set.
- **Fail fast when listing an unmanaged namespace.** The manager rejects
  `WatchWorkloads` on an unmanaged namespace with `FailedPrecondition`, but
  `WatchWithRetry` retried it forever, so `telepresence list -n <unmanaged>`
  hung until a timeout. `WatchWithRetry` gains an optional `permanentCodes`, and
  the workloads watcher opts `FailedPrecondition` in, so the list now returns the
  clear "not managed" message immediately. Other `WatchWithRetry` callers are
  unchanged.
- Unit tests added/updated; integration suites `Namespaces` and
  `MultipleServices/Test_AllowsUnmanagedMappedNamespace` pass.

Closes #4170.
