### PR TITLE
Package the mirrord comparison for the queries people use

### DIFF
--- a/docs/compare/mirrord.md
+++ b/docs/compare/mirrord.md
@@ -1,17 +1,19 @@
 ---
-title: "Telepresence vs mirrord"
+title: "mirrord vs Telepresence"
+description: "An honest, maintainer-written comparison of mirrord and Telepresence for local Kubernetes development: architectures, security models, a feature table, and when each tool is the better alternative."
 hide_table_of_contents: true
 ---
 
-# Telepresence vs mirrord
+# mirrord vs Telepresence
 
 Telepresence and mirrord solve the same problem: run one service on your
 workstation, with your own IDE and debugger, while it behaves as if it were
 running inside the cluster. They solve it with fundamentally different
 architectures, and nearly every practical difference between the two tools
 follows from that choice. Neither architecture is simply better — they
-distribute their costs differently, and which tool fits you depends on which
-costs you would rather pay.
+distribute their costs differently, and which costs you would rather pay is
+what should decide, whether you are picking a first tool or looking for an
+alternative to the one you use today.
 
 ## Two architectures
 

--- a/docs/doc-links.yml
+++ b/docs/doc-links.yml
@@ -269,7 +269,7 @@
       link: reference/node-agent
 - title: Comparisons
   items:
-    - title: Telepresence vs mirrord
+    - title: mirrord vs Telepresence
       link: compare/mirrord
     - title: Telepresence vs Gefyra
       link: compare/gefyra

--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -14,3 +14,8 @@
 - {from: "reference/docker-run", to: "howtos/docker"}
 - {from: "reference/tun-device", to: "reference/routing"}
 - {from: "reference/dns", to: "reference/routing"}
+- {from: "howtos/intercepts", to: "howtos/attach"}
+- {from: "reference/intercepts/cli", to: "reference/attachments/cli"}
+- {from: "reference/cluster_config", to: "reference/cluster-config"}
+- {from: "reference/client", to: "reference/config"}
+- {from: "reference/teleroute", to: "howtos/docker"}


### PR DESCRIPTION
Search Console shows the reversed phrasing dominates: "mirrord vs telepresence" gets 25x the impressions of the title's word order, and the page ranks around position 40 for it while holding position 1 for the phrasing nobody searches. It also ranks first for "mirrord alternative" with zero clicks, because the snippet never says alternative.

- Flip the title and heading to "mirrord vs Telepresence" and align the nav label.
- Add a meta description that mentions the alternative-seeking reader, and touch the intro accordingly.
- Add redirects for the legacy unversioned paths the coverage report lists as 404s: the intercepts-era howto and CLI reference, the underscored cluster_config spelling, the old client reference, and the never-published teleroute page.