### PR TITLE
Consolidate per-client watchers into a combined session-events stream

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -39,6 +39,30 @@ items:
           fallback whenever the QUIC endpoint is disabled or unreachable, and
           <code>telepresence status</code> now reports which transport is
           active.
+      - type: change
+        title: One combined traffic-manager watcher per client
+        body: >-
+          The client now registers a single combined watcher stream
+          (<code>WatchSessionEvents</code>) with the traffic-manager for
+          everything related to workloads and attachments: agent pods and the
+          client's intercepts. The user daemon relays the agent-pod events to
+          the root daemon locally, halving the number of watcher streams the
+          traffic-manager serves per client. Bulk container data
+          (environments, mounts) is no longer streamed at all; it is fetched
+          on demand when an attachment needs it. Both directions remain fully
+          backward compatible: a new client degrades to the separate watchers
+          against an older traffic-manager, and an older client keeps using
+          them against a new one.
+      - type: bugfix
+        title: Ingests in other namespaces survive agent churn in the connected namespace
+        body: >-
+          An ingest into a namespace other than the connected one would lose
+          its volume mounts and port-forwards as soon as any traffic-agent
+          activity occurred in the connected namespace, because the agent
+          snapshot bookkeeping treated every ingest as belonging to the
+          connected namespace. The bookkeeping is now namespace-aware, and a
+          same-named workload in the connected namespace can no longer be
+          mistaken for the ingested one.
   - version: 2.30.1
     date: 2026-07-17
     notes:

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -619,14 +619,31 @@ func (s *service) WatchAgentPodsInNamespacesDelta(request *rpc.AgentsRequest, st
 	return s.watchAgentPodsDelta(ctx, namespaces, stream)
 }
 
