### PR TITLE
Surface GitHub Discussions in the README and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ for the full picture.
 
 ## Community
 
+- [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions) - Ask questions, share ideas, and help shape the roadmap
 - [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) - Join [#telepresence-oss](https://cloud-native.slack.com/archives/C06B36KJ85P)
 - [Troubleshooting](https://telepresence.io/docs/troubleshooting/) - Common issues and solutions
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -97,4 +97,4 @@ Yes, it is! You'll find both source code and documentation in the [Telepresence 
 
 #### How do I share my feedback on Telepresence?
 
-Your feedback is always appreciated and helps us build a product that provides as much value as possible for our community. You can chat with us directly on our #telepresence-oss channel at the [CNCF Slack](https://slack.cncf.io), and also report issues or create pull-requests on the GitHub repository.
+Your feedback is always appreciated and helps us build a product that provides as much value as possible for our community. You can ask questions and share ideas in [GitHub Discussions](https://github.com/telepresenceio/telepresence/discussions), chat with us on our #telepresence-oss channel at the [CNCF Slack](https://slack.cncf.io), and also report issues or create pull-requests on the GitHub repository.


### PR DESCRIPTION
Adds **GitHub Discussions** to the community touchpoints in the docs source and the repository README, listed ahead of the CNCF Slack. This is the telepresence-repo companion to telepresenceio/telepresence.io#291, which did the same across the website and blog.

## Changes
- **README** — new `GitHub Discussions` bullet at the top of the Community section, above the CNCF Slack.
- **docs/faqs.md** — the "How do I share my feedback?" answer now leads with GitHub Discussions before the #telepresence-oss / CNCF Slack link. This is the source the website's versioned FAQ is generated from.

## Why
GitHub Discussions has far lower entry friction than the CNCF Slack workspace (no separate sign-up), it lives next to the code, issues, and releases, and its threads are search-indexed so answers compound over time.

Docs source only — no generated files changed (`faqs.md` is hand-authored; the site regenerates its versioned copy from it).