### PR TITLE
Add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -15,6 +15,7 @@ post, conference talk, or case study. Sign off your commit
 | [Bitnami](https://bitnami.com) | [Case study](https://telepresence.io/case-studies/bitnami) |
 | [BlackRock](https://www.blackrock.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [Cisco](https://www.cisco.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [Displate](https://displate.com) | [Maintainer affiliation](https://github.com/telepresenceio/telepresence/blob/release/v2/MAINTAINERS.md) |
 | [Engel & Völkers](https://www.engelvoelkers.com) | [Case study](https://telepresence.io/case-studies/engel-volkers) |
 | [HelloFresh](https://www.hellofresh.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [IBM](https://www.ibm.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,22 @@
+# Telepresence Adopters
+
+Organizations that use Telepresence and are happy to say so publicly.
+This list helps the CNCF and prospective users gauge real-world adoption.
+
+Is your organization using Telepresence? Add it here! Open a pull request
+that appends a row to the table (kept in alphabetical order) with your
+organization's name and, if you have one, a public reference such as a blog
+post, conference talk, or case study. Sign off your commit
+(`git commit -s`) as required by the
+[DCO](https://developercertificate.org/) check.
+
+| Organization | Reference |
+|--------------|-----------|
+| [Bitnami](https://bitnami.com) | [Case study](https://telepresence.io/case-studies/bitnami) |
+| [Engel & Völkers](https://www.engelvoelkers.com) | [Case study](https://telepresence.io/case-studies/engel-volkers) |
+| [IRIS.TV](https://www.iris.tv) | [Case study](https://telepresence.io/case-studies/iris-tv) |
+| [Sight Machine](https://sightmachine.com) | [Case study](https://telepresence.io/case-studies/sight-machine) |
+| [Verloop](https://verloop.io) | [Case study](https://telepresence.io/case-studies/verloop) |
+
+The initial entries were seeded from the case studies published on
+[telepresence.io](https://telepresence.io/case-studies/).

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,10 +13,25 @@ post, conference talk, or case study. Sign off your commit
 | Organization | Reference |
 |--------------|-----------|
 | [Bitnami](https://bitnami.com) | [Case study](https://telepresence.io/case-studies/bitnami) |
+| [BlackRock](https://www.blackrock.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [Cisco](https://www.cisco.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [Engel & Völkers](https://www.engelvoelkers.com) | [Case study](https://telepresence.io/case-studies/engel-volkers) |
+| [HelloFresh](https://www.hellofresh.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [IBM](https://www.ibm.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [IRIS.TV](https://www.iris.tv) | [Case study](https://telepresence.io/case-studies/iris-tv) |
+| [Manhattan Associates](https://www.manh.com) | |
+| [monday.com](https://monday.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [OpenAI](https://openai.com) | |
 | [Sight Machine](https://sightmachine.com) | [Case study](https://telepresence.io/case-studies/sight-machine) |
+| [Unity](https://unity.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [Verloop](https://verloop.io) | [Case study](https://telepresence.io/case-studies/verloop) |
+| [VMware](https://www.vmware.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [Walmart](https://www.walmart.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [Wellframe](https://www.wellframe.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
+| [Zipcar](https://www.zipcar.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 
 The initial entries were seeded from the case studies published on
-[telepresence.io](https://telepresence.io/case-studies/).
+[telepresence.io](https://telepresence.io/case-studies/), the featured
+customers on the
+[Telepresence product page](https://www.linkedin.com/products/ambassadorlabs-telepresence/)
+on LinkedIn, and users known to the maintainers.

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -23,6 +23,7 @@ post, conference talk, or case study. Sign off your commit
 | [Manhattan Associates](https://www.manh.com) | |
 | [monday.com](https://monday.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [OpenAI](https://openai.com) | |
+| [Polar Sky](https://polarsky.ai) | [Maintainer affiliation](https://github.com/telepresenceio/telepresence/blob/release/v2/MAINTAINERS.md) |
 | [Sight Machine](https://sightmachine.com) | [Case study](https://telepresence.io/case-studies/sight-machine) |
 | [Unity](https://unity.com) | [Featured customer](https://www.linkedin.com/products/ambassadorlabs-telepresence/) |
 | [Verloop](https://verloop.io) | [Case study](https://telepresence.io/case-studies/verloop) |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ Maintainers are listed in alphabetical order.
 |-----------------|-------------------------------------------|-------------|
 | Blazej Gruszka  | [bgruszka](https://github.com/bgruszka)   | Displate    |
 | Nick Powell     | [njayp](https://github.com/njayp)         |             |
-| Thomas Hallgren | [thallgren](https://github.com/thallgren) |             |
+| Thomas Hallgren | [thallgren](https://github.com/thallgren) | Polar Sky   |
 
 ## Maintainers Emeriti
 


### PR DESCRIPTION
Adds the CNCF-standard adopters list requested by the .project onboarding (telepresenceio/.project#1). Seeded from three sources: the five case studies published on [telepresence.io](https://telepresence.io/case-studies/), the ten featured customers on the [Telepresence product page](https://www.linkedin.com/products/ambassadorlabs-telepresence/) on LinkedIn, and two users known to the maintainers (Manhattan Associates and OpenAI). Everyone else is invited to add themselves by pull request.