### PR TITLE
Tidy the 2.30.1 changelog

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -39,12 +39,6 @@ items:
           can keep the sidecar as the default while still allowing node-agent
           attachments by setting it to <code>false</code>.
         docs: reference/node-agent
-      - type: change
-        title: The traffic-manager reports node-agent and agent-injector enablement
-        body: >-
-          The traffic-manager's anonymous usage report now records whether
-          node-agent mode and the agent-injector are enabled, so adoption of
-          the agent modes can be measured.
       - type: bugfix
         title: Ports forwarded with --to-pod bind the loopback interface only
         body: >-

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,12 +8,6 @@
 Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
 </div>
 
-## <div style="display:flex;"><img src="images/change.png" alt="change" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">The traffic-manager reports node-agent and agent-injector enablement</div></div>
-<div style="margin-left: 15px">
-
-The traffic-manager's anonymous usage report now records whether node-agent mode and the agent-injector are enabled, so adoption of the agent modes can be measured.
-</div>
-
 ## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ports forwarded with --to-pod bind the loopback interface only</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -15,12 +15,6 @@ Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also
   </Body>
 </Note>
 <Note>
-	<Title type="change">The traffic-manager reports node-agent and agent-injector enablement</Title>
-	<Body>
-The traffic-manager's anonymous usage report now records whether node-agent mode and the agent-injector are enabled, so adoption of the agent modes can be measured.
-  </Body>
-</Note>
-<Note>
 	<Title type="bugfix">Ports forwarded with --to-pod bind the loopback interface only</Title>
 	<Body>
 The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.


### PR DESCRIPTION
Drops a 2.30.1 release-note entry that didn't need to be in the notes. No functional change.