### PR TITLE
Prepare v2.30.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/telepresenceio/go-fuseftp v1.0.1
 	github.com/telepresenceio/go-fuseftp/rpc v1.0.1
 	github.com/telepresenceio/telepresence/cmd/cobraparser/v2 v2.0.0-20260623110129-2888ce1c36e3
-	github.com/telepresenceio/telepresence/rpc/v2 v2.29.3
+	github.com/telepresenceio/telepresence/rpc/v2 v2.30.0-rc.0
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/net v0.56.0

--- a/integration_test/node_agent_cluster_default_test.go
+++ b/integration_test/node_agent_cluster_default_test.go
@@ -1,0 +1,131 @@
+package integration_test
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/telepresenceio/telepresence/v2/integration_test/itest"
+)
+
+// nodeAgentClusterDefaultSuite exercises the cluster-provided client default
+// for node-agent mode (Helm value client.nodeAgent.enabled=true): a flagless
+// intercept must be served by a node-agent, and an explicit
+// --node-agent=false must override the default and fall back to sidecar
+// injection. The two cases use separate workloads because an injected
+// sidecar outlives its intercept and makes the workload inadmissible for
+// later node-agent attachments.
+type nodeAgentClusterDefaultSuite struct {
+	nodeAgentBase
+}
+
+func (s *nodeAgentClusterDefaultSuite) SuiteName() string {
+	return "NodeAgentClusterDefault"
+}
+
+func init() {
+	itest.AddNamespacePairSuite("", func(h itest.NamespacePair) itest.TestingSuite {
+		return &nodeAgentClusterDefaultSuite{nodeAgentBase{Suite: itest.Suite{Harness: h}, NamespacePair: h}}
+	})
+}
+
+func (s *nodeAgentClusterDefaultSuite) SetupSuite() {
+	s.Suite.SetupSuite()
+	s.skipUnlessNodeAgentSupported()
+	ctx := s.Context()
+	s.reapLeftoverNodeAgentJobs(ctx)
+	s.skipUnlessNodeAgentPodSecurityOK(ctx)
+
+	// h2c probing is disabled for the same reason as the sibling node-agent
+	// suites: the echo-server image answers HTTP/2 prior-knowledge probes,
+	// and the local echo helpers are HTTP/1.1-only.
+	s.TelepresenceHelmInstallOK(ctx, false,
+		"--set", "nodeAgent.enabled=true",
+		"--set", "client.nodeAgent.enabled=true",
+		"--set", "agent.enableH2cProbing=false")
+	itest.ApplyEchoService(ctx, "echo-default", s.AppNamespace(), 80)
+	itest.ApplyEchoService(ctx, "echo-optout", s.AppNamespace(), 80)
+	s.TelepresenceConnect(ctx)
+}
+
+func (s *nodeAgentClusterDefaultSuite) TearDownSuite() {
+	ctx := s.Context()
+	itest.TelepresenceQuitOk(ctx)
+	s.DeleteSvcAndWorkload(ctx, "deploy", "echo-default")
+	s.DeleteSvcAndWorkload(ctx, "deploy", "echo-optout")
+	s.UninstallTrafficManager(ctx, s.ManagerNamespace())
+}
+
+// Test_ClusterDefaultSelectsNodeAgent verifies that with
+// client.nodeAgent.enabled=true in the Helm chart, an intercept that never
+// mentions node-agent mode is served by a node-agent: a Job appears, the
+// workload's pod is left untouched, and the Job is reaped on detach.
+func (s *nodeAgentClusterDefaultSuite) Test_ClusterDefaultSelectsNodeAgent() {
+	const svc = "echo-default"
+	ctx := s.Context()
+	rq := s.Require()
+
+	origPods := itest.RunningPods(ctx, svc, s.AppNamespace())
+	rq.NotEmpty(origPods)
+
+	port, cancel := itest.StartLocalHttpEchoServer(ctx, svc)
+	defer cancel()
+
+	itest.TelepresenceOk(ctx, "intercept",
+		"--port", strconv.Itoa(port)+":80",
+		"--mount", "false",
+		svc)
+	mustDetach := true
+	defer func() {
+		if mustDetach {
+			itest.TelepresenceOk(ctx, "detach", svc)
+		}
+	}()
+
+	itest.PingInterceptedEchoServer(ctx, svc, "80")
+
+	rq.Len(s.nodeAgentJobNames(ctx, svc), 1,
+		"expected a node-agent Job when client.nodeAgent.enabled=true and --node-agent is not passed")
+	s.assertNoAgentInjected(ctx, svc, origPods)
+
+	itest.TelepresenceOk(ctx, "detach", svc)
+	mustDetach = false
+
+	rq.Eventually(func() bool {
+		return len(s.nodeAgentJobNames(ctx, svc)) == 0
+	}, 60*time.Second, 2*time.Second, "node-agent Job was not reaped after detach")
+}
+
+// Test_FlagOverridesClusterDefault verifies that an explicit
+// --node-agent=false wins over the cluster-provided default: the intercept
+// falls back to sidecar injection, so a traffic-agent container appears in
+// the workload's pod and no node-agent Job is created.
+func (s *nodeAgentClusterDefaultSuite) Test_FlagOverridesClusterDefault() {
+	const svc = "echo-optout"
+	ctx := s.Context()
+	rq := s.Require()
+
+	port, cancel := itest.StartLocalHttpEchoServer(ctx, svc)
+	defer cancel()
+
+	itest.TelepresenceOk(ctx, "intercept",
+		"--node-agent=false",
+		"--port", strconv.Itoa(port)+":80",
+		"--mount", "false",
+		svc)
+	mustDetach := true
+	defer func() {
+		if mustDetach {
+			itest.TelepresenceOk(ctx, "detach", svc)
+		}
+	}()
+
+	itest.PingInterceptedEchoServer(ctx, svc, "80")
+
+	s.Empty(s.nodeAgentJobNames(ctx, svc),
+		"no node-agent Job may be created when --node-agent=false is given")
+	rq.NotEmpty(itest.RunningPodsWithAgents(ctx, svc, s.AppNamespace()),
+		"expected a traffic-agent sidecar to be injected when --node-agent=false overrides the cluster default")
+
+	itest.TelepresenceOk(ctx, "detach", svc)
+	mustDetach = false
+}

--- a/pkg/vif/testdata/router/go.mod
+++ b/pkg/vif/testdata/router/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
-	github.com/telepresenceio/telepresence/rpc/v2 v2.29.3 // indirect
+	github.com/telepresenceio/telepresence/rpc/v2 v2.30.0-rc.0 // indirect
 	github.com/vishvananda/netlink v1.3.1 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect


### PR DESCRIPTION
Release preparation for the v2.30.0-rc.0 release candidate: go.mod references updated by `make prepare-release`. The release ships the node-agent (node-hosted traffic-agent) feature, the nftables migration, and the restructured documentation with the new attachment vocabulary and the `telepresence detach` command.