### PR TITLE
Replace getambassador.io Argo link with argoproj Argo Rollouts

### DIFF
--- a/docs/reference/engagements/cli.md
+++ b/docs/reference/engagements/cli.md
@@ -81,7 +81,7 @@ Oftentimes, there's a 1-to-1 relationship between a service and a
 workload, so telepresence is able to auto-detect which service it
 should intercept based on the workload you are trying to intercept.
 But if you use something like
-[Argo](https://www.getambassador.io/docs/argo/latest/), there may be
+[Argo Rollouts](https://argoproj.github.io/argo-rollouts/), there may be
 two services (that use the same labels) to manage traffic between a
 canary and a stable service.
 


### PR DESCRIPTION
The `getambassador.io` Argo docs link in the CLI engagements reference is no longer relevant to Telepresence. This points the example at the canonical CNCF/argoproj Argo Rollouts documentation instead, which is also a more accurate target since the surrounding text describes Argo Rollouts' canary/stable service pattern.