-func (s *service) watchAgentPodsDelta(ctx context.Context, namespaces []string, stream grpc.ServerStreamingServer[rpc.AgentPodInfoDelta]) error {
-	clientSessionID := managerutil.GetSessionID(ctx)
-	agentsCh, interceptsCh, sessionDone := s.createAgentPodWatchers(ctx, namespaces)
-	agentPodInfos := cache.NewMap[string, *rpc.AgentPodInfo](func(a *rpc.AgentPodInfo, b *rpc.AgentPodInfo) bool {
-		return proto.Equal(a, b)
-	}, time.Millisecond)
+// agentPodProjection folds AgentSession deltas into a debounced, deduped map
+// of rpc.AgentPodInfo -- the projection shared by watchAgentPodsDelta and
+// WatchSessionEvents: inactive-pod filtering (mutator.Map), the per-client
+// Intercepted flag (state.IsInterceptedBy) and QuicSni (quicSNIForAgent).
+type agentPodProjection struct {
+	s               *service
+	clientSessionID tunnel.SessionID
+	m               mutator.Map
+	agentPodInfos   *cache.Map[string, *rpc.AgentPodInfo]
+}
 
-	m := mutator.GetMap(ctx)
+func (s *service) newAgentPodProjection(ctx context.Context, clientSessionID tunnel.SessionID) *agentPodProjection {
+	return &agentPodProjection{
+		s:               s,
+		clientSessionID: clientSessionID,
+		m:               mutator.GetMap(ctx),
+		agentPodInfos: cache.NewMap[string, *rpc.AgentPodInfo](func(a *rpc.AgentPodInfo, b *rpc.AgentPodInfo) bool {
+			return proto.Equal(a, b)
+		}, time.Millisecond),
+	}
+}
+
+// run starts the goroutine that folds agentsCh deltas into the projection.
+// It exits when ctx is done or sessionDone is closed.
+func (p *agentPodProjection) run(ctx context.Context, sessionDone <-chan struct{}, agentsCh <-chan cache.Delta[tunnel.SessionID, *state.AgentSession]) {
 	go func() {
 		for {
 			select {
@@ -636,7 +653,7 @@ func (s *service) watchAgentPodsDelta(ctx context.Context, namespaces []string, 
 				return
 			case delta := <-agentsCh:
 				for k, a := range delta.Upserts {
-					if m.IsInactive(types.UID(a.PodUid)) {
+					if p.m.IsInactive(types.UID(a.PodUid)) {
 						continue
 					}
 					aip, parseErr := netip.ParseAddr(a.PodIp)
@@ -651,38 +668,54 @@ func (s *service) watchAgentPodsDelta(ctx context.Context, namespaces []string, 
 						Namespace:    a.Namespace,
 						PodIp:        aip.AsSlice(),
 						ApiPort:      a.ApiPort,
-						Intercepted:  s.state.IsInterceptedBy(a.Name, a.Namespace, clientSessionID),
+						Intercepted:  p.s.state.IsInterceptedBy(a.Name, a.Namespace, p.clientSessionID),
 						NodeAgent:    a.NodeAgent,
 						QuicSni:      quicSNIForAgent(a.QuicPort, a.PodUid),
+						Version:      a.Version,
 					}
-					agentPodInfos.Store(string(k), ap)
+					p.agentPodInfos.Store(string(k), ap)
 				}
 				for k := range delta.Removals {
-					agentPodInfos.Delete(string(k))
+					p.agentPodInfos.Delete(string(k))
 				}
 			}
 		}
 	}()
+}
 
-	refreshIntercepted := func() {
-		agentPodInfos.Range(func(k string, a *rpc.AgentPodInfo) bool {
-			if m.IsInactive(types.UID(a.PodId)) {
-				return true
-			}
-			intercepted := s.state.IsInterceptedBy(a.WorkloadName, a.Namespace, clientSessionID)
-			agentPodInfos.Compute(k, func(a *rpc.AgentPodInfo, loaded bool) (*rpc.AgentPodInfo, xsync.ComputeOp) {
-				if loaded && a.Intercepted != intercepted {
-					a := proto.Clone(a).(*rpc.AgentPodInfo)
-					a.Intercepted = intercepted
-					return a, xsync.UpdateOp
-				}
-				return a, xsync.CancelOp
-			})
+// refreshIntercepted recomputes the Intercepted flag for every projected
+// pod, updating (and thereby re-notifying) only the ones whose flag
+// actually flipped.
+func (p *agentPodProjection) refreshIntercepted() {
+	p.agentPodInfos.Range(func(k string, a *rpc.AgentPodInfo) bool {
+		if p.m.IsInactive(types.UID(a.PodId)) {
 			return true
+		}
+		intercepted := p.s.state.IsInterceptedBy(a.WorkloadName, a.Namespace, p.clientSessionID)
+		p.agentPodInfos.Compute(k, func(a *rpc.AgentPodInfo, loaded bool) (*rpc.AgentPodInfo, xsync.ComputeOp) {
+			if loaded && a.Intercepted != intercepted {
+				a := proto.Clone(a).(*rpc.AgentPodInfo)
+				a.Intercepted = intercepted
+				return a, xsync.UpdateOp
+			}
+			return a, xsync.CancelOp
 		})
-	}
+		return true
+	})
+}
 
-	agentPodInfosCh := agentPodInfos.Subscribe(ctx.Done(), nil)
+// subscribe returns the channel of deltas produced by the projection.
+func (p *agentPodProjection) subscribe(done <-chan struct{}) <-chan cache.Delta[string, *rpc.AgentPodInfo] {
+	return p.agentPodInfos.Subscribe(done, nil)
+}
+
+func (s *service) watchAgentPodsDelta(ctx context.Context, namespaces []string, stream grpc.ServerStreamingServer[rpc.AgentPodInfoDelta]) error {
+	clientSessionID := managerutil.GetSessionID(ctx)
+	agentsCh, interceptsCh, sessionDone := s.createAgentPodWatchers(ctx, namespaces)
+	proj := s.newAgentPodProjection(ctx, clientSessionID)
+	proj.run(ctx, sessionDone, agentsCh)
+
+	agentPodInfosCh := proj.subscribe(ctx.Done())
 	for {
 		select {
 		case <-ctx.Done():
@@ -690,7 +723,7 @@ func (s *service) watchAgentPodsDelta(ctx context.Context, namespaces []string, 
 		case <-sessionDone:
 			return nil
 		case <-interceptsCh:
-			refreshIntercepted()
+			proj.refreshIntercepted()
 		case delta := <-agentPodInfosCh:
 			if err := stream.Send(&rpc.AgentPodInfoDelta{Upserts: delta.Upserts, Removals: maps2.KeySlice(delta.Removals)}); err != nil {
 				return err
@@ -907,6 +940,65 @@ func (s *service) WatchInterceptsDelta(session *rpc.SessionInfo, stream grpc.Ser
 			clog.Debugf(ctx, "Sending %d upserts and %d removals", len(iid.Upserts), len(iid.Removals))
 			err = stream.Send(&iid)
 			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// WatchSessionEvents multiplexes the agent-pod projection (scoped to the
+// connected namespace plus the requested namespaces, same shape and
+// semantics as watchAgentPodsDelta) and this client's own intercepts onto a
+// single stream.
+func (s *service) WatchSessionEvents(request *rpc.SessionEventsRequest, stream grpc.ServerStreamingServer[rpc.SessionEventsDelta]) error {
+	ctx, clientInfo, err := s.ensureClientSession(stream.Context(), request.Session)
+	if err != nil {
+		return err
+	}
+	namespaces, err := s.agentPodNamespaces(ctx, clientInfo, request.Namespaces)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(namespaces, clientInfo.Namespace) {
+		namespaces = append(namespaces, clientInfo.Namespace)
+		sort.Strings(namespaces)
+	}
+
+	clientSessionID := managerutil.GetSessionID(ctx)
+	agentsCh, refreshCh, sessionDone := s.createAgentPodWatchers(ctx, namespaces)
+	proj := s.newAgentPodProjection(ctx, clientSessionID)
+	proj.run(ctx, sessionDone, agentsCh)
+	agentPodInfosCh := proj.subscribe(ctx.Done())
+
+	interceptsCh, _, err := s.watchIntercepts(ctx, request.Session)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sessionDone:
+			return nil
+		case <-refreshCh:
+			proj.refreshIntercepted()
+		case delta := <-agentPodInfosCh:
+			clog.Debugf(ctx, "Sending %d agent-pod upserts and %d agent-pod removals", len(delta.Upserts), len(delta.Removals))
+			apid := &rpc.AgentPodInfoDelta{Upserts: delta.Upserts, Removals: maps2.KeySlice(delta.Removals)}
+			if err := stream.Send(&rpc.SessionEventsDelta{AgentPods: apid}); err != nil {
+				return err
+			}
+		case delta := <-interceptsCh:
+			iid := rpc.InterceptInfoDelta{Removals: maps2.KeySlice(delta.Removals)}
+			if rl := len(delta.Upserts); rl > 0 {
+				iid.Upserts = make(map[string]*rpc.InterceptInfo, rl)
+				for k, v := range delta.Upserts {
+					iid.Upserts[k] = v.InterceptInfo
+				}
+			}
+			clog.Debugf(ctx, "Sending %d intercept upserts and %d intercept removals", len(iid.Upserts), len(iid.Removals))
+			if err := stream.Send(&rpc.SessionEventsDelta{Intercepts: &iid}); err != nil {
 				return err
 			}
 		}

--- a/cmd/traffic/cmd/manager/service_sessionevents_test.go
+++ b/cmd/traffic/cmd/manager/service_sessionevents_test.go
@@ -1,0 +1,400 @@
+package manager
+
+import (
+	"io"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/types"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+
+	"github.com/telepresenceio/clog/testutil"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
+	testdata "github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/test"
+)
+
+// recvAgentPodsDelta receives from wse until it gets a message whose
+// AgentPods field carries an actual upsert or removal. The underlying
+// cache.Map subscription (shared with watchAgentPodsDelta) always sends an
+// initial snapshot on subscribe -- even an empty one -- so a non-empty check
+// is needed to skip past it and past any interleaved intercepts-only
+// message.
+func recvAgentPodsDelta(t *testing.T, wse rpc.Manager_WatchSessionEventsClient) *rpc.AgentPodInfoDelta {
+	t.Helper()
+	for {
+		delta, err := wse.Recv()
+		require.NoError(t, err)
+		if delta.AgentPods != nil && (len(delta.AgentPods.Upserts) > 0 || len(delta.AgentPods.Removals) > 0) {
+			return delta.AgentPods
+		}
+	}
+}
+
+// recvInterceptsDelta receives from wse until it gets a message whose
+// Intercepts field carries an actual upsert or removal. Unlike the
+// agent-pods branch, the intercepts branch mirrors WatchInterceptsDelta and
+// always sends -- including an empty message for the initial (empty)
+// subscription snapshot -- so a non-empty check is needed to skip past it.
+func recvInterceptsDelta(t *testing.T, wse rpc.Manager_WatchSessionEventsClient) *rpc.InterceptInfoDelta {
+	t.Helper()
+	for {
+		delta, err := wse.Recv()
+		require.NoError(t, err)
+		if delta.Intercepts != nil && (len(delta.Intercepts.Upserts) > 0 || len(delta.Intercepts.Removals) > 0) {
+			return delta.Intercepts
+		}
+	}
+}
+
+// TestWatchSessionEvents_AgentInConnectedNamespace proves that an agent
+// arriving in the client's connected namespace is delivered on the
+// agent-pods side of the multiplexed stream, projected into AgentPodInfo
+// (workload name, pod name, namespace, pod IP, api port, and the agent's
+// version).
+func TestWatchSessionEvents_AgentInConnectedNamespace(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+	testAgents := testdata.GetTestAgents(t)
+
+	conn, _, _ := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{Session: aliceSess})
+	req.NoError(err)
+
+	helloAgent := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+	helloAgent.PodIp = "10.1.2.3"
+	_, err = client.ArriveAsAgent(ctx, helloAgent)
+	req.NoError(err)
+
+	agentPods := recvAgentPodsDelta(t, wse)
+	req.Len(agentPods.Upserts, 1)
+	for _, a := range agentPods.Upserts {
+		req.Equal(helloAgent.Name, a.WorkloadName)
+		req.Equal(helloAgent.PodName, a.PodName)
+		req.Equal(helloAgent.Namespace, a.Namespace)
+		ip, ok := netip.AddrFromSlice(a.PodIp)
+		req.True(ok)
+		req.Equal(helloAgent.PodIp, ip.String())
+		req.Equal(helloAgent.ApiPort, a.ApiPort)
+		req.Equal(helloAgent.Version, a.Version, "the agent's version must be carried on the projected AgentPodInfo")
+	}
+}
+
+// TestWatchSessionEvents_AgentInRequestedNamespace proves that an agent in a
+// namespace that was requested (via SessionEventsRequest.Namespaces) but is
+// not the client's connected namespace arrives too -- there is no slimming
+// concept on this stream: AgentPodInfo is always fully populated, whatever
+// namespace the agent is in.
+func TestWatchSessionEvents_AgentInRequestedNamespace(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+	testAgents := testdata.GetTestAgents(t)
+
+	conn, _, _ := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{
+		Session:    aliceSess,
+		Namespaces: []string{"other"},
+	})
+	req.NoError(err)
+
+	otherAgent := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+	otherAgent.Namespace = "other"
+	otherAgent.PodUid = "other-ns-pod-uid"
+	otherAgent.PodIp = "10.1.2.3"
+	_, err = client.ArriveAsAgent(ctx, otherAgent)
+	req.NoError(err)
+
+	agentPods := recvAgentPodsDelta(t, wse)
+	req.Len(agentPods.Upserts, 1)
+	for _, a := range agentPods.Upserts {
+		req.Equal("other", a.Namespace)
+		req.Equal(otherAgent.Version, a.Version)
+	}
+}
+
+// TestWatchSessionEvents_AgentOutsideRequestedNamespaceExcluded proves that
+// an agent whose namespace is neither the connected namespace nor among the
+// requested namespaces is never delivered on the stream.
+func TestWatchSessionEvents_AgentOutsideRequestedNamespaceExcluded(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+	testAgents := testdata.GetTestAgents(t)
+
+	conn, _, _ := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{
+		Session:    aliceSess,
+		Namespaces: []string{"other"},
+	})
+	req.NoError(err)
+
+	// This agent's namespace is not requested and not the connected namespace:
+	// it must never produce a delta message on this stream.
+	excludedAgent := proto.Clone(testAgents["demo1"]).(*rpc.AgentInfo)
+	excludedAgent.Namespace = "excluded"
+	excludedAgent.PodUid = "excluded-ns-pod-uid"
+	excludedAgent.PodIp = "10.1.2.5"
+	_, err = client.ArriveAsAgent(ctx, excludedAgent)
+	req.NoError(err)
+
+	// A sentinel agent in the connected namespace is used to prove that the
+	// stream is alive and that the excluded agent's arrival produced no
+	// message of its own -- the first (and only) delta received must be the
+	// sentinel.
+	sentinel := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+	sentinel.PodIp = "10.1.2.3"
+	_, err = client.ArriveAsAgent(ctx, sentinel)
+	req.NoError(err)
+
+	agentPods := recvAgentPodsDelta(t, wse)
+	req.Len(agentPods.Upserts, 1)
+	for _, a := range agentPods.Upserts {
+		req.Equal(sentinel.PodUid, a.PodId, "the excluded-namespace agent must not be delivered")
+	}
+}
+
+// TestWatchSessionEvents_OwnInterceptOnly proves that the intercepts side of
+// the multiplexed stream carries this client's own intercepts, and not
+// another client's.
+func TestWatchSessionEvents_OwnInterceptOnly(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+
+	conn, mgr, svcCtx := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+	bobSess, err := client.ArriveAsClient(ctx, testClients["bob"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{Session: aliceSess})
+	req.NoError(err)
+
+	aliceIntercept := &rpc.InterceptInfo{
+		Id: aliceSess.SessionId + ":alice-intercept",
+		Spec: &rpc.InterceptSpec{
+			Name:      "alice-intercept",
+			Client:    testClients["alice"].Name,
+			Agent:     "hello",
+			Namespace: "default",
+			Mechanism: "tcp",
+		},
+		Disposition:   rpc.InterceptDispositionType_WAITING,
+		ClientSession: aliceSess,
+	}
+	bobIntercept := &rpc.InterceptInfo{
+		Id: bobSess.SessionId + ":bob-intercept",
+		Spec: &rpc.InterceptSpec{
+			Name:      "bob-intercept",
+			Client:    testClients["bob"].Name,
+			Agent:     "hello",
+			Namespace: "default",
+			Mechanism: "tcp",
+		},
+		Disposition:   rpc.InterceptDispositionType_WAITING,
+		ClientSession: bobSess,
+	}
+	// Bob's intercept is restored first: since it is filtered out at the
+	// subscription level (not Alice's own), it must produce no delta message
+	// of its own -- the first non-empty delta Alice's stream receives must be
+	// for her own intercept, restored second. RestoreIntercepts is given the
+	// server's own context (not the test's) because it looks up the target
+	// workload via the k8s client installed on that context.
+	mgr.State().RestoreIntercepts(svcCtx, []*rpc.InterceptInfo{bobIntercept}, time.Now())
+	mgr.State().RestoreIntercepts(svcCtx, []*rpc.InterceptInfo{aliceIntercept}, time.Now())
+
+	intercepts := recvInterceptsDelta(t, wse)
+	req.Len(intercepts.Upserts, 1)
+	for _, ii := range intercepts.Upserts {
+		req.Equal(aliceIntercept.Id, ii.Id, "only the client's own intercept must be delivered")
+	}
+}
+
+// TestWatchSessionEvents_InterceptedFlipsOnActiveIntercept proves that once
+// the watching client's intercept for a workload transitions to ACTIVE, the
+// agent-pod projection for that workload's pod is re-sent with
+// Intercepted == true -- driven by the refresh-intercepted channel, exactly
+// as watchAgentPodsDelta behaves.
+func TestWatchSessionEvents_InterceptedFlipsOnActiveIntercept(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+	testAgents := testdata.GetTestAgents(t)
+
+	conn, mgr, svcCtx := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{Session: aliceSess})
+	req.NoError(err)
+
+	helloAgent := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+	helloAgent.PodIp = "10.1.2.3"
+	_, err = client.ArriveAsAgent(ctx, helloAgent)
+	req.NoError(err)
+
+	agentPods := recvAgentPodsDelta(t, wse)
+	req.Len(agentPods.Upserts, 1)
+	for _, a := range agentPods.Upserts {
+		req.False(a.Intercepted, "must not be intercepted before any intercept exists")
+	}
+
+	aliceIntercept := &rpc.InterceptInfo{
+		Id: aliceSess.SessionId + ":alice-intercept",
+		Spec: &rpc.InterceptSpec{
+			Name:      "alice-intercept",
+			Client:    testClients["alice"].Name,
+			Agent:     helloAgent.Name,
+			Namespace: helloAgent.Namespace,
+			Mechanism: "tcp",
+		},
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: aliceSess,
+	}
+	mgr.State().RestoreIntercepts(svcCtx, []*rpc.InterceptInfo{aliceIntercept}, time.Now())
+
+	// The restore drives both the intercepts field (own intercept, ACTIVE)
+	// and, via the refresh-intercepted channel, a re-sent agent-pod upsert.
+	// Read agent-pod deltas (skipping any interleaved intercepts-field
+	// message) until the workload's Intercepted flag is seen flipped to true.
+	for {
+		delta := recvAgentPodsDelta(t, wse)
+		flipped := false
+		for _, a := range delta.Upserts {
+			if a.WorkloadName == helloAgent.Name && a.Intercepted {
+				flipped = true
+			}
+		}
+		if flipped {
+			break
+		}
+	}
+}
+
+// TestWatchSessionEvents_StreamEndsOnSessionDone proves that the stream ends
+// cleanly (io.EOF, no error) when the watching client's session is removed.
+func TestWatchSessionEvents_StreamEndsOnSessionDone(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+
+	conn, _, _ := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{Session: aliceSess})
+	req.NoError(err)
+
+	// Wait for the handler's initial (empty) intercepts snapshot so the
+	// server-side subscriptions are known to be armed; departing before the
+	// handler has looked the session up makes it error out rather than end
+	// cleanly, which is correct behavior but not what this test is about.
+	_, err = wse.Recv()
+	req.NoError(err)
+
+	_, err = client.Depart(ctx, aliceSess)
+	req.NoError(err)
+
+	// Drain any messages already in flight (e.g. the initial, empty
+	// intercepts snapshot) before the stream closes; the terminal error must
+	// be io.EOF, not something else.
+	for {
+		_, err = wse.Recv()
+		if err != nil {
+			break
+		}
+	}
+	req.ErrorIs(err, io.EOF, "the stream must end cleanly when the client session is removed")
+}
+
+// TestWatchSessionEvents_InactiveAgentFiltered proves that an agent whose
+// pod has been marked inactive via mutator.Map.Inactivate is never delivered
+// as an upsert.
+func TestWatchSessionEvents_InactiveAgentFiltered(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	req := require.New(t)
+
+	testClients := testdata.GetTestClients(t)
+	testAgents := testdata.GetTestAgents(t)
+
+	conn, mgr, svcCtx := getTestClientConnAndService(ctx, t, nil)
+	defer conn.Close()
+	client := rpc.NewManagerClient(conn)
+
+	aliceSess, err := client.ArriveAsClient(ctx, testClients["alice"])
+	req.NoError(err)
+
+	wse, err := client.WatchSessionEvents(ctx, &rpc.SessionEventsRequest{Session: aliceSess})
+	req.NoError(err)
+
+	inactiveAgent := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+	inactiveAgent.PodUid = "inactive-pod-uid"
+
+	// Mark the pod inactive before the agent's AgentSession ever lands in state.
+	// ArriveAsAgent (which calls state.AddAgent) itself refuses to add an agent
+	// for an already-inactive pod, so RestoreAgents -- which performs no such
+	// check -- is used to get the (inactive) AgentSession into state directly,
+	// the way a manager restart would restore agents that raced with an
+	// eviction.
+	mutator.GetMap(svcCtx).Inactivate(types.UID(inactiveAgent.PodUid))
+	mgr.State().RestoreAgents([]*rpc.AgentInfo{inactiveAgent}, time.Now())
+
+	// A sentinel arrives normally right after; it proves the stream is alive
+	// and that the inactive agent's upsert produced no message of its own.
+	sentinel := proto.Clone(testAgents["demo1"]).(*rpc.AgentInfo)
+	sentinel.PodIp = "10.1.2.6"
+	_, err = client.ArriveAsAgent(ctx, sentinel)
+	req.NoError(err)
+
+	agentPods := recvAgentPodsDelta(t, wse)
+	req.Len(agentPods.Upserts, 1)
+	for _, a := range agentPods.Upserts {
+		req.Equal(sentinel.PodUid, a.PodId, "the inactive agent must not be delivered")
+	}
+}

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -447,6 +447,17 @@ func TestGetQuicTunnelEndpoint_Gating(t *testing.T) {
 }
 
 func getTestClientConn(ctx context.Context, t *testing.T, extraObjects []runtime.Object, envMods ...func(*managerutil.Env)) *grpc.ClientConn {
+	conn, _, _ := getTestClientConnAndService(ctx, t, extraObjects, envMods...)
+	return conn
+}
+
+// getTestClientConnAndService is identical to getTestClientConn, but also
+// returns the manager Service (for direct state access, e.g. RestoreIntercepts)
+// and the context the server runs with (for direct mutator.Map access, e.g.
+// marking a pod inactive via mutator.GetMap(ctx).Inactivate).
+func getTestClientConnAndService(
+	ctx context.Context, t *testing.T, extraObjects []runtime.Object, envMods ...func(*managerutil.Env),
+) (*grpc.ClientConn, Service, context.Context) {
 	const bufsize = 64 * 1024
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
@@ -489,12 +500,13 @@ func getTestClientConn(ctx context.Context, t *testing.T, extraObjects []runtime
 			Namespace: mgrNs,
 		},
 		Data: map[string]string{
-			"namespace-selector.yaml": ` 
+			"namespace-selector.yaml": `
 matchExpressions:
 - key: kubernetes.io/metadata.name
   operator: In
   values:
     - default
+    - other
 `,
 			"agent-state.yaml": ``,
 		},
@@ -571,7 +583,7 @@ matchExpressions:
 			t.Error(err)
 		}
 	})
-	return conn
+	return conn, mgr, ctx
 }
 
 func Test_hasDomainSuffix(t *testing.T) {

--- a/docs/plans/single-client-watcher/design.md
+++ b/docs/plans/single-client-watcher/design.md
@@ -1,0 +1,334 @@
+# Single client watcher for workload and attachment events
+
+## Problem
+
+Each connected client currently holds four concurrent watcher streams against the
+traffic-manager, spread over two gRPC connections (the user daemon's and the root
+daemon's):
+
+| Stream | Held by | Payload | Scope |
+|--------|---------|---------|-------|
+| `WatchAgentsDelta` | user daemon (`trafficmgr/agents.go`) | `AgentInfo` (heavy: container env, mounts) | connected namespace |
+| `WatchInterceptsDelta` | user daemon (`trafficmgr/intercept.go`) | `InterceptInfo` | this client's intercepts |
+| `WatchAgentPodsInNamespacesDelta` | root daemon (`agentpf/clients.go`) | `AgentPodInfo` (slim: pod IP, api port, intercepted, quic SNI) | all port-forwardable mapped namespaces |
+| `WatchClusterInfo` | root daemon (`rootd/session.go`) | `ClusterInfo` | cluster networking |
+
+On the manager side, the first three all derive from the same two internal state
+watchers (`state.WatchAgents`, `state.WatchIntercepts`); serving them as separate
+streams costs one goroutine set and one set of internal subscriptions per stream,
+per client: five subscriptions across three streams.
+
+The streams are also denormalized and heavy:
+
+- For the connected namespace, every agent pod is transmitted twice, in two
+  shapes, on two connections (`AgentInfo` on the user daemon's watcher,
+  `AgentPodInfo` on the root daemon's).
+- The `AgentInfo` stream continuously carries the containers map — per-container
+  **environment variables** (which can be tens of KB), mount points, and mount
+  policies — re-sending all of it in every upsert of an agent, on every pod
+  churn event, even though the user daemon only reads it when an ingest is
+  created or its backing pod is replaced. Intercepts never read it at all:
+  their environment, ports, and mount point arrive in `InterceptInfo`.
+
+## Goal
+
+One traffic-manager watcher stream per client for everything related to
+workloads and attachments, registered by the **user daemon**, which relays the
+agent-pod events to the root daemon. The second remaining stream is
+`WatchClusterInfo` (unchanged, still held by the root daemon).
+
+Requirements:
+
+1. **Full normalization.** Each fact crosses the manager→client boundary
+   exactly once, in exactly one shape. Bulk container data (environments,
+   mounts, ports) is not streamed at all: it is retrieved on demand — from
+   the `EnsureAgent` response when an ingest needs it, and from
+   `InterceptInfo` for intercepts.
+2. **No partially populated structs.** A message type on a stream is always
+   fully populated. In particular, no "slimmed" `AgentInfo` whose containers
+   map is silently absent.
+3. **Bidirectional backward compatibility.** A new client against any older
+   supported traffic-manager, and an old client against a new traffic-manager,
+   must both behave exactly as today. Compatibility is discovered the way the
+   existing fallback chains discover it — by probing and reacting to
+   `Unimplemented` — never by assuming version parity.
+
+Net result per client: manager-side watcher streams go from 4 to 2, internal
+manager subscriptions from 5 to 3, `AgentInfo` (and its container payload)
+disappears from watch streams entirely, and the agent-pod projection is
+computed once, by the manager, in one shape.
+
+## Design
+
+### 1. New manager RPC: `WatchSessionEvents`
+
+```proto
+message SessionEventsRequest {
+  SessionInfo session = 1;
+  // Namespaces in which the client wants agent-pod events in addition to
+  // the connected namespace: the mapped namespaces the client is permitted
+  // to port-forward to. Validated by the manager exactly like
+  // WatchAgentPodsInNamespacesDelta (agentPodNamespaces).
+  repeated string namespaces = 2;
+}
+
+message SessionEventsDelta {
+  // Agent pods in the requested namespaces plus the session's connected
+  // namespace. Same projection as WatchAgentPodsInNamespacesDelta,
+  // including the per-client intercepted flag and quic_sni.
+  AgentPodInfoDelta agent_pods = 1;
+
+  // The watching client's intercepts.
+  InterceptInfoDelta intercepts = 2;
+}
+
+rpc WatchSessionEvents(SessionEventsRequest) returns (stream SessionEventsDelta);
+```
+
+`AgentPodInfo` is amended with one field — `string version = 10` (the agent's
+version, needed by `telepresence list`); with that, it is sufficient for every
+stream consumer, and every instance on the wire is fully populated. The
+`intercepted` flag stays manager-computed (as on the legacy agent-pod streams):
+it is derivable from the intercepts on the same stream, but it is one boolean,
+and carrying it makes the userd→rootd relay a pure pass-through instead of a
+derivation layer whose equivalence with the manager would have to be
+maintained by tests. The payload-redundancy requirement is about bulk data,
+which this stream no longer carries at all.
+
+The three legacy RPCs (and their non-delta fallbacks) remain served, unchanged,
+for older clients.
+
+**Manager implementation** (`cmd/traffic/cmd/manager/service.go`): the
+agent-pod projection used by `watchAgentPodsDelta` (AgentSession →
+`AgentPodInfo` with inactive-pod filtering, `IsInterceptedBy`,
+`quicSNIForAgent`, debounced `cache.Map` dedup — now also filling `version`)
+is extracted into a helper shared by the legacy handler and the new one. The
+combined handler runs three internal subscriptions per client (down from five
+across three streams):
+
+- one `state.WatchAgents` filtered on namespace ∈ (requested ∪ connected),
+  feeding the shared projection;
+- one `state.WatchIntercepts` with the legacy client-session filter, driving
+  the `Intercepted` refresh (exactly `createAgentPodWatchers`' channel);
+- one `state.WatchIntercepts` via the existing `watchIntercepts` helper (own,
+  not REMOVED, not child), feeding the stream's `intercepts` field.
+
+Ordering bonus: agent-pod and intercept events arrive serialized on one
+stream, removing a class of cross-stream races.
+
+### 2. User daemon: one combined watcher loop, on-demand container data
+
+`startServices` runs one `session-events` goroutine (replacing the `agents`
+and `intercept-port-forward` pair) plus the relay runner. The combined loop is
+a single `watcher.WatchWithRetry` over `WatchSessionEvents`, maintaining an
+agent-pod map and an intercept map, dispatching:
+
+- `delta.AgentPods` → fold into the pod map; update the session's internal
+  agent-pod cache (below); run the ingest lifecycle; forward the delta as-is
+  to the relay.
+- `delta.Intercepts` → fold, `handleInterceptSnapshot` (unchanged consumer,
+  including the `podAccessTracker`) — **on a dedicated goroutine**, fed
+  through a one-slot coalescing mailbox of full snapshots. The intercept
+  handler can block in `ensureAccess` waiting for the root daemon to learn
+  an agent-pod IP, and that pod's delta may be queued *behind* the intercept
+  delta on the same multiplexed stream; handling intercepts inline would
+  starve the relay until the wait times out (observed on stream
+  re-establishment after a traffic-manager restart, where the initial
+  intercepts snapshot precedes the initial agent-pod snapshot). The
+  dedicated goroutine restores the legacy concurrency model, where the
+  intercept loop only ever blocked itself.
+
+The repair function clears both maps, marks the relay for a reset
+(`beginSync`), and calls `s.reconnectManager()`. Final cleanup on exit mirrors
+the legacy loops' tails (empty snapshots so port-forwards and mounts are
+cancelled), skipped when an immediate `Unimplemented` probe failure hands the
+lifecycle to the legacy fallback.
+
+**Internal agent-pod cache.** `session.currentAgents []*manager.AgentInfo` is
+replaced by a small domain type holding exactly what its consumers read —
+workload, namespace, pod name, agent version, node-agent flag — built from
+`AgentPodInfo` in combined mode and projected from `AgentInfo` in legacy
+fallback mode. This keeps proto structs fully populated or absent, never
+partial. Consumers:
+
+- `WorkloadInfoSnapshot` (list): workload name + agent version.
+- `Ingest`: existence and node-agent flag only (see below).
+- `ReconnectClient`: **no longer sends agents at all.** The client has no
+  full `AgentInfo`s to restore, and restoring pod-shaped stubs into manager
+  state would hand other consumers partially populated structs. Traffic-agents
+  hold their own manager sessions and re-arrive on their own within seconds of
+  a manager restart; intercepts are still restored in full (the client keeps
+  complete `InterceptInfo`s). The proto field remains for older clients.
+
+**Ingest reads container data on demand.** `Ingest` always obtains its full
+`AgentInfo` (env, mounts, container names, kind, sftp/ftp ports) from the
+`EnsureAgent` response — the path cross-namespace ingests already take today.
+The pod cache is consulted only for the fast path (an existing ingest for the
+same key returns immediately) and for node-agent semantics: a cached
+node-agent silently satisfies a plain ingest request (the request to
+`EnsureAgent` is made with node-agent set so the manager must not inject a
+sidecar on top), and a cached sidecar rejects a `--node-agent` request, both
+exactly as today.
+
+**Ingest lifecycle (fixes a pre-existing defect).** The per-snapshot walk that
+keeps ingest mounts alive becomes namespace-correct:
+
+- Matching is by workload **and namespace** (today `infosForKey` matches by
+  workload name only, so a same-named workload in the connected namespace can
+  hijack a cross-namespace ingest's agent identity).
+- When the backing pod of an ingest is replaced, the full `AgentInfo` for the
+  new pod is refetched via `EnsureAgent` (synchronously, with the standard
+  API timeout; pod replacement is rare) and the container environment is
+  re-translated. This makes replacement failover work for cross-namespace
+  ingests for the first time.
+- `cancelUnwanted` is scoped to the namespaces the snapshot actually covers
+  (requested ∪ connected in combined mode, connected only in legacy mode), so
+  an ingest in an uncovered namespace is no longer killed by unrelated agent
+  churn — the pre-existing latent bug that the combined stream would otherwise
+  have made deterministic.
+
+**Manager compatibility: the user daemon owns it entirely.** On
+`Unimplemented`, the loop falls back to driving the three legacy manager
+watchers itself: `WatchAgentsDelta`→`WatchAgents` (feeding the internal pod
+cache via projection), `WatchInterceptsDelta`→`WatchIntercepts`, and the
+agent-pod chain `WatchAgentPodsInNamespacesDelta`→`WatchAgentPodsDelta`→
+`WatchAgentPods` (extracted as `agentpf.WatchPods`, shared with the root
+daemon's legacy self-watch mode), feeding the relay as-is. The relay contract
+toward the root daemon is identical no matter how old the manager is.
+`s.managerVersion` may be consulted to skip a doomed probe, but `Unimplemented`
+handling is the authoritative mechanism.
+
+### 3. Relaying agent-pod events to the root daemon
+
+New RPC on the root daemon's `daemon.Daemon` service (user daemon is the
+caller — the root daemon is already the gRPC server in this pair):
+
+```proto
+message AgentPodsDelta {
+  // When true, discard all previously received agent-pod state before
+  // applying the upserts/removals in this message. Set on the first message
+  // of every relay stream and whenever the user daemon's traffic-manager
+  // watcher has been re-established.
+  bool reset = 1;
+  map<string, manager.AgentPodInfo> upserts = 2;
+  repeated string removals = 3;
+}
+
+rpc WatchAgentPods(stream AgentPodsDelta) returns (google.protobuf.Empty);
+```
+
+The relay is a **pass-through** in both combined and legacy modes: the
+manager-computed `AgentPodInfo` is forwarded unchanged, so both modes are
+identical by construction. The user daemon accumulates the current pod map so
+that a (re)connecting root daemon can be brought to a known state with a
+`reset` + full snapshot; subsequent pushes are minimal diffs.
+
+- The user daemon opens this client-streaming call after `connectRootDaemon`
+  succeeds (and re-opens it after `reconnectRootDaemon`). Deltas that arrive
+  while the relay is down are absorbed into the accumulated map — nothing is
+  lost, the next `reset` snapshot covers them.
+- In-process mode (`RootSessionInProcess`, docker/pod daemon): no gRPC —
+  `InProcSession` exposes `ApplyAgentPodsDelta` and the user daemon calls it
+  directly.
+
+**Namespace source of truth.** The user daemon computes the port-forwardable
+namespace set once (`GetCurrentNamespaces(true)` filtered through
+`k8s.CanPortForward` — the computation the root daemon's `Start` used to do)
+and passes it both to the manager (`SessionEventsRequest.namespaces`) and to
+the root daemon (`NetworkConfig.agent_pod_namespaces`), so all parties agree
+without computing it independently. Non-empty presence of the `NetworkConfig`
+field also tells the root daemon that the user daemon owns the agent-pod
+watch.
+
+### 4. Root daemon / agentpf changes
+
+`agentpf.Clients` gains a delta-sink entry point alongside the existing
+self-watching `WatchAgentPods`:
+
+```go
+ApplyPodsDelta(reset bool, upserts map[string]*manager.AgentPodInfo, removals []string) error
+RunDeltaSink(rmc manager.ManagerClient) error
+```
+
+`ApplyPodsDelta` shares the snapshot-map + `updateClients` path with the
+self-watching mode; `RunDeltaSink` takes over the lifecycle duties (manager
+client registration for lazy QUIC endpoint fetches, teardown) that previously
+rode on the self-watch. In `rootd/session.Start`, the mode is decided solely
+by `NetworkConfig.agent_pod_namespaces` — the manager's version plays no part
+(the user daemon absorbs manager compatibility, §2). The legacy self-watch
+remains, its fallback chain extracted into `agentpf.WatchPods` so the user
+daemon reuses the same implementation.
+
+A relay stream that dies while the session lives is re-established by the user
+daemon (with `reset=true`); the root daemon never falls back to self-watching
+mid-session — if the user daemon is gone, the session is dead anyway.
+
+### 5. Compatibility matrix
+
+| user daemon | root daemon | manager | Behavior |
+|-------------|-------------|---------|----------|
+| new | new | new | Combined watcher + relay. 2 manager streams per client. |
+| new | new | old | `WatchSessionEvents` probe → `Unimplemented` → userd drives the three legacy manager watchers itself and relays pod info as-is. Rootd stays in relay mode, oblivious to manager age. Same manager load as today (4 streams), all on the userd's connection. |
+| new | new | very old (pre-delta RPCs) | The per-watcher fallback chains bottom out exactly as today (`WatchAgents`, `WatchIntercepts`, `WatchAgentPods` full snapshots). Relay unchanged. |
+| new | old | new/old | Rootd ignores the unknown `NetworkConfig` field and self-watches (legacy manager RPCs still served, with rootd's own fallback chain); userd's relay call returns `Unimplemented` → log and stop relaying. Correct, just one redundant stream. |
+| old | new | new | No `agent_pod_namespaces` in `NetworkConfig` → rootd self-watches via its retained legacy code. Today's behavior. |
+| old | any | new | Legacy RPCs, unchanged wire behavior — additions only in the proto, no field or RPC removed or renumbered. |
+
+No legacy RPC is removed from the manager, and no legacy fallback chain is
+removed from the client. The traffic-agent's use of `WatchInterceptsDelta`
+(agent→manager) is untouched. `ReconnectClientRequest.agents` remains served
+for old clients; new clients simply leave it empty.
+
+### 6. Normalization constraints going forward
+
+- `AgentPodInfo` is the single streamed shape for everything pod-level that
+  clients learn from the manager. Any future pod-level fact goes there.
+- Container-level data (environments, mounts, ports) is never streamed; it
+  travels only in `EnsureAgent`/`GetAgentConfig` responses and in
+  `InterceptInfo`. Any future bulk per-container fact follows the same rule.
+- Proto messages on a stream are always fully populated; a consumer that needs
+  less defines its own narrower type (as the user daemon's internal agent-pod
+  cache does) rather than receiving a partially filled shared shape.
+
+### 7. Out of scope / future work
+
+- **`WatchClusterInfo` stays as-is** (root daemon, own stream). The user
+  daemon's `GetClusterSubnets` also opens a short-lived `WatchClusterInfo`;
+  request-scoped, unchanged.
+- **`WatchWorkloads`** (per-namespace, started lazily by `ensureWatchers` for
+  list/status) is not folded in; a natural follow-up once the combined stream
+  exists.
+
+### 8. Testing
+
+- **Manager**: unit tests for `WatchSessionEvents`: pod projection per
+  namespace scoping (requested ∪ connected, exclusion outside), version
+  field, `Intercepted` flip on intercept creation/removal, inactive-pod
+  filtering, own-intercepts-only on the intercepts field, session-done
+  teardown. Shared-projection refactor must keep `watchAgentPodsDelta` tests
+  green.
+- **proto**: additions only; `make protoc` + protolint; `proto-rpc-reviewer`
+  checks.
+- **userd**: pod-cache building from both stream shapes; ingest lifecycle
+  (namespace-correct matching, replacement refetch, scoped cancelUnwanted —
+  an ingest in an uncovered namespace survives connected-namespace churn);
+  Ingest node-agent semantics via the pod cache; relay pass-through and reset
+  semantics (fake sink, both stream and in-process); fallback compatibility
+  (degrade through legacy chains with identical relay output).
+- **agentpf**: existing `ApplyPodsDelta`/`WatchPods` tests unchanged.
+- **Integration**: intercept + ingest suites against the new path; verify via
+  manager logs that clients ride `WatchSessionEvents`; manager-restart
+  reconnect (intercepts restored, agents re-arrive on their own).
+
+### 9. Implementation order
+
+1. proto: amend `AgentPodInfo` (`version`), redefine `SessionEventsDelta`
+   (`agent_pods`), `make protoc`. (The previous `AgentInfoDelta`-based shape
+   never shipped; this branch is its only user.)
+2. Manager: shared agent-pod projection helper (+`version`), reworked
+   combined handler, tests.
+3. userd: internal pod cache, `Ingest` via `EnsureAgent`, namespace-correct
+   ingest lifecycle + scoped `cancelUnwanted`, pass-through relay, reconnect
+   without agents, legacy fallback projection; tests.
+4. Changelog (feature wording + bugfix entry for the cross-namespace ingest
+   mount defect) and verification chain.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,19 @@ The client now registers a single combined watcher stream (<code>WatchSessionEve
 An ingest into a namespace other than the connected one would lose its volume mounts and port-forwards as soon as any traffic-agent activity occurred in the connected namespace, because the agent snapshot bookkeeping treated every ingest as belonging to the connected namespace. The bookkeeping is now namespace-aware, and a same-named workload in the connected namespace can no longer be mistaken for the ingested one.
 </div>
 
+## Version 2.30.1 <span style="font-size: 16px;">(July 17)</span>
+## <div style="display:flex;"><img src="images/change.png" alt="change" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Enabling node-agent mode makes it the client default](reference/node-agent)</div></div>
+<div style="margin-left: 15px">
+
+Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
+</div>
+
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ports forwarded with --to-pod bind the loopback interface only</div></div>
+<div style="margin-left: 15px">
+
+The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.
+</div>
+
 ## Version 2.30.0 <span style="font-size: 16px;">(July 14)</span>
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Node-hosted traffic-agent](reference/node-agent)</div></div>
 <div style="margin-left: 15px">

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,17 +8,16 @@
 The traffic-manager can now expose a QUIC endpoint for the tunnel (Helm chart value <code>quicTunnel.enabled</code>). When the endpoint is reachable, the client automatically upgrades new tunneled connections to it, removing the head-of-line blocking that the shared port-forwarded gRPC connection imposes across flows. The port-forwarded gRPC transport remains the default and is used as the fallback whenever the QUIC endpoint is disabled or unreachable, and <code>telepresence status</code> now reports which transport is active.
 </div>
 
-## Version 2.30.1 <span style="font-size: 16px;">(July 17)</span>
-## <div style="display:flex;"><img src="images/change.png" alt="change" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Enabling node-agent mode makes it the client default](reference/node-agent)</div></div>
+## <div style="display:flex;"><img src="images/change.png" alt="change" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">One combined traffic-manager watcher per client</div></div>
 <div style="margin-left: 15px">
 
-Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
+The client now registers a single combined watcher stream (<code>WatchSessionEvents</code>) with the traffic-manager for everything related to workloads and attachments: agent pods and the client's intercepts. The user daemon relays the agent-pod events to the root daemon locally, halving the number of watcher streams the traffic-manager serves per client. Bulk container data (environments, mounts) is no longer streamed at all; it is fetched on demand when an attachment needs it. Both directions remain fully backward compatible: a new client degrades to the separate watchers against an older traffic-manager, and an older client keeps using them against a new one.
 </div>
 
-## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ports forwarded with --to-pod bind the loopback interface only</div></div>
+## <div style="display:flex;"><img src="images/bugfix.png" alt="bugfix" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">Ingests in other namespaces survive agent churn in the connected namespace</div></div>
 <div style="margin-left: 15px">
 
-The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.
+An ingest into a namespace other than the connected one would lose its volume mounts and port-forwards as soon as any traffic-agent activity occurred in the connected namespace, because the agent snapshot bookkeeping treated every ingest as belonging to the connected namespace. The bookkeeping is now namespace-aware, and a same-named workload in the connected namespace can no longer be mistaken for the ingested one.
 </div>
 
 ## Version 2.30.0 <span style="font-size: 16px;">(July 14)</span>

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -14,17 +14,16 @@ import { Note, Title, Body } from '@site/src/components/ReleaseNotes'
 The traffic-manager can now expose a QUIC endpoint for the tunnel (Helm chart value <code>quicTunnel.enabled</code>). When the endpoint is reachable, the client automatically upgrades new tunneled connections to it, removing the head-of-line blocking that the shared port-forwarded gRPC connection imposes across flows. The port-forwarded gRPC transport remains the default and is used as the fallback whenever the QUIC endpoint is disabled or unreachable, and <code>telepresence status</code> now reports which transport is active.
   </Body>
 </Note>
-## Version 2.30.1 <span style={{fontSize:'16px'}}>(July 17)</span>
 <Note>
-	<Title type="change" docs="reference/node-agent">Enabling node-agent mode makes it the client default</Title>
+	<Title type="change">One combined traffic-manager watcher per client</Title>
 	<Body>
-Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
+The client now registers a single combined watcher stream (<code>WatchSessionEvents</code>) with the traffic-manager for everything related to workloads and attachments: agent pods and the client's intercepts. The user daemon relays the agent-pod events to the root daemon locally, halving the number of watcher streams the traffic-manager serves per client. Bulk container data (environments, mounts) is no longer streamed at all; it is fetched on demand when an attachment needs it. Both directions remain fully backward compatible: a new client degrades to the separate watchers against an older traffic-manager, and an older client keeps using them against a new one.
   </Body>
 </Note>
 <Note>
-	<Title type="bugfix">Ports forwarded with --to-pod bind the loopback interface only</Title>
+	<Title type="bugfix">Ingests in other namespaces survive agent churn in the connected namespace</Title>
 	<Body>
-The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.
+An ingest into a namespace other than the connected one would lose its volume mounts and port-forwards as soon as any traffic-agent activity occurred in the connected namespace, because the agent snapshot bookkeeping treated every ingest as belonging to the connected namespace. The bookkeeping is now namespace-aware, and a same-named workload in the connected namespace can no longer be mistaken for the ingested one.
   </Body>
 </Note>
 ## Version 2.30.0 <span style={{fontSize:'16px'}}>(July 14)</span>

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -26,6 +26,19 @@ The client now registers a single combined watcher stream (<code>WatchSessionEve
 An ingest into a namespace other than the connected one would lose its volume mounts and port-forwards as soon as any traffic-agent activity occurred in the connected namespace, because the agent snapshot bookkeeping treated every ingest as belonging to the connected namespace. The bookkeeping is now namespace-aware, and a same-named workload in the connected namespace can no longer be mistaken for the ingested one.
   </Body>
 </Note>
+## Version 2.30.1 <span style={{fontSize:'16px'}}>(July 17)</span>
+<Note>
+	<Title type="change" docs="reference/node-agent">Enabling node-agent mode makes it the client default</Title>
+	<Body>
+Installing the traffic-manager with <code>nodeAgent.enabled=true</code> now also makes the node-agent the default mode for client attachments; previously the client-side default had to be enabled separately through the Helm chart's <code>client.nodeAgent.enabled</code> value. An explicitly set <code>client.nodeAgent.enabled</code> always wins, so administrators can keep the sidecar as the default while still allowing node-agent attachments by setting it to <code>false</code>.
+  </Body>
+</Note>
+<Note>
+	<Title type="bugfix">Ports forwarded with --to-pod bind the loopback interface only</Title>
+	<Body>
+The local listeners created for <code>--to-pod</code> ports bound all workstation interfaces, exposing the forwarded pod ports to the local network. They now bind the loopback interface, matching the flag's documented <code>localhost:PORT</code> contract. A containerized daemon is unaffected: its listeners stay on all interfaces of the daemon container's private network namespace, which docker port publishing requires.
+  </Body>
+</Note>
 ## Version 2.30.0 <span style={{fontSize:'16px'}}>(July 14)</span>
 <Note>
 	<Title type="feature" docs="reference/node-agent">Node-hosted traffic-agent</Title>

--- a/integration_test/itest/cluster.go
+++ b/integration_test/itest/cluster.go
@@ -890,6 +890,11 @@ func TelepresenceCmd(ctx context.Context, args ...string) *exec.Cmd {
 	})
 
 	gh := GetGlobalHarness(ctx)
+	if len(args) > 0 && args[0] == "detach" && !gh.ClientIsVersion(">2.29.x") {
+		// The detach verb was introduced in 2.30.0. Older clients, driven when
+		// DEV_CLIENT_VERSION points at a previous release, use its predecessor.
+		args = append([]string{"leave"}, args[1:]...)
+	}
 	if len(args) > 0 && (args[0] == "connect") {
 		rest := args[1:]
 		args = append(make([]string, 0, len(args)+3), args[0])

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -27,7 +27,6 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/portforward"
 	grpcClient "github.com/telepresenceio/telepresence/v2/pkg/grpc/client"
-	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
@@ -338,6 +337,16 @@ type Clients interface {
 	GetRandomAgent(context.Context) agent.AgentClient
 	GetClient(netip.Addr) tunnel.Provider
 	WatchAgentPods(rmc manager.ManagerClient) error
+
+	// ApplyPodsDelta applies one agent-pod delta pushed by the user daemon. When reset
+	// is true, all previously applied state is discarded first.
+	ApplyPodsDelta(reset bool, upserts map[string]*manager.AgentPodInfo, removals []string) error
+
+	// RunDeltaSink is the relay-mode counterpart of WatchAgentPods: it records the
+	// manager client used for lazy QUIC endpoint fetches, then blocks until the
+	// session ends, performing the same teardown as WatchAgentPods on exit.
+	RunDeltaSink(rmc manager.ManagerClient) error
+
 	WaitForIP(ctx context.Context, timeout time.Duration, namespace string, ip netip.Addr) error
 	WaitForWorkload(timeout time.Duration, name string) error
 	GetWorkloadClient(workload string) (ag tunnel.Provider)
@@ -411,6 +420,13 @@ type clients struct {
 	// retried. Guarded by snapshotMu.
 	snapshotMu sync.RWMutex
 	snapshot   map[string]*manager.AgentPodInfo
+
+	// deltaMu guards deltaSnapshot, the snapshot map maintained by ApplyPodsDelta.
+	// Separate from snapshotMu (and from the self-watch mode's local snapMap in
+	// WatchAgentPods) because relay pushes can race with the user daemon's relay
+	// stream being re-established.
+	deltaMu       sync.Mutex
+	deltaSnapshot map[string]*manager.AgentPodInfo
 
 	// dialMetrics, when non-nil, receives a callback for every dial
 	// request accepted (or rejected) by a started dial watcher. Guarded
@@ -494,13 +510,6 @@ func (s *clients) watchesNamespace(namespace string) bool {
 	_, ok := s.namespaces[namespace]
 	s.namespacesMu.RUnlock()
 	return ok
-}
-
-func (s *clients) agentsRequest() *manager.AgentsRequest {
-	return &manager.AgentsRequest{
-		Session:    s.session,
-		Namespaces: s.namespaceList(),
-	}
 }
 
 // GetClient returns tunnel.Provider that opens a tunnel to a known traffic-agent.
@@ -724,65 +733,60 @@ func (s *clients) Transports() []AgentTransport {
 
 func (s *clients) WatchAgentPods(rmc manager.ManagerClient) error {
 	s.setManagerClient(rmc)
-	defer func() {
-		activeCount := 0
-		s.clients.Range(func(_ string, ac *client) bool {
-			if ac.cancel() {
-				activeCount++
-			}
-			return true
-		})
-		clog.Debugf(s, "WatchAgentPods ending with %d clients still active", activeCount)
-		s.disabled.Store(true)
-	}()
+	defer s.teardown()
 
 	snapMap := make(map[string]*manager.AgentPodInfo)
-	err := watcher.WatchWithRetry(s, "WatchAgentPodsInNamespacesDelta", tpClient.GetConfig(s).Grpc().WatchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoDelta], error) {
-			clog.Debugf(ctx, "WatchAgentPodsInNamespacesDelta starting")
-			return rmc.WatchAgentPodsInNamespacesDelta(ctx, s.agentsRequest())
-		},
-		func(delta *manager.AgentPodInfoDelta) error {
-			clog.Debugf(s, "WatchAgentPodsInNamespacesDelta received %d upserts, %d removals", len(delta.Upserts), len(delta.Removals))
-			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
+	return WatchPods(s, rmc, s.session, s.namespaceList(), s.Namespace,
+		func(upserts map[string]*manager.AgentPodInfo, removals []string) error {
+			maps.DeltaUpdate(snapMap, upserts, removals)
 			return s.updateClients(maps.Values(snapMap))
-		}, func() error {
+		},
+		func() error {
 			clear(snapMap)
 			return nil
-		})
-	if err == nil || status.Code(err) != codes.Unimplemented {
-		return err
-	}
-
-	// Older traffic-manager. Fall back to watching agents in the connected namespace.
-	s.setNamespaces([]string{s.Namespace})
-	clog.Warnf(s, "WatchAgentPodsInNamespacesDelta is not implemented by the traffic-manager, falling back to WatchAgentPodsDelta in namespace %s", s.Namespace)
-	err = watcher.WatchWithRetry(s, "WatchAgentPodsDelta", tpClient.GetConfig(s).Grpc().WatchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoDelta], error) {
-			clog.Debugf(ctx, "WatchAgentPodsDelta starting")
-			return rmc.WatchAgentPodsDelta(ctx, s.session)
 		},
-		func(delta *manager.AgentPodInfoDelta) error {
-			clog.Debugf(s, "WatchAgentPodsDelta received %d upserts, %d removals", len(delta.Upserts), len(delta.Removals))
-			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
-			return s.updateClients(maps.Values(snapMap))
-		}, func() error {
-			clear(snapMap)
-			return nil
-		})
-	if err == nil || status.Code(err) != codes.Unimplemented {
-		return err
-	}
+		s.setNamespaces)
+}
 
-	clog.Warnf(s, "WatchAgentPodsDelta is not implemented by the traffic-manager, falling back to WatchAgentPods and full snapshots")
-	return watcher.WatchWithRetry(s, "WatchAgentPods", tpClient.GetConfig(s).Grpc().WatchRetryInterval,
-		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoSnapshot], error) {
-			clog.Debugf(ctx, "No delta support in traffic-manager, starting WatchAgentPods instead")
-			return rmc.WatchAgentPods(ctx, s.session)
-		},
-		func(snapshot *manager.AgentPodInfoSnapshot) error {
-			return s.updateClients(snapshot.Agents)
-		}, nil)
+// ApplyPodsDelta implements Clients. It applies one agent-pod delta pushed by the user
+// daemon through the relay. Guarded by deltaMu because relay pushes can race with the
+// user daemon's relay stream being re-established.
+func (s *clients) ApplyPodsDelta(reset bool, upserts map[string]*manager.AgentPodInfo, removals []string) error {
+	s.deltaMu.Lock()
+	defer s.deltaMu.Unlock()
+	if s.deltaSnapshot == nil {
+		s.deltaSnapshot = make(map[string]*manager.AgentPodInfo)
+	}
+	if reset {
+		clear(s.deltaSnapshot)
+	}
+	maps.DeltaUpdate(s.deltaSnapshot, upserts, removals)
+	return s.updateClients(maps.Values(s.deltaSnapshot))
+}
+
+// RunDeltaSink implements Clients. It is the relay-mode counterpart of WatchAgentPods:
+// it records the manager client used for lazy QUIC endpoint fetches, then blocks until
+// the session ends, performing the same teardown as WatchAgentPods on exit.
+func (s *clients) RunDeltaSink(rmc manager.ManagerClient) error {
+	s.setManagerClient(rmc)
+	defer s.teardown()
+	<-s.Done()
+	return nil
+}
+
+// teardown cancels every live agent client and disables further use of this Clients
+// instance. It runs when the watch (self-watching or relay) that feeds this instance
+// ends, whichever mode that is.
+func (s *clients) teardown() {
+	activeCount := 0
+	s.clients.Range(func(_ string, ac *client) bool {
+		if ac.cancel() {
+			activeCount++
+		}
+		return true
+	})
+	clog.Debugf(s, "WatchAgentPods ending with %d clients still active", activeCount)
+	s.disabled.Store(true)
 }
 
 func (ac *client) notify(waiter chan struct{}) {

--- a/pkg/client/agentpf/sink_test.go
+++ b/pkg/client/agentpf/sink_test.go
@@ -1,0 +1,178 @@
+package agentpf
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
+)
+
+// newTestClients returns a *clients backed by a bare k8s.Cluster (no live cluster access,
+// exactly as TestClientRefresh_ResetsQuicDead constructs one), suitable for exercising
+// ApplyPodsDelta/updateClients without dialing anything -- none of the fixtures below set
+// Intercepted, which is what would otherwise trigger a real agent dial.
+func newTestClients(ctx context.Context, namespace string) *clients {
+	cl := &k8s.Cluster{
+		Kubeconfig: &k8s.Kubeconfig{
+			Context:   ctx,
+			Namespace: namespace,
+		},
+	}
+	cs := NewClients(cl, &manager.SessionInfo{SessionId: "s"}, []string{namespace})
+	return cs.(*clients)
+}
+
+func podInfo(name, namespace, ip string) *manager.AgentPodInfo {
+	addr := netip.MustParseAddr(ip)
+	b := addr.As4()
+	return &manager.AgentPodInfo{
+		PodName:      name,
+		Namespace:    namespace,
+		PodIp:        b[:],
+		WorkloadName: name,
+	}
+}
+
+func TestApplyPodsDelta_AccumulatesAcrossUpserts(t *testing.T) {
+	cs := newTestClients(context.Background(), "ns")
+
+	require.NoError(t, cs.ApplyPodsDelta(false, map[string]*manager.AgentPodInfo{
+		"a.ns": podInfo("a", "ns", "10.0.0.1"),
+	}, nil))
+	require.NoError(t, cs.ApplyPodsDelta(false, map[string]*manager.AgentPodInfo{
+		"b.ns": podInfo("b", "ns", "10.0.0.2"),
+	}, nil))
+
+	wl, ns, ok := cs.WorkloadForIP(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+	assert.Equal(t, "a", wl)
+	assert.Equal(t, "ns", ns)
+
+	wl, ns, ok = cs.WorkloadForIP(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, ok)
+	assert.Equal(t, "b", wl)
+	assert.Equal(t, "ns", ns)
+}
+
+func TestApplyPodsDelta_RemovalRemovesOnlyNamedPod(t *testing.T) {
+	cs := newTestClients(context.Background(), "ns")
+
+	require.NoError(t, cs.ApplyPodsDelta(true, map[string]*manager.AgentPodInfo{
+		"a.ns": podInfo("a", "ns", "10.0.0.1"),
+		"b.ns": podInfo("b", "ns", "10.0.0.2"),
+	}, nil))
+	require.NoError(t, cs.ApplyPodsDelta(false, nil, []string{"a.ns"}))
+
+	_, _, ok := cs.WorkloadForIP(netip.MustParseAddr("10.0.0.1"))
+	assert.False(t, ok, "removed pod must be gone")
+
+	wl, ns, ok := cs.WorkloadForIP(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, ok, "pod not named in the removal must remain")
+	assert.Equal(t, "b", wl)
+	assert.Equal(t, "ns", ns)
+}
+
+func TestApplyPodsDelta_ResetDiscardsPriorState(t *testing.T) {
+	cs := newTestClients(context.Background(), "ns")
+
+	require.NoError(t, cs.ApplyPodsDelta(false, map[string]*manager.AgentPodInfo{
+		"a.ns": podInfo("a", "ns", "10.0.0.1"),
+	}, nil))
+	require.NoError(t, cs.ApplyPodsDelta(true, map[string]*manager.AgentPodInfo{
+		"b.ns": podInfo("b", "ns", "10.0.0.2"),
+	}, nil))
+
+	_, _, ok := cs.WorkloadForIP(netip.MustParseAddr("10.0.0.1"))
+	assert.False(t, ok, "reset must discard pods absent from the reset message")
+
+	wl, ns, ok := cs.WorkloadForIP(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, ok)
+	assert.Equal(t, "b", wl)
+	assert.Equal(t, "ns", ns)
+}
+
+// TestApplyPodsDelta_EquivalentToSelfWatch proves that feeding the same logical event
+// sequence through ApplyPodsDelta produces the same accumulated state (via updateClients)
+// as feeding it through the WatchPods onDelta/onReset callbacks the way the WatchAgentPods
+// wrapper wires them (a local snapMap + maps.DeltaUpdate + updateClients). Both sides run
+// the real updateClients path; only the entry point differs.
+func TestApplyPodsDelta_EquivalentToSelfWatch(t *testing.T) {
+	events := []struct {
+		reset    bool
+		upserts  map[string]*manager.AgentPodInfo
+		removals []string
+	}{
+		{
+			reset: true,
+			upserts: map[string]*manager.AgentPodInfo{
+				"a.ns": podInfo("a", "ns", "10.0.0.1"),
+				"b.ns": podInfo("b", "ns", "10.0.0.2"),
+			},
+		},
+		{
+			upserts: map[string]*manager.AgentPodInfo{
+				"c.ns": podInfo("c", "ns", "10.0.0.3"),
+			},
+		},
+		{
+			removals: []string{"a.ns"},
+		},
+	}
+
+	selfWatch := newTestClients(context.Background(), "ns")
+	relay := newTestClients(context.Background(), "ns")
+
+	// Mirrors the composition WatchAgentPods wraps WatchPods with.
+	snapMap := make(map[string]*manager.AgentPodInfo)
+	onDelta := func(upserts map[string]*manager.AgentPodInfo, removals []string) error {
+		maps.DeltaUpdate(snapMap, upserts, removals)
+		return selfWatch.updateClients(maps.Values(snapMap))
+	}
+	onReset := func() error {
+		clear(snapMap)
+		return nil
+	}
+
+	for _, e := range events {
+		if e.reset {
+			require.NoError(t, onReset())
+		}
+		require.NoError(t, onDelta(e.upserts, e.removals))
+		require.NoError(t, relay.ApplyPodsDelta(e.reset, e.upserts, e.removals))
+	}
+
+	assert.Equal(t, selfWatch.snapshot, relay.snapshot)
+}
+
+func TestRunDeltaSink_BlocksUntilDoneAndTearsDown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cs := newTestClients(ctx, "ns")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cs.RunDeltaSink(nil)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("RunDeltaSink returned before the session was done: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunDeltaSink did not return after the session ended")
+	}
+
+	assert.True(t, cs.disabled.Load(), "RunDeltaSink must run the same teardown as WatchAgentPods")
+}

--- a/pkg/client/agentpf/watch.go
+++ b/pkg/client/agentpf/watch.go
@@ -1,0 +1,95 @@
+package agentpf
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	tpClient "github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
+)
+
+// WatchPods runs the legacy agent-pod watcher chain against rmc, trying
+// WatchAgentPodsInNamespacesDelta, then WatchAgentPodsDelta, then the
+// full-snapshot WatchAgentPods, falling back one level on Unimplemented.
+// onDelta is invoked for every received delta (for the full-snapshot level,
+// each snapshot is delivered as onReset followed by onDelta with all agents
+// as upserts). onReset is invoked whenever accumulated state must be
+// discarded: before a stream is re-established after failure, and when the
+// chain falls back a level. onNarrowed is invoked (if non-nil) when a
+// fallback narrows the watch scope to just the connected namespace.
+func WatchPods(
+	ctx context.Context,
+	rmc manager.ManagerClient,
+	session *manager.SessionInfo,
+	namespaces []string,
+	connectedNamespace string,
+	onDelta func(upserts map[string]*manager.AgentPodInfo, removals []string) error,
+	onReset func() error,
+	onNarrowed func([]string),
+) error {
+	retryInterval := tpClient.GetConfig(ctx).Grpc().WatchRetryInterval
+	err := watcher.WatchWithRetry(ctx, "WatchAgentPodsInNamespacesDelta", retryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoDelta], error) {
+			clog.Debugf(ctx, "WatchAgentPodsInNamespacesDelta starting")
+			return rmc.WatchAgentPodsInNamespacesDelta(ctx, &manager.AgentsRequest{Session: session, Namespaces: namespaces})
+		},
+		func(delta *manager.AgentPodInfoDelta) error {
+			clog.Debugf(ctx, "WatchAgentPodsInNamespacesDelta received %d upserts, %d removals", len(delta.Upserts), len(delta.Removals))
+			return onDelta(delta.Upserts, delta.Removals)
+		}, onReset)
+	if err == nil || status.Code(err) != codes.Unimplemented {
+		return err
+	}
+
+	// Older traffic-manager. Fall back to watching agents in the connected namespace.
+	if onReset != nil {
+		if err = onReset(); err != nil {
+			return err
+		}
+	}
+	if onNarrowed != nil {
+		onNarrowed([]string{connectedNamespace})
+	}
+	clog.Warnf(ctx, "WatchAgentPodsInNamespacesDelta is not implemented by the traffic-manager, falling back to WatchAgentPodsDelta in namespace %s", connectedNamespace)
+	err = watcher.WatchWithRetry(ctx, "WatchAgentPodsDelta", retryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoDelta], error) {
+			clog.Debugf(ctx, "WatchAgentPodsDelta starting")
+			return rmc.WatchAgentPodsDelta(ctx, session)
+		},
+		func(delta *manager.AgentPodInfoDelta) error {
+			clog.Debugf(ctx, "WatchAgentPodsDelta received %d upserts, %d removals", len(delta.Upserts), len(delta.Removals))
+			return onDelta(delta.Upserts, delta.Removals)
+		}, onReset)
+	if err == nil || status.Code(err) != codes.Unimplemented {
+		return err
+	}
+
+	clog.Warnf(ctx, "WatchAgentPodsDelta is not implemented by the traffic-manager, falling back to WatchAgentPods and full snapshots")
+	if onReset != nil {
+		if err = onReset(); err != nil {
+			return err
+		}
+	}
+	return watcher.WatchWithRetry(ctx, "WatchAgentPods", retryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentPodInfoSnapshot], error) {
+			clog.Debugf(ctx, "No delta support in traffic-manager, starting WatchAgentPods instead")
+			return rmc.WatchAgentPods(ctx, session)
+		},
+		func(snapshot *manager.AgentPodInfoSnapshot) error {
+			if onReset != nil {
+				if err := onReset(); err != nil {
+					return err
+				}
+			}
+			upserts := make(map[string]*manager.AgentPodInfo, len(snapshot.Agents))
+			for _, ai := range snapshot.Agents {
+				upserts[ai.PodName+"."+ai.Namespace] = ai
+			}
+			return onDelta(upserts, nil)
+		}, nil)
+}

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -2,6 +2,7 @@ package rootd
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -267,6 +268,26 @@ func (s *service) RerouteRemotePort(ctx context.Context, request *rpc.ReroutePor
 		return err
 	})
 	return &emptypb.Empty{}, err
+}
+
+// WatchAgentPods is called by the user daemon, in relay mode, to push the agent-pod
+// projection it derives from its combined traffic-manager watcher. The call ends (and
+// the user daemon retries it) once there is no active session to relay to.
+func (s *service) WatchAgentPods(stream rpc.Daemon_WatchAgentPodsServer) error {
+	for {
+		delta, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return stream.SendAndClose(&emptypb.Empty{})
+			}
+			return err
+		}
+		if err := s.withSession(stream.Context(), func(_ context.Context, session *session) error {
+			return session.applyAgentPodsDelta(delta)
+		}); err != nil {
+			return err
+		}
+	}
 }
 
 func (s *service) withSession(ctx context.Context, f func(context.Context, *session) error) (err error) {

--- a/pkg/client/rootd/in_process.go
+++ b/pkg/client/rootd/in_process.go
@@ -123,6 +123,20 @@ func (rd *InProcSession) ActivityWatcher(ctx context.Context, in *empty.Empty, o
 	return nil, status.Error(codes.Unimplemented, "ActivityWatcher not implemented")
 }
 
+func (rd *InProcSession) WatchAgentPods(
+	ctx context.Context,
+	opts ...grpc.CallOption,
+) (grpc.ClientStreamingClient[rpc.AgentPodsDelta, empty.Empty], error) {
+	// The InProcSession is relayed to directly via ApplyAgentPodsDelta instead of a stream.
+	return nil, status.Error(codes.Unimplemented, "WatchAgentPods not implemented")
+}
+
+// ApplyAgentPodsDelta lets the user daemon apply a relayed agent-pod delta directly when
+// the root session runs in-process, bypassing gRPC.
+func (rd *InProcSession) ApplyAgentPodsDelta(_ context.Context, delta *rpc.AgentPodsDelta) error {
+	return rd.applyAgentPodsDelta(delta)
+}
+
 // NewInProcSession returns a root daemon session suitable to use in-process (from the user daemon) and is primarily intended for
 // when the user daemon runs in a docker container with NET_ADMIN capabilities.
 func NewInProcSession(

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -192,6 +192,11 @@ type session struct {
 
 	subnetViaWorkloads []*rpc.SubnetViaWorkload
 
+	// agentPodNamespaces are the namespaces in which the user daemon relays agent-pod
+	// events using the daemon.Daemon WatchAgentPods RPC. When non-empty, this daemon
+	// does not watch agent pods itself; see session.Start.
+	agentPodNamespaces []string
+
 	// daemon runs as part of a pod-daemon setup.
 	podDaemon bool
 	routesCh  chan []netip.Prefix
@@ -368,6 +373,7 @@ func newSession(
 		managerConn:           managerConn,
 		managerVersion:        ver,
 		subnetViaWorkloads:    mi.SubnetViaWorkloads,
+		agentPodNamespaces:    mi.AgentPodNamespaces,
 		proxyClusterPods:      true,
 		proxyClusterSvcs:      true,
 		vifReady:              make(chan error, 2),
@@ -1378,9 +1384,18 @@ func (s *session) run(initErrs chan<- error) {
 func (s *session) Start(g log.Group, teleroutePort uint16) error {
 	clusterCfg := client.GetConfig(s).Cluster()
 	if clusterCfg.AgentPortForward {
-		agentNamespaces := slices.DeleteFunc(s.GetCurrentNamespaces(true), func(ns string) bool {
-			return !k8s.CanPortForward(s, ns)
-		})
+		// Relay mode: the user daemon has already computed the namespace set (the
+		// same one it requests from the traffic-manager) and pushes deltas via
+		// WatchAgentPods instead of this daemon watching the traffic-manager itself.
+		relayMode := len(s.agentPodNamespaces) > 0
+		var agentNamespaces []string
+		if relayMode {
+			agentNamespaces = s.agentPodNamespaces
+		} else {
+			agentNamespaces = slices.DeleteFunc(s.GetCurrentNamespaces(true), func(ns string) bool {
+				return !k8s.CanPortForward(s, ns)
+			})
+		}
 		if len(agentNamespaces) > 0 {
 			s.agentClients = agentpf.NewClients(s.Cluster, s.session, agentNamespaces)
 			// Receive a callback per dial accepted from the dial watchers,
@@ -1401,9 +1416,15 @@ func (s *session) Start(g log.Group, teleroutePort uint16) error {
 				}
 				return ""
 			})
-			g.Go("agentPods", func(ctx context.Context) error {
-				return s.agentClients.WatchAgentPods(s.managerClient())
-			})
+			if relayMode {
+				g.Go("agentPods", func(ctx context.Context) error {
+					return s.agentClients.RunDeltaSink(s.managerClient())
+				})
+			} else {
+				g.Go("agentPods", func(ctx context.Context) error {
+					return s.agentClients.WatchAgentPods(s.managerClient())
+				})
+			}
 		} else {
 			clog.Infof(s, "Agent port-forwards are disabled. Client is not permitted to do port-forward to any mapped namespace")
 		}
@@ -1732,6 +1753,18 @@ func (s *session) waitForAgentIP(ctx context.Context, request *rpc.WaitForAgentI
 		return nil, err
 	}
 	return &rpc.WaitForAgentIPResponse{LocalIp: ip.AsSlice()}, nil
+}
+
+// applyAgentPodsDelta forwards a relayed agent-pod delta, pushed by the user daemon's
+// WatchAgentPods call, to the agent-pod client set. s.agentClients is nil whenever this
+// daemon isn't running an agent-pod watch at all (AgentPortForward disabled, or no
+// port-forwardable namespace); the caller must treat the resulting error as a reason to
+// stop relaying.
+func (s *session) applyAgentPodsDelta(delta *rpc.AgentPodsDelta) error {
+	if s.agentClients == nil {
+		return status.Error(codes.FailedPrecondition, "no agent-pod client set for this session")
+	}
+	return s.agentClients.ApplyPodsDelta(delta.Reset_, delta.Upserts, delta.Removals)
 }
 
 func (s *session) ManagerVersion() semver.Version {

--- a/pkg/client/userd/trafficmgr/agents.go
+++ b/pkg/client/userd/trafficmgr/agents.go
@@ -15,15 +15,62 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/maps"
 )
 
+// agentPod is the client's internal record of one traffic-agent pod, holding
+// exactly what its consumers read. Built from AgentPodInfo in combined mode
+// and projected from AgentInfo in legacy fallback mode.
+type agentPod struct {
+	workload  string
+	namespace string
+	podName   string
+	version   string
+	nodeAgent bool
+}
+
+// agentPodFromPodInfo builds an agentPod from the manager's AgentPodInfo
+// projection (combined mode).
+func agentPodFromPodInfo(ap *manager.AgentPodInfo) agentPod {
+	return agentPod{
+		workload:  ap.WorkloadName,
+		namespace: ap.Namespace,
+		podName:   ap.PodName,
+		version:   ap.Version,
+		nodeAgent: ap.NodeAgent,
+	}
+}
+
+// agentPodFromAgentInfo builds an agentPod from the manager's AgentInfo
+// (legacy fallback mode).
+func agentPodFromAgentInfo(ai *manager.AgentInfo) agentPod {
+	return agentPod{
+		workload:  ai.Name,
+		namespace: ai.Namespace,
+		podName:   ai.PodName,
+		version:   ai.Version,
+		nodeAgent: ai.NodeAgent,
+	}
+}
+
+// watchAgentsLoop drives the legacy WatchAgentsDelta/WatchAgents watcher, used
+// only by watchSessionEventsLegacy. Its snapshots are scoped to the connected
+// namespace, so the covered predicate it feeds handleAgentPodSnapshot only
+// ever declares that one namespace covered.
 func (s *session) watchAgentsLoop(ctx context.Context) error {
+	covered := func(namespace string) bool { return namespace == s.Namespace }
 	snapMap := make(map[string]*manager.AgentInfo)
+	toPods := func() []agentPod {
+		pods := make([]agentPod, 0, len(snapMap))
+		for _, ai := range snapMap {
+			pods = append(pods, agentPodFromAgentInfo(ai))
+		}
+		return pods
+	}
 	err := watcher.WatchWithRetry(ctx, "WatchAgentsDelta", client.GetConfig(ctx).Grpc().WatchRetryInterval,
 		func(ctx context.Context) (grpc.ServerStreamingClient[manager.AgentInfoDelta], error) {
 			return s.ManagerClient().WatchAgentsDelta(ctx, s.SessionInfo())
 		},
 		func(delta *manager.AgentInfoDelta) error {
 			maps.DeltaUpdate(snapMap, delta.Upserts, delta.Removals)
-			s.handleAgentSnapshot(ctx, maps.Values(snapMap))
+			s.handleAgentPodSnapshot(ctx, toPods(), covered)
 			return nil
 		}, func() error {
 			clear(snapMap)
@@ -37,61 +84,134 @@ func (s *session) watchAgentsLoop(ctx context.Context) error {
 				return s.ManagerClient().WatchAgents(ctx, s.SessionInfo())
 			},
 			func(snapshot *manager.AgentInfoSnapshot) error {
-				s.handleAgentSnapshot(ctx, snapshot.Agents)
+				pods := make([]agentPod, len(snapshot.Agents))
+				for i, ai := range snapshot.Agents {
+					pods[i] = agentPodFromAgentInfo(ai)
+				}
+				s.handleAgentPodSnapshot(ctx, pods, covered)
 				return nil
 			}, nil)
 	}
 	// Handle as if we had an empty snapshot. This will ensure that port forwards and volume mounts are canceled correctly.
-	s.handleAgentSnapshot(ctx, nil)
+	s.handleAgentPodSnapshot(ctx, nil, covered)
 	return err
 }
 
-func (s *session) handleAgentSnapshot(ctx context.Context, infos []*manager.AgentInfo) {
-	s.ingestTracker.initSnapshot()
-	s.setCurrentAgents(infos)
+// ingestPodDecision is the outcome of matching one ingest's key and current
+// pod name against a fresh agent-pod snapshot.
+type ingestPodDecision int
 
-	// infoForKey returns the AgentInfos that matches the ingestKey
-	infosForKey := func(key ingestKey) (ais []*manager.AgentInfo) {
-		for _, info := range infos {
-			if info.Name == key.workload {
-				for cn := range info.Containers {
-					if cn == key.container {
-						ais = append(ais, info)
-					}
-				}
-			}
+const (
+	// ingestPodNoMatch: no pod in the snapshot matches the ingest's workload
+	// and namespace. The ingest is left untouched this round; cancelUnwanted
+	// decides its fate based on whether its namespace is covered.
+	ingestPodNoMatch ingestPodDecision = iota
+	// ingestPodKeepAlive: the ingest's current pod is still among the
+	// matching pods; its mounts/port-forwards stay alive.
+	ingestPodKeepAlive
+	// ingestPodReplaced: matching pods exist, but not under the ingest's
+	// current pod name; its agent must be refetched.
+	ingestPodReplaced
+)
+
+// decideIngestPod matches key (workload+namespace; container matching is not
+// needed since membership was already validated when the ingest was
+// created) and the ingest's current pod name against pods, a fresh
+// agent-pod snapshot. matching is the set of pods sharing key's workload and
+// namespace -- non-empty exactly when the decision isn't ingestPodNoMatch.
+func decideIngestPod(pods []agentPod, key ingestKey, currentPodName string) (decision ingestPodDecision, matching []agentPod) {
+	for _, ap := range pods {
+		if ap.workload == key.workload && ap.namespace == key.namespace {
+			matching = append(matching, ap)
 		}
-		return ais
 	}
+	if len(matching) == 0 {
+		return ingestPodNoMatch, nil
+	}
+	if slices.ContainsFunc(matching, func(ap agentPod) bool { return ap.podName == currentPodName }) {
+		return ingestPodKeepAlive, matching
+	}
+	return ingestPodReplaced, matching
+}
+
+// selectReplacementAgent picks the AgentInfo to adopt for a replaced ingest
+// pod: the first candidate whose PodName is among matching, or (when none
+// matches, which should not normally happen) the first candidate. Returns
+// nil when candidates is empty.
+func selectReplacementAgent(candidates []*manager.AgentInfo, matching []agentPod) *manager.AgentInfo {
+	for _, cand := range candidates {
+		if slices.ContainsFunc(matching, func(ap agentPod) bool { return ap.podName == cand.PodName }) {
+			return cand
+		}
+	}
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+	return nil
+}
+
+// handleAgentPodSnapshot updates the internal agent-pod cache and drives the
+// ingest keep-alive/replacement lifecycle from a fresh agent-pod snapshot,
+// then cancels port-forwards and mounts left over from pods that are no
+// longer present, scoped to the namespaces this snapshot actually covers.
+func (s *session) handleAgentPodSnapshot(ctx context.Context, pods []agentPod, covered func(namespace string) bool) {
+	s.ingestTracker.initSnapshot()
+	s.setCurrentAgentPods(pods)
 
 	s.currentIngests.Range(func(key ingestKey, ig *ingest) bool {
-		ais := infosForKey(key)
-		if len(ais) > 0 {
-			if slices.IndexFunc(ais, func(cai *manager.AgentInfo) bool { return cai.PodName == ig.PodName }) < 0 {
-				// The pod selected for the ingest is no longer active, so replace it.
-				ai := ais[0]
-				err := s.translateContainerEnv(ctx, ai, ig.container)
-				if err != nil {
-					clog.Errorf(ctx, "failed to translate container env: %v", err)
-				}
-				ig.AgentInfo = ai
-			}
+		decision, matching := decideIngestPod(pods, key, ig.PodName)
+		switch decision {
+		case ingestPodNoMatch:
+			// Not covered by this snapshot; cancelUnwanted below decides its fate.
+			return true
+		case ingestPodKeepAlive:
 			s.startIngestPodAccess(ctx, ig, false)
+			return true
 		}
+
+		// ingestPodReplaced: the pod backing this ingest is gone; refetch its
+		// AgentInfo so replacement failover works for cross-namespace ingests too.
+		timeoutCtx, cancel := client.GetConfig(s).Timeouts().TimeoutContext(s, client.TimeoutTrafficManagerAPI)
+		as, err := s.ManagerClient().EnsureAgent(timeoutCtx, &manager.EnsureAgentRequest{
+			Session:   s.sessionInfo,
+			Name:      key.workload,
+			Namespace: key.namespace,
+			NodeAgent: ig.NodeAgent,
+		})
+		cancel()
+		if err != nil {
+			clog.Errorf(ctx, "failed to refetch agent for ingest %s: %v", key, err)
+			return true
+		}
+		ai := selectReplacementAgent(as.Agents, matching)
+		if ai == nil {
+			clog.Errorf(ctx, "EnsureAgent returned no agents for ingest %s", key)
+			return true
+		}
+		if _, ok := ai.Containers[ig.container]; !ok {
+			clog.Errorf(ctx, "workload %s has no container named %s after replacement", key.workload, ig.container)
+			return true
+		}
+		if err := s.translateContainerEnv(ctx, ai, ig.container); err != nil {
+			clog.Errorf(ctx, "failed to translate container env: %v", err)
+			return true
+		}
+		ig.AgentInfo = ai
+		s.startIngestPodAccess(ctx, ig, false)
 		return true
 	})
-	s.ingestTracker.cancelUnwanted(ctx)
+	s.ingestTracker.cancelUnwanted(ctx, covered)
 }
 
-func (s *session) getCurrentAgents() []*manager.AgentInfo {
+func (s *session) getCurrentAgentPods() []agentPod {
 	s.currentInterceptsLock.Lock()
-	agents := s.currentAgents
+	pods := s.currentAgentPods
 	s.currentInterceptsLock.Unlock()
-	return agents
+	return pods
 }
 
-func (s *session) setCurrentAgents(agents []*manager.AgentInfo) {
+func (s *session) setCurrentAgentPods(pods []agentPod) {
 	s.currentInterceptsLock.Lock()
-	s.currentAgents = agents
+	s.currentAgentPods = pods
 	s.currentInterceptsLock.Unlock()
 }

--- a/pkg/client/userd/trafficmgr/agents_test.go
+++ b/pkg/client/userd/trafficmgr/agents_test.go
@@ -1,0 +1,112 @@
+package trafficmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+// TestDecideIngestPod exercises the pure pod-matching decision behind
+// handleAgentPodSnapshot's ingest walk: workload+namespace matching (not
+// workload-only, the pre-existing cross-namespace hijack bug this rework
+// fixes) and replacement detection by pod name.
+func TestDecideIngestPod(t *testing.T) {
+	key := ingestKey{workload: "echo", namespace: "default", container: "cn"}
+
+	t.Run("no pods for workload+namespace", func(t *testing.T) {
+		pods := []agentPod{
+			{workload: "other", namespace: "default", podName: "other-1"},
+			{workload: "echo", namespace: "other-ns", podName: "echo-1"},
+		}
+		decision, matching := decideIngestPod(pods, key, "echo-1")
+		assert.Equal(t, ingestPodNoMatch, decision)
+		assert.Nil(t, matching)
+	})
+
+	t.Run("current pod still present keeps alive", func(t *testing.T) {
+		pods := []agentPod{
+			{workload: "echo", namespace: "default", podName: "echo-1"},
+			{workload: "echo", namespace: "default", podName: "echo-2"},
+		}
+		decision, matching := decideIngestPod(pods, key, "echo-1")
+		assert.Equal(t, ingestPodKeepAlive, decision)
+		assert.Len(t, matching, 2)
+	})
+
+	t.Run("current pod gone but sibling pods remain means replaced", func(t *testing.T) {
+		pods := []agentPod{
+			{workload: "echo", namespace: "default", podName: "echo-2"},
+		}
+		decision, matching := decideIngestPod(pods, key, "echo-1")
+		assert.Equal(t, ingestPodReplaced, decision)
+		require.Len(t, matching, 1)
+		assert.Equal(t, "echo-2", matching[0].podName)
+	})
+
+	t.Run("same workload name in a different namespace does not match", func(t *testing.T) {
+		// This is the namespace-blind matching bug the rework fixes: a
+		// same-named workload in another namespace must not be treated as a
+		// match for this ingest's key.
+		pods := []agentPod{
+			{workload: "echo", namespace: "other-ns", podName: "echo-1"},
+		}
+		decision, matching := decideIngestPod(pods, key, "echo-1")
+		assert.Equal(t, ingestPodNoMatch, decision)
+		assert.Nil(t, matching)
+	})
+}
+
+// TestSelectReplacementAgent exercises the pure candidate-selection step used
+// after an EnsureAgent refetch: prefer a candidate whose pod is among the
+// snapshot's matching pods, falling back to the first candidate otherwise.
+func TestSelectReplacementAgent(t *testing.T) {
+	matching := []agentPod{{workload: "echo", namespace: "default", podName: "echo-2"}}
+
+	t.Run("picks the candidate matching the snapshot", func(t *testing.T) {
+		candidates := []*manager.AgentInfo{
+			{PodName: "echo-1"},
+			{PodName: "echo-2"},
+		}
+		ai := selectReplacementAgent(candidates, matching)
+		require.NotNil(t, ai)
+		assert.Equal(t, "echo-2", ai.PodName)
+	})
+
+	t.Run("falls back to the first candidate when none matches", func(t *testing.T) {
+		candidates := []*manager.AgentInfo{{PodName: "echo-9"}}
+		ai := selectReplacementAgent(candidates, matching)
+		require.NotNil(t, ai)
+		assert.Equal(t, "echo-9", ai.PodName)
+	})
+
+	t.Run("nil when there are no candidates", func(t *testing.T) {
+		assert.Nil(t, selectReplacementAgent(nil, matching))
+	})
+}
+
+func TestAgentPodFromPodInfo(t *testing.T) {
+	ap := &manager.AgentPodInfo{
+		WorkloadName: "echo",
+		Namespace:    "default",
+		PodName:      "echo-1",
+		Version:      "2.30.0",
+		NodeAgent:    true,
+	}
+	got := agentPodFromPodInfo(ap)
+	assert.Equal(t, agentPod{workload: "echo", namespace: "default", podName: "echo-1", version: "2.30.0", nodeAgent: true}, got)
+}
+
+func TestAgentPodFromAgentInfo(t *testing.T) {
+	ai := &manager.AgentInfo{
+		Name:      "echo",
+		Namespace: "default",
+		PodName:   "echo-1",
+		Version:   "2.30.0",
+		NodeAgent: true,
+	}
+	got := agentPodFromAgentInfo(ai)
+	assert.Equal(t, agentPod{workload: "echo", namespace: "default", podName: "echo-1", version: "2.30.0", nodeAgent: true}, got)
+}

--- a/pkg/client/userd/trafficmgr/ingest.go
+++ b/pkg/client/userd/trafficmgr/ingest.go
@@ -108,14 +108,15 @@ func (s *session) validateAgentForIngest(ai *manager.AgentInfo) error {
 	return nil
 }
 
-// getCurrentAgent returns the locally-cached agent matching the workload name in the
-// given namespace, or nil when no such agent is cached. The cache only contains agents
-// from the connected namespace, so cross-namespace lookups always fall through to
-// EnsureAgent on the traffic-manager.
-func (s *session) getCurrentAgent(name, namespace string) *manager.AgentInfo {
-	for _, ai := range s.getCurrentAgents() {
-		if ai.Name == name && ai.Namespace == namespace {
-			return ai
+// getCurrentAgent returns the cached agentPod matching the workload name in the
+// given namespace, or nil when no such agent is cached. Consulted only for the
+// ingest fast path and node-agent semantics; container-level data always comes
+// from EnsureAgent.
+func (s *session) getCurrentAgent(workload, namespace string) *agentPod {
+	for _, ap := range s.getCurrentAgentPods() {
+		if ap.workload == workload && ap.namespace == namespace {
+			found := ap
+			return &found
 		}
 	}
 	return nil
@@ -144,59 +145,78 @@ func (s *session) Ingest(ctx context.Context, rq *rpc.IngestRequest) (ir *rpc.In
 		container: id.ContainerName,
 		namespace: ns,
 	}
-	ai := s.getCurrentAgent(ik.workload, ik.namespace)
 
-	if ai != nil {
-		if rq.NodeAgent && !ai.NodeAgent {
-			return nil, errcat.User.Newf(
-				"workload %s already has an injected traffic-agent, which a node-agent cannot replace; "+
-					"omit --node-agent, or uninstall the existing agent and retry",
-				ik.workload)
-		}
-		// A node-agent serves env and mounts identically to a sidecar, so a
-		// cached node-agent silently satisfies a plain (non-node-agent)
-		// ingest request too. Injecting a sidecar on top of it would break
-		// the live node-agent, so it is reused rather than rejected.
-		if ik.container == "" {
-			ik.container, err = s.getSingleContainerName(ai)
-			if err != nil {
-				return nil, err
-			}
-		}
+	// Fast path: an ingest already exists for this key -- or, when the
+	// container is unspecified, exactly one ingest exists for this
+	// workload+namespace.
+	if ik.container != "" {
 		if ig, loaded := s.currentIngests.Load(ik); loaded {
 			return ig.response(), nil
 		}
+	} else {
+		var found *ingest
+		s.currentIngests.Range(func(key ingestKey, ig *ingest) bool {
+			if key.workload != ik.workload || key.namespace != ik.namespace {
+				return true
+			}
+			if found != nil {
+				err = status.Error(codes.NotFound, fmt.Sprintf("workload %s has multiple ingests. Please specify which one to use", ik.workload))
+				return false
+			}
+			found = ig
+			return true
+		})
+		if err != nil {
+			return nil, err
+		}
+		if found != nil {
+			return found.response(), nil
+		}
 	}
+
+	// Node-agent semantics via the pod cache: existence and node-agent flag
+	// only, container-level data is never cached (see the agentPod comment).
+	ap := s.getCurrentAgent(ik.workload, ik.namespace)
+	if rq.NodeAgent && ap != nil && !ap.nodeAgent {
+		return nil, errcat.User.Newf(
+			"workload %s already has an injected traffic-agent, which a node-agent cannot replace; "+
+				"omit --node-agent, or uninstall the existing agent and retry",
+			ik.workload)
+	}
+	// A node-agent serves env and mounts identically to a sidecar, so a
+	// cached node-agent silently satisfies a plain (non-node-agent) ingest
+	// request too. Requesting NodeAgent from EnsureAgent in that case
+	// prevents the manager from injecting a sidecar on top of the live
+	// node-agent.
+	nodeAgent := rq.NodeAgent || (ap != nil && ap.nodeAgent)
 
 	err = s.ensureNoMountConflict(rq.MountPoint, rq.LocalMountPort)
 	if err != nil {
 		return nil, err
 	}
 
-	if ai == nil {
-		var as *manager.AgentInfoSnapshot
-		timeoutCtx, cancel := client.GetConfig(s).Timeouts().TimeoutContext(s, client.TimeoutIntercept)
-		defer cancel()
-		as, err = s.ManagerClient().EnsureAgent(timeoutCtx, &manager.EnsureAgentRequest{
-			Session:   s.sessionInfo,
-			Name:      ik.workload,
-			Namespace: ik.namespace,
-			NodeAgent: rq.NodeAgent,
-		})
-		if err != nil {
-			return nil, err
-		}
-		ai = as.Agents[0]
-		// A sidecar returned when a node-agent was explicitly requested must
-		// never be used silently: its env/mounts assume no sidecar was
-		// injected, so a mismatch here means the traffic-manager did not
-		// honor node-agent mode (e.g. the version gate above was bypassed by
-		// a manager that predates the node_agent field). Fail loudly instead
-		// of quietly falling back to sidecar semantics.
-		if rq.NodeAgent && !ai.NodeAgent {
-			return nil, errcat.User.Newf(
-				"traffic-manager did not honor node-agent mode for workload %s", ik.workload)
-		}
+	var as *manager.AgentInfoSnapshot
+	timeoutCtx, cancel := client.GetConfig(s).Timeouts().TimeoutContext(s, client.TimeoutIntercept)
+	defer cancel()
+	as, err = s.ManagerClient().EnsureAgent(timeoutCtx, &manager.EnsureAgentRequest{
+		Session:   s.sessionInfo,
+		Name:      ik.workload,
+		Namespace: ik.namespace,
+		NodeAgent: nodeAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ai := as.Agents[0]
+	// A sidecar returned when a node-agent was explicitly requested must
+	// never be used silently: its env/mounts assume no sidecar was
+	// injected, so a mismatch here means the traffic-manager did not
+	// honor node-agent mode (e.g. the version gate above was bypassed by
+	// a manager that predates the node_agent field). Fail loudly instead
+	// of quietly falling back to sidecar semantics.
+	if rq.NodeAgent && !ai.NodeAgent {
+		return nil, errcat.User.Newf(
+			"traffic-manager did not honor node-agent mode for workload %s", ik.workload)
 	}
 	if err = s.validateAgentForIngest(ai); err != nil {
 		return nil, err

--- a/pkg/client/userd/trafficmgr/ingest_node_agent_test.go
+++ b/pkg/client/userd/trafficmgr/ingest_node_agent_test.go
@@ -16,11 +16,34 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/connector"
+	rootdRpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
 	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
 	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 )
+
+// fakeIngestRootDaemon is a minimal daemon.Daemon gRPC server that only echoes
+// TranslateEnvIPs, used to let Ingest's translateContainerEnv step succeed
+// without a real root daemon.
+type fakeIngestRootDaemon struct {
+	rootdRpc.UnimplementedDaemonServer
+}
+
+func (f *fakeIngestRootDaemon) TranslateEnvIPs(_ context.Context, e *rootdRpc.Environment) (*rootdRpc.Environment, error) {
+	return e, nil
+}
+
+// withFakeRootDaemon wires s up with a bufconn-backed root daemon that only
+// supports TranslateEnvIPs, so Ingest's post-EnsureAgent env-translation step
+// succeeds.
+func withFakeRootDaemon(t *testing.T, s *session) {
+	t.Helper()
+	conn, cleanup, err := dialTestRootDaemon(&fakeIngestRootDaemon{})
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	s.setRootDaemon(rootdRpc.NewDaemonClient(conn), conn, nil, false)
+}
 
 // fakeManagerServer is a minimal manager.ManagerServer used to observe and canned-answer
 // the EnsureAgent/ReleaseAgent calls made by session.Ingest and session.LeaveIngest.
@@ -32,13 +55,23 @@ type fakeManagerServer struct {
 
 	mu                sync.Mutex
 	releaseAgentCalls []*manager.ReleaseAgentRequest
+	ensureAgentCalls_ []*manager.EnsureAgentRequest
 }
 
-func (f *fakeManagerServer) EnsureAgent(context.Context, *manager.EnsureAgentRequest) (*manager.AgentInfoSnapshot, error) {
+func (f *fakeManagerServer) EnsureAgent(_ context.Context, rq *manager.EnsureAgentRequest) (*manager.AgentInfoSnapshot, error) {
+	f.mu.Lock()
+	f.ensureAgentCalls_ = append(f.ensureAgentCalls_, rq)
+	f.mu.Unlock()
 	if f.ensureAgentErr != nil {
 		return nil, f.ensureAgentErr
 	}
 	return f.ensureAgentResponse, nil
+}
+
+func (f *fakeManagerServer) ensureAgentCalls() []*manager.EnsureAgentRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*manager.EnsureAgentRequest(nil), f.ensureAgentCalls_...)
 }
 
 func (f *fakeManagerServer) ReleaseAgent(_ context.Context, rq *manager.ReleaseAgentRequest) (*emptypb.Empty, error) {
@@ -112,15 +145,8 @@ func TestSession_Ingest_NodeAgentVersionGate(t *testing.T) {
 
 func TestSession_Ingest_CachedSidecarRejectsNodeAgentRequest(t *testing.T) {
 	s := newIngestTestSession(t, nil)
-	s.currentAgents = []*manager.AgentInfo{
-		{
-			Name:      "wl",
-			Namespace: "default",
-			NodeAgent: false,
-			Containers: map[string]*manager.AgentInfo_ContainerInfo{
-				"cn": {},
-			},
-		},
+	s.currentAgentPods = []agentPod{
+		{workload: "wl", namespace: "default", podName: "wl-pod", nodeAgent: false},
 	}
 
 	_, err := s.Ingest(s, &rpc.IngestRequest{
@@ -132,18 +158,25 @@ func TestSession_Ingest_CachedSidecarRejectsNodeAgentRequest(t *testing.T) {
 }
 
 func TestSession_Ingest_CachedNodeAgentReusedSilentlyForPlainRequest(t *testing.T) {
-	s := newIngestTestSession(t, nil)
-	ik := ingestKey{workload: "wl", container: "cn", namespace: "default"}
-	ai := &manager.AgentInfo{
-		Name:      "wl",
-		Namespace: "default",
-		NodeAgent: true,
-		Containers: map[string]*manager.AgentInfo_ContainerInfo{
-			"cn": {},
+	fake := &fakeManagerServer{
+		ensureAgentResponse: &manager.AgentInfoSnapshot{
+			Agents: []*manager.AgentInfo{
+				{
+					Name:      "wl",
+					Namespace: "default",
+					NodeAgent: true,
+					Containers: map[string]*manager.AgentInfo_ContainerInfo{
+						"cn": {},
+					},
+				},
+			},
 		},
 	}
-	s.currentAgents = []*manager.AgentInfo{ai}
-	s.currentIngests.Store(ik, &ingest{ingestKey: ik, AgentInfo: ai})
+	s := newIngestTestSession(t, dialTestManager(t, fake))
+	withFakeRootDaemon(t, s)
+	s.currentAgentPods = []agentPod{
+		{workload: "wl", namespace: "default", podName: "wl-pod", nodeAgent: true},
+	}
 
 	ii, err := s.Ingest(s, &rpc.IngestRequest{
 		Identifier: &rpc.IngestIdentifier{WorkloadName: "wl", ContainerName: "cn"},
@@ -151,6 +184,10 @@ func TestSession_Ingest_CachedNodeAgentReusedSilentlyForPlainRequest(t *testing.
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "wl", ii.Workload)
+
+	calls := fake.ensureAgentCalls()
+	require.Len(t, calls, 1)
+	assert.True(t, calls[0].NodeAgent, "a cached node-agent must be requested explicitly from EnsureAgent so the manager does not inject a sidecar on top of it")
 }
 
 func TestSession_Ingest_ResponseHardeningRejectsSidecarFromManager(t *testing.T) {

--- a/pkg/client/userd/trafficmgr/intercept.go
+++ b/pkg/client/userd/trafficmgr/intercept.go
@@ -232,7 +232,7 @@ func (s *session) handleInterceptSnapshot(pat *podAccessTracker, intercepts []*m
 		}
 		pat.start(pa)
 	}
-	pat.cancelUnwanted(s)
+	pat.cancelUnwanted(s, nil)
 	s.pushInterceptShortcuts(intercepts)
 }
 

--- a/pkg/client/userd/trafficmgr/podaccess.go
+++ b/pkg/client/userd/trafficmgr/podaccess.go
@@ -294,10 +294,16 @@ func (lpf *podAccessTracker) cancelContainer(workload, container string) {
 	lpf.Unlock()
 }
 
-// cancelUnwanted cancels all mounts and port forwards that haven't been started since initSnapshot.
-func (lpf *podAccessTracker) cancelUnwanted(ctx context.Context) {
+// cancelUnwanted cancels all mounts and port forwards that haven't been started since
+// initSnapshot, skipping entries whose namespace covered reports as not covered by this
+// snapshot -- those survive unrelated churn in other namespaces. covered == nil means every
+// namespace is covered.
+func (lpf *podAccessTracker) cancelUnwanted(ctx context.Context, covered func(namespace string) bool) {
 	lpf.Lock()
 	for fk, lp := range lpf.alivePods {
+		if covered != nil && !covered(fk.namespace) {
+			continue
+		}
 		if _, isWanted := lpf.snapshot[fk]; !isWanted {
 			clog.Infof(ctx, "Terminating mounts and port-forwards for %+v", fk)
 			lpf.privateDelete(fk, lp)

--- a/pkg/client/userd/trafficmgr/podaccess_test.go
+++ b/pkg/client/userd/trafficmgr/podaccess_test.go
@@ -1,0 +1,66 @@
+package trafficmgr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// alivePodKey seeds lpf.alivePods directly with a no-op podAccessSync so
+// cancelUnwanted's scoping can be exercised without going through start's
+// mount/port-forward machinery.
+func alivePodKey(lpf *podAccessTracker, fk podAccessKey) {
+	lpf.alivePods[fk] = &podAccessSync{cancelPod: func() {}}
+}
+
+// TestCancelUnwantedNamespaceScoping exercises cancelUnwanted's covered
+// predicate: entries in namespaces covered decides against survive, entries
+// in namespaces it doesn't cover are cancelled, and covered == nil cancels
+// everything left over from the snapshot.
+func TestCancelUnwantedNamespaceScoping(t *testing.T) {
+	t.Run("uncovered namespace survives, covered one is cancelled", func(t *testing.T) {
+		lpf := newPodAccessTracker()
+		lpf.initSnapshot() // empty snapshot: nothing was started this round
+
+		covered := podAccessKey{namespace: "covered-ns", podIP: "10.0.0.1"}
+		uncovered := podAccessKey{namespace: "uncovered-ns", podIP: "10.0.0.2"}
+		alivePodKey(lpf, covered)
+		alivePodKey(lpf, uncovered)
+
+		lpf.cancelUnwanted(context.Background(), func(namespace string) bool {
+			return namespace == "covered-ns"
+		})
+
+		_, coveredStillAlive := lpf.alivePods[covered]
+		_, uncoveredStillAlive := lpf.alivePods[uncovered]
+		assert.False(t, coveredStillAlive, "an unwanted entry in a covered namespace must be cancelled")
+		assert.True(t, uncoveredStillAlive, "an entry in an uncovered namespace must survive unrelated churn")
+	})
+
+	t.Run("an entry still in the snapshot survives even when covered", func(t *testing.T) {
+		lpf := newPodAccessTracker()
+		lpf.initSnapshot()
+		fk := podAccessKey{namespace: "ns", podIP: "10.0.0.1"}
+		alivePodKey(lpf, fk)
+		lpf.snapshot[fk] = struct{}{} // marked wanted this round
+
+		lpf.cancelUnwanted(context.Background(), func(string) bool { return true })
+
+		_, stillAlive := lpf.alivePods[fk]
+		assert.True(t, stillAlive)
+	})
+
+	t.Run("nil covered cancels every unwanted entry regardless of namespace", func(t *testing.T) {
+		lpf := newPodAccessTracker()
+		lpf.initSnapshot()
+		a := podAccessKey{namespace: "ns-a", podIP: "10.0.0.1"}
+		b := podAccessKey{namespace: "ns-b", podIP: "10.0.0.2"}
+		alivePodKey(lpf, a)
+		alivePodKey(lpf, b)
+
+		lpf.cancelUnwanted(context.Background(), nil)
+
+		assert.Empty(t, lpf.alivePods)
+	})
+}

--- a/pkg/client/userd/trafficmgr/podrelay.go
+++ b/pkg/client/userd/trafficmgr/podrelay.go
@@ -1,0 +1,233 @@
+package trafficmgr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/telepresenceio/clog"
+	rootdRpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
+)
+
+// podRelayApplier is implemented by the root daemon's in-process session,
+// letting the relay bypass gRPC entirely when the root daemon runs in the
+// same process as the user daemon.
+type podRelayApplier interface {
+	ApplyAgentPodsDelta(context.Context, *rootdRpc.AgentPodsDelta) error
+}
+
+// podRelayUnimplementedWarning is logged once, the only time the root daemon
+// reports that it doesn't support the relay (it's old enough to self-watch
+// agent pods instead).
+const podRelayUnimplementedWarning = "root daemon does not support relayed agent-pod events; it watches agent pods itself"
+
+// podRelay accumulates the manager-computed AgentPodInfo -- relayed as-is in
+// both combined and legacy fallback mode, since the manager (not the client)
+// computes the projection in the new design -- and relays it to the root
+// daemon, either in-process (podRelayApplier) or over the WatchAgentPods
+// client-streaming RPC.
+type podRelay struct {
+	mu       sync.Mutex
+	current  map[string]*manager.AgentPodInfo
+	lastSent map[string]*manager.AgentPodInfo // nil means the next send must be a full reset
+	syncing  bool
+	notifyCh chan struct{}
+}
+
+func newPodRelay() *podRelay {
+	return &podRelay{notifyCh: make(chan struct{}, 1)}
+}
+
+// beginSync discards the accumulated state and suppresses relay pushes until
+// the next apply call, at which point the push is a full reset: the upstream
+// watcher (manager stream, in combined or legacy mode) is being
+// re-established, and the root daemon's last snapshot may no longer be
+// current by the time it's rebuilt, so it must be replaced wholesale rather
+// than diffed against.
+func (r *podRelay) beginSync() {
+	r.mu.Lock()
+	r.current = nil
+	r.lastSent = nil
+	r.syncing = true
+	r.mu.Unlock()
+}
+
+// apply feeds a delta of manager-computed AgentPodInfo, relayed as-is,
+// whether it originated from the combined stream's AgentPods field or from
+// the legacy agent-pod watch chain.
+func (r *podRelay) apply(upserts map[string]*manager.AgentPodInfo, removals []string) {
+	r.mu.Lock()
+	if r.current == nil {
+		r.current = make(map[string]*manager.AgentPodInfo, len(upserts))
+	}
+	maps.DeltaUpdate(r.current, upserts, removals)
+	r.syncing = false
+	r.mu.Unlock()
+	r.notify()
+}
+
+func (r *podRelay) notify() {
+	select {
+	case r.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+// nextDelta computes the AgentPodsDelta to send next, together with the
+// current snapshot that commitSent must be called with after a successful
+// send. ok is false when there's nothing to send: a sync is in progress, or
+// nothing has changed since the last successful send.
+func (r *podRelay) nextDelta() (delta *rootdRpc.AgentPodsDelta, snapshot map[string]*manager.AgentPodInfo, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.syncing {
+		return nil, nil, false
+	}
+	if r.lastSent == nil {
+		snapshot = maps.Copy(r.current)
+		return &rootdRpc.AgentPodsDelta{Reset_: true, Upserts: snapshot}, snapshot, true
+	}
+	upserts := make(map[string]*manager.AgentPodInfo)
+	for k, v := range r.current {
+		if old, ok := r.lastSent[k]; !ok || !proto.Equal(old, v) {
+			upserts[k] = v
+		}
+	}
+	var removals []string
+	for k := range r.lastSent {
+		if _, ok := r.current[k]; !ok {
+			removals = append(removals, k)
+		}
+	}
+	if len(upserts) == 0 && len(removals) == 0 {
+		return nil, nil, false
+	}
+	snapshot = maps.Copy(r.current)
+	return &rootdRpc.AgentPodsDelta{Upserts: upserts, Removals: removals}, snapshot, true
+}
+
+// commitSent records snapshot as the state last successfully relayed.
+func (r *podRelay) commitSent(snapshot map[string]*manager.AgentPodInfo) {
+	r.mu.Lock()
+	r.lastSent = snapshot
+	r.mu.Unlock()
+}
+
+// resetSent forgets what was last relayed, so the next successful send is a
+// full reset. Used after a failed send, so the root daemon (which may not
+// have received that message, or may be a newly (re)connected one) is
+// brought back to a known state rather than trusted to hold a partial one.
+func (r *podRelay) resetSent() {
+	r.mu.Lock()
+	r.lastSent = nil
+	r.mu.Unlock()
+}
+
+// run relays the accumulated projection to the root daemon until ctx is
+// done, or the root daemon reports that it doesn't support the relay (an old
+// root daemon self-watches agent pods; there is nothing more to do for this
+// session, ever).
+func (r *podRelay) run(ctx context.Context, s *session) error {
+	interval := client.GetConfig(ctx).Grpc().WatchRetryInterval
+	var stream rootdRpc.Daemon_WatchAgentPodsClient
+	defer func() {
+		if stream != nil {
+			_, _ = stream.CloseAndRecv()
+		}
+	}()
+
+	var lastGeneration uint64
+	needRetry := false
+	for {
+		var retryCh <-chan time.Time
+		if needRetry {
+			retryCh = time.After(interval)
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.notifyCh:
+		case <-retryCh:
+		}
+		needRetry = false
+
+		rd, generation := s.getRootDaemon()
+		if rd == nil {
+			needRetry = true
+			continue
+		}
+		if generation != lastGeneration {
+			// A (re)connected root daemon holds none of our state; the next
+			// send must be a full reset, and any stream referencing the
+			// previous connection is stale.
+			stream = nil
+			r.resetSent()
+			lastGeneration = generation
+		}
+
+		if applier, ok := rd.(podRelayApplier); ok {
+			delta, snapshot, ok := r.nextDelta()
+			if !ok {
+				continue
+			}
+			if err := applier.ApplyAgentPodsDelta(ctx, delta); err != nil {
+				if status.Code(err) == codes.Unimplemented {
+					clog.Warnf(ctx, podRelayUnimplementedWarning)
+					return nil
+				}
+				r.resetSent()
+				needRetry = true
+				continue
+			}
+			r.commitSent(snapshot)
+			continue
+		}
+
+		if stream == nil {
+			var err error
+			stream, err = rd.WatchAgentPods(ctx)
+			if err != nil {
+				if status.Code(err) == codes.Unimplemented {
+					clog.Warnf(ctx, podRelayUnimplementedWarning)
+					return nil
+				}
+				r.resetSent()
+				needRetry = true
+				continue
+			}
+		}
+
+		delta, snapshot, ok := r.nextDelta()
+		if !ok {
+			continue
+		}
+		if sendErr := stream.Send(delta); sendErr != nil {
+			failed := stream
+			stream = nil
+			if errors.Is(sendErr, io.EOF) {
+				// Send does not surface the server's actual status when the
+				// stream ended from the server side (e.g. Unimplemented):
+				// grpc-go only returns io.EOF there, and the real status
+				// must be retrieved by finishing the call.
+				_, sendErr = failed.CloseAndRecv()
+			}
+			if status.Code(sendErr) == codes.Unimplemented {
+				clog.Warnf(ctx, podRelayUnimplementedWarning)
+				return nil
+			}
+			r.resetSent()
+			needRetry = true
+			continue
+		}
+		r.commitSent(snapshot)
+	}
+}

--- a/pkg/client/userd/trafficmgr/podrelay_test.go
+++ b/pkg/client/userd/trafficmgr/podrelay_test.go
@@ -1,0 +1,313 @@
+package trafficmgr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rootdRpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+)
+
+func testPod(ip string) *manager.AgentPodInfo {
+	return &manager.AgentPodInfo{PodId: "uid", PodName: "n", Namespace: "ns", PodIp: []byte(ip)}
+}
+
+// TestPodRelayNextDelta exercises the send-one-delta step (nextDelta /
+// commitSent / resetSent) standalone, without a runner or a session.
+func TestPodRelayNextDelta(t *testing.T) {
+	t.Run("first push after apply is a full reset", func(t *testing.T) {
+		r := newPodRelay()
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a"), "b": testPod("b")}, nil)
+
+		delta, snapshot, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.True(t, delta.Reset_)
+		assert.Empty(t, delta.Removals)
+		assert.Len(t, delta.Upserts, 2)
+		r.commitSent(snapshot)
+
+		// Nothing changed: no further delta until something mutates.
+		_, _, ok = r.nextDelta()
+		assert.False(t, ok)
+	})
+
+	t.Run("subsequent apply produces a minimal diff", func(t *testing.T) {
+		r := newPodRelay()
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a"), "b": testPod("b")}, nil)
+		_, snap, _ := r.nextDelta()
+		r.commitSent(snap)
+
+		// "a" changes, "b" is dropped, "c" is added.
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a-changed"), "c": testPod("c")}, []string{"b"})
+		delta, snap2, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.False(t, delta.Reset_)
+		assert.ElementsMatch(t, []string{"b"}, delta.Removals)
+		require.Len(t, delta.Upserts, 2)
+		assert.Equal(t, []byte("a-changed"), delta.Upserts["a"].PodIp)
+		assert.Equal(t, []byte("c"), delta.Upserts["c"].PodIp)
+		r.commitSent(snap2)
+
+		_, _, ok = r.nextDelta()
+		assert.False(t, ok)
+	})
+
+	t.Run("apply feeds legacy deltas incrementally", func(t *testing.T) {
+		r := newPodRelay()
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+		delta, snap, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.True(t, delta.Reset_)
+		assert.Len(t, delta.Upserts, 1)
+		r.commitSent(snap)
+
+		r.apply(map[string]*manager.AgentPodInfo{"b": testPod("b")}, []string{"a"})
+		delta, snap2, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.False(t, delta.Reset_)
+		assert.Equal(t, []string{"a"}, delta.Removals)
+		assert.Len(t, delta.Upserts, 1)
+		r.commitSent(snap2)
+	})
+
+	t.Run("beginSync suppresses pushes until the next mutation", func(t *testing.T) {
+		r := newPodRelay()
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+		_, snap, _ := r.nextDelta()
+		r.commitSent(snap)
+
+		r.beginSync()
+		_, _, ok := r.nextDelta()
+		assert.False(t, ok, "nextDelta must not produce anything while syncing")
+
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+		delta, _, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.True(t, delta.Reset_, "the push after beginSync must be a full reset")
+	})
+
+	t.Run("resetSent forces the next push to be a full reset", func(t *testing.T) {
+		r := newPodRelay()
+		r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+		_, snap, _ := r.nextDelta()
+		r.commitSent(snap)
+
+		// Simulate a failed send.
+		r.resetSent()
+		delta, _, ok := r.nextDelta()
+		require.True(t, ok)
+		assert.True(t, delta.Reset_)
+		assert.Len(t, delta.Upserts, 1)
+	})
+}
+
+// fakeApplierRootDaemon implements the podRelayApplier interface used for the
+// in-process root session, and returns Unimplemented (or another error) when
+// configured to, to exercise the runner's degradation path.
+type fakeApplierRootDaemon struct {
+	rootdRpc.DaemonClient // nil: only ApplyAgentPodsDelta is exercised by the runner in this mode
+	received              chan *rootdRpc.AgentPodsDelta
+	err                   error
+}
+
+func (f *fakeApplierRootDaemon) ApplyAgentPodsDelta(_ context.Context, delta *rootdRpc.AgentPodsDelta) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.received <- delta
+	return nil
+}
+
+// testRelayContext returns a context configured with a short watch-retry
+// interval, plus a cancel function the caller must invoke (and then wait for
+// runErr) before the test returns, so the runner goroutine and its gRPC
+// resources don't outlive the test.
+func testRelayContext(t *testing.T) (context.Context, context.CancelFunc) {
+	cfg := client.GetDefaultConfig()
+	cfg.Grpc().WatchRetryInterval = 20 * time.Millisecond
+	return context.WithCancel(client.WithConfig(context.Background(), cfg))
+}
+
+func TestPodRelayRunInProcess(t *testing.T) {
+	ctx, cancel := testRelayContext(t)
+	fake := &fakeApplierRootDaemon{received: make(chan *rootdRpc.AgentPodsDelta, 4)}
+	s := &session{}
+	s.setRootDaemon(fake, nil, nil, false)
+
+	r := newPodRelay()
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.run(ctx, s) }()
+
+	r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+	select {
+	case delta := <-fake.received:
+		assert.True(t, delta.Reset_)
+		assert.Len(t, delta.Upserts, 1)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relayed delta")
+	}
+
+	r.apply(map[string]*manager.AgentPodInfo{"b": testPod("b")}, nil)
+	select {
+	case delta := <-fake.received:
+		assert.False(t, delta.Reset_)
+		assert.Len(t, delta.Upserts, 1)
+		assert.Contains(t, delta.Upserts, "b")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relayed delta")
+	}
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("run returned early: %v", err)
+	default:
+	}
+	cancel()
+	<-runErr
+}
+
+func TestPodRelayRunInProcessUnimplemented(t *testing.T) {
+	ctx, cancel := testRelayContext(t)
+	defer cancel()
+	fake := &fakeApplierRootDaemon{
+		received: make(chan *rootdRpc.AgentPodsDelta, 4),
+		err:      status.Error(codes.Unimplemented, "no relay support"),
+	}
+	s := &session{}
+	s.setRootDaemon(fake, nil, nil, false)
+
+	r := newPodRelay()
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.run(ctx, s) }()
+
+	r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+	select {
+	case err := <-runErr:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for run to stop after Unimplemented")
+	}
+}
+
+// podRelayTestServer is a minimal daemon.Daemon gRPC server that only
+// implements WatchAgentPods, used to exercise the runner's client-streaming
+// path end-to-end.
+type podRelayTestServer struct {
+	rootdRpc.UnimplementedDaemonServer
+	received      chan *rootdRpc.AgentPodsDelta
+	unimplemented bool
+}
+
+func (s *podRelayTestServer) WatchAgentPods(stream grpc.ClientStreamingServer[rootdRpc.AgentPodsDelta, emptypb.Empty]) error {
+	if s.unimplemented {
+		return status.Error(codes.Unimplemented, "not implemented")
+	}
+	for {
+		delta, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return stream.SendAndClose(&emptypb.Empty{})
+			}
+			return err
+		}
+		s.received <- delta
+	}
+}
+
+func TestPodRelayRunStream(t *testing.T) {
+	ctx, cancel := testRelayContext(t)
+	defer cancel()
+	server := &podRelayTestServer{received: make(chan *rootdRpc.AgentPodsDelta, 4)}
+	conn, cleanup, err := dialTestRootDaemon(server)
+	require.NoError(t, err)
+	defer cleanup()
+
+	s := &session{}
+	s.setRootDaemon(rootdRpc.NewDaemonClient(conn), conn, nil, false)
+
+	r := newPodRelay()
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.run(ctx, s) }()
+
+	r.apply(map[string]*manager.AgentPodInfo{"a": testPod("a")}, nil)
+	select {
+	case delta := <-server.received:
+		assert.True(t, delta.Reset_)
+		assert.Len(t, delta.Upserts, 1)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relayed delta")
+	}
+
+	r.apply(map[string]*manager.AgentPodInfo{"b": testPod("b")}, nil)
+	select {
+	case delta := <-server.received:
+		assert.False(t, delta.Reset_)
+		assert.Contains(t, delta.Upserts, "b")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relayed delta")
+	}
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("run returned early: %v", err)
+	default:
+	}
+
+	// Cancel and wait for the runner to finish (it does a best-effort
+	// CloseAndRecv) before the deferred cleanup tears down the connection and
+	// server, so this test doesn't leak a goroutine racing the next test's
+	// bufconn setup.
+	cancel()
+	<-runErr
+}
+
+func TestPodRelayRunStreamUnimplemented(t *testing.T) {
+	ctx, cancel := testRelayContext(t)
+	defer cancel()
+	server := &podRelayTestServer{received: make(chan *rootdRpc.AgentPodsDelta, 4), unimplemented: true}
+	conn, cleanup, err := dialTestRootDaemon(server)
+	require.NoError(t, err)
+	defer cleanup()
+
+	s := &session{}
+	s.setRootDaemon(rootdRpc.NewDaemonClient(conn), conn, nil, false)
+
+	r := newPodRelay()
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.run(ctx, s) }()
+
+	// grpc-go's Send can return nil for a message written right after the
+	// stream was opened, even though the server already ended the RPC with
+	// Unimplemented without reading anything: the local write completes
+	// before the client's transport has processed the server's trailers-only
+	// response. Keep mutating until the runner observes the failure (it does
+	// within a send or two, once that processing catches up), rather than
+	// relying on exactly one Send to surface it.
+	i := 0
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-runErr:
+			assert.NoError(t, err)
+			return
+		case <-ticker.C:
+			i++
+			r.apply(map[string]*manager.AgentPodInfo{"a": testPod(fmt.Sprintf("a%d", i))}, nil)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for run to stop after Unimplemented")
+		}
+	}
+}

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -124,13 +124,14 @@ type session struct {
 
 	ingestTracker *podAccessTracker
 
-	// currentInterceptsLock ensures that all accesses to currentAgents, currentIntercepts, currentMatchers,
+	// currentInterceptsLock ensures that all accesses to currentAgentPods, currentIntercepts, currentMatchers,
 	// currentAPIServers, interceptWaiters, and ingressInfo are synchronized
 	//
 	currentInterceptsLock sync.Mutex
 
-	// currentAgents is the latest snapshot returned by the agents watcher.
-	currentAgents []*manager.AgentInfo
+	// currentAgentPods is the latest agent-pod snapshot: built from AgentPodInfo in
+	// combined mode, projected from AgentInfo in legacy fallback mode.
+	currentAgentPods []agentPod
 
 	// currentIntercepts is the latest snapshot returned by the intercept watcher. It
 	// is keyeed by the intercept ID
@@ -168,6 +169,37 @@ type session struct {
 	// root daemon. Captured here so the usage reporter can read it when the
 	// session itself shuts down.
 	rootEndMetrics *rootdRpc.Activity
+
+	// podRelay accumulates the agent-pod projection and relays it to the root
+	// daemon. Only driven when agentPodWatchNamespaces is non-empty.
+	podRelay *podRelay
+
+	// agentPodWatchNamespacesOnce and agentPodWatchNamespacesValue memoize
+	// agentPodWatchNamespaces; the mapped namespace set is fixed after the
+	// session is constructed.
+	agentPodWatchNamespacesOnce  sync.Once
+	agentPodWatchNamespacesValue []string
+}
+
+// agentPodWatchNamespaces returns the namespaces in which this client watches
+// agent pods: nil when cluster.agentPortForward is disabled (there's no
+// channel to traffic-agents at all), otherwise the mapped namespaces this
+// client can port-forward to. This is the same computation the root daemon's
+// Start used to perform on its own (rootd/session.go); the user daemon now
+// performs it once and passes the result to the traffic-manager
+// (SessionEventsRequest.Namespaces) and to the root daemon
+// (NetworkConfig.AgentPodNamespaces) so both sides agree without computing it
+// independently.
+func (s *session) agentPodWatchNamespaces() []string {
+	s.agentPodWatchNamespacesOnce.Do(func() {
+		if !client.GetConfig(s).Cluster().AgentPortForward {
+			return
+		}
+		s.agentPodWatchNamespacesValue = slices.DeleteFunc(s.GetCurrentNamespaces(true), func(ns string) bool {
+			return !k8s.CanPortForward(s, ns)
+		})
+	})
+	return s.agentPodWatchNamespacesValue
 }
 
 func (s *session) RevokeIntercept(ctx context.Context, interceptID string) error {
@@ -396,6 +428,7 @@ func connectMgr(
 		interceptWaiters:   make(map[string]*awaitIntercept),
 		isPodDaemon:        cr.IsPodDaemon,
 		subnetViaWorkloads: cr.SubnetViaWorkloads,
+		podRelay:           newPodRelay(),
 	}
 	sess.Context = withSession(sess.Context, sess)
 	return sess, nil
@@ -417,6 +450,9 @@ func (s *session) reconnectManager() (returnedErr error) {
 		}
 	}()
 
+	// Agents is intentionally left empty: traffic-agents hold their own manager
+	// sessions and re-arrive on their own within seconds of a manager restart;
+	// intercepts are restored in full below.
 	_, err = manager.NewManagerClient(conn).ReconnectClient(tc, &manager.ReconnectClientRequest{
 		Session: s.sessionInfo,
 		Client: &manager.ClientInfo{
@@ -427,7 +463,6 @@ func (s *session) reconnectManager() (returnedErr error) {
 			Version:   client.Version(),
 		},
 		Intercepts: s.getCurrentInterceptInfos(),
-		Agents:     s.getCurrentAgents(),
 	})
 	if err != nil {
 		return fmt.Errorf("unable to reconnect client: %w", err)
@@ -557,13 +592,16 @@ func (s *session) rootDaemonReconnectConfig() (*rootdRpc.NetworkConfig, bool) {
 	nc.Session = s.sessionInfo
 	nc.SubnetViaWorkloads = s.subnetViaWorkloads
 	nc.ClientConfig, _ = json.Marshal(client.GetConfig(s))
+	nc.AgentPodNamespaces = s.agentPodWatchNamespaces()
 	return nc, isPodDaemon
 }
 
 func (s *session) startServices(g log.Group) {
 	g.Go("remain", s.remainLoop)
-	g.Go("agents", s.watchAgentsLoop)
-	g.Go("intercept-port-forward", s.watchInterceptsHandler)
+	g.Go("session-events", s.sessionEventsHandler)
+	if len(s.agentPodWatchNamespaces()) > 0 {
+		g.Go("agent-pods-relay", func(ctx context.Context) error { return s.podRelay.run(ctx, s) })
+	}
 }
 
 func runWithRetry(ctx context.Context, f func(context.Context) error) error {
@@ -789,10 +827,12 @@ func (s *session) WorkloadInfoSnapshot(
 		return &rpc.WorkloadInfoSnapshot{}, nil
 	}
 	if len(nss) == 1 && nss[0] == s.Namespace {
-		cas := s.getCurrentAgents()
+		cas := s.getCurrentAgentPods()
 		sMap = make(map[string]string, len(cas))
 		for _, a := range cas {
-			sMap[a.Name] = a.Version
+			if a.namespace == s.Namespace {
+				sMap[a.workload] = a.version
+			}
 		}
 	}
 	s.ensureWatchers(nss)
@@ -1015,6 +1055,7 @@ func (s *session) getNetworkInfo(cr *rpc.ConnectRequest) *rootdRpc.NetworkConfig
 		SubnetViaWorkloads: s.subnetViaWorkloads,
 		HomeDir:            homedir.HomeDir(),
 		ClientConfig:       jsonCfg,
+		AgentPodNamespaces: s.agentPodWatchNamespaces(),
 	}
 }
 

--- a/pkg/client/userd/trafficmgr/sessionevents.go
+++ b/pkg/client/userd/trafficmgr/sessionevents.go
@@ -1,0 +1,178 @@
+package trafficmgr
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/agentpf"
+	"github.com/telepresenceio/telepresence/v2/pkg/grpc/watcher"
+	"github.com/telepresenceio/telepresence/v2/pkg/log"
+	"github.com/telepresenceio/telepresence/v2/pkg/maps"
+)
+
+// sessionEventsHandler drives the combined WatchSessionEvents watcher for as
+// long as the session lives, degrading to watchSessionEventsLegacy the first
+// time the traffic-manager reports it doesn't support the combined stream.
+func (s *session) sessionEventsHandler(ctx context.Context) error {
+	return runWithRetry(ctx, s.watchSessionEventsLoop)
+}
+
+func (s *session) watchSessionEventsLoop(ctx context.Context) error {
+	err := s.watchSessionEvents(ctx)
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		clog.Warnf(ctx, "WatchSessionEvents is not implemented by the traffic-manager, falling back to separate watchers")
+		return s.watchSessionEventsLegacy(ctx)
+	}
+	return err
+}
+
+// coveredCombined reports whether namespace is one the combined stream keeps
+// agent-pod state current for -- the namespaces requested in
+// SessionEventsRequest plus the connected namespace.
+func (s *session) coveredCombined(namespace string) bool {
+	if namespace == s.Namespace {
+		return true
+	}
+	for _, ns := range s.agentPodWatchNamespaces() {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// applyAgentPodsDelta folds delta into podMap and returns the resulting
+// snapshot as []agentPod. Pulled out of watchSessionEvents so the
+// accumulation step is exercisable without a stream.
+func applyAgentPodsDelta(podMap map[string]*manager.AgentPodInfo, delta *manager.AgentPodInfoDelta) []agentPod {
+	maps.DeltaUpdate(podMap, delta.Upserts, delta.Removals)
+	pods := make([]agentPod, 0, len(podMap))
+	for _, ap := range podMap {
+		pods = append(pods, agentPodFromPodInfo(ap))
+	}
+	return pods
+}
+
+// applyInterceptsDelta folds delta into icMap and returns the resulting
+// intercept snapshot. Pulled out of watchSessionEvents for the same reason as
+// applyAgentPodsDelta.
+func applyInterceptsDelta(icMap map[string]*manager.InterceptInfo, delta *manager.InterceptInfoDelta) []*manager.InterceptInfo {
+	maps.DeltaUpdate(icMap, delta.Upserts, delta.Removals)
+	return maps.Values(icMap)
+}
+
+// watchSessionEvents runs the combined manager watcher: it maintains the
+// accumulated agent-pod map fed by delta.AgentPods (driving the ingest
+// lifecycle and the internal agent-pod cache, then forwarding the delta
+// unchanged to the relay), and the intercept map fed by delta.Intercepts
+// (driving handleInterceptSnapshot, unchanged from the legacy watcher).
+//
+// Intercept snapshots are handled on their own goroutine, mirroring the
+// concurrency model of the legacy loops (which run on separate goroutines
+// over separate streams). handleInterceptSnapshot can block in ensureAccess,
+// waiting for the root daemon to learn an agent-pod IP -- and that pod's
+// delta may be queued behind the intercept delta on this very stream, so
+// handling intercepts inline would starve the relay until the wait times
+// out. Snapshots are full, so a newer one supersedes an unprocessed older
+// one (coalesced through a one-slot mailbox).
+func (s *session) watchSessionEvents(ctx context.Context) error {
+	pat := newPodAccessTracker()
+	podMap := make(map[string]*manager.AgentPodInfo)
+	icMap := make(map[string]*manager.InterceptInfo)
+	relayEnabled := len(s.agentPodWatchNamespaces()) > 0
+	everReceived := false
+
+	icSnapshots := make(chan []*manager.InterceptInfo, 1)
+	icDone := make(chan struct{})
+	go func() {
+		defer close(icDone)
+		for snap := range icSnapshots {
+			s.handleInterceptSnapshot(pat, snap)
+		}
+	}()
+
+	err := watcher.WatchWithRetry(ctx, "WatchSessionEvents", client.GetConfig(ctx).Grpc().WatchRetryInterval,
+		func(ctx context.Context) (grpc.ServerStreamingClient[manager.SessionEventsDelta], error) {
+			return s.ManagerClient().WatchSessionEvents(ctx, &manager.SessionEventsRequest{
+				Session:    s.SessionInfo(),
+				Namespaces: s.agentPodWatchNamespaces(),
+			})
+		},
+		func(delta *manager.SessionEventsDelta) error {
+			everReceived = true
+			if ad := delta.AgentPods; ad != nil {
+				pods := applyAgentPodsDelta(podMap, ad)
+				s.handleAgentPodSnapshot(ctx, pods, s.coveredCombined)
+				if relayEnabled {
+					s.podRelay.apply(ad.Upserts, ad.Removals)
+				}
+			}
+			if id := delta.Intercepts; id != nil {
+				snap := applyInterceptsDelta(icMap, id)
+				select {
+				case <-icSnapshots: // discard a superseded, unprocessed snapshot
+				default:
+				}
+				icSnapshots <- snap
+			}
+			return nil
+		}, func() error {
+			clear(podMap)
+			clear(icMap)
+			if relayEnabled {
+				s.podRelay.beginSync()
+			}
+			return s.reconnectManager()
+		})
+
+	// Stop the intercept consumer and wait it out, so the final cleanup below
+	// never runs concurrently with a snapshot it is still processing.
+	close(icSnapshots)
+	<-icDone
+
+	if err != nil && status.Code(err) == codes.Unimplemented && !everReceived {
+		// The probe failed immediately; watchSessionEventsLegacy owns the
+		// consumers' lifecycle from here on.
+		return err
+	}
+	// Handle as if we had empty snapshots. This ensures port forwards and volume mounts
+	// are cancelled correctly, exactly as the legacy loops' tails do.
+	s.handleAgentPodSnapshot(ctx, nil, s.coveredCombined)
+	s.handleInterceptSnapshot(pat, nil)
+	return err
+}
+
+// watchSessionEventsLegacy drives the three legacy manager watchers
+// concurrently, for traffic-managers that don't implement
+// WatchSessionEvents. It feeds the relay exactly as the combined loop does:
+// the manager-computed AgentPodInfo, relayed as-is.
+func (s *session) watchSessionEventsLegacy(ctx context.Context) error {
+	relayEnabled := len(s.agentPodWatchNamespaces()) > 0
+
+	g := log.NewGroup(ctx)
+	g.Go("agents", s.watchAgentsLoop)
+	g.Go("intercept-port-forward", s.watchInterceptsHandler)
+	if relayEnabled {
+		g.Go("agent-pods-legacy", func(ctx context.Context) error {
+			return agentpf.WatchPods(ctx, s.ManagerClient(), s.SessionInfo(), s.agentPodWatchNamespaces(), s.Namespace,
+				func(upserts map[string]*manager.AgentPodInfo, removals []string) error {
+					s.podRelay.apply(upserts, removals)
+					return nil
+				},
+				func() error {
+					s.podRelay.beginSync()
+					return nil
+				},
+				func(narrowed []string) {
+					clog.Warnf(ctx, "agent-pod watch narrowed to namespaces %v", narrowed)
+				})
+		})
+	}
+	return g.Wait()
+}

--- a/pkg/client/userd/trafficmgr/sessionevents_test.go
+++ b/pkg/client/userd/trafficmgr/sessionevents_test.go
@@ -1,0 +1,96 @@
+package trafficmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
+)
+
+func testAgentPodInfo(workload, namespace, podName string) *manager.AgentPodInfo {
+	return &manager.AgentPodInfo{WorkloadName: workload, Namespace: namespace, PodName: podName, Version: "v1"}
+}
+
+// TestApplyAgentPodsDelta exercises the pure accumulation step behind
+// watchSessionEvents' delta.AgentPods dispatch: upserts and removals fold
+// into the running map, and the returned snapshot is the []agentPod
+// projection of that map (all namespaces, not just the connected one).
+func TestApplyAgentPodsDelta(t *testing.T) {
+	t.Run("upserts accumulate into agentPod entries", func(t *testing.T) {
+		podMap := make(map[string]*manager.AgentPodInfo)
+		pods := applyAgentPodsDelta(podMap, &manager.AgentPodInfoDelta{
+			Upserts: map[string]*manager.AgentPodInfo{
+				"a1": testAgentPodInfo("echo", "default", "echo-1"),
+				"a2": testAgentPodInfo("other", "other-ns", "other-1"),
+			},
+		})
+		require.Len(t, pods, 2)
+		byWorkload := make(map[string]agentPod, len(pods))
+		for _, p := range pods {
+			byWorkload[p.workload] = p
+		}
+		assert.Equal(t, "default", byWorkload["echo"].namespace)
+		assert.Equal(t, "other-ns", byWorkload["other"].namespace)
+		assert.Equal(t, "v1", byWorkload["echo"].version)
+	})
+
+	t.Run("removals drop entries from subsequent snapshots", func(t *testing.T) {
+		podMap := make(map[string]*manager.AgentPodInfo)
+		applyAgentPodsDelta(podMap, &manager.AgentPodInfoDelta{
+			Upserts: map[string]*manager.AgentPodInfo{
+				"a1": testAgentPodInfo("echo", "default", "echo-1"),
+				"a2": testAgentPodInfo("other", "default", "other-1"),
+			},
+		})
+		pods := applyAgentPodsDelta(podMap, &manager.AgentPodInfoDelta{Removals: []string{"a2"}})
+		require.Len(t, pods, 1)
+		assert.Equal(t, "echo", pods[0].workload)
+	})
+
+	t.Run("a pod replacement (same key, new pod name) is reflected", func(t *testing.T) {
+		podMap := make(map[string]*manager.AgentPodInfo)
+		applyAgentPodsDelta(podMap, &manager.AgentPodInfoDelta{
+			Upserts: map[string]*manager.AgentPodInfo{"a1": testAgentPodInfo("echo", "default", "echo-1")},
+		})
+		pods := applyAgentPodsDelta(podMap, &manager.AgentPodInfoDelta{
+			Upserts: map[string]*manager.AgentPodInfo{"a1": testAgentPodInfo("echo", "default", "echo-2")},
+		})
+		require.Len(t, pods, 1)
+		assert.Equal(t, "echo-2", pods[0].podName)
+	})
+}
+
+// TestApplyInterceptsDelta exercises the pure accumulation step behind
+// watchSessionEvents' delta.Intercepts dispatch.
+func TestApplyInterceptsDelta(t *testing.T) {
+	icMap := make(map[string]*manager.InterceptInfo)
+	ics := applyInterceptsDelta(icMap, &manager.InterceptInfoDelta{
+		Upserts: map[string]*manager.InterceptInfo{
+			"i1": {Id: "i1", Disposition: manager.InterceptDispositionType_ACTIVE},
+		},
+	})
+	require.Len(t, ics, 1)
+
+	ics = applyInterceptsDelta(icMap, &manager.InterceptInfoDelta{Removals: []string{"i1"}})
+	assert.Empty(t, ics)
+}
+
+// TestCoveredCombined exercises the namespace-scoping predicate the combined
+// loop passes to handleAgentPodSnapshot / cancelUnwanted: the connected
+// namespace and the explicitly requested (port-forwardable) namespaces are
+// covered, anything else is not.
+func TestCoveredCombined(t *testing.T) {
+	s := &session{
+		Cluster: &k8s.Cluster{Kubeconfig: &k8s.Kubeconfig{Namespace: "default"}},
+	}
+	s.agentPodWatchNamespacesValue = []string{"team-a", "team-b"}
+	s.agentPodWatchNamespacesOnce.Do(func() {}) // pre-seed so agentPodWatchNamespaces() doesn't recompute
+
+	assert.True(t, s.coveredCombined("default"))
+	assert.True(t, s.coveredCombined("team-a"))
+	assert.True(t, s.coveredCombined("team-b"))
+	assert.False(t, s.coveredCombined("team-c"))
+}

--- a/rpc/daemon/daemon.pb.go
+++ b/rpc/daemon/daemon.pb.go
@@ -525,9 +525,13 @@ type NetworkConfig struct {
 	// Kubeconfig YAML, if not to be loaded from file.
 	KubeconfigData []byte `protobuf:"bytes,6,opt,name=kubeconfig_data,json=kubeconfigData,proto3,oneof" json:"kubeconfig_data,omitempty"`
 	// The completely merged client Config, unless daemon runs embedded
-	ClientConfig  []byte `protobuf:"bytes,7,opt,name=client_config,json=clientConfig,proto3,oneof" json:"client_config,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ClientConfig []byte `protobuf:"bytes,7,opt,name=client_config,json=clientConfig,proto3,oneof" json:"client_config,omitempty"`
+	// Namespaces in which the user daemon relays agent-pod events using
+	// WatchAgentPods. When non-empty, this daemon must not watch agent pods
+	// itself.
+	AgentPodNamespaces []string `protobuf:"bytes,11,rep,name=agent_pod_namespaces,json=agentPodNamespaces,proto3" json:"agent_pod_namespaces,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *NetworkConfig) Reset() {
@@ -630,6 +634,79 @@ func (x *NetworkConfig) GetClientConfig() []byte {
 	return nil
 }
 
+func (x *NetworkConfig) GetAgentPodNamespaces() []string {
+	if x != nil {
+		return x.AgentPodNamespaces
+	}
+	return nil
+}
+
+// AgentPodsDelta is pushed by the user daemon, carrying the agent-pod
+// projection it derives from its combined traffic-manager watcher.
+type AgentPodsDelta struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When true, discard all previously received agent-pod state before
+	// applying the upserts/removals in this message. Set on the first message
+	// of every relay stream and whenever the user daemon's traffic-manager
+	// watcher has been re-established.
+	Reset_        bool                             `protobuf:"varint,1,opt,name=reset,proto3" json:"reset,omitempty"`
+	Upserts       map[string]*manager.AgentPodInfo `protobuf:"bytes,2,rep,name=upserts,proto3" json:"upserts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Removals      []string                         `protobuf:"bytes,3,rep,name=removals,proto3" json:"removals,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentPodsDelta) Reset() {
+	*x = AgentPodsDelta{}
+	mi := &file_daemon_daemon_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentPodsDelta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentPodsDelta) ProtoMessage() {}
+
+func (x *AgentPodsDelta) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_daemon_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentPodsDelta.ProtoReflect.Descriptor instead.
+func (*AgentPodsDelta) Descriptor() ([]byte, []int) {
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *AgentPodsDelta) GetReset_() bool {
+	if x != nil {
+		return x.Reset_
+	}
+	return false
+}
+
+func (x *AgentPodsDelta) GetUpserts() map[string]*manager.AgentPodInfo {
+	if x != nil {
+		return x.Upserts
+	}
+	return nil
+}
+
+func (x *AgentPodsDelta) GetRemovals() []string {
+	if x != nil {
+		return x.Removals
+	}
+	return nil
+}
+
 type SetDNSExcludesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Excludes      []string               `protobuf:"bytes,1,rep,name=excludes,proto3" json:"excludes,omitempty"`
@@ -639,7 +716,7 @@ type SetDNSExcludesRequest struct {
 
 func (x *SetDNSExcludesRequest) Reset() {
 	*x = SetDNSExcludesRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[8]
+	mi := &file_daemon_daemon_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -651,7 +728,7 @@ func (x *SetDNSExcludesRequest) String() string {
 func (*SetDNSExcludesRequest) ProtoMessage() {}
 
 func (x *SetDNSExcludesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[8]
+	mi := &file_daemon_daemon_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -664,7 +741,7 @@ func (x *SetDNSExcludesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetDNSExcludesRequest.ProtoReflect.Descriptor instead.
 func (*SetDNSExcludesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{8}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SetDNSExcludesRequest) GetExcludes() []string {
@@ -683,7 +760,7 @@ type SetDNSMappingsRequest struct {
 
 func (x *SetDNSMappingsRequest) Reset() {
 	*x = SetDNSMappingsRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[9]
+	mi := &file_daemon_daemon_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -695,7 +772,7 @@ func (x *SetDNSMappingsRequest) String() string {
 func (*SetDNSMappingsRequest) ProtoMessage() {}
 
 func (x *SetDNSMappingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[9]
+	mi := &file_daemon_daemon_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -708,7 +785,7 @@ func (x *SetDNSMappingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetDNSMappingsRequest.ProtoReflect.Descriptor instead.
 func (*SetDNSMappingsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{9}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SetDNSMappingsRequest) GetMappings() []*DNSMapping {
@@ -729,7 +806,7 @@ type WaitForAgentIPRequest struct {
 
 func (x *WaitForAgentIPRequest) Reset() {
 	*x = WaitForAgentIPRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[10]
+	mi := &file_daemon_daemon_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -741,7 +818,7 @@ func (x *WaitForAgentIPRequest) String() string {
 func (*WaitForAgentIPRequest) ProtoMessage() {}
 
 func (x *WaitForAgentIPRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[10]
+	mi := &file_daemon_daemon_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -754,7 +831,7 @@ func (x *WaitForAgentIPRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WaitForAgentIPRequest.ProtoReflect.Descriptor instead.
 func (*WaitForAgentIPRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{10}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *WaitForAgentIPRequest) GetIp() []byte {
@@ -788,7 +865,7 @@ type WaitForAgentIPResponse struct {
 
 func (x *WaitForAgentIPResponse) Reset() {
 	*x = WaitForAgentIPResponse{}
-	mi := &file_daemon_daemon_proto_msgTypes[11]
+	mi := &file_daemon_daemon_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -800,7 +877,7 @@ func (x *WaitForAgentIPResponse) String() string {
 func (*WaitForAgentIPResponse) ProtoMessage() {}
 
 func (x *WaitForAgentIPResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[11]
+	mi := &file_daemon_daemon_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -813,7 +890,7 @@ func (x *WaitForAgentIPResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WaitForAgentIPResponse.ProtoReflect.Descriptor instead.
 func (*WaitForAgentIPResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{11}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *WaitForAgentIPResponse) GetLocalIp() []byte {
@@ -832,7 +909,7 @@ type LookupIPRequest struct {
 
 func (x *LookupIPRequest) Reset() {
 	*x = LookupIPRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[12]
+	mi := &file_daemon_daemon_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -844,7 +921,7 @@ func (x *LookupIPRequest) String() string {
 func (*LookupIPRequest) ProtoMessage() {}
 
 func (x *LookupIPRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[12]
+	mi := &file_daemon_daemon_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -857,7 +934,7 @@ func (x *LookupIPRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupIPRequest.ProtoReflect.Descriptor instead.
 func (*LookupIPRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{12}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LookupIPRequest) GetName() string {
@@ -877,7 +954,7 @@ type LookupIPResponse struct {
 
 func (x *LookupIPResponse) Reset() {
 	*x = LookupIPResponse{}
-	mi := &file_daemon_daemon_proto_msgTypes[13]
+	mi := &file_daemon_daemon_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -889,7 +966,7 @@ func (x *LookupIPResponse) String() string {
 func (*LookupIPResponse) ProtoMessage() {}
 
 func (x *LookupIPResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[13]
+	mi := &file_daemon_daemon_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -902,7 +979,7 @@ func (x *LookupIPResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupIPResponse.ProtoReflect.Descriptor instead.
 func (*LookupIPResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{13}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *LookupIPResponse) GetIp() []byte {
@@ -921,7 +998,7 @@ type Environment struct {
 
 func (x *Environment) Reset() {
 	*x = Environment{}
-	mi := &file_daemon_daemon_proto_msgTypes[14]
+	mi := &file_daemon_daemon_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -933,7 +1010,7 @@ func (x *Environment) String() string {
 func (*Environment) ProtoMessage() {}
 
 func (x *Environment) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[14]
+	mi := &file_daemon_daemon_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -946,7 +1023,7 @@ func (x *Environment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Environment.ProtoReflect.Descriptor instead.
 func (*Environment) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{14}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Environment) GetEnv() map[string]string {
@@ -968,7 +1045,7 @@ type ResolvePortRequest struct {
 
 func (x *ResolvePortRequest) Reset() {
 	*x = ResolvePortRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[15]
+	mi := &file_daemon_daemon_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -980,7 +1057,7 @@ func (x *ResolvePortRequest) String() string {
 func (*ResolvePortRequest) ProtoMessage() {}
 
 func (x *ResolvePortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[15]
+	mi := &file_daemon_daemon_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -993,7 +1070,7 @@ func (x *ResolvePortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolvePortRequest.ProtoReflect.Descriptor instead.
 func (*ResolvePortRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{15}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ResolvePortRequest) GetHost() string {
@@ -1020,7 +1097,7 @@ type ResolvePortResponse struct {
 
 func (x *ResolvePortResponse) Reset() {
 	*x = ResolvePortResponse{}
-	mi := &file_daemon_daemon_proto_msgTypes[16]
+	mi := &file_daemon_daemon_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1032,7 +1109,7 @@ func (x *ResolvePortResponse) String() string {
 func (*ResolvePortResponse) ProtoMessage() {}
 
 func (x *ResolvePortResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[16]
+	mi := &file_daemon_daemon_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1045,7 +1122,7 @@ func (x *ResolvePortResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolvePortResponse.ProtoReflect.Descriptor instead.
 func (*ResolvePortResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{16}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ResolvePortResponse) GetHostPort() []byte {
@@ -1067,7 +1144,7 @@ type ReroutePortRequest struct {
 
 func (x *ReroutePortRequest) Reset() {
 	*x = ReroutePortRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[17]
+	mi := &file_daemon_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1079,7 +1156,7 @@ func (x *ReroutePortRequest) String() string {
 func (*ReroutePortRequest) ProtoMessage() {}
 
 func (x *ReroutePortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[17]
+	mi := &file_daemon_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1092,7 +1169,7 @@ func (x *ReroutePortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReroutePortRequest.ProtoReflect.Descriptor instead.
 func (*ReroutePortRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{17}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ReroutePortRequest) GetDstHostPort() []byte {
@@ -1132,7 +1209,7 @@ type InterceptShortcut struct {
 
 func (x *InterceptShortcut) Reset() {
 	*x = InterceptShortcut{}
-	mi := &file_daemon_daemon_proto_msgTypes[18]
+	mi := &file_daemon_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1144,7 +1221,7 @@ func (x *InterceptShortcut) String() string {
 func (*InterceptShortcut) ProtoMessage() {}
 
 func (x *InterceptShortcut) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[18]
+	mi := &file_daemon_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1157,7 +1234,7 @@ func (x *InterceptShortcut) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterceptShortcut.ProtoReflect.Descriptor instead.
 func (*InterceptShortcut) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *InterceptShortcut) GetNamespace() string {
@@ -1211,7 +1288,7 @@ type SetInterceptShortcutsRequest struct {
 
 func (x *SetInterceptShortcutsRequest) Reset() {
 	*x = SetInterceptShortcutsRequest{}
-	mi := &file_daemon_daemon_proto_msgTypes[19]
+	mi := &file_daemon_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1223,7 +1300,7 @@ func (x *SetInterceptShortcutsRequest) String() string {
 func (*SetInterceptShortcutsRequest) ProtoMessage() {}
 
 func (x *SetInterceptShortcutsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[19]
+	mi := &file_daemon_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1236,7 +1313,7 @@ func (x *SetInterceptShortcutsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetInterceptShortcutsRequest.ProtoReflect.Descriptor instead.
 func (*SetInterceptShortcutsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SetInterceptShortcutsRequest) GetShortcuts() []*InterceptShortcut {
@@ -1256,7 +1333,7 @@ type QuitResponse struct {
 
 func (x *QuitResponse) Reset() {
 	*x = QuitResponse{}
-	mi := &file_daemon_daemon_proto_msgTypes[20]
+	mi := &file_daemon_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1268,7 +1345,7 @@ func (x *QuitResponse) String() string {
 func (*QuitResponse) ProtoMessage() {}
 
 func (x *QuitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[20]
+	mi := &file_daemon_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1281,7 +1358,7 @@ func (x *QuitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuitResponse.ProtoReflect.Descriptor instead.
 func (*QuitResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *QuitResponse) GetRootDaemonWillContinue() bool {
@@ -1322,7 +1399,7 @@ type Activity struct {
 
 func (x *Activity) Reset() {
 	*x = Activity{}
-	mi := &file_daemon_daemon_proto_msgTypes[21]
+	mi := &file_daemon_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1334,7 +1411,7 @@ func (x *Activity) String() string {
 func (*Activity) ProtoMessage() {}
 
 func (x *Activity) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[21]
+	mi := &file_daemon_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1347,7 +1424,7 @@ func (x *Activity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Activity.ProtoReflect.Descriptor instead.
 func (*Activity) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Activity) GetActivity() *timestamppb.Timestamp {
@@ -1436,7 +1513,7 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\x05error\x18\a \x01(\tR\x05error\"G\n" +
 	"\x11SubnetViaWorkload\x12\x16\n" +
 	"\x06subnet\x18\x01 \x01(\tR\x06subnet\x12\x1a\n" +
-	"\bworkload\x18\x02 \x01(\tR\bworkload\"\xec\x04\n" +
+	"\bworkload\x18\x02 \x01(\tR\bworkload\"\x9e\x05\n" +
 	"\rNetworkConfig\x12;\n" +
 	"\asession\x18\x01 \x01(\v2!.telepresence.manager.SessionInfoR\asession\x12X\n" +
 	"\x14subnet_via_workloads\x18\x02 \x03(\v2&.telepresence.daemon.SubnetViaWorkloadR\x12subnetViaWorkloads\x12#\n" +
@@ -1449,12 +1526,20 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\n" +
 	"kube_flags\x18\x05 \x03(\v21.telepresence.daemon.NetworkConfig.KubeFlagsEntryR\tkubeFlags\x12,\n" +
 	"\x0fkubeconfig_data\x18\x06 \x01(\fH\x00R\x0ekubeconfigData\x88\x01\x01\x12(\n" +
-	"\rclient_config\x18\a \x01(\fH\x01R\fclientConfig\x88\x01\x01\x1a<\n" +
+	"\rclient_config\x18\a \x01(\fH\x01R\fclientConfig\x88\x01\x01\x120\n" +
+	"\x14agent_pod_namespaces\x18\v \x03(\tR\x12agentPodNamespaces\x1a<\n" +
 	"\x0eKubeFlagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x12\n" +
 	"\x10_kubeconfig_dataB\x10\n" +
-	"\x0e_client_config\"3\n" +
+	"\x0e_client_config\"\xee\x01\n" +
+	"\x0eAgentPodsDelta\x12\x14\n" +
+	"\x05reset\x18\x01 \x01(\bR\x05reset\x12J\n" +
+	"\aupserts\x18\x02 \x03(\v20.telepresence.daemon.AgentPodsDelta.UpsertsEntryR\aupserts\x12\x1a\n" +
+	"\bremovals\x18\x03 \x03(\tR\bremovals\x1a^\n" +
+	"\fUpsertsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x128\n" +
+	"\x05value\x18\x02 \x01(\v2\".telepresence.manager.AgentPodInfoR\x05value:\x028\x01\"3\n" +
 	"\x15SetDNSExcludesRequest\x12\x1a\n" +
 	"\bexcludes\x18\x01 \x03(\tR\bexcludes\"T\n" +
 	"\x15SetDNSMappingsRequest\x12;\n" +
@@ -1501,7 +1586,7 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\x10outbound_tunnels\x18\x04 \x01(\x03R\x0foutboundTunnels\x124\n" +
 	"\x16outbound_tunnel_errors\x18\x05 \x01(\x03R\x14outboundTunnelErrors\x12%\n" +
 	"\x0eincoming_dials\x18\x06 \x01(\x03R\rincomingDials\x120\n" +
-	"\x14incoming_dial_errors\x18\a \x01(\x03R\x12incomingDialErrors2\xc3\v\n" +
+	"\x14incoming_dial_errors\x18\a \x01(\x03R\x12incomingDialErrors2\x94\f\n" +
 	"\x06Daemon\x12C\n" +
 	"\aVersion\x12\x16.google.protobuf.Empty\x1a .telepresence.common.VersionInfo\x12C\n" +
 	"\x06Status\x12\x16.google.protobuf.Empty\x1a!.telepresence.daemon.DaemonStatus\x12A\n" +
@@ -1521,7 +1606,8 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\vResolvePort\x12'.telepresence.daemon.ResolvePortRequest\x1a(.telepresence.daemon.ResolvePortResponse\x12T\n" +
 	"\x11RerouteRemotePort\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12b\n" +
 	"\x15SetInterceptShortcuts\x121.telepresence.daemon.SetInterceptShortcutsRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
-	"\x0fActivityWatcher\x12\x16.google.protobuf.Empty\x1a\x1d.telepresence.daemon.Activity0\x01B6Z4github.com/telepresenceio/telepresence/rpc/v2/daemonb\x06proto3"
+	"\x0fActivityWatcher\x12\x16.google.protobuf.Empty\x1a\x1d.telepresence.daemon.Activity0\x01\x12O\n" +
+	"\x0eWatchAgentPods\x12#.telepresence.daemon.AgentPodsDelta\x1a\x16.google.protobuf.Empty(\x01B6Z4github.com/telepresenceio/telepresence/rpc/v2/daemonb\x06proto3"
 
 var (
 	file_daemon_daemon_proto_rawDescOnce sync.Once
@@ -1535,7 +1621,7 @@ func file_daemon_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_daemon_proto_rawDescData
 }
 
-var file_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_daemon_daemon_proto_goTypes = []any{
 	(*DaemonStatus)(nil),                 // 0: telepresence.daemon.DaemonStatus
 	(*TunnelTransport)(nil),              // 1: telepresence.daemon.TunnelTransport
@@ -1545,86 +1631,93 @@ var file_daemon_daemon_proto_goTypes = []any{
 	(*DNSConfig)(nil),                    // 5: telepresence.daemon.DNSConfig
 	(*SubnetViaWorkload)(nil),            // 6: telepresence.daemon.SubnetViaWorkload
 	(*NetworkConfig)(nil),                // 7: telepresence.daemon.NetworkConfig
-	(*SetDNSExcludesRequest)(nil),        // 8: telepresence.daemon.SetDNSExcludesRequest
-	(*SetDNSMappingsRequest)(nil),        // 9: telepresence.daemon.SetDNSMappingsRequest
-	(*WaitForAgentIPRequest)(nil),        // 10: telepresence.daemon.WaitForAgentIPRequest
-	(*WaitForAgentIPResponse)(nil),       // 11: telepresence.daemon.WaitForAgentIPResponse
-	(*LookupIPRequest)(nil),              // 12: telepresence.daemon.LookupIPRequest
-	(*LookupIPResponse)(nil),             // 13: telepresence.daemon.LookupIPResponse
-	(*Environment)(nil),                  // 14: telepresence.daemon.Environment
-	(*ResolvePortRequest)(nil),           // 15: telepresence.daemon.ResolvePortRequest
-	(*ResolvePortResponse)(nil),          // 16: telepresence.daemon.ResolvePortResponse
-	(*ReroutePortRequest)(nil),           // 17: telepresence.daemon.ReroutePortRequest
-	(*InterceptShortcut)(nil),            // 18: telepresence.daemon.InterceptShortcut
-	(*SetInterceptShortcutsRequest)(nil), // 19: telepresence.daemon.SetInterceptShortcutsRequest
-	(*QuitResponse)(nil),                 // 20: telepresence.daemon.QuitResponse
-	(*Activity)(nil),                     // 21: telepresence.daemon.Activity
-	nil,                                  // 22: telepresence.daemon.NetworkConfig.KubeFlagsEntry
-	nil,                                  // 23: telepresence.daemon.Environment.EnvEntry
-	(*common.VersionInfo)(nil),           // 24: telepresence.common.VersionInfo
-	(*durationpb.Duration)(nil),          // 25: google.protobuf.Duration
-	(*manager.SessionInfo)(nil),          // 26: telepresence.manager.SessionInfo
-	(*timestamppb.Timestamp)(nil),        // 27: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                // 28: google.protobuf.Empty
-	(*manager.LogLevelRequest)(nil),      // 29: telepresence.manager.LogLevelRequest
+	(*AgentPodsDelta)(nil),               // 8: telepresence.daemon.AgentPodsDelta
+	(*SetDNSExcludesRequest)(nil),        // 9: telepresence.daemon.SetDNSExcludesRequest
+	(*SetDNSMappingsRequest)(nil),        // 10: telepresence.daemon.SetDNSMappingsRequest
+	(*WaitForAgentIPRequest)(nil),        // 11: telepresence.daemon.WaitForAgentIPRequest
+	(*WaitForAgentIPResponse)(nil),       // 12: telepresence.daemon.WaitForAgentIPResponse
+	(*LookupIPRequest)(nil),              // 13: telepresence.daemon.LookupIPRequest
+	(*LookupIPResponse)(nil),             // 14: telepresence.daemon.LookupIPResponse
+	(*Environment)(nil),                  // 15: telepresence.daemon.Environment
+	(*ResolvePortRequest)(nil),           // 16: telepresence.daemon.ResolvePortRequest
+	(*ResolvePortResponse)(nil),          // 17: telepresence.daemon.ResolvePortResponse
+	(*ReroutePortRequest)(nil),           // 18: telepresence.daemon.ReroutePortRequest
+	(*InterceptShortcut)(nil),            // 19: telepresence.daemon.InterceptShortcut
+	(*SetInterceptShortcutsRequest)(nil), // 20: telepresence.daemon.SetInterceptShortcutsRequest
+	(*QuitResponse)(nil),                 // 21: telepresence.daemon.QuitResponse
+	(*Activity)(nil),                     // 22: telepresence.daemon.Activity
+	nil,                                  // 23: telepresence.daemon.NetworkConfig.KubeFlagsEntry
+	nil,                                  // 24: telepresence.daemon.AgentPodsDelta.UpsertsEntry
+	nil,                                  // 25: telepresence.daemon.Environment.EnvEntry
+	(*common.VersionInfo)(nil),           // 26: telepresence.common.VersionInfo
+	(*durationpb.Duration)(nil),          // 27: google.protobuf.Duration
+	(*manager.SessionInfo)(nil),          // 28: telepresence.manager.SessionInfo
+	(*timestamppb.Timestamp)(nil),        // 29: google.protobuf.Timestamp
+	(*manager.AgentPodInfo)(nil),         // 30: telepresence.manager.AgentPodInfo
+	(*emptypb.Empty)(nil),                // 31: google.protobuf.Empty
+	(*manager.LogLevelRequest)(nil),      // 32: telepresence.manager.LogLevelRequest
 }
 var file_daemon_daemon_proto_depIdxs = []int32{
 	7,  // 0: telepresence.daemon.DaemonStatus.outbound_config:type_name -> telepresence.daemon.NetworkConfig
-	24, // 1: telepresence.daemon.DaemonStatus.version:type_name -> telepresence.common.VersionInfo
+	26, // 1: telepresence.daemon.DaemonStatus.version:type_name -> telepresence.common.VersionInfo
 	1,  // 2: telepresence.daemon.DaemonStatus.tunnel_transport:type_name -> telepresence.daemon.TunnelTransport
 	2,  // 3: telepresence.daemon.DaemonStatus.agent_transports:type_name -> telepresence.daemon.AgentTransport
 	4,  // 4: telepresence.daemon.DNSConfig.mappings:type_name -> telepresence.daemon.DNSMapping
-	25, // 5: telepresence.daemon.DNSConfig.lookup_timeout:type_name -> google.protobuf.Duration
-	26, // 6: telepresence.daemon.NetworkConfig.session:type_name -> telepresence.manager.SessionInfo
+	27, // 5: telepresence.daemon.DNSConfig.lookup_timeout:type_name -> google.protobuf.Duration
+	28, // 6: telepresence.daemon.NetworkConfig.session:type_name -> telepresence.manager.SessionInfo
 	6,  // 7: telepresence.daemon.NetworkConfig.subnet_via_workloads:type_name -> telepresence.daemon.SubnetViaWorkload
-	22, // 8: telepresence.daemon.NetworkConfig.kube_flags:type_name -> telepresence.daemon.NetworkConfig.KubeFlagsEntry
-	4,  // 9: telepresence.daemon.SetDNSMappingsRequest.mappings:type_name -> telepresence.daemon.DNSMapping
-	25, // 10: telepresence.daemon.WaitForAgentIPRequest.timeout:type_name -> google.protobuf.Duration
-	23, // 11: telepresence.daemon.Environment.env:type_name -> telepresence.daemon.Environment.EnvEntry
-	18, // 12: telepresence.daemon.SetInterceptShortcutsRequest.shortcuts:type_name -> telepresence.daemon.InterceptShortcut
-	27, // 13: telepresence.daemon.Activity.activity:type_name -> google.protobuf.Timestamp
-	25, // 14: telepresence.daemon.Activity.session_duration:type_name -> google.protobuf.Duration
-	28, // 15: telepresence.daemon.Daemon.Version:input_type -> google.protobuf.Empty
-	28, // 16: telepresence.daemon.Daemon.Status:input_type -> google.protobuf.Empty
-	28, // 17: telepresence.daemon.Daemon.Quit:input_type -> google.protobuf.Empty
-	7,  // 18: telepresence.daemon.Daemon.Connect:input_type -> telepresence.daemon.NetworkConfig
-	28, // 19: telepresence.daemon.Daemon.Disconnect:input_type -> google.protobuf.Empty
-	28, // 20: telepresence.daemon.Daemon.GetNetworkConfig:input_type -> google.protobuf.Empty
-	3,  // 21: telepresence.daemon.Daemon.SetDNSTopLevelDomains:input_type -> telepresence.daemon.Domains
-	8,  // 22: telepresence.daemon.Daemon.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
-	9,  // 23: telepresence.daemon.Daemon.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
-	29, // 24: telepresence.daemon.Daemon.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	14, // 25: telepresence.daemon.Daemon.TranslateEnvIPs:input_type -> telepresence.daemon.Environment
-	28, // 26: telepresence.daemon.Daemon.WaitForNetwork:input_type -> google.protobuf.Empty
-	10, // 27: telepresence.daemon.Daemon.WaitForAgentIP:input_type -> telepresence.daemon.WaitForAgentIPRequest
-	12, // 28: telepresence.daemon.Daemon.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
-	15, // 29: telepresence.daemon.Daemon.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
-	17, // 30: telepresence.daemon.Daemon.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
-	19, // 31: telepresence.daemon.Daemon.SetInterceptShortcuts:input_type -> telepresence.daemon.SetInterceptShortcutsRequest
-	28, // 32: telepresence.daemon.Daemon.ActivityWatcher:input_type -> google.protobuf.Empty
-	24, // 33: telepresence.daemon.Daemon.Version:output_type -> telepresence.common.VersionInfo
-	0,  // 34: telepresence.daemon.Daemon.Status:output_type -> telepresence.daemon.DaemonStatus
-	20, // 35: telepresence.daemon.Daemon.Quit:output_type -> telepresence.daemon.QuitResponse
-	0,  // 36: telepresence.daemon.Daemon.Connect:output_type -> telepresence.daemon.DaemonStatus
-	28, // 37: telepresence.daemon.Daemon.Disconnect:output_type -> google.protobuf.Empty
-	7,  // 38: telepresence.daemon.Daemon.GetNetworkConfig:output_type -> telepresence.daemon.NetworkConfig
-	28, // 39: telepresence.daemon.Daemon.SetDNSTopLevelDomains:output_type -> google.protobuf.Empty
-	28, // 40: telepresence.daemon.Daemon.SetDNSExcludes:output_type -> google.protobuf.Empty
-	28, // 41: telepresence.daemon.Daemon.SetDNSMappings:output_type -> google.protobuf.Empty
-	28, // 42: telepresence.daemon.Daemon.SetLogLevel:output_type -> google.protobuf.Empty
-	14, // 43: telepresence.daemon.Daemon.TranslateEnvIPs:output_type -> telepresence.daemon.Environment
-	28, // 44: telepresence.daemon.Daemon.WaitForNetwork:output_type -> google.protobuf.Empty
-	11, // 45: telepresence.daemon.Daemon.WaitForAgentIP:output_type -> telepresence.daemon.WaitForAgentIPResponse
-	13, // 46: telepresence.daemon.Daemon.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
-	16, // 47: telepresence.daemon.Daemon.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
-	28, // 48: telepresence.daemon.Daemon.RerouteRemotePort:output_type -> google.protobuf.Empty
-	28, // 49: telepresence.daemon.Daemon.SetInterceptShortcuts:output_type -> google.protobuf.Empty
-	21, // 50: telepresence.daemon.Daemon.ActivityWatcher:output_type -> telepresence.daemon.Activity
-	33, // [33:51] is the sub-list for method output_type
-	15, // [15:33] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	23, // 8: telepresence.daemon.NetworkConfig.kube_flags:type_name -> telepresence.daemon.NetworkConfig.KubeFlagsEntry
+	24, // 9: telepresence.daemon.AgentPodsDelta.upserts:type_name -> telepresence.daemon.AgentPodsDelta.UpsertsEntry
+	4,  // 10: telepresence.daemon.SetDNSMappingsRequest.mappings:type_name -> telepresence.daemon.DNSMapping
+	27, // 11: telepresence.daemon.WaitForAgentIPRequest.timeout:type_name -> google.protobuf.Duration
+	25, // 12: telepresence.daemon.Environment.env:type_name -> telepresence.daemon.Environment.EnvEntry
+	19, // 13: telepresence.daemon.SetInterceptShortcutsRequest.shortcuts:type_name -> telepresence.daemon.InterceptShortcut
+	29, // 14: telepresence.daemon.Activity.activity:type_name -> google.protobuf.Timestamp
+	27, // 15: telepresence.daemon.Activity.session_duration:type_name -> google.protobuf.Duration
+	30, // 16: telepresence.daemon.AgentPodsDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	31, // 17: telepresence.daemon.Daemon.Version:input_type -> google.protobuf.Empty
+	31, // 18: telepresence.daemon.Daemon.Status:input_type -> google.protobuf.Empty
+	31, // 19: telepresence.daemon.Daemon.Quit:input_type -> google.protobuf.Empty
+	7,  // 20: telepresence.daemon.Daemon.Connect:input_type -> telepresence.daemon.NetworkConfig
+	31, // 21: telepresence.daemon.Daemon.Disconnect:input_type -> google.protobuf.Empty
+	31, // 22: telepresence.daemon.Daemon.GetNetworkConfig:input_type -> google.protobuf.Empty
+	3,  // 23: telepresence.daemon.Daemon.SetDNSTopLevelDomains:input_type -> telepresence.daemon.Domains
+	9,  // 24: telepresence.daemon.Daemon.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
+	10, // 25: telepresence.daemon.Daemon.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
+	32, // 26: telepresence.daemon.Daemon.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	15, // 27: telepresence.daemon.Daemon.TranslateEnvIPs:input_type -> telepresence.daemon.Environment
+	31, // 28: telepresence.daemon.Daemon.WaitForNetwork:input_type -> google.protobuf.Empty
+	11, // 29: telepresence.daemon.Daemon.WaitForAgentIP:input_type -> telepresence.daemon.WaitForAgentIPRequest
+	13, // 30: telepresence.daemon.Daemon.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
+	16, // 31: telepresence.daemon.Daemon.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
+	18, // 32: telepresence.daemon.Daemon.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
+	20, // 33: telepresence.daemon.Daemon.SetInterceptShortcuts:input_type -> telepresence.daemon.SetInterceptShortcutsRequest
+	31, // 34: telepresence.daemon.Daemon.ActivityWatcher:input_type -> google.protobuf.Empty
+	8,  // 35: telepresence.daemon.Daemon.WatchAgentPods:input_type -> telepresence.daemon.AgentPodsDelta
+	26, // 36: telepresence.daemon.Daemon.Version:output_type -> telepresence.common.VersionInfo
+	0,  // 37: telepresence.daemon.Daemon.Status:output_type -> telepresence.daemon.DaemonStatus
+	21, // 38: telepresence.daemon.Daemon.Quit:output_type -> telepresence.daemon.QuitResponse
+	0,  // 39: telepresence.daemon.Daemon.Connect:output_type -> telepresence.daemon.DaemonStatus
+	31, // 40: telepresence.daemon.Daemon.Disconnect:output_type -> google.protobuf.Empty
+	7,  // 41: telepresence.daemon.Daemon.GetNetworkConfig:output_type -> telepresence.daemon.NetworkConfig
+	31, // 42: telepresence.daemon.Daemon.SetDNSTopLevelDomains:output_type -> google.protobuf.Empty
+	31, // 43: telepresence.daemon.Daemon.SetDNSExcludes:output_type -> google.protobuf.Empty
+	31, // 44: telepresence.daemon.Daemon.SetDNSMappings:output_type -> google.protobuf.Empty
+	31, // 45: telepresence.daemon.Daemon.SetLogLevel:output_type -> google.protobuf.Empty
+	15, // 46: telepresence.daemon.Daemon.TranslateEnvIPs:output_type -> telepresence.daemon.Environment
+	31, // 47: telepresence.daemon.Daemon.WaitForNetwork:output_type -> google.protobuf.Empty
+	12, // 48: telepresence.daemon.Daemon.WaitForAgentIP:output_type -> telepresence.daemon.WaitForAgentIPResponse
+	14, // 49: telepresence.daemon.Daemon.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
+	17, // 50: telepresence.daemon.Daemon.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
+	31, // 51: telepresence.daemon.Daemon.RerouteRemotePort:output_type -> google.protobuf.Empty
+	31, // 52: telepresence.daemon.Daemon.SetInterceptShortcuts:output_type -> google.protobuf.Empty
+	22, // 53: telepresence.daemon.Daemon.ActivityWatcher:output_type -> telepresence.daemon.Activity
+	31, // 54: telepresence.daemon.Daemon.WatchAgentPods:output_type -> google.protobuf.Empty
+	36, // [36:55] is the sub-list for method output_type
+	17, // [17:36] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_daemon_daemon_proto_init() }
@@ -1639,7 +1732,7 @@ func file_daemon_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_daemon_proto_rawDesc), len(file_daemon_daemon_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   24,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/daemon/daemon.proto
+++ b/rpc/daemon/daemon.proto
@@ -66,6 +66,13 @@ service Daemon {
   rpc SetInterceptShortcuts(SetInterceptShortcutsRequest) returns (google.protobuf.Empty);
 
   rpc ActivityWatcher(google.protobuf.Empty) returns (stream Activity);
+
+  // WatchAgentPods is called by the user daemon to push the agent-pod
+  // projection it derives from its combined traffic-manager watcher. It is
+  // only used when the NetworkConfig passed to Connect has a non-empty
+  // agent_pod_namespaces, which tells this daemon not to watch agent pods
+  // itself.
+  rpc WatchAgentPods(stream AgentPodsDelta) returns (google.protobuf.Empty);
 }
 
 message DaemonStatus {
@@ -192,6 +199,23 @@ message NetworkConfig {
 
   // The completely merged client Config, unless daemon runs embedded
   optional bytes client_config = 7;
+
+  // Namespaces in which the user daemon relays agent-pod events using
+  // WatchAgentPods. When non-empty, this daemon must not watch agent pods
+  // itself.
+  repeated string agent_pod_namespaces = 11;
+}
+
+// AgentPodsDelta is pushed by the user daemon, carrying the agent-pod
+// projection it derives from its combined traffic-manager watcher.
+message AgentPodsDelta {
+  // When true, discard all previously received agent-pod state before
+  // applying the upserts/removals in this message. Set on the first message
+  // of every relay stream and whenever the user daemon's traffic-manager
+  // watcher has been re-established.
+  bool reset = 1;
+  map<string, manager.AgentPodInfo> upserts = 2;
+  repeated string removals = 3;
 }
 
 message SetDNSExcludesRequest {

--- a/rpc/daemon/daemon_grpc.pb.go
+++ b/rpc/daemon/daemon_grpc.pb.go
@@ -40,6 +40,7 @@ const (
 	Daemon_RerouteRemotePort_FullMethodName     = "/telepresence.daemon.Daemon/RerouteRemotePort"
 	Daemon_SetInterceptShortcuts_FullMethodName = "/telepresence.daemon.Daemon/SetInterceptShortcuts"
 	Daemon_ActivityWatcher_FullMethodName       = "/telepresence.daemon.Daemon/ActivityWatcher"
+	Daemon_WatchAgentPods_FullMethodName        = "/telepresence.daemon.Daemon/WatchAgentPods"
 )
 
 // DaemonClient is the client API for Daemon service.
@@ -86,6 +87,12 @@ type DaemonClient interface {
 	// Each call replaces the previously declared set.
 	SetInterceptShortcuts(ctx context.Context, in *SetInterceptShortcutsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	ActivityWatcher(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Activity], error)
+	// WatchAgentPods is called by the user daemon to push the agent-pod
+	// projection it derives from its combined traffic-manager watcher. It is
+	// only used when the NetworkConfig passed to Connect has a non-empty
+	// agent_pod_namespaces, which tells this daemon not to watch agent pods
+	// itself.
+	WatchAgentPods(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[AgentPodsDelta, emptypb.Empty], error)
 }
 
 type daemonClient struct {
@@ -285,6 +292,19 @@ func (c *daemonClient) ActivityWatcher(ctx context.Context, in *emptypb.Empty, o
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Daemon_ActivityWatcherClient = grpc.ServerStreamingClient[Activity]
 
+func (c *daemonClient) WatchAgentPods(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[AgentPodsDelta, emptypb.Empty], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[1], Daemon_WatchAgentPods_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[AgentPodsDelta, emptypb.Empty]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Daemon_WatchAgentPodsClient = grpc.ClientStreamingClient[AgentPodsDelta, emptypb.Empty]
+
 // DaemonServer is the server API for Daemon service.
 // All implementations must embed UnimplementedDaemonServer
 // for forward compatibility.
@@ -329,6 +349,12 @@ type DaemonServer interface {
 	// Each call replaces the previously declared set.
 	SetInterceptShortcuts(context.Context, *SetInterceptShortcutsRequest) (*emptypb.Empty, error)
 	ActivityWatcher(*emptypb.Empty, grpc.ServerStreamingServer[Activity]) error
+	// WatchAgentPods is called by the user daemon to push the agent-pod
+	// projection it derives from its combined traffic-manager watcher. It is
+	// only used when the NetworkConfig passed to Connect has a non-empty
+	// agent_pod_namespaces, which tells this daemon not to watch agent pods
+	// itself.
+	WatchAgentPods(grpc.ClientStreamingServer[AgentPodsDelta, emptypb.Empty]) error
 	mustEmbedUnimplementedDaemonServer()
 }
 
@@ -392,6 +418,9 @@ func (UnimplementedDaemonServer) SetInterceptShortcuts(context.Context, *SetInte
 }
 func (UnimplementedDaemonServer) ActivityWatcher(*emptypb.Empty, grpc.ServerStreamingServer[Activity]) error {
 	return status.Error(codes.Unimplemented, "method ActivityWatcher not implemented")
+}
+func (UnimplementedDaemonServer) WatchAgentPods(grpc.ClientStreamingServer[AgentPodsDelta, emptypb.Empty]) error {
+	return status.Error(codes.Unimplemented, "method WatchAgentPods not implemented")
 }
 func (UnimplementedDaemonServer) mustEmbedUnimplementedDaemonServer() {}
 func (UnimplementedDaemonServer) testEmbeddedByValue()                {}
@@ -731,6 +760,13 @@ func _Daemon_ActivityWatcher_Handler(srv interface{}, stream grpc.ServerStream) 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Daemon_ActivityWatcherServer = grpc.ServerStreamingServer[Activity]
 
+func _Daemon_WatchAgentPods_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(DaemonServer).WatchAgentPods(&grpc.GenericServerStream[AgentPodsDelta, emptypb.Empty]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Daemon_WatchAgentPodsServer = grpc.ClientStreamingServer[AgentPodsDelta, emptypb.Empty]
+
 // Daemon_ServiceDesc is the grpc.ServiceDesc for Daemon service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -812,6 +848,11 @@ var Daemon_ServiceDesc = grpc.ServiceDesc{
 			StreamName:    "ActivityWatcher",
 			Handler:       _Daemon_ActivityWatcher_Handler,
 			ServerStreams: true,
+		},
+		{
+			StreamName:    "WatchAgentPods",
+			Handler:       _Daemon_WatchAgentPods_Handler,
+			ClientStreams: true,
 		},
 	},
 	Metadata: "daemon/daemon.proto",

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -169,7 +169,7 @@ func (x WorkloadInfo_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_Kind.Descriptor instead.
 func (WorkloadInfo_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56, 0}
 }
 
 type WorkloadInfo_State int32
@@ -229,7 +229,7 @@ func (x WorkloadInfo_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_State.Descriptor instead.
 func (WorkloadInfo_State) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54, 1}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56, 1}
 }
 
 type WorkloadInfo_AgentState int32
@@ -281,7 +281,7 @@ func (x WorkloadInfo_AgentState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_AgentState.Descriptor instead.
 func (WorkloadInfo_AgentState) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54, 2}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56, 2}
 }
 
 type WorkloadEvent_Type int32
@@ -330,7 +330,7 @@ func (x WorkloadEvent_Type) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadEvent_Type.Descriptor instead.
 func (WorkloadEvent_Type) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{55, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{57, 0}
 }
 
 // ClientInfo is the self-reported metadata that the on-laptop
@@ -1569,6 +1569,125 @@ func (x *InterceptInfoDelta) GetRemovals() []string {
 	return nil
 }
 
+// SessionEventsRequest identifies the watching session and scopes the agent
+// portion of the WatchSessionEvents stream.
+type SessionEventsRequest struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Session *SessionInfo           `protobuf:"bytes,1,opt,name=session,proto3" json:"session,omitempty"`
+	// Namespaces in which the client wants agent events in addition to the
+	// session's connected namespace. This is the set of mapped namespaces that
+	// the client is permitted to port-forward to.
+	Namespaces    []string `protobuf:"bytes,2,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionEventsRequest) Reset() {
+	*x = SessionEventsRequest{}
+	mi := &file_manager_manager_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionEventsRequest) ProtoMessage() {}
+
+func (x *SessionEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionEventsRequest.ProtoReflect.Descriptor instead.
+func (*SessionEventsRequest) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *SessionEventsRequest) GetSession() *SessionInfo {
+	if x != nil {
+		return x.Session
+	}
+	return nil
+}
+
+func (x *SessionEventsRequest) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+// SessionEventsDelta multiplexes agent-pod and intercept deltas onto one
+// stream. Either or both fields may be present in a single message.
+//
+// Container-level agent data (environments, mounts, ports) is deliberately
+// not streamed; clients retrieve it on demand from the EnsureAgent response
+// or from InterceptInfo.
+type SessionEventsDelta struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Agent pods in the requested namespaces plus the session's connected
+	// namespace. Same projection as the WatchAgentPodsInNamespacesDelta
+	// stream, including the per-client intercepted flag.
+	AgentPods *AgentPodInfoDelta `protobuf:"bytes,1,opt,name=agent_pods,json=agentPods,proto3" json:"agent_pods,omitempty"`
+	// The watching client's intercepts.
+	Intercepts    *InterceptInfoDelta `protobuf:"bytes,2,opt,name=intercepts,proto3" json:"intercepts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SessionEventsDelta) Reset() {
+	*x = SessionEventsDelta{}
+	mi := &file_manager_manager_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionEventsDelta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionEventsDelta) ProtoMessage() {}
+
+func (x *SessionEventsDelta) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionEventsDelta.ProtoReflect.Descriptor instead.
+func (*SessionEventsDelta) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *SessionEventsDelta) GetAgentPods() *AgentPodInfoDelta {
+	if x != nil {
+		return x.AgentPods
+	}
+	return nil
+}
+
+func (x *SessionEventsDelta) GetIntercepts() *InterceptInfoDelta {
+	if x != nil {
+		return x.Intercepts
+	}
+	return nil
+}
+
 type CreateInterceptRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Session       *SessionInfo           `protobuf:"bytes,1,opt,name=session,proto3" json:"session,omitempty"`
@@ -1579,7 +1698,7 @@ type CreateInterceptRequest struct {
 
 func (x *CreateInterceptRequest) Reset() {
 	*x = CreateInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1710,7 @@ func (x *CreateInterceptRequest) String() string {
 func (*CreateInterceptRequest) ProtoMessage() {}
 
 func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1723,7 @@ func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInterceptRequest.ProtoReflect.Descriptor instead.
 func (*CreateInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{13}
+	return file_manager_manager_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateInterceptRequest) GetSession() *SessionInfo {
@@ -1637,7 +1756,7 @@ type EnsureAgentRequest struct {
 
 func (x *EnsureAgentRequest) Reset() {
 	*x = EnsureAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1649,7 +1768,7 @@ func (x *EnsureAgentRequest) String() string {
 func (*EnsureAgentRequest) ProtoMessage() {}
 
 func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1662,7 +1781,7 @@ func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnsureAgentRequest.ProtoReflect.Descriptor instead.
 func (*EnsureAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{14}
+	return file_manager_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *EnsureAgentRequest) GetSession() *SessionInfo {
@@ -1704,7 +1823,7 @@ type ReleaseAgentRequest struct {
 
 func (x *ReleaseAgentRequest) Reset() {
 	*x = ReleaseAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1716,7 +1835,7 @@ func (x *ReleaseAgentRequest) String() string {
 func (*ReleaseAgentRequest) ProtoMessage() {}
 
 func (x *ReleaseAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1729,7 +1848,7 @@ func (x *ReleaseAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReleaseAgentRequest.ProtoReflect.Descriptor instead.
 func (*ReleaseAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{15}
+	return file_manager_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ReleaseAgentRequest) GetSession() *SessionInfo {
@@ -1776,7 +1895,7 @@ type PreparedIntercept struct {
 
 func (x *PreparedIntercept) Reset() {
 	*x = PreparedIntercept{}
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1788,7 +1907,7 @@ func (x *PreparedIntercept) String() string {
 func (*PreparedIntercept) ProtoMessage() {}
 
 func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1801,7 +1920,7 @@ func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedIntercept.ProtoReflect.Descriptor instead.
 func (*PreparedIntercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{16}
+	return file_manager_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *PreparedIntercept) GetError() string {
@@ -1912,7 +2031,7 @@ type RemoveInterceptRequest2 struct {
 
 func (x *RemoveInterceptRequest2) Reset() {
 	*x = RemoveInterceptRequest2{}
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1924,7 +2043,7 @@ func (x *RemoveInterceptRequest2) String() string {
 func (*RemoveInterceptRequest2) ProtoMessage() {}
 
 func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1937,7 +2056,7 @@ func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveInterceptRequest2.ProtoReflect.Descriptor instead.
 func (*RemoveInterceptRequest2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{17}
+	return file_manager_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RemoveInterceptRequest2) GetSession() *SessionInfo {
@@ -1964,7 +2083,7 @@ type GetInterceptRequest struct {
 
 func (x *GetInterceptRequest) Reset() {
 	*x = GetInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2095,7 @@ func (x *GetInterceptRequest) String() string {
 func (*GetInterceptRequest) ProtoMessage() {}
 
 func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2108,7 @@ func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInterceptRequest.ProtoReflect.Descriptor instead.
 func (*GetInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{18}
+	return file_manager_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetInterceptRequest) GetSession() *SessionInfo {
@@ -2031,7 +2150,7 @@ type ReviewInterceptRequest struct {
 
 func (x *ReviewInterceptRequest) Reset() {
 	*x = ReviewInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2043,7 +2162,7 @@ func (x *ReviewInterceptRequest) String() string {
 func (*ReviewInterceptRequest) ProtoMessage() {}
 
 func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2056,7 +2175,7 @@ func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewInterceptRequest.ProtoReflect.Descriptor instead.
 func (*ReviewInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{19}
+	return file_manager_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ReviewInterceptRequest) GetSession() *SessionInfo {
@@ -2146,7 +2265,7 @@ type RemainRequest struct {
 
 func (x *RemainRequest) Reset() {
 	*x = RemainRequest{}
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2158,7 +2277,7 @@ func (x *RemainRequest) String() string {
 func (*RemainRequest) ProtoMessage() {}
 
 func (x *RemainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2171,7 +2290,7 @@ func (x *RemainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemainRequest.ProtoReflect.Descriptor instead.
 func (*RemainRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{20}
+	return file_manager_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RemainRequest) GetSession() *SessionInfo {
@@ -2200,7 +2319,7 @@ type LogLevelRequest struct {
 
 func (x *LogLevelRequest) Reset() {
 	*x = LogLevelRequest{}
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2212,7 +2331,7 @@ func (x *LogLevelRequest) String() string {
 func (*LogLevelRequest) ProtoMessage() {}
 
 func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2225,7 +2344,7 @@ func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogLevelRequest.ProtoReflect.Descriptor instead.
 func (*LogLevelRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{21}
+	return file_manager_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LogLevelRequest) GetLogLevel() string {
@@ -2258,7 +2377,7 @@ type GetLogsRequest struct {
 
 func (x *GetLogsRequest) Reset() {
 	*x = GetLogsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2270,7 +2389,7 @@ func (x *GetLogsRequest) String() string {
 func (*GetLogsRequest) ProtoMessage() {}
 
 func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2283,7 +2402,7 @@ func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetLogsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{22}
+	return file_manager_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetLogsRequest) GetTrafficManager() bool {
@@ -2325,7 +2444,7 @@ type LogsResponse struct {
 
 func (x *LogsResponse) Reset() {
 	*x = LogsResponse{}
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2337,7 +2456,7 @@ func (x *LogsResponse) String() string {
 func (*LogsResponse) ProtoMessage() {}
 
 func (x *LogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2350,7 +2469,7 @@ func (x *LogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogsResponse.ProtoReflect.Descriptor instead.
 func (*LogsResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{23}
+	return file_manager_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *LogsResponse) GetPodLogs() map[string]string {
@@ -2384,7 +2503,7 @@ type TelepresenceAPIInfo struct {
 
 func (x *TelepresenceAPIInfo) Reset() {
 	*x = TelepresenceAPIInfo{}
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2396,7 +2515,7 @@ func (x *TelepresenceAPIInfo) String() string {
 func (*TelepresenceAPIInfo) ProtoMessage() {}
 
 func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2409,7 +2528,7 @@ func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelepresenceAPIInfo.ProtoReflect.Descriptor instead.
 func (*TelepresenceAPIInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{24}
+	return file_manager_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TelepresenceAPIInfo) GetPort() int32 {
@@ -2431,7 +2550,7 @@ type VersionInfo2 struct {
 
 func (x *VersionInfo2) Reset() {
 	*x = VersionInfo2{}
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2443,7 +2562,7 @@ func (x *VersionInfo2) String() string {
 func (*VersionInfo2) ProtoMessage() {}
 
 func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2456,7 +2575,7 @@ func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionInfo2.ProtoReflect.Descriptor instead.
 func (*VersionInfo2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{25}
+	return file_manager_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *VersionInfo2) GetName() string {
@@ -2483,7 +2602,7 @@ type TunnelMessage struct {
 
 func (x *TunnelMessage) Reset() {
 	*x = TunnelMessage{}
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2495,7 +2614,7 @@ func (x *TunnelMessage) String() string {
 func (*TunnelMessage) ProtoMessage() {}
 
 func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2508,7 +2627,7 @@ func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMessage.ProtoReflect.Descriptor instead.
 func (*TunnelMessage) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{26}
+	return file_manager_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TunnelMessage) GetPayload() []byte {
@@ -2553,7 +2672,7 @@ type QuicTunnelEndpoint struct {
 
 func (x *QuicTunnelEndpoint) Reset() {
 	*x = QuicTunnelEndpoint{}
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2565,7 +2684,7 @@ func (x *QuicTunnelEndpoint) String() string {
 func (*QuicTunnelEndpoint) ProtoMessage() {}
 
 func (x *QuicTunnelEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2578,7 +2697,7 @@ func (x *QuicTunnelEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicTunnelEndpoint.ProtoReflect.Descriptor instead.
 func (*QuicTunnelEndpoint) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{27}
+	return file_manager_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *QuicTunnelEndpoint) GetEnabled() bool {
@@ -2656,7 +2775,7 @@ type QuicEndpointCandidate struct {
 
 func (x *QuicEndpointCandidate) Reset() {
 	*x = QuicEndpointCandidate{}
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2668,7 +2787,7 @@ func (x *QuicEndpointCandidate) String() string {
 func (*QuicEndpointCandidate) ProtoMessage() {}
 
 func (x *QuicEndpointCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2681,7 +2800,7 @@ func (x *QuicEndpointCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicEndpointCandidate.ProtoReflect.Descriptor instead.
 func (*QuicEndpointCandidate) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{28}
+	return file_manager_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *QuicEndpointCandidate) GetHost() string {
@@ -2719,7 +2838,7 @@ type QuicBackend struct {
 
 func (x *QuicBackend) Reset() {
 	*x = QuicBackend{}
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2731,7 +2850,7 @@ func (x *QuicBackend) String() string {
 func (*QuicBackend) ProtoMessage() {}
 
 func (x *QuicBackend) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2744,7 +2863,7 @@ func (x *QuicBackend) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicBackend.ProtoReflect.Descriptor instead.
 func (*QuicBackend) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{29}
+	return file_manager_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *QuicBackend) GetIp() []byte {
@@ -2788,7 +2907,7 @@ type QuicBackendSnapshot struct {
 
 func (x *QuicBackendSnapshot) Reset() {
 	*x = QuicBackendSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +2919,7 @@ func (x *QuicBackendSnapshot) String() string {
 func (*QuicBackendSnapshot) ProtoMessage() {}
 
 func (x *QuicBackendSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2813,7 +2932,7 @@ func (x *QuicBackendSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicBackendSnapshot.ProtoReflect.Descriptor instead.
 func (*QuicBackendSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{30}
+	return file_manager_manager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *QuicBackendSnapshot) GetBackends() []*QuicBackend {
@@ -2834,7 +2953,7 @@ type DialRequest struct {
 
 func (x *DialRequest) Reset() {
 	*x = DialRequest{}
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +2965,7 @@ func (x *DialRequest) String() string {
 func (*DialRequest) ProtoMessage() {}
 
 func (x *DialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +2978,7 @@ func (x *DialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialRequest.ProtoReflect.Descriptor instead.
 func (*DialRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{31}
+	return file_manager_manager_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DialRequest) GetConnId() []byte {
@@ -2907,7 +3026,7 @@ type QuicAgentCert struct {
 
 func (x *QuicAgentCert) Reset() {
 	*x = QuicAgentCert{}
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2919,7 +3038,7 @@ func (x *QuicAgentCert) String() string {
 func (*QuicAgentCert) ProtoMessage() {}
 
 func (x *QuicAgentCert) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2932,7 +3051,7 @@ func (x *QuicAgentCert) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicAgentCert.ProtoReflect.Descriptor instead.
 func (*QuicAgentCert) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{32}
+	return file_manager_manager_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *QuicAgentCert) GetEnabled() bool {
@@ -2982,7 +3101,7 @@ type LookupRequest struct {
 
 func (x *LookupRequest) Reset() {
 	*x = LookupRequest{}
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2994,7 +3113,7 @@ func (x *LookupRequest) String() string {
 func (*LookupRequest) ProtoMessage() {}
 
 func (x *LookupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3007,7 +3126,7 @@ func (x *LookupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupRequest.ProtoReflect.Descriptor instead.
 func (*LookupRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{33}
+	return file_manager_manager_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LookupRequest) GetSession() *SessionInfo {
@@ -3034,7 +3153,7 @@ type LookupResponse struct {
 
 func (x *LookupResponse) Reset() {
 	*x = LookupResponse{}
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3046,7 +3165,7 @@ func (x *LookupResponse) String() string {
 func (*LookupResponse) ProtoMessage() {}
 
 func (x *LookupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3059,7 +3178,7 @@ func (x *LookupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupResponse.ProtoReflect.Descriptor instead.
 func (*LookupResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{34}
+	return file_manager_manager_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *LookupResponse) GetIps() [][]byte {
@@ -3082,7 +3201,7 @@ type DNSRequest struct {
 
 func (x *DNSRequest) Reset() {
 	*x = DNSRequest{}
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3094,7 +3213,7 @@ func (x *DNSRequest) String() string {
 func (*DNSRequest) ProtoMessage() {}
 
 func (x *DNSRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3107,7 +3226,7 @@ func (x *DNSRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSRequest.ProtoReflect.Descriptor instead.
 func (*DNSRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{35}
+	return file_manager_manager_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DNSRequest) GetSession() *SessionInfo {
@@ -3143,7 +3262,7 @@ type DNSResponse struct {
 
 func (x *DNSResponse) Reset() {
 	*x = DNSResponse{}
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3155,7 +3274,7 @@ func (x *DNSResponse) String() string {
 func (*DNSResponse) ProtoMessage() {}
 
 func (x *DNSResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3168,7 +3287,7 @@ func (x *DNSResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSResponse.ProtoReflect.Descriptor instead.
 func (*DNSResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{36}
+	return file_manager_manager_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DNSResponse) GetRCode() int32 {
@@ -3199,7 +3318,7 @@ type DNSAgentResponse struct {
 
 func (x *DNSAgentResponse) Reset() {
 	*x = DNSAgentResponse{}
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3211,7 +3330,7 @@ func (x *DNSAgentResponse) String() string {
 func (*DNSAgentResponse) ProtoMessage() {}
 
 func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3224,7 +3343,7 @@ func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSAgentResponse.ProtoReflect.Descriptor instead.
 func (*DNSAgentResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{37}
+	return file_manager_manager_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *DNSAgentResponse) GetSession() *SessionInfo {
@@ -3259,7 +3378,7 @@ type IPNet struct {
 
 func (x *IPNet) Reset() {
 	*x = IPNet{}
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3271,7 +3390,7 @@ func (x *IPNet) String() string {
 func (*IPNet) ProtoMessage() {}
 
 func (x *IPNet) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3284,7 +3403,7 @@ func (x *IPNet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPNet.ProtoReflect.Descriptor instead.
 func (*IPNet) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{38}
+	return file_manager_manager_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *IPNet) GetIp() []byte {
@@ -3332,7 +3451,7 @@ type ClusterInfo struct {
 
 func (x *ClusterInfo) Reset() {
 	*x = ClusterInfo{}
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3344,7 +3463,7 @@ func (x *ClusterInfo) String() string {
 func (*ClusterInfo) ProtoMessage() {}
 
 func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3357,7 +3476,7 @@ func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterInfo.ProtoReflect.Descriptor instead.
 func (*ClusterInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{39}
+	return file_manager_manager_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ClusterInfo) GetServiceCidrs() [][]byte {
@@ -3441,7 +3560,7 @@ type Routing struct {
 
 func (x *Routing) Reset() {
 	*x = Routing{}
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3453,7 +3572,7 @@ func (x *Routing) String() string {
 func (*Routing) ProtoMessage() {}
 
 func (x *Routing) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3466,7 +3585,7 @@ func (x *Routing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Routing.ProtoReflect.Descriptor instead.
 func (*Routing) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{40}
+	return file_manager_manager_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *Routing) GetAlsoProxySubnets() []*IPNet {
@@ -3505,7 +3624,7 @@ type DNS struct {
 
 func (x *DNS) Reset() {
 	*x = DNS{}
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3517,7 +3636,7 @@ func (x *DNS) String() string {
 func (*DNS) ProtoMessage() {}
 
 func (x *DNS) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3530,7 +3649,7 @@ func (x *DNS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNS.ProtoReflect.Descriptor instead.
 func (*DNS) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{41}
+	return file_manager_manager_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *DNS) GetIncludeSuffixes() []string {
@@ -3571,7 +3690,7 @@ type CLIConfig struct {
 
 func (x *CLIConfig) Reset() {
 	*x = CLIConfig{}
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3583,7 +3702,7 @@ func (x *CLIConfig) String() string {
 func (*CLIConfig) ProtoMessage() {}
 
 func (x *CLIConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3596,7 +3715,7 @@ func (x *CLIConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CLIConfig.ProtoReflect.Descriptor instead.
 func (*CLIConfig) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42}
+	return file_manager_manager_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CLIConfig) GetConfigYaml() []byte {
@@ -3615,7 +3734,7 @@ type AgentImageFQN struct {
 
 func (x *AgentImageFQN) Reset() {
 	*x = AgentImageFQN{}
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3627,7 +3746,7 @@ func (x *AgentImageFQN) String() string {
 func (*AgentImageFQN) ProtoMessage() {}
 
 func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3640,7 +3759,7 @@ func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentImageFQN.ProtoReflect.Descriptor instead.
 func (*AgentImageFQN) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{43}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AgentImageFQN) GetFQN() string {
@@ -3666,14 +3785,16 @@ type AgentPodInfo struct {
 	// SNI name (quicfwd.AgentSNI(pod UID)) to dial, through the QUIC forwarder,
 	// to reach this agent's QUIC listener. Empty means this agent has no QUIC
 	// listener, so it must be dialed via port-forward only.
-	QuicSni       string `protobuf:"bytes,9,opt,name=quic_sni,json=quicSni,proto3" json:"quic_sni,omitempty"`
+	QuicSni string `protobuf:"bytes,9,opt,name=quic_sni,json=quicSni,proto3" json:"quic_sni,omitempty"`
+	// The agent's version.
+	Version       string `protobuf:"bytes,10,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AgentPodInfo) Reset() {
 	*x = AgentPodInfo{}
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3685,7 +3806,7 @@ func (x *AgentPodInfo) String() string {
 func (*AgentPodInfo) ProtoMessage() {}
 
 func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3698,7 +3819,7 @@ func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfo.ProtoReflect.Descriptor instead.
 func (*AgentPodInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{44}
+	return file_manager_manager_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *AgentPodInfo) GetPodId() string {
@@ -3764,6 +3885,13 @@ func (x *AgentPodInfo) GetQuicSni() string {
 	return ""
 }
 
+func (x *AgentPodInfo) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 type AgentPodInfoSnapshot struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Agents        []*AgentPodInfo        `protobuf:"bytes,1,rep,name=agents,proto3" json:"agents,omitempty"`
@@ -3773,7 +3901,7 @@ type AgentPodInfoSnapshot struct {
 
 func (x *AgentPodInfoSnapshot) Reset() {
 	*x = AgentPodInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3785,7 +3913,7 @@ func (x *AgentPodInfoSnapshot) String() string {
 func (*AgentPodInfoSnapshot) ProtoMessage() {}
 
 func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3798,7 +3926,7 @@ func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*AgentPodInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45}
+	return file_manager_manager_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AgentPodInfoSnapshot) GetAgents() []*AgentPodInfo {
@@ -3818,7 +3946,7 @@ type AgentPodInfoDelta struct {
 
 func (x *AgentPodInfoDelta) Reset() {
 	*x = AgentPodInfoDelta{}
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3830,7 +3958,7 @@ func (x *AgentPodInfoDelta) String() string {
 func (*AgentPodInfoDelta) ProtoMessage() {}
 
 func (x *AgentPodInfoDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3843,7 +3971,7 @@ func (x *AgentPodInfoDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfoDelta.ProtoReflect.Descriptor instead.
 func (*AgentPodInfoDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *AgentPodInfoDelta) GetUpserts() map[string]*AgentPodInfo {
@@ -3871,7 +3999,7 @@ type AgentConfigRequest struct {
 
 func (x *AgentConfigRequest) Reset() {
 	*x = AgentConfigRequest{}
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3883,7 +4011,7 @@ func (x *AgentConfigRequest) String() string {
 func (*AgentConfigRequest) ProtoMessage() {}
 
 func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3896,7 +4024,7 @@ func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigRequest.ProtoReflect.Descriptor instead.
 func (*AgentConfigRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+	return file_manager_manager_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AgentConfigRequest) GetSession() *SessionInfo {
@@ -3929,7 +4057,7 @@ type AgentConfigResponse struct {
 
 func (x *AgentConfigResponse) Reset() {
 	*x = AgentConfigResponse{}
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3941,7 +4069,7 @@ func (x *AgentConfigResponse) String() string {
 func (*AgentConfigResponse) ProtoMessage() {}
 
 func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3954,7 +4082,7 @@ func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigResponse.ProtoReflect.Descriptor instead.
 func (*AgentConfigResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{48}
+	return file_manager_manager_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *AgentConfigResponse) GetData() []byte {
@@ -3977,7 +4105,7 @@ type TunnelMetrics struct {
 
 func (x *TunnelMetrics) Reset() {
 	*x = TunnelMetrics{}
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3989,7 +4117,7 @@ func (x *TunnelMetrics) String() string {
 func (*TunnelMetrics) ProtoMessage() {}
 
 func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4002,7 +4130,7 @@ func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMetrics.ProtoReflect.Descriptor instead.
 func (*TunnelMetrics) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{49}
+	return file_manager_manager_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *TunnelMetrics) GetClientSessionId() string {
@@ -4035,7 +4163,7 @@ type KnownWorkloadKinds struct {
 
 func (x *KnownWorkloadKinds) Reset() {
 	*x = KnownWorkloadKinds{}
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4047,7 +4175,7 @@ func (x *KnownWorkloadKinds) String() string {
 func (*KnownWorkloadKinds) ProtoMessage() {}
 
 func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4060,7 +4188,7 @@ func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KnownWorkloadKinds.ProtoReflect.Descriptor instead.
 func (*KnownWorkloadKinds) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{50}
+	return file_manager_manager_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *KnownWorkloadKinds) GetKinds() []WorkloadInfo_Kind {
@@ -4081,7 +4209,7 @@ type ServicePort struct {
 
 func (x *ServicePort) Reset() {
 	*x = ServicePort{}
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4093,7 +4221,7 @@ func (x *ServicePort) String() string {
 func (*ServicePort) ProtoMessage() {}
 
 func (x *ServicePort) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4106,7 +4234,7 @@ func (x *ServicePort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServicePort.ProtoReflect.Descriptor instead.
 func (*ServicePort) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{51}
+	return file_manager_manager_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ServicePort) GetName() string {
@@ -4152,7 +4280,7 @@ type RouteAssociation struct {
 
 func (x *RouteAssociation) Reset() {
 	*x = RouteAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[52]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4164,7 +4292,7 @@ func (x *RouteAssociation) String() string {
 func (*RouteAssociation) ProtoMessage() {}
 
 func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[52]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4177,7 +4305,7 @@ func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteAssociation.ProtoReflect.Descriptor instead.
 func (*RouteAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{52}
+	return file_manager_manager_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *RouteAssociation) GetType() string {
@@ -4250,7 +4378,7 @@ type ServiceAssociation struct {
 
 func (x *ServiceAssociation) Reset() {
 	*x = ServiceAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[53]
+	mi := &file_manager_manager_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4262,7 +4390,7 @@ func (x *ServiceAssociation) String() string {
 func (*ServiceAssociation) ProtoMessage() {}
 
 func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[53]
+	mi := &file_manager_manager_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4275,7 +4403,7 @@ func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAssociation.ProtoReflect.Descriptor instead.
 func (*ServiceAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{53}
+	return file_manager_manager_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ServiceAssociation) GetName() string {
@@ -4319,7 +4447,7 @@ type WorkloadInfo struct {
 
 func (x *WorkloadInfo) Reset() {
 	*x = WorkloadInfo{}
-	mi := &file_manager_manager_proto_msgTypes[54]
+	mi := &file_manager_manager_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4331,7 +4459,7 @@ func (x *WorkloadInfo) String() string {
 func (*WorkloadInfo) ProtoMessage() {}
 
 func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[54]
+	mi := &file_manager_manager_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4344,7 +4472,7 @@ func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *WorkloadInfo) GetKind() WorkloadInfo_Kind {
@@ -4427,7 +4555,7 @@ type WorkloadEvent struct {
 
 func (x *WorkloadEvent) Reset() {
 	*x = WorkloadEvent{}
-	mi := &file_manager_manager_proto_msgTypes[55]
+	mi := &file_manager_manager_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4439,7 +4567,7 @@ func (x *WorkloadEvent) String() string {
 func (*WorkloadEvent) ProtoMessage() {}
 
 func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[55]
+	mi := &file_manager_manager_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4452,7 +4580,7 @@ func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadEvent) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{55}
+	return file_manager_manager_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *WorkloadEvent) GetType() WorkloadEvent_Type {
@@ -4484,7 +4612,7 @@ type WorkloadEventsDelta struct {
 
 func (x *WorkloadEventsDelta) Reset() {
 	*x = WorkloadEventsDelta{}
-	mi := &file_manager_manager_proto_msgTypes[56]
+	mi := &file_manager_manager_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4496,7 +4624,7 @@ func (x *WorkloadEventsDelta) String() string {
 func (*WorkloadEventsDelta) ProtoMessage() {}
 
 func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[56]
+	mi := &file_manager_manager_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4509,7 +4637,7 @@ func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsDelta.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{56}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *WorkloadEventsDelta) GetSince() *timestamppb.Timestamp {
@@ -4543,7 +4671,7 @@ type WorkloadEventsRequest struct {
 
 func (x *WorkloadEventsRequest) Reset() {
 	*x = WorkloadEventsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[57]
+	mi := &file_manager_manager_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4555,7 +4683,7 @@ func (x *WorkloadEventsRequest) String() string {
 func (*WorkloadEventsRequest) ProtoMessage() {}
 
 func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[57]
+	mi := &file_manager_manager_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4568,7 +4696,7 @@ func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsRequest.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57}
+	return file_manager_manager_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *WorkloadEventsRequest) GetSessionInfo() *SessionInfo {
@@ -4605,7 +4733,7 @@ type UninstallAgentsRequest struct {
 
 func (x *UninstallAgentsRequest) Reset() {
 	*x = UninstallAgentsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[58]
+	mi := &file_manager_manager_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4617,7 +4745,7 @@ func (x *UninstallAgentsRequest) String() string {
 func (*UninstallAgentsRequest) ProtoMessage() {}
 
 func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[58]
+	mi := &file_manager_manager_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4630,7 +4758,7 @@ func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UninstallAgentsRequest.ProtoReflect.Descriptor instead.
 func (*UninstallAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{58}
+	return file_manager_manager_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UninstallAgentsRequest) GetSessionInfo() *SessionInfo {
@@ -4669,7 +4797,7 @@ type AgentInfo_Mechanism struct {
 
 func (x *AgentInfo_Mechanism) Reset() {
 	*x = AgentInfo_Mechanism{}
-	mi := &file_manager_manager_proto_msgTypes[59]
+	mi := &file_manager_manager_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4681,7 +4809,7 @@ func (x *AgentInfo_Mechanism) String() string {
 func (*AgentInfo_Mechanism) ProtoMessage() {}
 
 func (x *AgentInfo_Mechanism) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[59]
+	mi := &file_manager_manager_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4732,7 +4860,7 @@ type AgentInfo_ContainerInfo struct {
 
 func (x *AgentInfo_ContainerInfo) Reset() {
 	*x = AgentInfo_ContainerInfo{}
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4744,7 +4872,7 @@ func (x *AgentInfo_ContainerInfo) String() string {
 func (*AgentInfo_ContainerInfo) ProtoMessage() {}
 
 func (x *AgentInfo_ContainerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4791,7 +4919,7 @@ type WorkloadInfo_Intercept struct {
 
 func (x *WorkloadInfo_Intercept) Reset() {
 	*x = WorkloadInfo_Intercept{}
-	mi := &file_manager_manager_proto_msgTypes[75]
+	mi := &file_manager_manager_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4803,7 +4931,7 @@ func (x *WorkloadInfo_Intercept) String() string {
 func (*WorkloadInfo_Intercept) ProtoMessage() {}
 
 func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[75]
+	mi := &file_manager_manager_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4816,7 +4944,7 @@ func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo_Intercept.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo_Intercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56, 0}
 }
 
 func (x *WorkloadInfo_Intercept) GetClient() string {
@@ -4994,7 +5122,18 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\bremovals\x18\x02 \x03(\tR\bremovals\x1a_\n" +
 	"\fUpsertsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
-	"\x05value\x18\x02 \x01(\v2#.telepresence.manager.InterceptInfoR\x05value:\x028\x01\"\xa7\x01\n" +
+	"\x05value\x18\x02 \x01(\v2#.telepresence.manager.InterceptInfoR\x05value:\x028\x01\"s\n" +
+	"\x14SessionEventsRequest\x12;\n" +
+	"\asession\x18\x01 \x01(\v2!.telepresence.manager.SessionInfoR\asession\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\x02 \x03(\tR\n" +
+	"namespaces\"\xa6\x01\n" +
+	"\x12SessionEventsDelta\x12F\n" +
+	"\n" +
+	"agent_pods\x18\x01 \x01(\v2'.telepresence.manager.AgentPodInfoDeltaR\tagentPods\x12H\n" +
+	"\n" +
+	"intercepts\x18\x02 \x01(\v2(.telepresence.manager.InterceptInfoDeltaR\n" +
+	"intercepts\"\xa7\x01\n" +
 	"\x16CreateInterceptRequest\x12;\n" +
 	"\asession\x18\x01 \x01(\v2!.telepresence.manager.SessionInfoR\asession\x12J\n" +
 	"\x0eintercept_spec\x18\x02 \x01(\v2#.telepresence.manager.InterceptSpecR\rinterceptSpecJ\x04\b\x03\x10\x04\"\xa2\x01\n" +
@@ -5161,7 +5300,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\vconfig_yaml\x18\x01 \x01(\fR\n" +
 	"configYaml\"#\n" +
 	"\rAgentImageFQN\x12\x12\n" +
-	"\x05f_q_n\x18\x01 \x01(\tR\x03fQN\"\x91\x02\n" +
+	"\x05f_q_n\x18\x01 \x01(\tR\x03fQN\"\xab\x02\n" +
 	"\fAgentPodInfo\x12\x15\n" +
 	"\x06pod_id\x18\a \x01(\tR\x05podId\x12\x19\n" +
 	"\bpod_name\x18\x01 \x01(\tR\apodName\x12\x1c\n" +
@@ -5172,7 +5311,9 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\rworkload_name\x18\x06 \x01(\tR\fworkloadName\x12\x1d\n" +
 	"\n" +
 	"node_agent\x18\b \x01(\bR\tnodeAgent\x12\x19\n" +
-	"\bquic_sni\x18\t \x01(\tR\aquicSni\"R\n" +
+	"\bquic_sni\x18\t \x01(\tR\aquicSni\x12\x18\n" +
+	"\aversion\x18\n" +
+	" \x01(\tR\aversion\"R\n" +
 	"\x14AgentPodInfoSnapshot\x12:\n" +
 	"\x06agents\x18\x01 \x03(\v2\".telepresence.manager.AgentPodInfoR\x06agents\"\xdf\x01\n" +
 	"\x11AgentPodInfoDelta\x12N\n" +
@@ -5272,7 +5413,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\fNO_MECHANISM\x10\x05\x12\f\n" +
 	"\bNO_PORTS\x10\x06\x12\x0f\n" +
 	"\vAGENT_ERROR\x10\a\x12\f\n" +
-	"\bBAD_ARGS\x10\b2\xd6\x1b\n" +
+	"\bBAD_ARGS\x10\b2\xc4\x1c\n" +
 	"\aManager\x12E\n" +
 	"\aVersion\x12\x16.google.protobuf.Empty\x1a\".telepresence.manager.VersionInfo2\x12O\n" +
 	"\x10GetAgentImageFQN\x12\x16.google.protobuf.Empty\x1a#.telepresence.manager.AgentImageFQN\x12e\n" +
@@ -5293,7 +5434,8 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\vWatchAgents\x12!.telepresence.manager.SessionInfo\x1a'.telepresence.manager.AgentInfoSnapshot0\x01\x12]\n" +
 	"\x10WatchAgentsDelta\x12!.telepresence.manager.SessionInfo\x1a$.telepresence.manager.AgentInfoDelta0\x01\x12c\n" +
 	"\x0fWatchIntercepts\x12!.telepresence.manager.SessionInfo\x1a+.telepresence.manager.InterceptInfoSnapshot0\x01\x12e\n" +
-	"\x14WatchInterceptsDelta\x12!.telepresence.manager.SessionInfo\x1a(.telepresence.manager.InterceptInfoDelta0\x01\x12j\n" +
+	"\x14WatchInterceptsDelta\x12!.telepresence.manager.SessionInfo\x1a(.telepresence.manager.InterceptInfoDelta0\x01\x12l\n" +
+	"\x12WatchSessionEvents\x12*.telepresence.manager.SessionEventsRequest\x1a(.telepresence.manager.SessionEventsDelta0\x01\x12j\n" +
 	"\x0eWatchWorkloads\x12+.telepresence.manager.WorkloadEventsRequest\x1a).telepresence.manager.WorkloadEventsDelta0\x01\x12Z\n" +
 	"\x10WatchClusterInfo\x12!.telepresence.manager.SessionInfo\x1a!.telepresence.manager.ClusterInfo0\x01\x12`\n" +
 	"\vEnsureAgent\x12(.telepresence.manager.EnsureAgentRequest\x1a'.telepresence.manager.AgentInfoSnapshot\x12Q\n" +
@@ -5327,7 +5469,7 @@ func file_manager_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_manager_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
+var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 78)
 var file_manager_manager_proto_goTypes = []any{
 	(InterceptDispositionType)(0),   // 0: telepresence.manager.InterceptDispositionType
 	(WorkloadInfo_Kind)(0),          // 1: telepresence.manager.WorkloadInfo.Kind
@@ -5347,84 +5489,86 @@ var file_manager_manager_proto_goTypes = []any{
 	(*AgentInfoDelta)(nil),          // 15: telepresence.manager.AgentInfoDelta
 	(*InterceptInfoSnapshot)(nil),   // 16: telepresence.manager.InterceptInfoSnapshot
 	(*InterceptInfoDelta)(nil),      // 17: telepresence.manager.InterceptInfoDelta
-	(*CreateInterceptRequest)(nil),  // 18: telepresence.manager.CreateInterceptRequest
-	(*EnsureAgentRequest)(nil),      // 19: telepresence.manager.EnsureAgentRequest
-	(*ReleaseAgentRequest)(nil),     // 20: telepresence.manager.ReleaseAgentRequest
-	(*PreparedIntercept)(nil),       // 21: telepresence.manager.PreparedIntercept
-	(*RemoveInterceptRequest2)(nil), // 22: telepresence.manager.RemoveInterceptRequest2
-	(*GetInterceptRequest)(nil),     // 23: telepresence.manager.GetInterceptRequest
-	(*ReviewInterceptRequest)(nil),  // 24: telepresence.manager.ReviewInterceptRequest
-	(*RemainRequest)(nil),           // 25: telepresence.manager.RemainRequest
-	(*LogLevelRequest)(nil),         // 26: telepresence.manager.LogLevelRequest
-	(*GetLogsRequest)(nil),          // 27: telepresence.manager.GetLogsRequest
-	(*LogsResponse)(nil),            // 28: telepresence.manager.LogsResponse
-	(*TelepresenceAPIInfo)(nil),     // 29: telepresence.manager.TelepresenceAPIInfo
-	(*VersionInfo2)(nil),            // 30: telepresence.manager.VersionInfo2
-	(*TunnelMessage)(nil),           // 31: telepresence.manager.TunnelMessage
-	(*QuicTunnelEndpoint)(nil),      // 32: telepresence.manager.QuicTunnelEndpoint
-	(*QuicEndpointCandidate)(nil),   // 33: telepresence.manager.QuicEndpointCandidate
-	(*QuicBackend)(nil),             // 34: telepresence.manager.QuicBackend
-	(*QuicBackendSnapshot)(nil),     // 35: telepresence.manager.QuicBackendSnapshot
-	(*DialRequest)(nil),             // 36: telepresence.manager.DialRequest
-	(*QuicAgentCert)(nil),           // 37: telepresence.manager.QuicAgentCert
-	(*LookupRequest)(nil),           // 38: telepresence.manager.LookupRequest
-	(*LookupResponse)(nil),          // 39: telepresence.manager.LookupResponse
-	(*DNSRequest)(nil),              // 40: telepresence.manager.DNSRequest
-	(*DNSResponse)(nil),             // 41: telepresence.manager.DNSResponse
-	(*DNSAgentResponse)(nil),        // 42: telepresence.manager.DNSAgentResponse
-	(*IPNet)(nil),                   // 43: telepresence.manager.IPNet
-	(*ClusterInfo)(nil),             // 44: telepresence.manager.ClusterInfo
-	(*Routing)(nil),                 // 45: telepresence.manager.Routing
-	(*DNS)(nil),                     // 46: telepresence.manager.DNS
-	(*CLIConfig)(nil),               // 47: telepresence.manager.CLIConfig
-	(*AgentImageFQN)(nil),           // 48: telepresence.manager.AgentImageFQN
-	(*AgentPodInfo)(nil),            // 49: telepresence.manager.AgentPodInfo
-	(*AgentPodInfoSnapshot)(nil),    // 50: telepresence.manager.AgentPodInfoSnapshot
-	(*AgentPodInfoDelta)(nil),       // 51: telepresence.manager.AgentPodInfoDelta
-	(*AgentConfigRequest)(nil),      // 52: telepresence.manager.AgentConfigRequest
-	(*AgentConfigResponse)(nil),     // 53: telepresence.manager.AgentConfigResponse
-	(*TunnelMetrics)(nil),           // 54: telepresence.manager.TunnelMetrics
-	(*KnownWorkloadKinds)(nil),      // 55: telepresence.manager.KnownWorkloadKinds
-	(*ServicePort)(nil),             // 56: telepresence.manager.ServicePort
-	(*RouteAssociation)(nil),        // 57: telepresence.manager.RouteAssociation
-	(*ServiceAssociation)(nil),      // 58: telepresence.manager.ServiceAssociation
-	(*WorkloadInfo)(nil),            // 59: telepresence.manager.WorkloadInfo
-	(*WorkloadEvent)(nil),           // 60: telepresence.manager.WorkloadEvent
-	(*WorkloadEventsDelta)(nil),     // 61: telepresence.manager.WorkloadEventsDelta
-	(*WorkloadEventsRequest)(nil),   // 62: telepresence.manager.WorkloadEventsRequest
-	(*UninstallAgentsRequest)(nil),  // 63: telepresence.manager.UninstallAgentsRequest
-	(*AgentInfo_Mechanism)(nil),     // 64: telepresence.manager.AgentInfo.Mechanism
-	(*AgentInfo_ContainerInfo)(nil), // 65: telepresence.manager.AgentInfo.ContainerInfo
-	nil,                             // 66: telepresence.manager.AgentInfo.ContainersEntry
-	nil,                             // 67: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	nil,                             // 68: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	nil,                             // 69: telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	nil,                             // 70: telepresence.manager.InterceptSpec.MetadataEntry
-	nil,                             // 71: telepresence.manager.InterceptInfo.EnvironmentEntry
-	nil,                             // 72: telepresence.manager.InterceptInfo.MountsEntry
-	nil,                             // 73: telepresence.manager.AgentInfoDelta.UpsertsEntry
-	nil,                             // 74: telepresence.manager.InterceptInfoDelta.UpsertsEntry
-	nil,                             // 75: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	nil,                             // 76: telepresence.manager.ReviewInterceptRequest.MountsEntry
-	nil,                             // 77: telepresence.manager.LogsResponse.PodLogsEntry
-	nil,                             // 78: telepresence.manager.LogsResponse.PodYamlEntry
-	nil,                             // 79: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
-	(*WorkloadInfo_Intercept)(nil),  // 80: telepresence.manager.WorkloadInfo.Intercept
-	(*timestamppb.Timestamp)(nil),   // 81: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),     // 82: google.protobuf.Duration
-	(*emptypb.Empty)(nil),           // 83: google.protobuf.Empty
+	(*SessionEventsRequest)(nil),    // 18: telepresence.manager.SessionEventsRequest
+	(*SessionEventsDelta)(nil),      // 19: telepresence.manager.SessionEventsDelta
+	(*CreateInterceptRequest)(nil),  // 20: telepresence.manager.CreateInterceptRequest
+	(*EnsureAgentRequest)(nil),      // 21: telepresence.manager.EnsureAgentRequest
+	(*ReleaseAgentRequest)(nil),     // 22: telepresence.manager.ReleaseAgentRequest
+	(*PreparedIntercept)(nil),       // 23: telepresence.manager.PreparedIntercept
+	(*RemoveInterceptRequest2)(nil), // 24: telepresence.manager.RemoveInterceptRequest2
+	(*GetInterceptRequest)(nil),     // 25: telepresence.manager.GetInterceptRequest
+	(*ReviewInterceptRequest)(nil),  // 26: telepresence.manager.ReviewInterceptRequest
+	(*RemainRequest)(nil),           // 27: telepresence.manager.RemainRequest
+	(*LogLevelRequest)(nil),         // 28: telepresence.manager.LogLevelRequest
+	(*GetLogsRequest)(nil),          // 29: telepresence.manager.GetLogsRequest
+	(*LogsResponse)(nil),            // 30: telepresence.manager.LogsResponse
+	(*TelepresenceAPIInfo)(nil),     // 31: telepresence.manager.TelepresenceAPIInfo
+	(*VersionInfo2)(nil),            // 32: telepresence.manager.VersionInfo2
+	(*TunnelMessage)(nil),           // 33: telepresence.manager.TunnelMessage
+	(*QuicTunnelEndpoint)(nil),      // 34: telepresence.manager.QuicTunnelEndpoint
+	(*QuicEndpointCandidate)(nil),   // 35: telepresence.manager.QuicEndpointCandidate
+	(*QuicBackend)(nil),             // 36: telepresence.manager.QuicBackend
+	(*QuicBackendSnapshot)(nil),     // 37: telepresence.manager.QuicBackendSnapshot
+	(*DialRequest)(nil),             // 38: telepresence.manager.DialRequest
+	(*QuicAgentCert)(nil),           // 39: telepresence.manager.QuicAgentCert
+	(*LookupRequest)(nil),           // 40: telepresence.manager.LookupRequest
+	(*LookupResponse)(nil),          // 41: telepresence.manager.LookupResponse
+	(*DNSRequest)(nil),              // 42: telepresence.manager.DNSRequest
+	(*DNSResponse)(nil),             // 43: telepresence.manager.DNSResponse
+	(*DNSAgentResponse)(nil),        // 44: telepresence.manager.DNSAgentResponse
+	(*IPNet)(nil),                   // 45: telepresence.manager.IPNet
+	(*ClusterInfo)(nil),             // 46: telepresence.manager.ClusterInfo
+	(*Routing)(nil),                 // 47: telepresence.manager.Routing
+	(*DNS)(nil),                     // 48: telepresence.manager.DNS
+	(*CLIConfig)(nil),               // 49: telepresence.manager.CLIConfig
+	(*AgentImageFQN)(nil),           // 50: telepresence.manager.AgentImageFQN
+	(*AgentPodInfo)(nil),            // 51: telepresence.manager.AgentPodInfo
+	(*AgentPodInfoSnapshot)(nil),    // 52: telepresence.manager.AgentPodInfoSnapshot
+	(*AgentPodInfoDelta)(nil),       // 53: telepresence.manager.AgentPodInfoDelta
+	(*AgentConfigRequest)(nil),      // 54: telepresence.manager.AgentConfigRequest
+	(*AgentConfigResponse)(nil),     // 55: telepresence.manager.AgentConfigResponse
+	(*TunnelMetrics)(nil),           // 56: telepresence.manager.TunnelMetrics
+	(*KnownWorkloadKinds)(nil),      // 57: telepresence.manager.KnownWorkloadKinds
+	(*ServicePort)(nil),             // 58: telepresence.manager.ServicePort
+	(*RouteAssociation)(nil),        // 59: telepresence.manager.RouteAssociation
+	(*ServiceAssociation)(nil),      // 60: telepresence.manager.ServiceAssociation
+	(*WorkloadInfo)(nil),            // 61: telepresence.manager.WorkloadInfo
+	(*WorkloadEvent)(nil),           // 62: telepresence.manager.WorkloadEvent
+	(*WorkloadEventsDelta)(nil),     // 63: telepresence.manager.WorkloadEventsDelta
+	(*WorkloadEventsRequest)(nil),   // 64: telepresence.manager.WorkloadEventsRequest
+	(*UninstallAgentsRequest)(nil),  // 65: telepresence.manager.UninstallAgentsRequest
+	(*AgentInfo_Mechanism)(nil),     // 66: telepresence.manager.AgentInfo.Mechanism
+	(*AgentInfo_ContainerInfo)(nil), // 67: telepresence.manager.AgentInfo.ContainerInfo
+	nil,                             // 68: telepresence.manager.AgentInfo.ContainersEntry
+	nil,                             // 69: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	nil,                             // 70: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	nil,                             // 71: telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	nil,                             // 72: telepresence.manager.InterceptSpec.MetadataEntry
+	nil,                             // 73: telepresence.manager.InterceptInfo.EnvironmentEntry
+	nil,                             // 74: telepresence.manager.InterceptInfo.MountsEntry
+	nil,                             // 75: telepresence.manager.AgentInfoDelta.UpsertsEntry
+	nil,                             // 76: telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	nil,                             // 77: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	nil,                             // 78: telepresence.manager.ReviewInterceptRequest.MountsEntry
+	nil,                             // 79: telepresence.manager.LogsResponse.PodLogsEntry
+	nil,                             // 80: telepresence.manager.LogsResponse.PodYamlEntry
+	nil,                             // 81: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	(*WorkloadInfo_Intercept)(nil),  // 82: telepresence.manager.WorkloadInfo.Intercept
+	(*timestamppb.Timestamp)(nil),   // 83: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),     // 84: google.protobuf.Duration
+	(*emptypb.Empty)(nil),           // 85: google.protobuf.Empty
 }
 var file_manager_manager_proto_depIdxs = []int32{
-	64,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
-	66,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
-	69,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	70,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
+	66,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
+	68,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
+	71,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	72,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
 	8,   // 4: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
 	12,  // 5: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
 	0,   // 6: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	71,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
-	72,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
-	81,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
+	73,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
+	74,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
+	83,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
 	12,  // 10: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
 	6,   // 11: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
 	12,  // 12: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
@@ -5433,145 +5577,150 @@ var file_manager_manager_proto_depIdxs = []int32{
 	6,   // 15: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
 	12,  // 16: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
 	6,   // 17: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
-	73,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
+	75,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
 	9,   // 19: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
-	74,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
-	12,  // 21: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	8,   // 22: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
-	12,  // 23: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 24: telepresence.manager.ReleaseAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 25: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 26: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 27: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	0,   // 28: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	75,  // 29: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	76,  // 30: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
-	12,  // 31: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
-	81,  // 32: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
-	82,  // 33: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	77,  // 34: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
-	78,  // 35: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
-	33,  // 36: telepresence.manager.QuicTunnelEndpoint.candidates:type_name -> telepresence.manager.QuicEndpointCandidate
-	34,  // 37: telepresence.manager.QuicBackendSnapshot.backends:type_name -> telepresence.manager.QuicBackend
-	12,  // 38: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 39: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 40: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
-	40,  // 41: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
-	41,  // 42: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
-	43,  // 43: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
-	43,  // 44: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
-	45,  // 45: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
-	46,  // 46: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
-	43,  // 47: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
-	43,  // 48: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
-	43,  // 49: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
-	49,  // 50: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
-	79,  // 51: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
-	12,  // 52: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
-	1,   // 53: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
-	56,  // 54: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
-	57,  // 55: telepresence.manager.ServiceAssociation.routes:type_name -> telepresence.manager.RouteAssociation
-	1,   // 56: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
-	58,  // 57: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
-	3,   // 58: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
-	80,  // 59: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
-	2,   // 60: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
-	4,   // 61: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
-	59,  // 62: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
-	81,  // 63: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
-	60,  // 64: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
-	12,  // 65: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	81,  // 66: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
-	12,  // 67: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	67,  // 68: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	68,  // 69: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	65,  // 70: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
-	6,   // 71: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
-	9,   // 72: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
-	49,  // 73: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
-	83,  // 74: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
-	83,  // 75: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
-	52,  // 76: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	83,  // 77: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
-	83,  // 78: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
-	5,   // 79: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
-	10,  // 80: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
-	11,  // 81: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
-	6,   // 82: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
-	25,  // 83: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
-	12,  // 84: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
-	26,  // 85: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	27,  // 86: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
-	12,  // 87: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
-	12,  // 88: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
-	13,  // 89: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
-	12,  // 90: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
-	12,  // 91: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
-	12,  // 92: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
-	12,  // 93: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
-	62,  // 94: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
-	12,  // 95: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
-	19,  // 96: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
-	20,  // 97: telepresence.manager.Manager.ReleaseAgent:input_type -> telepresence.manager.ReleaseAgentRequest
-	18,  // 98: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	18,  // 99: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	22,  // 100: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	23,  // 101: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	24,  // 102: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
-	12,  // 103: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
-	38,  // 104: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
-	40,  // 105: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
-	83,  // 106: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
-	31,  // 107: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
-	12,  // 108: telepresence.manager.Manager.GetQuicTunnelEndpoint:input_type -> telepresence.manager.SessionInfo
-	12,  // 109: telepresence.manager.Manager.GetQuicAgentCert:input_type -> telepresence.manager.SessionInfo
-	83,  // 110: telepresence.manager.Manager.WatchQuicBackends:input_type -> google.protobuf.Empty
-	54,  // 111: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
-	63,  // 112: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
-	30,  // 113: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
-	48,  // 114: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	53,  // 115: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	47,  // 116: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
-	29,  // 117: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
-	12,  // 118: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
-	83,  // 119: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
-	83,  // 120: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
-	12,  // 121: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
-	83,  // 122: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
-	83,  // 123: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
-	83,  // 124: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
-	28,  // 125: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
-	50,  // 126: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
-	51,  // 127: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	51,  // 128: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	14,  // 129: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
-	15,  // 130: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
-	16,  // 131: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
-	17,  // 132: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
-	61,  // 133: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
-	44,  // 134: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
-	14,  // 135: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
-	83,  // 136: telepresence.manager.Manager.ReleaseAgent:output_type -> google.protobuf.Empty
-	21,  // 137: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
-	9,   // 138: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	83,  // 139: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
-	9,   // 140: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	83,  // 141: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
-	55,  // 142: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	39,  // 143: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
-	41,  // 144: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
-	26,  // 145: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
-	31,  // 146: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
-	32,  // 147: telepresence.manager.Manager.GetQuicTunnelEndpoint:output_type -> telepresence.manager.QuicTunnelEndpoint
-	37,  // 148: telepresence.manager.Manager.GetQuicAgentCert:output_type -> telepresence.manager.QuicAgentCert
-	35,  // 149: telepresence.manager.Manager.WatchQuicBackends:output_type -> telepresence.manager.QuicBackendSnapshot
-	83,  // 150: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
-	83,  // 151: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
-	113, // [113:152] is the sub-list for method output_type
-	74,  // [74:113] is the sub-list for method input_type
-	74,  // [74:74] is the sub-list for extension type_name
-	74,  // [74:74] is the sub-list for extension extendee
-	0,   // [0:74] is the sub-list for field type_name
+	76,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	12,  // 21: telepresence.manager.SessionEventsRequest.session:type_name -> telepresence.manager.SessionInfo
+	53,  // 22: telepresence.manager.SessionEventsDelta.agent_pods:type_name -> telepresence.manager.AgentPodInfoDelta
+	17,  // 23: telepresence.manager.SessionEventsDelta.intercepts:type_name -> telepresence.manager.InterceptInfoDelta
+	12,  // 24: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	8,   // 25: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
+	12,  // 26: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 27: telepresence.manager.ReleaseAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 28: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 29: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 30: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	0,   // 31: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
+	77,  // 32: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	78,  // 33: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
+	12,  // 34: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
+	83,  // 35: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
+	84,  // 36: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	79,  // 37: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
+	80,  // 38: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
+	35,  // 39: telepresence.manager.QuicTunnelEndpoint.candidates:type_name -> telepresence.manager.QuicEndpointCandidate
+	36,  // 40: telepresence.manager.QuicBackendSnapshot.backends:type_name -> telepresence.manager.QuicBackend
+	12,  // 41: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 42: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
+	12,  // 43: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
+	42,  // 44: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
+	43,  // 45: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
+	45,  // 46: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
+	45,  // 47: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
+	47,  // 48: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
+	48,  // 49: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
+	45,  // 50: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
+	45,  // 51: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
+	45,  // 52: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
+	51,  // 53: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
+	81,  // 54: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	12,  // 55: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
+	1,   // 56: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
+	58,  // 57: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
+	59,  // 58: telepresence.manager.ServiceAssociation.routes:type_name -> telepresence.manager.RouteAssociation
+	1,   // 59: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
+	60,  // 60: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
+	3,   // 61: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
+	82,  // 62: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
+	2,   // 63: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
+	4,   // 64: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
+	61,  // 65: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
+	83,  // 66: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
+	62,  // 67: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
+	12,  // 68: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	83,  // 69: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
+	12,  // 70: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	69,  // 71: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	70,  // 72: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	67,  // 73: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
+	6,   // 74: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
+	9,   // 75: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
+	51,  // 76: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	85,  // 77: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
+	85,  // 78: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
+	54,  // 79: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	85,  // 80: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
+	85,  // 81: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
+	5,   // 82: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
+	10,  // 83: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
+	11,  // 84: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
+	6,   // 85: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
+	27,  // 86: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
+	12,  // 87: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
+	28,  // 88: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	29,  // 89: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
+	12,  // 90: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
+	12,  // 91: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
+	13,  // 92: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
+	12,  // 93: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
+	12,  // 94: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
+	12,  // 95: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
+	12,  // 96: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
+	18,  // 97: telepresence.manager.Manager.WatchSessionEvents:input_type -> telepresence.manager.SessionEventsRequest
+	64,  // 98: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
+	12,  // 99: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
+	21,  // 100: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
+	22,  // 101: telepresence.manager.Manager.ReleaseAgent:input_type -> telepresence.manager.ReleaseAgentRequest
+	20,  // 102: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	20,  // 103: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	24,  // 104: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	25,  // 105: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	26,  // 106: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
+	12,  // 107: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
+	40,  // 108: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
+	42,  // 109: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
+	85,  // 110: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
+	33,  // 111: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
+	12,  // 112: telepresence.manager.Manager.GetQuicTunnelEndpoint:input_type -> telepresence.manager.SessionInfo
+	12,  // 113: telepresence.manager.Manager.GetQuicAgentCert:input_type -> telepresence.manager.SessionInfo
+	85,  // 114: telepresence.manager.Manager.WatchQuicBackends:input_type -> google.protobuf.Empty
+	56,  // 115: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
+	65,  // 116: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
+	32,  // 117: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
+	50,  // 118: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	55,  // 119: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	49,  // 120: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
+	31,  // 121: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
+	12,  // 122: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
+	85,  // 123: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
+	85,  // 124: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
+	12,  // 125: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
+	85,  // 126: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
+	85,  // 127: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
+	85,  // 128: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
+	30,  // 129: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
+	52,  // 130: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
+	53,  // 131: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	53,  // 132: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	14,  // 133: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
+	15,  // 134: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
+	16,  // 135: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
+	17,  // 136: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
+	19,  // 137: telepresence.manager.Manager.WatchSessionEvents:output_type -> telepresence.manager.SessionEventsDelta
+	63,  // 138: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
+	46,  // 139: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
+	14,  // 140: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
+	85,  // 141: telepresence.manager.Manager.ReleaseAgent:output_type -> google.protobuf.Empty
+	23,  // 142: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
+	9,   // 143: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	85,  // 144: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
+	9,   // 145: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	85,  // 146: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
+	57,  // 147: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	41,  // 148: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
+	43,  // 149: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
+	28,  // 150: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
+	33,  // 151: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
+	34,  // 152: telepresence.manager.Manager.GetQuicTunnelEndpoint:output_type -> telepresence.manager.QuicTunnelEndpoint
+	39,  // 153: telepresence.manager.Manager.GetQuicAgentCert:output_type -> telepresence.manager.QuicAgentCert
+	37,  // 154: telepresence.manager.Manager.WatchQuicBackends:output_type -> telepresence.manager.QuicBackendSnapshot
+	85,  // 155: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
+	85,  // 156: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
+	117, // [117:157] is the sub-list for method output_type
+	77,  // [77:117] is the sub-list for method input_type
+	77,  // [77:77] is the sub-list for extension type_name
+	77,  // [77:77] is the sub-list for extension extendee
+	0,   // [0:77] is the sub-list for field type_name
 }
 
 func init() { file_manager_manager_proto_init() }
@@ -5586,7 +5735,7 @@ func file_manager_manager_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_manager_manager_proto_rawDesc), len(file_manager_manager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   76,
+			NumMessages:   78,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -354,6 +354,33 @@ message InterceptInfoDelta {
   repeated string removals = 2;
 }
 
+// SessionEventsRequest identifies the watching session and scopes the agent
+// portion of the WatchSessionEvents stream.
+message SessionEventsRequest {
+  SessionInfo session = 1;
+
+  // Namespaces in which the client wants agent events in addition to the
+  // session's connected namespace. This is the set of mapped namespaces that
+  // the client is permitted to port-forward to.
+  repeated string namespaces = 2;
+}
+
+// SessionEventsDelta multiplexes agent-pod and intercept deltas onto one
+// stream. Either or both fields may be present in a single message.
+//
+// Container-level agent data (environments, mounts, ports) is deliberately
+// not streamed; clients retrieve it on demand from the EnsureAgent response
+// or from InterceptInfo.
+message SessionEventsDelta {
+  // Agent pods in the requested namespaces plus the session's connected
+  // namespace. Same projection as the WatchAgentPodsInNamespacesDelta
+  // stream, including the per-client intercepted flag.
+  AgentPodInfoDelta agent_pods = 1;
+
+  // The watching client's intercepts.
+  InterceptInfoDelta intercepts = 2;
+}
+
 message CreateInterceptRequest {
   SessionInfo session = 1;
   InterceptSpec intercept_spec = 2;
@@ -729,6 +756,9 @@ message AgentPodInfo {
   // to reach this agent's QUIC listener. Empty means this agent has no QUIC
   // listener, so it must be dialed via port-forward only.
   string quic_sni = 9;
+
+  // The agent's version.
+  string version = 10;
 }
 
 message AgentPodInfoSnapshot {
@@ -980,6 +1010,13 @@ service Manager {
   // WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
   // relevant to that client or agent.
   rpc WatchInterceptsDelta(SessionInfo) returns (stream InterceptInfoDelta);
+
+  // WatchSessionEvents notifies a client of changes to the set of known
+  // agent pods in the requested namespaces and to the client's own
+  // intercepts, multiplexed onto a single stream. It replaces the
+  // combination of WatchAgentsDelta, WatchInterceptsDelta, and
+  // WatchAgentPodsInNamespacesDelta for clients that support it.
+  rpc WatchSessionEvents(SessionEventsRequest) returns (stream SessionEventsDelta);
 
   // WatchWorkloads notifies a client of the set of Workloads from the client
   // connection's namespace.

--- a/rpc/manager/manager_grpc.pb.go
+++ b/rpc/manager/manager_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	Manager_WatchAgentsDelta_FullMethodName                = "/telepresence.manager.Manager/WatchAgentsDelta"
 	Manager_WatchIntercepts_FullMethodName                 = "/telepresence.manager.Manager/WatchIntercepts"
 	Manager_WatchInterceptsDelta_FullMethodName            = "/telepresence.manager.Manager/WatchInterceptsDelta"
+	Manager_WatchSessionEvents_FullMethodName              = "/telepresence.manager.Manager/WatchSessionEvents"
 	Manager_WatchWorkloads_FullMethodName                  = "/telepresence.manager.Manager/WatchWorkloads"
 	Manager_WatchClusterInfo_FullMethodName                = "/telepresence.manager.Manager/WatchClusterInfo"
 	Manager_EnsureAgent_FullMethodName                     = "/telepresence.manager.Manager/EnsureAgent"
@@ -128,6 +129,12 @@ type ManagerClient interface {
 	// WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
 	// relevant to that client or agent.
 	WatchInterceptsDelta(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[InterceptInfoDelta], error)
+	// WatchSessionEvents notifies a client of changes to the set of known
+	// agent pods in the requested namespaces and to the client's own
+	// intercepts, multiplexed onto a single stream. It replaces the
+	// combination of WatchAgentsDelta, WatchInterceptsDelta, and
+	// WatchAgentPodsInNamespacesDelta for clients that support it.
+	WatchSessionEvents(ctx context.Context, in *SessionEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SessionEventsDelta], error)
 	// WatchWorkloads notifies a client of the set of Workloads from the client
 	// connection's namespace.
 	WatchWorkloads(ctx context.Context, in *WorkloadEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WorkloadEventsDelta], error)
@@ -475,9 +482,28 @@ func (c *managerClient) WatchInterceptsDelta(ctx context.Context, in *SessionInf
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchInterceptsDeltaClient = grpc.ServerStreamingClient[InterceptInfoDelta]
 
+func (c *managerClient) WatchSessionEvents(ctx context.Context, in *SessionEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SessionEventsDelta], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[7], Manager_WatchSessionEvents_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[SessionEventsRequest, SessionEventsDelta]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchSessionEventsClient = grpc.ServerStreamingClient[SessionEventsDelta]
+
 func (c *managerClient) WatchWorkloads(ctx context.Context, in *WorkloadEventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WorkloadEventsDelta], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[7], Manager_WatchWorkloads_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[8], Manager_WatchWorkloads_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +522,7 @@ type Manager_WatchWorkloadsClient = grpc.ServerStreamingClient[WorkloadEventsDel
 
 func (c *managerClient) WatchClusterInfo(ctx context.Context, in *SessionInfo, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ClusterInfo], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[8], Manager_WatchClusterInfo_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[9], Manager_WatchClusterInfo_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +641,7 @@ func (c *managerClient) LookupDNS(ctx context.Context, in *DNSRequest, opts ...g
 
 func (c *managerClient) WatchLogLevel(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LogLevelRequest], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[9], Manager_WatchLogLevel_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[10], Manager_WatchLogLevel_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +660,7 @@ type Manager_WatchLogLevelClient = grpc.ServerStreamingClient[LogLevelRequest]
 
 func (c *managerClient) Tunnel(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TunnelMessage, TunnelMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[10], Manager_Tunnel_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[11], Manager_Tunnel_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +693,7 @@ func (c *managerClient) GetQuicAgentCert(ctx context.Context, in *SessionInfo, o
 
 func (c *managerClient) WatchQuicBackends(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[QuicBackendSnapshot], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[11], Manager_WatchQuicBackends_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Manager_ServiceDesc.Streams[12], Manager_WatchQuicBackends_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -767,6 +793,12 @@ type ManagerServer interface {
 	// WatchInterceptsDelta notifies a client or agent of changes in the set of intercepts
 	// relevant to that client or agent.
 	WatchInterceptsDelta(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoDelta]) error
+	// WatchSessionEvents notifies a client of changes to the set of known
+	// agent pods in the requested namespaces and to the client's own
+	// intercepts, multiplexed onto a single stream. It replaces the
+	// combination of WatchAgentsDelta, WatchInterceptsDelta, and
+	// WatchAgentPodsInNamespacesDelta for clients that support it.
+	WatchSessionEvents(*SessionEventsRequest, grpc.ServerStreamingServer[SessionEventsDelta]) error
 	// WatchWorkloads notifies a client of the set of Workloads from the client
 	// connection's namespace.
 	WatchWorkloads(*WorkloadEventsRequest, grpc.ServerStreamingServer[WorkloadEventsDelta]) error
@@ -910,6 +942,9 @@ func (UnimplementedManagerServer) WatchIntercepts(*SessionInfo, grpc.ServerStrea
 }
 func (UnimplementedManagerServer) WatchInterceptsDelta(*SessionInfo, grpc.ServerStreamingServer[InterceptInfoDelta]) error {
 	return status.Error(codes.Unimplemented, "method WatchInterceptsDelta not implemented")
+}
+func (UnimplementedManagerServer) WatchSessionEvents(*SessionEventsRequest, grpc.ServerStreamingServer[SessionEventsDelta]) error {
+	return status.Error(codes.Unimplemented, "method WatchSessionEvents not implemented")
 }
 func (UnimplementedManagerServer) WatchWorkloads(*WorkloadEventsRequest, grpc.ServerStreamingServer[WorkloadEventsDelta]) error {
 	return status.Error(codes.Unimplemented, "method WatchWorkloads not implemented")
@@ -1299,6 +1334,17 @@ func _Manager_WatchInterceptsDelta_Handler(srv interface{}, stream grpc.ServerSt
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Manager_WatchInterceptsDeltaServer = grpc.ServerStreamingServer[InterceptInfoDelta]
+
+func _Manager_WatchSessionEvents_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SessionEventsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ManagerServer).WatchSessionEvents(m, &grpc.GenericServerStream[SessionEventsRequest, SessionEventsDelta]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Manager_WatchSessionEventsServer = grpc.ServerStreamingServer[SessionEventsDelta]
 
 func _Manager_WatchWorkloads_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(WorkloadEventsRequest)
@@ -1753,6 +1799,11 @@ var Manager_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "WatchInterceptsDelta",
 			Handler:       _Manager_WatchInterceptsDelta_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "WatchSessionEvents",
+			Handler:       _Manager_WatchSessionEvents_Handler,
 			ServerStreams: true,
 		},
 		{


### PR DESCRIPTION
Consolidates the per-client watcher streams into a single combined `WatchSessionEvents` stream between the client and the traffic-manager.

## What this does

The client registers one combined watcher for everything related to workloads and attachments — agent pods and the client's intercepts — instead of separate streams. The user daemon relays agent-pod events to the root daemon locally, halving the number of watcher streams the traffic-manager serves per client. Bulk container data (environments, mounts) is no longer streamed at all; it is fetched on demand when an attachment needs it.

Both directions remain fully backward compatible: a new client degrades to the separate watchers against an older traffic-manager, and an older client keeps using them against a new one.

## Also fixed

Ingests into a namespace other than the connected one no longer lose their volume mounts and port-forwards when traffic-agent activity occurs in the connected namespace: the agent snapshot bookkeeping is now namespace-aware, and a same-named workload in the connected namespace can no longer be mistaken for the ingested one.

## Notes

- New proto contracts (`WatchSessionEvents`) in `rpc/manager`; both RPC sides are updated, and older peers negotiate down to the pre-existing per-stream watchers.
- The integration harness can drive pre-2.30 clients past the detach rename.
- The design plan under `docs/plans/` stays until review completes, per the repo workflow.
