### PR TITLE
Forward filter-matched wiretapped requests to the application

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -39,6 +39,17 @@ items:
           mechanism and filters, so traffic is delivered no matter which
           replica the service picks. Previously only intercepts with HTTP
           filters received this treatment.
+      - type: bugfix
+        title: HTTP-filtered wiretaps no longer block matching requests
+        body: >-
+          A wiretap with an HTTP filter (such as <code>--http-path-prefix</code>
+          or <code>--http-header</code>) copied each matching request to the
+          client but never forwarded the original to the application: the
+          traffic-agent served the tap synchronously and deadlocked on its own
+          copy of the request, so matching traffic was silently black-holed
+          and callers timed out. Taps are now served concurrently and the
+          request always proceeds to its real destination, whether that is the
+          application container or an intercepting client.
   - version: 2.29.2
     date: 2026-07-04
     notes:

--- a/cmd/traffic/cmd/agent/fwd/http.go
+++ b/cmd/traffic/cmd/agent/fwd/http.go
@@ -138,12 +138,27 @@ func (f *tcp) handleHTTPRequest(writer http.ResponseWriter, req *http.Request, d
 			}
 		}
 		if tapCount := len(wts); tapCount > 0 {
-			taps, err := addRequestTaps(f.lCtx, req, tapCount, 1024)
+			taps, tapReader, err := addRequestTaps(f.lCtx, req, tapCount, wiretapCacheSize)
 			if err != nil {
 				clog.Errorf(f.lCtx, "Failed to add request taps: %v", err)
 			} else {
+				// A wiretap is lossy and best-effort and must never block or
+				// delay the real request. Nothing guarantees the request body
+				// is ever read (a bodyless GET is never read by
+				// httputil.ReverseProxy), so closeTaps is called unconditionally
+				// once the request has been served, regardless of which return
+				// path was taken and regardless of whether the body was read.
+				// It is idempotent, so it is harmless if the body was already
+				// read to completion (which independently sends the taps a
+				// terminal EOF) or the server itself later closes the body.
+				// The tap goroutines below are intentionally not awaited: they
+				// finish shortly after the handler returns, bounded by the
+				// per-intercept context and the pipe closing.
+				defer tapReader.closeTaps()
 				for i, ii := range wts {
-					f.serveTap(ii.ctx, src, taps[i], ii.InterceptInfo)
+					go func(tap io.Reader, ii *interceptController) {
+						f.serveTap(ii.ctx, src, tap, ii.InterceptInfo)
+					}(taps[i], ii)
 				}
 			}
 		}

