### PR TITLE
Log usage-reporting problems at trace level instead of info

### DIFF
--- a/pkg/usg/bootstrap.go
+++ b/pkg/usg/bootstrap.go
@@ -30,12 +30,12 @@ func InstallClient(ctx context.Context) (context.Context, Sink) {
 	}
 	id, err := client.InstallID(ctx)
 	if err != nil {
-		clog.Infof(ctx, "usg: installation id unavailable, reporting disabled: %v", err)
+		clog.Tracef(ctx, "usg: installation id unavailable, reporting disabled: %v", err)
 		return ctx, nil
 	}
 	sink, err := NewDiskSink(ClientQueueDir(ctx))
 	if err != nil {
-		clog.Infof(ctx, "usg: disk queue unavailable, reporting disabled: %v", err)
+		clog.Tracef(ctx, "usg: disk queue unavailable, reporting disabled: %v", err)
 		return ctx, nil
 	}
 	return WithProducer(ctx, newProducer(SourceClient, id, version.Version, sink)), sink

--- a/pkg/usg/report.go
+++ b/pkg/usg/report.go
@@ -20,7 +20,7 @@
 //   - Reporting can be disabled via config. When disabled, no producer is
 //     installed on the context, New() returns nil, and methods on a nil
 //     Report are no-ops, so nothing is buffered or sent.
-//   - Problems are logged at info level only, never warning or error.
+//   - Problems are logged at trace level only, never warning or error.
 //
 // Sensitive data is the caller's responsibility. This package performs no
 // scrubbing or validation of entry values — anything passed to Add is sent

--- a/pkg/usg/sender.go
+++ b/pkg/usg/sender.go
@@ -25,7 +25,7 @@ type SenderConfig struct {
 // It returns only when ctx is cancelled. If the address is empty, the function
 // drains the sink to discard any backlog but never dials a server.
 //
-// Per the design rules, all transient failures are logged at info level only;
+// Per the design rules, all transient failures are logged at trace level only;
 // the function never returns an error to its caller and never surfaces a
 // warning. Reports lost to a transient failure are re-enqueued and may be
 // dropped if the sink is at cap.
@@ -52,7 +52,7 @@ func RunSender(ctx context.Context, sink Sink, cfg SenderConfig) {
 		var err error
 		conn, err = dialCollector(cfg.Address, cfg.Insecure)
 		if err != nil {
-			clog.Infof(ctx, "usg: collector unreachable, reports will be dropped: %v", err)
+			clog.Tracef(ctx, "usg: collector unreachable, reports will be dropped: %v", err)
 		} else {
 			client = usgrpc.NewUsgClient(conn)
 		}
@@ -91,7 +91,7 @@ func flush(ctx context.Context, sink Sink, client usgrpc.UsgClient, batch int) {
 	defer cancel()
 	_, err := client.ReportBatch(sendCtx, &usgrpc.UsageReportBatch{Reports: reports})
 	if err != nil {
-		clog.Infof(ctx, "usg: batch of %d reports could not be sent: %v", len(reports), err)
+		clog.Tracef(ctx, "usg: batch of %d reports could not be sent: %v", len(reports), err)
 		// Re-enqueue best-effort; overflow drops silently as required.
 		for _, r := range reports {
 			sink.Enqueue(r)


### PR DESCRIPTION
Transient failures in the usage sender (unreachable collector, failed batch sends) and bootstrap problems (missing installation id or disk queue) were logged at info level, showing up as noise in the connector log, e.g.:

```
INFO  userd/usage-sender: usg: batch of 10 reports could not be sent: rpc error: code = Unavailable ...
```

Usage reporting is best-effort by design and its problems are of no concern to the user, so all logging from the `pkg/usg` package now uses trace level. The package documentation is updated to match.