### PR TITLE
Refresh the compose CLI model for Docker Compose v5.3

### DIFF
--- a/docs/reference/cli/telepresence_compose_run.md
+++ b/docs/reference/cli/telepresence_compose_run.md
@@ -37,8 +37,8 @@ Run a one-off command on a service
   -i, --interactive                 Keep STDIN open even if not attached (default true)
   -l, --label stringArray           Add or override a label
       --name string                 Assign a name to the container
-  -T, --no-TTY                      Disable pseudo-TTY allocation (default: auto-detected) (default true)
       --no-deps                     Don't start linked services
+  -T, --no-tty                      Disable pseudo-TTY allocation (default: auto-detected) (default true)
   -p, --publish stringArray         Publish a container's port(s) to the host
       --pull string                 Pull image before running (&quot;always&quot;|&quot;missing&quot;|&quot;never&quot;) (default &quot;policy&quot;)
   -q, --quiet                       Don't print anything to STDOUT

--- a/pkg/client/cli/docker/compose/dc-cli.json
+++ b/pkg/client/cli/docker/compose/dc-cli.json
@@ -1097,15 +1097,15 @@
           "description": "Assign a name to the container"
         },
         {
-          "name": "no-TTY",
-          "shorthand": "T",
-          "type": "bool",
-          "description": "Disable pseudo-TTY allocation (default: auto-detected) (default true)"
-        },
-        {
           "name": "no-deps",
           "type": "bool",
           "description": "Don't start linked services"
+        },
+        {
+          "name": "no-tty",
+          "shorthand": "T",
+          "type": "bool",
+          "description": "Disable pseudo-TTY allocation (default: auto-detected) (default true)"
         },
         {
           "name": "publish",


### PR DESCRIPTION
Docker Compose renamed `--no-TTY` to `--no-tty` on the run command. This regenerates `dc-cli.json` against Compose v5.3.0 and the compose CLI reference doc with it. Until committed, every local build regenerates the file and leaves the working tree dirty for anyone on a current Compose.