### PR TITLE
Report agent type and node-agent creation in usage reports

### DIFF
--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -38,6 +38,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
+	"github.com/telepresenceio/telepresence/v2/pkg/usg"
 )
 
 // PrepareIntercept ensures that the given request can be matched against the intercept configuration of
@@ -519,6 +520,12 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		// has stored it.
 		s.startNodeAgentPodWatch(spec.Agent, spec.Namespace)
 	}
+
+	agentType := "sidecar"
+	if spec.NodeAgent {
+		agentType = "node"
+	}
+	usg.Quick(ctx, "manager.attach", "agent.type", agentType, "mechanism", spec.Mechanism)
 	return client, is.InterceptInfo, nil
 }
 
@@ -636,10 +643,14 @@ func (s *State) EnsureAgent(ctx context.Context, sessionID tunnel.SessionID, n, 
 			s.removeLease(sessionID, n, ns)
 			return nil, err
 		}
+		usg.Quick(ctx, "manager.attach", "agent.type", "node")
 		return as, nil
 	}
 
 	_, as, err = s.ensureAgent(ctx, wl, false, false, nil, agentconfig.ReplacePolicyInactive)
+	if err == nil {
+		usg.Quick(ctx, "manager.attach", "agent.type", "sidecar")
+	}
 	return as, err
 }
 

--- a/cmd/traffic/cmd/manager/state/intercept_test.go
+++ b/cmd/traffic/cmd/manager/state/intercept_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/log"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/usg"
 )
 
 // TestAllowGlobalIntercepts_ValidationLogic tests the validation logic
@@ -720,4 +721,85 @@ func TestWaitForAgents_AccumulatesToExpectedCount(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("waitForAgents did not return after the second agent arrived")
 	}
+}
+
+// TestAddIntercept_NodeAgent_ReportsAttach verifies that a successful
+// node-agent AddIntercept emits a "manager.attach" usage report carrying
+// agent.type=node and the intercept's mechanism.
+func TestAddIntercept_NodeAgent_ReportsAttach(t *testing.T) {
+	t.Parallel()
+
+	const ns = "default"
+	const mgrNs = "ambassador"
+
+	dep := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "test-agent", Namespace: ns},
+		Spec: apps.DeploymentSpec{
+			Selector: &meta.LabelSelector{MatchLabels: map[string]string{"app": "test-agent"}},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{Labels: map[string]string{"app": "test-agent"}},
+				Spec: core.PodSpec{
+					Containers: []core.Container{{
+						Name:  "app",
+						Ports: []core.ContainerPort{{ContainerPort: 8080}},
+					}},
+				},
+			},
+		},
+	}
+	pod := nodeAgentTestPod(ns, "test-agent-abc123")
+
+	ci := fake.NewSimpleClientset(dep, pod)
+	ctx := k8sapi.WithJoinedClientSetInterface(t.Context(), ci, argorolloutsfake.NewSimpleClientset())
+
+	env := &managerutil.Env{
+		ManagerNamespace:     mgrNs,
+		NodeAgentEnabled:     true,
+		NodeAgentCRISocket:   "/run/containerd/containerd.sock",
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind},
+		AgentArrivalTimeout:  5 * time.Second,
+	}
+	ctx = managerutil.WithEnv(ctx, env)
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	ctx = managerutil.WithResolvedAgentImageRetriever(ctx, managerutil.ImageFromEnv("ghcr.io/telepresenceio/tel2:2.99.0"))
+	ctx, sink := usg.InstallManager(ctx, "test-install")
+
+	s := &State{
+		backgroundCtx:        ctx,
+		intercepts:           cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:               cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		clients:              xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		leases:               xsync.NewMap[leaseKey, struct{}](),
+		workloadWatchers:     xsync.NewMap[string, Watcher](),
+		nodeAgentPodWatchers: xsync.NewMap[nodeAgentWatchKey, struct{}](),
+		timedLogLevel:        log.NewTimedLevel(slog.LevelDebug, clog.SetTreeLevel),
+		llSubs:               newLoglevelSubscribers(),
+	}
+
+	const sessionID = tunnel.SessionID("sessionA")
+	s.clients.Store(sessionID, &ClientSession{ClientInfo: &rpc.ClientInfo{Name: "userA@hostA"}, sessionState: sessionState{id: sessionID}})
+
+	// The node-agent Job's own agent session is already registered by the
+	// time AddIntercept waits for it, mirroring waitForAgents' immediate-wait
+	// property exercised elsewhere in this file.
+	s.agents.Store(sessionID, &AgentSession{AgentInfo: &rpc.AgentInfo{
+		Name: "test-agent", Namespace: ns, NodeAgent: true, PodUid: "uid-1", PodName: "test-agent-abc123",
+	}})
+
+	cir := &rpc.CreateInterceptRequest{
+		Session: &rpc.SessionInfo{SessionId: string(sessionID)},
+		InterceptSpec: &rpc.InterceptSpec{
+			Name: "ic1", Client: "userA@hostA", Agent: "test-agent", Namespace: ns,
+			WorkloadKind: string(k8sapi.DeploymentKind), NodeAgent: true, Wiretap: true, Mechanism: "tcp",
+		},
+	}
+	_, ii, err := s.AddIntercept(ctx, cir)
+	require.NoError(t, err)
+	require.NotNil(t, ii)
+
+	reports := sink.Drain(0)
+	require.Len(t, reports, 1)
+	assert.Equal(t, "manager.attach", reports[0].Topic)
+	assert.Equal(t, "node", reports[0].Entries["agent.type"])
+	assert.Equal(t, "tcp", reports[0].Entries["mechanism"])
 }