--- a/cmd/traffic/cmd/agent/fwd/http_test.go
+++ b/cmd/traffic/cmd/agent/fwd/http_test.go
@@ -1,12 +1,22 @@
 package fwd
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
 
 func TestHTTPInterceptor_shouldInterceptRequest(t *testing.T) {
@@ -115,4 +125,235 @@ func TestHTTPInterceptor_noFilters(t *testing.T) {
 	// No filters means intercept everything
 	result := shouldInterceptRequest(req, headerFilters, pathFilters)
 	assert.True(t, result)
+}
+
+// fakeTapStream is a minimal tunnel.Stream that records everything sent to it.
+type fakeTapStream struct {
+	mu   sync.Mutex
+	sent [][]byte
+}
+
+func (s *fakeTapStream) Tag() tunnel.Tag   { return tunnel.AgentToClient }
+func (s *fakeTapStream) ID() tunnel.ConnID { return "" }
+func (s *fakeTapStream) Receive(context.Context) (tunnel.Message, error) {
+	return nil, io.EOF
+}
+
+func (s *fakeTapStream) Send(_ context.Context, m tunnel.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = append(s.sent, append([]byte(nil), m.Payload()...))
+	return nil
+}
+
+func (s *fakeTapStream) CloseSend(context.Context) error { return nil }
+func (s *fakeTapStream) PeerVersion() uint16             { return tunnel.Version }
+func (s *fakeTapStream) SessionID() tunnel.SessionID     { return "" }
+func (s *fakeTapStream) DialTimeout() time.Duration      { return 0 }
+func (s *fakeTapStream) RoundtripLatency() time.Duration { return 0 }
+func (s *fakeTapStream) SetTag(tunnel.Tag)               {}
+
+func (s *fakeTapStream) bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var all []byte
+	for _, b := range s.sent {
+		all = append(all, b...)
+	}
+	return all
+}
+
+// fakeStreamProvider always hands out the same stream, regardless of the requested intercept.
+type fakeStreamProvider struct {
+	stream tunnel.Stream
+}
+
+func (p *fakeStreamProvider) CreateClientStream(
+	context.Context, tunnel.Tag, tunnel.SessionID, tunnel.ConnID, time.Duration, time.Duration,
+) (tunnel.Stream, error) {
+	return p.stream, nil
+}
+
+func (p *fakeStreamProvider) ReportMetrics(context.Context, *manager.TunnelMetrics) {}
+func (p *fakeStreamProvider) MetricsEnabled() bool                                  { return false }
+
+// TestHandleHTTPRequest_WiretapMatch_ForwardsAndTaps proves that a bodied request matching an
+// HTTP-filtered wiretap both reaches the application (through defaultHandler) and is streamed to
+// the tap as its body is read. The tap goroutine is detached from handleHTTPRequest, so its
+// delivery is asserted with a bounded wait rather than immediately after the handler returns.
+func TestHandleHTTPRequest_WiretapMatch_ForwardsAndTaps(t *testing.T) {
+	ctx := context.Background()
+	stream := &fakeTapStream{}
+	f := &tcp{interceptor: &interceptor{
+		lCtx:           ctx,
+		intercepts:     make(interceptControllerMap),
+		wiretaps:       make(interceptControllerMap),
+		streamProvider: &fakeStreamProvider{stream: stream},
+	}}
+
+	wt := &manager.InterceptInfo{
+		Id: "wt-1",
+		Spec: &manager.InterceptSpec{
+			Wiretap:       true,
+			TargetHost:    "127.0.0.1",
+			TargetPort:    8080,
+			HeaderFilters: map[string]string{"k": "v"},
+		},
+		ClientSession: &manager.SessionInfo{SessionId: "sess-1"},
+	}
+	f.wiretaps.reconcile(ctx, []*manager.InterceptInfo{wt})
+
+	const body = "hello wiretap"
+	var handlerCalled atomic.Bool
+	defaultHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, string(b))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("app-response"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/path", strings.NewReader(body))
+	req.Header.Set("k", "v")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		f.handleHTTPRequest(rec, req, defaultHandler)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleHTTPRequest deadlocked: request never reached the application")
+	}
+
+	require.True(t, handlerCalled.Load(), "matched request was never forwarded to the application")
+	require.Equal(t, "app-response", rec.Body.String())
+
+	// The tap is served by a detached goroutine that is intentionally not awaited by
+	// handleHTTPRequest, so it may finish slightly after the handler returns.
+	require.Eventually(t, func() bool {
+		tapped := string(stream.bytes())
+		return strings.Contains(tapped, "POST /path") && strings.Contains(tapped, body)
+	}, 2*time.Second, 10*time.Millisecond, "tap did not receive the request line and body")
+}
+
+// TestHandleHTTPRequest_WiretapMatch_BodylessRequest_ForwardsAndTaps is a regression test for
+// the live deadlock this package's tap-request code had: a bodyless GET is never read by
+// httputil.ReverseProxy (or any handler that has no reason to touch the body), so nothing ever
+// drives the tapped request body to EOF. handleHTTPRequest used to gate its return on a
+// defer wg.Wait() for the tap goroutines, and the tap goroutines in turn blocked forever reading
+// a pipe that would only ever see EOF once the body was read - so the handler itself hung and
+// the caller received nothing. handleHTTPRequest must return once the request has been served,
+// regardless of whether anything read the body, while the tap still receives what could be
+// captured (the request line and headers).
+//
+// The defaultHandler below intentionally never reads r.Body, modeling a bodyless GET forwarded
+// through httputil.ReverseProxy. Without the fix this test times out instead of failing fast,
+// which is why it uses a done-channel with a bounded wait rather than letting a hang block
+// `go test` indefinitely.
+func TestHandleHTTPRequest_WiretapMatch_BodylessRequest_ForwardsAndTaps(t *testing.T) {
+	ctx := context.Background()
+	stream := &fakeTapStream{}
+	f := &tcp{interceptor: &interceptor{
+		lCtx:           ctx,
+		intercepts:     make(interceptControllerMap),
+		wiretaps:       make(interceptControllerMap),
+		streamProvider: &fakeStreamProvider{stream: stream},
+	}}
+
+	wt := &manager.InterceptInfo{
+		Id: "wt-1",
+		Spec: &manager.InterceptSpec{
+			Wiretap:       true,
+			TargetHost:    "127.0.0.1",
+			TargetPort:    8080,
+			HeaderFilters: map[string]string{"k": "v"},
+		},
+		ClientSession: &manager.SessionInfo{SessionId: "sess-1"},
+	}
+	f.wiretaps.reconcile(ctx, []*manager.InterceptInfo{wt})
+
+	var handlerCalled atomic.Bool
+	// Models a reverse proxy forwarding a bodyless GET: it never reads r.Body.
+	defaultHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("app-response"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/path", nil)
+	req.Header.Set("k", "v")
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		f.handleHTTPRequest(rec, req, defaultHandler)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleHTTPRequest deadlocked: request never returned for a bodyless (GET) request")
+	}
+
+	require.True(t, handlerCalled.Load(), "matched request was never forwarded to the application")
+	require.Equal(t, "app-response", rec.Body.String())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(string(stream.bytes()), "GET /path")
+	}, 2*time.Second, 10*time.Millisecond, "tap did not receive the request line")
+}
+
+// TestHandleHTTPRequest_WiretapNoMatch_ForwardsWithoutTapping verifies that a request which
+// does not match any wiretap filter is forwarded to the application without being tapped.
+func TestHandleHTTPRequest_WiretapNoMatch_ForwardsWithoutTapping(t *testing.T) {
+	ctx := context.Background()
+	stream := &fakeTapStream{}
+	f := &tcp{interceptor: &interceptor{
+		lCtx:           ctx,
+		intercepts:     make(interceptControllerMap),
+		wiretaps:       make(interceptControllerMap),
+		streamProvider: &fakeStreamProvider{stream: stream},
+	}}
+
+	wt := &manager.InterceptInfo{
+		Id: "wt-1",
+		Spec: &manager.InterceptSpec{
+			Wiretap:       true,
+			TargetHost:    "127.0.0.1",
+			TargetPort:    8080,
+			HeaderFilters: map[string]string{"k": "v"},
+		},
+		ClientSession: &manager.SessionInfo{SessionId: "sess-1"},
+	}
+	f.wiretaps.reconcile(ctx, []*manager.InterceptInfo{wt})
+
+	var handlerCalled atomic.Bool
+	defaultHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/path", nil)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		f.handleHTTPRequest(rec, req, defaultHandler)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleHTTPRequest deadlocked")
+	}
+
+	require.True(t, handlerCalled.Load(), "non-matching request was never forwarded to the application")
+	require.Empty(t, stream.bytes(), "tap should not have received any data for a non-matching request")
 }

