### PR TITLE
Prevent one stream pair from corrupting the shared port-forward connection

### DIFF
--- a/docs/plans/stream-close-corruption/plan.md
+++ b/docs/plans/stream-close-corruption/plan.md
@@ -1,0 +1,122 @@
+# Fix #4222: stream-pair close corrupts the shared per-pod stream connection
+
+## Root cause (established empirically)
+
+Issue #4222 attributed the corruption to closing a stream pair. That framing
+is wrong: closing a pair — data FIN, error FIN, `RemoveStreams` — is clean.
+Reproduction against a live kind cluster (real API server → kubelet →
+containerd chain) shows a pair close under a live sibling pair is harmless on
+both transports. The actual defect is a **write-deadline leak across streams
+that share one connection**:
+
+1. `moby/spdystream` does not implement per-stream deadlines.
+   `Stream.SetWriteDeadline` sets the deadline on the **underlying network
+   connection**, shared by every stream pair on that pod connection (the
+   spdystream source marks this with
+   `// TODO set per stream values instead of connection-wide`).
+2. Our `portConn.SetWriteDeadline` (`pkg/client/portforward/streamconn.go`)
+   forwards deadline calls to the data stream whenever it implements
+   `net.Conn`.
+3. Whether it implements `net.Conn` depends on the transport:
+   - WebSocket tunneling (the default): streams are native
+     `*spdystream.Stream` → the deadline propagates connection-wide.
+   - Direct SPDY: client-go's `streamingStreamAdapter` (from
+     `NewDialerForStreaming`) does *not* implement `net.Conn` → deadline
+     calls are already silent no-ops.
+4. `crypto/tls.Conn.Close()` (`closeNotify`) always ends with
+   `SetWriteDeadline(time.Now())` — a deadline in the past, by design, so
+   that subsequent writes on the TLS conn fail. Run over a `portConn`, that
+   poison lands on the shared connection: **every write by every other
+   stream pair fails with `i/o timeout` from then on**. The gRPC channel's
+   next frame dies, the transport redials onto the same poisoned connection,
+   and the RPC hangs until its deadline — the exact 60-second failure that
+   led to #4222. The x509 auth handshake (a TLS client over a port-forward
+   stream) is a deterministic trigger; any future TLS-over-stream use would
+   be too.
+
+Evidence (probe tests, kept as part of this change where CI-viable):
+
+- In-process harness — production `podDialer` against a faithful
+  kubelet/containerd server chain — shows pair close is clean, and the
+  original x509 sequence is clean, over plain byte exchanges.
+- Live-cluster probe with a socat pod: pair close under a live pair is clean
+  on both transports; adding only the closeNotify deadline sequence breaks
+  the WebSocket transport (sibling pair write: `i/o timeout`) while direct
+  SPDY stays healthy (adapter no-op).
+- Live-cluster probe against a real x509-enabled traffic-manager: real gRPC
+  channel + real TLS auth exchange reproduces the original hang on
+  WebSocket, passes on SPDY, and pinpoints `tls.Conn.Close()` as the
+  trigger.
+
+## Fix
+
+Two parts, both in `portConn`:
+
+1. Make `SetDeadline`, `SetReadDeadline`, and `SetWriteDeadline` no-ops
+   (return nil). Per-stream deadlines are unimplementable on top of
+   spdystream's connection-wide semantics, and forwarding them turns one
+   consumer's deadline into whole-connection corruption. This makes the two
+   transports consistent: the direct-SPDY path has always no-opped these
+   calls, and every existing consumer (gRPC transports manage their own
+   timers) already tolerates that. Callers that need to bound an operation
+   must use a context/watchdog that closes the conn — which is what the
+   x509 token source already does, for exactly this reason.
+
+2. Call `Reset()` on both streams in `portConn.Close`, after the regular
+   `Close()`. A local stream close in spdystream does not unblock local
+   reads pending on that stream, so `portConn` violated the `net.Conn`
+   contract that Close unblocks pending Reads. Consumers depended on that
+   contract through the deadline hole: gRPC's transport teardown interrupts
+   its blocked reader by setting a past *read* deadline on the conn — the
+   same connection-wide poison as the crypto/tls case, and with part 1
+   alone, teardown of the last conn on a WebSocket tunnel stalls ~10s (the
+   tunnel's ping period) waiting for the remote to wind down. `Reset` after
+   a sent FIN closes the local channels and removes the streams from the
+   spdystream connection's stream map without putting anything on the wire.
+   It also ends the error-stream reader goroutine (previously leaked until
+   the remote closed its side) and lets the connection-level shutdown
+   proceed without waiting on stream-map stragglers.
+
+`LocalAddr`/`RemoteAddr` keep their current best-effort delegation; they are
+informational and harmless.
+
+Not chosen:
+
+- Fixing spdystream upstream (real per-stream deadlines): right long-term,
+  wrong vehicle — it is vendored transitively via k8s staging modules, and
+  the fix must work with every already-shipped version. An upstream issue is
+  worth filing separately.
+- Emulating read deadlines per-stream in `portConn`: no consumer needs it.
+
+Measured teardown of the manager gRPC channel over the WebSocket tunnel:
+~1s before the change (via the read-deadline poison), ~10s with part 1
+alone, ~0.4ms with both parts.
+
+## Tests
+
+- Keep the in-process reproduction harness (kubelet handler + containerd
+  copy-loop semantics + production `podDialer`) as a regression test:
+  - pair close under a live pair leaves the sibling and future dials healthy;
+  - the crypto/tls closeNotify sequence (write, past write-deadline, close)
+    through one pair leaves the sibling pair healthy. To be *red before the
+    fix*, this test dials through the k8s.io/streaming native SPDY client
+    (streams implement `net.Conn`, like the WebSocket path) rather than the
+    client-go adapter.
+- The live-cluster probes (socat pod, traffic-manager) are investigation
+  scaffolding: env-gated (`PROBE_KUBECONFIG`), skipped in CI. Dropped before
+  merge; the in-process regression covers the mechanism.
+- Manual verification: the traffic-manager live probe (WebSocket) passes
+  with the fix applied.
+
+## Follow-ups (separate changes)
+
+- Update #4222 with the root cause; close it when this merges.
+- x509 PR #4223: `OneShotDialer` was added to work around this defect. With
+  the fix in, the handshake can safely share the pod connection again —
+  evaluate dropping `OneShotDialer` on that branch once this lands.
+- Optional upstream issue against moby/spdystream (connection-wide
+  deadlines) and k8s.io/streaming (adapter/native `net.Conn` inconsistency).
+
+## Release
+
+Client-only, small, safe: candidate for 2.31.1 alongside the x509 work.

--- a/pkg/client/portforward/streamconn.go
+++ b/pkg/client/portforward/streamconn.go
@@ -230,8 +230,14 @@ func (pc *portConn) RemoteAddr() net.Addr {
 }
 
 func (pc *portConn) Close() error {
+	// Close sends a FIN on each stream. The Reset that follows unblocks local
+	// reads pending on the streams (the net.Conn contract for Close) and
+	// drops the streams from the spdystream connection's stream map; after
+	// the FIN it sends nothing on the wire.
 	pc.dataStream.Close()
 	pc.errorStream.Close()
+	_ = pc.dataStream.Reset()
+	_ = pc.errorStream.Reset()
 	pc.dialer.streamConn.RemoveStreams(pc.dataStream, pc.errorStream)
 	if atomic.AddInt64(&pc.dialer.refCount, -1) == 0 {
 		return pc.dialer.Close()
@@ -239,23 +245,20 @@ func (pc *portConn) Close() error {
 	return nil
 }
 
-func (pc *portConn) SetDeadline(t time.Time) error {
-	if dataConn, ok := pc.dataStream.(net.Conn); ok {
-		return dataConn.SetDeadline(t)
-	}
+// Deadlines are accepted and ignored. The spdystream layer has no per-stream
+// deadlines: a deadline set on a stream lands on the underlying network
+// connection, shared by every stream pair on the pod, so forwarding it would
+// let one consumer break all other streams (crypto/tls.Conn.Close, for one,
+// sets a write deadline in the past). Callers that need to bound an operation
+// must close the conn instead.
+func (pc *portConn) SetDeadline(time.Time) error {
 	return nil
 }
 
-func (pc *portConn) SetReadDeadline(t time.Time) error {
-	if dataConn, ok := pc.dataStream.(net.Conn); ok {
-		return dataConn.SetReadDeadline(t)
-	}
+func (pc *portConn) SetReadDeadline(time.Time) error {
 	return nil
 }
 
-func (pc *portConn) SetWriteDeadline(t time.Time) error {
-	if dataConn, ok := pc.dataStream.(net.Conn); ok {
-		return dataConn.SetWriteDeadline(t)
-	}
+func (pc *portConn) SetWriteDeadline(time.Time) error {
 	return nil
 }

--- a/pkg/client/portforward/streamconn_test.go
+++ b/pkg/client/portforward/streamconn_test.go
@@ -1,0 +1,524 @@
+package portforward
+
+// Regression tests for issue #4222: one consumer of the shared per-pod
+// stream connection must not be able to corrupt it for its sibling stream
+// pairs.
+//
+// The server side replicates the real chain that terminates a cluster's
+// port-forward: the SPDY response upgrader from k8s.io/streaming (the same
+// code kubelet and containerd use via k8s staging modules), the kubelet
+// httpStreamHandler (k8s.io/kubelet/pkg/cri/streaming/portforward, v1.35.0)
+// copied verbatim minus logging, and containerd's criService.portForward
+// copy loops (v2.2.0) including the 1-second grace after the first copy
+// direction ends.
+//
+// The client side dials with the k8s.io/streaming SPDY round tripper, whose
+// streams are native *spdystream.Stream values implementing net.Conn — the
+// same shape the WebSocket-tunneled transport produces. This is the shape
+// where a deadline forwarded by portConn reaches the shared underlying
+// connection.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"runtime/pprof"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+	"k8s.io/streaming/pkg/httpstream"
+	streamspdy "k8s.io/streaming/pkg/httpstream/spdy"
+)
+
+// testLog wraps testing.T logging so that harness goroutines that outlive
+// the test (containerd's 1s grace, copy loops unblocked at teardown) do not
+// log after the test has completed.
+type testLog struct {
+	mu   sync.Mutex
+	t    *testing.T
+	done bool
+}
+
+func newTestLog(t *testing.T) *testLog {
+	l := &testLog{t: t}
+	t.Cleanup(func() {
+		l.mu.Lock()
+		l.done = true
+		l.mu.Unlock()
+	})
+	return l
+}
+
+func (l *testLog) Logf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.done {
+		l.t.Logf(format, args...)
+	}
+}
+
+func (l *testLog) Log(args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.done {
+		l.t.Log(args...)
+	}
+}
+
+// containerdForward mimics containerd v2.2.0 criService.portForward: two copy
+// goroutines, return when the first direction ends, give the second direction
+// one second, then close both ends.
+func containerdForward(log *testLog, target string) func(stream io.ReadWriteCloser) error {
+	return func(stream io.ReadWriteCloser) error {
+		defer stream.Close()
+		conn, err := net.Dial("tcp", target)
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		errCh := make(chan error, 2)
+		go func() {
+			_, err := io.Copy(stream, conn)
+			log.Logf("server: pod->client copy ended: %v", err)
+			errCh <- err
+		}()
+		go func() {
+			_, err := io.Copy(conn, stream)
+			log.Logf("server: client->pod copy ended: %v", err)
+			errCh <- err
+		}()
+
+		errFwd := <-errCh
+		select {
+		case e := <-errCh:
+			if errFwd == nil {
+				errFwd = e
+			}
+		case <-time.After(time.Second):
+			log.Log("server: 1s grace expired with one copy direction still running")
+		}
+		return errFwd
+	}
+}
+
+// testStreamPair is kubelet's httpStreamPair.
+type testStreamPair struct {
+	lock        sync.RWMutex
+	requestID   string
+	dataStream  httpstream.Stream
+	errorStream httpstream.Stream
+	complete    chan struct{}
+}
+
+func (p *testStreamPair) add(stream httpstream.Stream) (bool, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	switch stream.Headers().Get(core.StreamType) {
+	case core.StreamTypeError:
+		if p.errorStream != nil {
+			return false, errors.New("error stream already assigned")
+		}
+		p.errorStream = stream
+	case core.StreamTypeData:
+		if p.dataStream != nil {
+			return false, errors.New("data stream already assigned")
+		}
+		p.dataStream = stream
+	}
+	complete := p.errorStream != nil && p.dataStream != nil
+	if complete {
+		close(p.complete)
+	}
+	return complete, nil
+}
+
+func (p *testStreamPair) printError(s string) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	if p.errorStream != nil {
+		_, _ = fmt.Fprint(p.errorStream, s)
+	}
+}
+
+// testStreamHandler is kubelet's httpStreamHandler (v1.35.0), minus logging.
+type testStreamHandler struct {
+	log                   *testLog
+	conn                  httpstream.Connection
+	streamChan            chan httpstream.Stream
+	streamPairsLock       sync.RWMutex
+	streamPairs           map[string]*testStreamPair
+	streamCreationTimeout time.Duration
+	forwarder             func(port int32, stream io.ReadWriteCloser) error
+}
+
+func (h *testStreamHandler) getStreamPair(requestID string) (*testStreamPair, bool) {
+	h.streamPairsLock.Lock()
+	defer h.streamPairsLock.Unlock()
+	if p, ok := h.streamPairs[requestID]; ok {
+		return p, false
+	}
+	p := &testStreamPair{requestID: requestID, complete: make(chan struct{})}
+	h.streamPairs[requestID] = p
+	return p, true
+}
+
+func (h *testStreamHandler) monitorStreamPair(p *testStreamPair, timeout <-chan time.Time) {
+	select {
+	case <-timeout:
+		p.printError(fmt.Sprintf("(request=%s) timed out waiting for streams", p.requestID))
+	case <-p.complete:
+	}
+	h.removeStreamPair(p.requestID)
+}
+
+func (h *testStreamHandler) removeStreamPair(requestID string) {
+	h.streamPairsLock.Lock()
+	defer h.streamPairsLock.Unlock()
+	if h.conn != nil {
+		pair := h.streamPairs[requestID]
+		h.conn.RemoveStreams(pair.dataStream, pair.errorStream)
+	}
+	delete(h.streamPairs, requestID)
+}
+
+func (h *testStreamHandler) requestID(stream httpstream.Stream) string {
+	requestID := stream.Headers().Get(core.PortForwardRequestIDHeader)
+	if len(requestID) == 0 {
+		streamType := stream.Headers().Get(core.StreamType)
+		switch streamType {
+		case core.StreamTypeError:
+			requestID = strconv.Itoa(int(stream.Identifier()))
+		case core.StreamTypeData:
+			requestID = strconv.Itoa(int(stream.Identifier()) - 2)
+		}
+	}
+	return requestID
+}
+
+func (h *testStreamHandler) run() {
+	for {
+		select {
+		case <-h.conn.CloseChan():
+			h.log.Log("server: stream connection closed, handler loop exiting")
+			return
+		case stream := <-h.streamChan:
+			requestID := h.requestID(stream)
+			p, created := h.getStreamPair(requestID)
+			if created {
+				go h.monitorStreamPair(p, time.After(h.streamCreationTimeout))
+			}
+			if complete, err := p.add(stream); err != nil {
+				p.printError(fmt.Sprintf("error processing stream for request %s: %v", requestID, err))
+			} else if complete {
+				go h.portForward(p)
+			}
+		}
+	}
+}
+
+func (h *testStreamHandler) portForward(p *testStreamPair) {
+	defer p.dataStream.Close()
+	defer p.errorStream.Close()
+
+	portString := p.dataStream.Headers().Get(core.PortHeader)
+	port, _ := strconv.ParseInt(portString, 10, 32)
+
+	err := h.forwarder(int32(port), p.dataStream)
+	h.log.Logf("server: forwarder for request %s port %d returned: %v", p.requestID, port, err)
+	if err != nil {
+		msg := fmt.Errorf("error forwarding port %d: %v", port, err)
+		_, _ = fmt.Fprint(p.errorStream, msg.Error())
+		h.log.Logf("server: wrote error to error stream and resetting streams for request %s", p.requestID)
+		p.dataStream.Reset()  //nolint:errcheck // kubelet ignores this too
+		p.errorStream.Reset() //nolint:errcheck // kubelet ignores this too
+	}
+}
+
+func streamReceived(streams chan httpstream.Stream) func(httpstream.Stream, <-chan struct{}) error {
+	return func(stream httpstream.Stream, replySent <-chan struct{}) error {
+		portString := stream.Headers().Get(core.PortHeader)
+		if len(portString) == 0 {
+			return fmt.Errorf("%q header is required", core.PortHeader)
+		}
+		if _, err := strconv.ParseUint(portString, 10, 16); err != nil {
+			return fmt.Errorf("unable to parse %q as a port: %v", portString, err)
+		}
+		streamType := stream.Headers().Get(core.StreamType)
+		if streamType != core.StreamTypeError && streamType != core.StreamTypeData {
+			return fmt.Errorf("invalid stream type %q", streamType)
+		}
+		streams <- stream
+		return nil
+	}
+}
+
+// startPortForwardServer starts an HTTP server that upgrades to SPDY and
+// forwards each stream pair to the target registered for its port, exactly as
+// a kubelet/containerd chain would.
+func startPortForwardServer(t *testing.T, targets map[int32]string) *httptest.Server {
+	log := newTestLog(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, err := httpstream.Handshake(req, w, []string{ProtocolV1Name})
+		if err != nil {
+			t.Errorf("handshake: %v", err)
+			return
+		}
+		streamChan := make(chan httpstream.Stream, 1)
+		upgrader := streamspdy.NewResponseUpgrader()
+		conn := upgrader.UpgradeResponse(w, req, streamReceived(streamChan))
+		if conn == nil {
+			t.Error("unable to upgrade connection")
+			return
+		}
+		defer conn.Close()
+		conn.SetIdleTimeout(4 * time.Hour)
+		h := &testStreamHandler{
+			log:                   log,
+			conn:                  conn,
+			streamChan:            streamChan,
+			streamPairs:           make(map[string]*testStreamPair),
+			streamCreationTimeout: 30 * time.Second,
+			forwarder: func(port int32, stream io.ReadWriteCloser) error {
+				target, ok := targets[port]
+				if !ok {
+					return fmt.Errorf("no target for port %d", port)
+				}
+				return containerdForward(log, target)(stream)
+			},
+		}
+		h.run()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// startEcho starts a TCP echo server standing in for a long-lived pod port
+// (the manager's gRPC port).
+func startEcho(t *testing.T) string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				_, _ = io.Copy(c, c)
+				_ = c.Close()
+			}()
+		}
+	}()
+	return l.Addr().String()
+}
+
+// startOneShot starts a TCP server standing in for a one-shot exchange pod
+// port (the manager's x509 auth listener): read a request, write a response,
+// close.
+func startOneShot(t *testing.T) string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				buf := make([]byte, 64)
+				n, err := c.Read(buf)
+				if err == nil {
+					_, _ = c.Write([]byte("reply:" + string(buf[:n])))
+				}
+				_ = c.Close()
+			}()
+		}
+	}()
+	return l.Addr().String()
+}
+
+// step runs f with a watchdog; on timeout it dumps all goroutines and fails.
+func step(t *testing.T, name string, timeout time.Duration, f func() error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- f() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err, name)
+		t.Logf("step %s: ok", name)
+	case <-time.After(timeout):
+		t.Logf("step %s: TIMED OUT, goroutine dump follows", name)
+		_ = pprof.Lookup("goroutine").WriteTo(testWriter{t}, 2)
+		t.Fatalf("step %s timed out after %s", name, timeout)
+	}
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+// dialTestPod upgrades a connection to the test server with the
+// k8s.io/streaming SPDY round tripper and wraps it in a podDialer.
+func dialTestPod(t *testing.T, serverURL string) *podDialer {
+	rt, err := streamspdy.NewRoundTripper(nil)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, serverURL, nil)
+	require.NoError(t, err)
+	req.Header.Add(httpstream.HeaderProtocolVersion, ProtocolV1Name)
+	resp, err := (&http.Client{Transport: rt}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	streamConn, err := rt.NewConnection(resp)
+	require.NoError(t, err)
+	require.Equal(t, ProtocolV1Name, resp.Header.Get(httpstream.HeaderProtocolVersion))
+	t.Cleanup(func() { _ = streamConn.Close() })
+	log := newTestLog(t)
+	return &podDialer{streamConn: streamConn, onClose: func() { log.Log("podDialer onClose (evicted)") }}
+}
+
+func roundtrip(conn net.Conn, payload string) error {
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	buf := make([]byte, 256)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if n == 0 {
+		return errors.New("empty reply")
+	}
+	return nil
+}
+
+// sharedConnFixture opens a long-lived pair (standing in for the gRPC
+// channel, with a continuous reader like a real h2 transport) plus a
+// short-lived pair against a one-shot target, on one shared stream
+// connection. It returns the podDialer, the short-lived conn, and a ping
+// function that does a write/read roundtrip on the long-lived pair.
+func sharedConnFixture(t *testing.T) (pd *podDialer, short net.Conn, longPing func(string) error) {
+	ctx := t.Context()
+	echo := startEcho(t)
+	oneShot := startOneShot(t)
+	srv := startPortForwardServer(t, map[int32]string{2222: echo, 1111: oneShot})
+	pd = dialTestPod(t, srv.URL)
+
+	var long net.Conn
+	step(t, "dial long-lived", 10*time.Second, func() (err error) {
+		long, err = pd.dial(ctx, 2222)
+		return err
+	})
+
+	log := newTestLog(t)
+	replies := make(chan []byte, 100)
+	go func() {
+		for {
+			buf := make([]byte, 256)
+			n, err := long.Read(buf)
+			if err != nil {
+				log.Logf("client: long-lived reader ended: %v", err)
+				close(replies)
+				return
+			}
+			replies <- buf[:n]
+		}
+	}()
+	longPing = func(payload string) error {
+		if _, err := long.Write([]byte(payload)); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+		select {
+		case r, ok := <-replies:
+			if !ok {
+				return errors.New("long-lived reader is gone")
+			}
+			log.Logf("client: long-lived reply: %q", string(r))
+			return nil
+		case <-time.After(5 * time.Second):
+			return errors.New("no reply within 5s")
+		}
+	}
+
+	step(t, "roundtrip long-lived", 10*time.Second, func() error {
+		return longPing("ping-baseline")
+	})
+
+	step(t, "dial short-lived", 10*time.Second, func() (err error) {
+		short, err = pd.dial(ctx, 1111)
+		return err
+	})
+	step(t, "exchange short-lived", 10*time.Second, func() error {
+		// The one-shot target replies and immediately closes its socket.
+		return roundtrip(short, "handshake")
+	})
+	return pd, short, longPing
+}
+
+// assertSiblingsHealthy verifies that the long-lived pair still works and
+// that a new pair can be dialed on the shared connection.
+func assertSiblingsHealthy(t *testing.T, pd *podDialer, longPing func(string) error) {
+	for i := range 3 {
+		step(t, fmt.Sprintf("roundtrip long-lived after close #%d", i), 15*time.Second, func() error {
+			return longPing(fmt.Sprintf("ping-post-%d", i))
+		})
+	}
+	var late net.Conn
+	step(t, "dial late pair", 15*time.Second, func() (err error) {
+		late, err = pd.dial(t.Context(), 2222)
+		return err
+	})
+	step(t, "roundtrip late pair", 10*time.Second, func() error {
+		return roundtrip(late, "ping-late")
+	})
+}
+
+// Test_PairCloseKeepsSiblingsHealthy closes a short-lived stream pair,
+// including a trailing write into the already-closed pod socket, while a
+// long-lived pair stays active on the same shared connection.
+func Test_PairCloseKeepsSiblingsHealthy(t *testing.T) {
+	pd, short, longPing := sharedConnFixture(t)
+
+	step(t, "close short-lived with trailing payload", 10*time.Second, func() error {
+		if _, err := short.Write([]byte("trailing")); err != nil {
+			t.Logf("client: trailing write error (acceptable): %v", err)
+		}
+		return short.Close()
+	})
+
+	assertSiblingsHealthy(t, pd, longPing)
+}
+
+// Test_PairDeadlineDoesNotPoisonSiblings performs, on the short-lived pair,
+// the exact deadline sequence crypto/tls.Conn.Close runs against its
+// underlying conn (closeNotify: a 5s write deadline, the close_notify write,
+// then a write deadline in the past), and then closes the pair. The
+// spdystream layer has no per-stream deadlines — a forwarded deadline lands
+// on the shared connection and breaks every sibling's writes with i/o
+// timeouts (issue #4222). portConn must swallow deadline calls instead.
+func Test_PairDeadlineDoesNotPoisonSiblings(t *testing.T) {
+	pd, short, longPing := sharedConnFixture(t)
+
+	step(t, "close short-lived the way crypto/tls does", 10*time.Second, func() error {
+		require.NoError(t, short.SetWriteDeadline(time.Now().Add(5*time.Second)))
+		if _, err := short.Write([]byte("close-notify")); err != nil {
+			t.Logf("client: close_notify write error (acceptable): %v", err)
+		}
+		require.NoError(t, short.SetWriteDeadline(time.Now()))
+		return short.Close()
+	})
+
+	assertSiblingsHealthy(t, pd, longPing)
+}


### PR DESCRIPTION
A consumer of the per-pod port-forward connection could break every other stream pair sharing it. Two defects in `portConn`, both now fixed:

- Deadline calls were forwarded to the spdystream layer, which has no per-stream deadlines — the deadline landed on the shared network connection. Anything that sets one (crypto/tls sets a past write deadline on every `Close`; gRPC's transport teardown interrupts its reader the same way) poisoned all sibling pairs. On the WebSocket-tunneled transport this hung the manager gRPC channel for its full dial deadline; on direct SPDY the calls happened to no-op. `portConn` now swallows deadlines on both transports.
- `portConn.Close` left local pending reads blocked, violating the `net.Conn` contract. It now resets the streams after the FIN, which unblocks local readers and ends the error-stream reader goroutine without putting anything on the wire.

The regression test runs the production `podDialer` against an in-process replica of the kubelet/containerd port-forward chain and fails without the fix. Root-cause analysis is in `docs/plans/stream-close-corruption/plan.md` (dropped before merge).

Fixes #4222