--- a/cmd/traffic/cmd/manager/state/nodeagent.go
+++ b/cmd/traffic/cmd/manager/state/nodeagent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/pkg/usg"
 )
 
 const (
@@ -340,6 +341,12 @@ func (s *State) ensureNodeAgent(
 	return ensureNodeAgentTarget(ctx, jobs, namespace, env.NodeAgentCRISocket, cfg, targets[0], allowImageReplace)
 }
 
+// reportNodeAgentJobCreate emits a manager.nodeagent.create usage report for
+// a newly created node-agent Job. No-op without a usage producer on ctx.
+func reportNodeAgentJobCreate(ctx context.Context, trigger string) {
+	usg.Quick(ctx, "manager.nodeagent.create", "trigger", trigger)
+}
+
 // ensureNodeAgentTarget ensures a single node-agent Job for target: the
 // per-Job create/AlreadyExists/staleness logic, extracted from
 // ensureNodeAgent so it runs unchanged whether it's applied to every target
@@ -387,6 +394,7 @@ func ensureNodeAgentTarget(
 			if _, err = jobs.Create(ctx, job, meta.CreateOptions{}); err != nil {
 				return fmt.Errorf("unable to create node-agent job %s.%s: %w", job.Name, namespace, err)
 			}
+			reportNodeAgentJobCreate(ctx, "ensure")
 			return nil
 		}
 		switch staleness, reason := nodeAgentJobStale(existing, job); staleness {
@@ -405,7 +413,9 @@ func ensureNodeAgentTarget(
 			// a re-request as idempotent.
 			clog.Debugf(ctx, "reusing existing node-agent job %s.%s", job.Name, namespace)
 		}
+		return nil
 	}
+	reportNodeAgentJobCreate(ctx, "ensure")
 	return nil
 }
 
@@ -509,6 +519,7 @@ func replaceNodeAgentJob(ctx context.Context, jobs batchClientV1.JobInterface, j
 	if _, err := jobs.Create(ctx, job, meta.CreateOptions{}); err != nil {
 		return fmt.Errorf("unable to create node-agent job %s: %w", job.Name, err)
 	}
+	reportNodeAgentJobCreate(ctx, "replace")
 	return nil
 }
 