--- a/cmd/traffic/cmd/agent/fwd/wiretap.go
+++ b/cmd/traffic/cmd/agent/fwd/wiretap.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/telepresenceio/clog"
@@ -136,9 +137,17 @@ func (mw *teeConn) send(rr readResult) {
 // causing a block.
 // Any error encountered during Read will be propagated to the pipe-writers in a
 // CloseWithError call.
+//
+// A teeReader's taps must not be relied on to terminate solely by the wrapped body being
+// read to EOF: nothing guarantees the body is ever read at all (e.g. httputil.ReverseProxy
+// never reads the body of a bodyless GET). Callers that install a teeReader on a request must
+// therefore call closeTaps once the request has been fully served, regardless of whether the
+// body was read. closeTaps is idempotent, so it is safe to call it again if the body does end
+// up being read to completion or the server itself closes the body.
 type teeReader struct {
 	io.ReadCloser
-	cs []chan readResult
+	cs        []chan readResult
+	closeOnce sync.Once
 }
 
 func (mw *teeReader) Read(b []byte) (n int, err error) {
@@ -152,8 +161,16 @@ func (mw *teeReader) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
+// closeTaps signals EOF to every tap pipe exactly once. It is safe to call multiple times and
+// from multiple goroutines.
+func (mw *teeReader) closeTaps() {
+	mw.closeOnce.Do(func() {
+		mw.send(readResult{err: io.EOF})
+	})
+}
+
 func (mw *teeReader) Close() error {
-	mw.send(readResult{err: io.EOF})
+	mw.closeTaps()
 	return mw.ReadCloser.Close()
 }
 
@@ -192,7 +209,8 @@ func writePump(ctx context.Context, ch <-chan readResult, w *io.PipeWriter) {
 	}
 }
 
-// addRequestTaps installs wiretaps on a request. The readers for the taps are returned.
+// addRequestTaps installs wiretaps on a request. The readers for the taps are returned, along
+// with the teeReader that was installed as the request's body.
 //
 // A wiretap will receive the request header and all data read from its body and has the following characteristics:
 //
@@ -207,10 +225,14 @@ func writePump(ctx context.Context, ch <-chan readResult, w *io.PipeWriter) {
 //   - A Read will return the same as a Read on the tapped request-body.
 //   - The reader is closed on error reading the tapped request-body, when the context is done, or when the
 //     tapped request-body is explicitly closed.
-
-func addRequestTaps(ctx context.Context, request *http.Request, count, cacheSize int) ([]io.Reader, error) {
+//
+// Nothing guarantees that the tapped request-body is ever read (e.g. the body of a bodyless GET
+// is never read by httputil.ReverseProxy), so the caller must call closeTaps on the returned
+// teeReader once the request has been fully served, regardless of whether the body was read, or
+// the taps will never see a terminating EOF.
+func addRequestTaps(ctx context.Context, request *http.Request, count, cacheSize int) ([]io.Reader, *teeReader, error) {
 	if count == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	body := request.Body
@@ -220,35 +242,45 @@ func addRequestTaps(ctx context.Context, request *http.Request, count, cacheSize
 	}
 	taps := make([]io.Reader, count)
 
-	// Write only the request header to the tap pipes. The body will be propagated by the teeReader.
-	headerBuf := new(bytes.Buffer)
-	request.Body = emptyReader{}
-	err := request.Write(headerBuf)
-	if err != nil {
-		// Restore the original body
-		request.Body = body
-		return nil, err
+	// Write only the request header to the tap pipes. The body will be propagated by the
+	// teeReader below.
+	//
+	// request.Write requires that the number of body bytes it writes matches a declared,
+	// known Content-Length, so an empty stand-in body only works when Content-Length is
+	// zero or unknown (chunked). When a positive length is declared, feed it that many
+	// zero bytes instead so the write succeeds; headerCaptureWriter stops retaining data
+	// once the header/body boundary is seen, so a large declared length is never buffered.
+	hw := &headerCaptureWriter{}
+	if cl := request.ContentLength; cl > 0 {
+		request.Body = io.NopCloser(io.LimitReader(zeroReader{}, cl))
+	} else {
+		request.Body = emptyReader{}
 	}
+	err := request.Write(hw)
+	// Restore the original body; it is only swapped for the teeReader below on success.
+	request.Body = body
+	if err != nil {
+		return nil, nil, err
+	}
+	headerData := hw.buf.Bytes()
 
 	// Replace the body with the teeReader.
 	request.Body = tc
 
-	headerData := headerBuf.Bytes()
 	for i := 0; i < count; i++ {
 		rd, wr := io.Pipe()
 		taps[i] = rd
 		c := make(chan readResult, cacheSize)
 		tc.cs[i] = c
 		go func() {
-			_, err = wr.Write(headerData)
-			if err != nil {
+			if _, err := wr.Write(headerData); err != nil {
 				clog.Errorf(ctx, "Failed to write request to tap: %v", err)
 			} else {
 				writePump(ctx, c, wr)
 			}
 		}()
 	}
-	return taps, nil
+	return taps, tc, nil
 }
 
 type emptyReader struct{}
@@ -259,4 +291,35 @@ func (emptyReader) Read([]byte) (int, error) {
 
 func (emptyReader) Close() error {
 	return nil
+}
+
+// zeroReader is an endless source of zero bytes, used to synthesize a stand-in request body
+// of a declared length without allocating it.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}
+
+// headerCaptureWriter retains everything written to it up to and including the first blank
+// line (the request-line/header block of an HTTP/1.x message), then silently discards
+// everything after it. This lets request.Write be fed a synthetic body of an arbitrary
+// declared length, for Content-Length validation purposes, without that body ending up
+// buffered in memory.
+type headerCaptureWriter struct {
+	buf       bytes.Buffer
+	sawHeader bool
+}
+
+func (w *headerCaptureWriter) Write(p []byte) (int, error) {
+	if w.sawHeader {
+		return len(p), nil
+	}
+	n, err := w.buf.Write(p)
+	if idx := bytes.Index(w.buf.Bytes(), []byte("\r\n\r\n")); idx >= 0 {
+		w.sawHeader = true
+		w.buf.Truncate(idx + 4)
+	}
+	return n, err
 }

--- a/cmd/traffic/cmd/agent/fwd/wiretap_test.go
+++ b/cmd/traffic/cmd/agent/fwd/wiretap_test.go
@@ -1,0 +1,59 @@
+package fwd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddRequestTaps_MultipleTaps_ReceiveHeaderAndBody is a regression test for two bugs in
+// addRequestTaps: it used to fail request.Write's Content-Length validation for any request
+// with a positive, known body length, and its per-tap goroutines raced on a shared "err"
+// variable instead of each using its own.
+func TestAddRequestTaps_MultipleTaps_ReceiveHeaderAndBody(t *testing.T) {
+	const body = "the quick brown fox"
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/path?q=1", strings.NewReader(body))
+	req.Header.Set("X-Test", "value")
+
+	const tapCount = 3
+	taps, tapReader, err := addRequestTaps(context.Background(), req, tapCount, wiretapCacheSize)
+	require.NoError(t, err)
+	require.Len(t, taps, tapCount)
+	defer tapReader.closeTaps()
+
+	// The teed body must still be fully readable by the real consumer (the reverse proxy
+	// or the intercepting client).
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(got))
+
+	wg := sync.WaitGroup{}
+	wg.Add(tapCount)
+	for i, tap := range taps {
+		go func(i int, tap io.Reader) {
+			defer wg.Done()
+			b, err := io.ReadAll(tap)
+			require.NoErrorf(t, err, "tap %d", i)
+			s := string(b)
+			require.Containsf(t, s, "POST /path?q=1", "tap %d missing request line", i)
+			require.Containsf(t, s, "X-Test: value", "tap %d missing header", i)
+			require.Containsf(t, s, body, "tap %d missing body", i)
+		}(i, tap)
+	}
+	wg.Wait()
+}
+
+// TestAddRequestTaps_ZeroCount verifies the no-op path.
+func TestAddRequestTaps_ZeroCount(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/path", nil)
+	taps, tapReader, err := addRequestTaps(context.Background(), req, 0, wiretapCacheSize)
+	require.NoError(t, err)
+	require.Nil(t, taps)
+	require.Nil(t, tapReader)
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,12 @@
 An intercept of a workload with several replicas only delivered the traffic that reached the pod recorded on the intercept. The agents in the other pods redirected their share of the requests but had no way to hand them to the client, so those requests timed out. The traffic-manager now tells the client to open a dial watcher to every agent pod of an intercepted workload, regardless of the intercept's mechanism and filters, so traffic is delivered no matter which replica the service picks. Previously only intercepts with HTTP filters received this treatment.
 </div>
 
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">HTTP-filtered wiretaps no longer block matching requests</div></div>
+<div style="margin-left: 15px">
+
+A wiretap with an HTTP filter (such as <code>--http-path-prefix</code> or <code>--http-header</code>) copied each matching request to the client but never forwarded the original to the application: the traffic-agent served the tap synchronously and deadlocked on its own copy of the request, so matching traffic was silently black-holed and callers timed out. Taps are now served concurrently and the request always proceeds to its real destination, whether that is the application container or an intercepting client.
+</div>
+
 ## Version 2.29.2 <span style="font-size: 16px;">(July  4)</span>
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Pod subnets are now routed when the traffic-manager runs with hostNetwork</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,6 +14,12 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 An intercept of a workload with several replicas only delivered the traffic that reached the pod recorded on the intercept. The agents in the other pods redirected their share of the requests but had no way to hand them to the client, so those requests timed out. The traffic-manager now tells the client to open a dial watcher to every agent pod of an intercepted workload, regardless of the intercept's mechanism and filters, so traffic is delivered no matter which replica the service picks. Previously only intercepts with HTTP filters received this treatment.
   </Body>
 </Note>
+<Note>
+	<Title type="bugfix">HTTP-filtered wiretaps no longer block matching requests</Title>
+	<Body>
+A wiretap with an HTTP filter (such as <code>--http-path-prefix</code> or <code>--http-header</code>) copied each matching request to the client but never forwarded the original to the application: the traffic-agent served the tap synchronously and deadlocked on its own copy of the request, so matching traffic was silently black-holed and callers timed out. Taps are now served concurrently and the request always proceeds to its real destination, whether that is the application container or an intercepting client.
+  </Body>
+</Note>
 ## Version 2.29.2 <span style={{fontSize:'16px'}}>(July  4)</span>
 <Note>
 	<Title type="bugfix">Pod subnets are now routed when the traffic-manager runs with hostNetwork</Title>

--- a/integration_test/ignored_mounts_test.go
+++ b/integration_test/ignored_mounts_test.go
@@ -66,10 +66,17 @@ func (s *mountsSuite) Test_IgnoredMounts() {
 				},
 			}
 			ctx := s.Context()
+			require := s.Require()
 			s.ApplyTemplate(ctx, filepath.Join("testdata", "k8s", "hello-w-volumes.goyaml"), &tpl)
 			defer s.DeleteSvcAndWorkload(ctx, "deploy", "hello")
 
-			require := s.Require()
+			// Wait for the rollout before intercepting. The nginx image may
+			// need to be pulled, and the intercept evicts the pod to inject
+			// the traffic-agent, so intercepting a deployment whose first pod
+			// is still starting puts two pod startups and an image pull
+			// inside the intercept timeout.
+			require.NoError(itest.RolloutStatusWait(ctx, s.AppNamespace(), "deploy/hello"))
+
 			stdout := itest.TelepresenceOk(ctx, "intercept", "hello", "--format", "json", "--detailed-output", "--port", fmt.Sprintf("%d:%d", localPort, tt.svcPort))
 			defer itest.TelepresenceOk(ctx, "leave", "hello")
 			var iInfo intercept.Info

--- a/integration_test/wiretap_test.go
+++ b/integration_test/wiretap_test.go
@@ -326,3 +326,112 @@ func (s *wiretapSuite) Test_MultipleTapsOnOnePort() { //nolint:gocognit
 		}
 	})
 }
+
+// Test_HTTPFilteredWiretap verifies that "telepresence wiretap --http-header
+// ..." taps only the traffic that matches the header filter, via the
+// traffic-agent's HTTP listener and reverse-proxy transport: a request
+// carrying the header keeps reaching the real application (a wiretap never
+// steals traffic) and a copy of it arrives at the local tap, while a
+// request without the header also keeps reaching the real application but
+// is never copied to the tap. Mirrors the node-agent variant,
+// Test_NodeAgentHTTPFilteredWiretap in node_agent_test.go.
+func (s *wiretapSuite) Test_HTTPFilteredWiretap() {
+	ctx := s.Context()
+	rq := s.Require()
+
+	s.TelepresenceConnect(ctx)
+	defer itest.TelepresenceQuitOk(ctx)
+
+	origPods := itest.RunningPods(ctx, s.svc, s.AppNamespace())
+	rq.Len(origPods, 1, "expected exactly one running %s pod before wiretapping", s.svc)
+
+	var tapOut chan string
+	tapPort, tapCancel := s.startWiretapHandler(ctx, s.svc+"-httpfilter", ":0", &tapOut)
+	defer tapCancel()
+
+	const headerName = "x-telepresence-test"
+	const headerValue = "http-filter-wiretap"
+	header := headerName + "=" + headerValue
+
+	stdout := itest.TelepresenceOk(ctx, "wiretap",
+		"--workload", s.svc,
+		"--mount=false",
+		"--port", fmt.Sprintf("%d:80", tapPort),
+		"--http-header", header,
+		"wt-filtered")
+	s.Contains(stdout, "Using Deployment "+s.svc)
+	s.CapturePodLogs(ctx, s.svc, "traffic-agent", s.AppNamespace())
+	mustLeave := true
+	defer func() {
+		if mustLeave {
+			itest.TelepresenceOk(ctx, "leave", "wt-filtered")
+		}
+	}()
+
+	curlWithHeader := func() (string, error) {
+		return itest.Output(ctx, "curl", "--silent", "--max-time", "2", "-H", headerName+": "+headerValue, s.svc)
+	}
+	curlNoHeader := func() (string, error) {
+		return itest.Output(ctx, "curl", "--silent", "--max-time", "2", s.svc)
+	}
+
+	// A request carrying the filter header must still reach the real
+	// application: a wiretap never steals traffic, it only copies it.
+	rq.Eventually(func() bool {
+		so, err := curlWithHeader()
+		if err != nil {
+			return false
+		}
+		return strings.Contains(so, "Request served by ")
+	}, 30*time.Second, 3*time.Second, "application did not keep serving header-matching traffic through the wiretap pass-through")
+
+	// The tap must receive a copy of the header-matching traffic. Since tap
+	// delivery is asynchronous, issue a request in each iteration and then
+	// check if a tap hit arrives.
+	tapOut = make(chan string, 5)
+	rq.Eventually(func() bool {
+		_, _ = curlWithHeader() // curl output is ignored; we only care about tap delivery
+		select {
+		case <-tapOut:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, 3*time.Second, "wiretap tap did not receive a copy of the header-matching traffic")
+
+	// Drain any straggler hits left over from the positive phase above --
+	// tap delivery is asynchronous, so a copy of the last matched request
+	// could still be in flight -- before checking the negative case below.
+	drainDeadline := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case <-tapOut:
+		case <-drainDeadline:
+			break drain
+		}
+	}
+
+	// A request without the header must keep reaching the real application.
+	rq.Eventually(func() bool {
+		so, err := curlNoHeader()
+		if err != nil {
+			return false
+		}
+		return strings.Contains(so, "Request served by ")
+	}, 30*time.Second, 3*time.Second, "application did not keep serving non-matching traffic through the wiretap pass-through")
+
+	// ...but it must never reach the tap. Issue several non-matching
+	// requests, then assert no tap hit shows up within a modest window.
+	for i := 0; i < 5; i++ {
+		_, _ = curlNoHeader() // curl output is ignored; we only care about tap delivery
+	}
+	select {
+	case out := <-tapOut:
+		s.Failf("wiretap tap received a copy of traffic that did not match the header filter", "output: %q", out)
+	case <-time.After(2 * time.Second):
+	}
+
+	itest.TelepresenceOk(ctx, "leave", "wt-filtered")
+	mustLeave = false
+}


### PR DESCRIPTION
## Problem

A wiretap with an HTTP filter (`--http-path-prefix`, `--http-header`) copied each matching request to the client, but the original request never reached the application. The reporter's scenario — a wiretap on a Spring Boot service's actuator port — showed health checks arriving at the workstation while the pod's log stayed silent, followed by timeouts.

## Cause

The traffic-agent's HTTP-filter path served each matching tap **synchronously**, before anything drained the tapped request body it had just installed. The tap pipe only advances (and only closes) as the real consumer reads the body — and for a bodyless GET, `httputil.ReverseProxy` never reads it at all — so the handler deadlocked on its own tap. Matching traffic was silently black-holed in both agent modes, and no test exercised a filtered wiretap.

## Fix

Taps are served concurrently, mirroring how the plain TCP path already treats wiretaps, and an unconditional, idempotent `closeTaps` covers the never-read-body case. The request always proceeds to its real destination — the application container or an intercepting client. Includes unit coverage for the routing decision and tap serialization, plus a sidecar-mode `Test_HTTPFilteredWiretap` integration test.

A second commit deflakes `Test_IgnoredMounts`, which intercepted a freshly applied deployment without waiting for its rollout, intermittently pushing an nginx image pull plus two pod startups into the 30-second intercept timeout on CI runners.

Closes #4184