--- a/cmd/traffic/cmd/manager/state/nodeagent_test.go
+++ b/cmd/traffic/cmd/manager/state/nodeagent_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/usg"
 )
 
 // TestNodeAgentGateErr_Disabled verifies that requesting node-agent mode
@@ -942,6 +943,7 @@ func TestEnsureNodeAgent_NoCRISocket(t *testing.T) {
 	ci := fake.NewSimpleClientset(pod)
 	ctx := k8sapi.WithK8sInterface(t.Context(), ci)
 	ctx = managerutil.WithEnv(ctx, &managerutil.Env{ManagerNamespace: mgrNs})
+	ctx, sink := usg.InstallManager(ctx, "test-install")
 
 	s := newNodeAgentTestState()
 	err := s.ensureNodeAgent(ctx, wl, cfg, true)
@@ -949,6 +951,11 @@ func TestEnsureNodeAgent_NoCRISocket(t *testing.T) {
 
 	created, _ := nodeAgentJobActionCounts(ci.Actions())
 	assert.Equal(t, 1, created, "a job should be created in auto-detect mode when the CRI socket is unset")
+
+	reports := sink.Drain(0)
+	require.Len(t, reports, 1)
+	assert.Equal(t, "manager.nodeagent.create", reports[0].Topic)
+	assert.Equal(t, "ensure", reports[0].Entries["trigger"])
 }
 
 // TestEnsureNodeAgent_ReusesHealthyExistingJob verifies that ensureNodeAgent
@@ -1010,6 +1017,7 @@ func TestEnsureNodeAgent_ReplacesFailedJob(t *testing.T) {
 	ci := fake.NewSimpleClientset(pod, existing)
 	ctx := k8sapi.WithK8sInterface(t.Context(), ci)
 	ctx = managerutil.WithEnv(ctx, &managerutil.Env{ManagerNamespace: mgrNs, NodeAgentCRISocket: "/run/containerd/containerd.sock"})
+	ctx, sink := usg.InstallManager(ctx, "test-install")
 
 	s := newNodeAgentTestState()
 	require.NoError(t, s.ensureNodeAgent(ctx, wl, cfg, true))
@@ -1022,6 +1030,11 @@ func TestEnsureNodeAgent_ReplacesFailedJob(t *testing.T) {
 	created, deleted := nodeAgentJobActionCounts(ci.Actions())
 	assert.Equal(t, 1, deleted)
 	assert.Equal(t, 2, created)
+
+	reports := sink.Drain(0)
+	require.Len(t, reports, 1, "only the replacement create should be reported, not the failed initial attempt")
+	assert.Equal(t, "manager.nodeagent.create", reports[0].Topic)
+	assert.Equal(t, "replace", reports[0].Entries["trigger"])
 }
 
 // TestEnsureNodeAgent_ReplacesTerminatingJob verifies that ensureNodeAgent


### PR DESCRIPTION
Usage reporting previously said nothing about which agent serves an attachment. Now:

- Every successful manager-side attachment emits a `manager.attach` report with `agent.type` (`sidecar` or `node`): from `AddIntercept` for the intercept-family modes (with the `mechanism` included), and from `EnsureAgent` for ingests.
- The manager emits `manager.nodeagent.create` whenever it actually creates a node-agent Job, with a `trigger` entry distinguishing first-time creation (`ensure`) from stale-Job replacement (`replace`). Idempotent reuse and failed creates stay silent.

Both values are bounded, tool-intrinsic strings per the pkg/usg ground rules; no workload, namespace, or user-derived data is added. No context plumbing was needed: gRPC handler contexts fall back to the manager's root context, which carries the producer, and the pod-watch reconciler runs on the state's background context.

Unit tests assert the report on the AddIntercept node-agent path and on both Job-creation triggers, including that a replacement emits exactly one report.