### PR TITLE
Bound the workloads a regression run keeps alive

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -303,10 +303,8 @@ jobs:
           container-runtime: containerd
       - name: Build client
         run: make build
-      - name: Build images
-        run: make tel2-image client-image
-      - name: Load images into minikube
-        run: minikube image load ${{env.TELEPRESENCE_REGISTRY}}/tel2:${{env.TELEPRESENCE_SEMVER}}
+      - name: Build and load images into minikube
+        run: make load-images
       - name: Run regression tests
         timeout-minutes: 45
         shell: bash

--- a/regression_test/framework/rt/fixture.go
+++ b/regression_test/framework/rt/fixture.go
@@ -1,8 +1,10 @@
 package rt
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -45,6 +47,9 @@ type memoEntry struct {
 	failed  error
 	always  bool
 	destroy func(Env) error
+	// used is the engine clock reading of this entry's most recent Get,
+	// which orders eviction candidates.
+	used uint64
 }
 
 // engine is the single, mutex-guarded fixture store owned by Runtime. It
@@ -54,24 +59,76 @@ type engine struct {
 	mu       sync.Mutex
 	entries  map[string]*memoEntry
 	sequence []*memoEntry // provision order, for LIFO teardown
+	clock    uint64       // ticks on every Get, stamping memoEntry.used
 }
 
 func newEngine() *engine {
 	return &engine{entries: map[string]*memoEntry{}}
 }
 
+// tick advances the engine clock and returns the new reading. Caller holds
+// e.mu.
+func (e *engine) tick() uint64 {
+	e.clock++
+	return e.clock
+}
+
 func (e *engine) lookup(hash string) (*memoEntry, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	en, ok := e.entries[hash]
+	if ok {
+		en.used = e.tick()
+	}
 	return en, ok
 }
 
 func (e *engine) store(en *memoEntry) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	en.used = e.tick()
 	e.entries[en.hash] = en
 	e.sequence = append(e.sequence, en)
+}
+
+// mark returns the current clock reading, which callers pass to evictIdle as
+// the boundary before which an entry counts as idle.
+func (e *engine) mark() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.clock
+}
+
+// evictIdle removes the workload memo entries whose last Get predates since,
+// keeping the keep most recently used among them, and returns them for the
+// caller to destroy. Entries are dropped from sequence as well: unlike
+// invalidate, eviction does destroy the resource, so the final teardown has
+// nothing left to do for them.
+//
+// Bounding by since is what makes eviction safe: an entry the running suite
+// touched is stamped at or after the mark taken when that suite began, so
+// only fixtures no live suite is holding are ever considered.
+func (e *engine) evictIdle(since uint64, keep int) []*memoEntry {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var idle []*memoEntry
+	for _, en := range e.entries {
+		if en.used <= since && en.destroy != nil && strings.HasPrefix(en.name, workloadFixturePrefix) {
+			idle = append(idle, en)
+		}
+	}
+	slices.SortFunc(idle, func(a, b *memoEntry) int { return cmp.Compare(b.used, a.used) })
+	if len(idle) <= keep {
+		return nil
+	}
+	evicted := idle[keep:]
+	for _, en := range evicted {
+		delete(e.entries, en.hash)
+	}
+	e.sequence = slices.DeleteFunc(e.sequence, func(en *memoEntry) bool {
+		return slices.Contains(evicted, en)
+	})
+	return evicted
 }
 
 // invalidate removes the memo entry for hash, used by Mutate's t.Cleanup so
@@ -175,6 +232,38 @@ func getOrProvision[T any](t testing.TB, f *Fixture[T]) T {
 	r.manifest.recordFixture(f.Name, f.Hash, action, dur)
 	r.Infof("[rtest] fixture %s: %s %s", f.Name, action, dur.Round(time.Millisecond))
 	return value
+}
+
+// workloadFixturePrefix opens the Name of every WorkloadFixture, which is
+// what makes workload entries identifiable as eviction candidates.
+const workloadFixturePrefix = "workload/"
+
+// maxLiveWorkloads bounds how many workload fixtures stay provisioned once a
+// suite ends. Every workload is a running pod, and a memo entry lives until
+// the run ends, so without a bound a long run holds every workload any suite
+// ever touched: past a single node's pod capacity, later managers cannot be
+// scheduled at all. The bound is well above any one suite's usage, so
+// fixtures a neighbouring suite reuses are still served from the memo.
+const maxLiveWorkloads = 25
+
+// evictIdleWorkloads destroys workload fixtures untouched since mark, past
+// maxLiveWorkloads. Called at suite boundaries, where mark is the reading
+// taken before the suite ran. Destroy runs outside the engine lock.
+//
+// This applies in dev mode too: WorkloadFixture is AlwaysDestroy, so a
+// workload is never a candidate for adoption by the next run and evicting it
+// early costs only its own re-provision.
+func (r *Runtime) evictIdleWorkloads(mark uint64) {
+	evicted := r.engine.evictIdle(mark, maxLiveWorkloads)
+	tb := &runTB{r: r}
+	for _, en := range evicted {
+		start := time.Now()
+		if err := en.destroy(Env{Ctx: r.ctx, T: tb, R: r}); err != nil {
+			r.Infof("[rtest] fixture %s: evict error: %v", en.name, err)
+			continue
+		}
+		r.Infof("[rtest] fixture %s: evicted %s", en.name, time.Since(start).Round(time.Millisecond))
+	}
 }
 
 // teardownFixtures destroys live fixtures in LIFO (reverse provision) order.

--- a/regression_test/framework/rt/fixture_connection.go
+++ b/regression_test/framework/rt/fixture_connection.go
@@ -265,10 +265,11 @@ func provisionConnection(e Env, ns string, args []string, cs *connSpec) (*Conn, 
 		overrides[k] = v
 	}
 	stdout, stderr, err := e.R.CLIWithEnv(overrides).Run(e.Ctx, args...)
-	if err != nil && strings.Contains(stderr, "failed to connect to root daemon") {
+	if err != nil && transientRootDaemonFailure(stderr) {
 		// Rapid quit+connect cycles can race the previous root daemon's VIF
-		// teardown ("failed to retrieve TAP link: Link not found"); one
-		// retry after the device settles is enough.
+		// teardown ("failed to retrieve TAP link: Link not found") or catch
+		// the user daemon before its root-daemon client is back; one retry
+		// after the device settles is enough.
 		e.R.Infof("[rtest] connect %s: transient root-daemon failure, retrying: %s", ns, strings.TrimSpace(stderr))
 		time.Sleep(3 * time.Second)
 		stdout, stderr, err = e.R.CLIWithEnv(overrides).Run(e.Ctx, args...)
@@ -280,6 +281,13 @@ func provisionConnection(e Env, ns string, args []string, cs *connSpec) (*Conn, 
 		e.R.Infof("[rtest] connect %s: %s", ns, s)
 	}
 	return &Conn{r: e.R, ctx: e.Ctx, namespace: ns, name: cs.name, docker: cs.docker}, nil
+}
+
+// transientRootDaemonFailure reports whether stderr names a root-daemon
+// state that clears on its own.
+func transientRootDaemonFailure(stderr string) bool {
+	return strings.Contains(stderr, "failed to connect to root daemon") ||
+		strings.Contains(stderr, "root daemon is reconnecting")
 }
 
 func adoptConnection(e Env, ns string) (*Conn, bool) {

--- a/regression_test/framework/rt/fixture_evict_test.go
+++ b/regression_test/framework/rt/fixture_evict_test.go
@@ -1,0 +1,102 @@
+package rt
+
+import (
+	"testing"
+)
+
+// newEntry stores a never-failing entry named name and returns it.
+func newEntry(e *engine, name, hash string) *memoEntry {
+	en := &memoEntry{name: name, hash: hash, destroy: func(Env) error { return nil }}
+	e.store(en)
+	return en
+}
+
+func TestEvictIdleKeepsMostRecent(t *testing.T) {
+	e := newEngine()
+	for _, h := range []string{"a", "b", "c", "d"} {
+		newEntry(e, "workload/ns/"+h, h)
+	}
+	mark := e.mark()
+
+	evicted := e.evictIdle(mark, 2)
+	if len(evicted) != 2 {
+		t.Fatalf("evicted %d entries, want 2", len(evicted))
+	}
+	// c and d were stored last, so a and b are the idle ones.
+	for _, en := range evicted {
+		if en.hash != "a" && en.hash != "b" {
+			t.Errorf("evicted %s, want only a or b", en.hash)
+		}
+	}
+	for _, h := range []string{"c", "d"} {
+		if _, ok := e.entries[h]; !ok {
+			t.Errorf("entry %s was evicted but should have been kept", h)
+		}
+	}
+}
+
+func TestEvictIdleSparesEntriesUsedSinceMark(t *testing.T) {
+	e := newEngine()
+	for _, h := range []string{"a", "b", "c", "d"} {
+		newEntry(e, "workload/ns/"+h, h)
+	}
+	// A suite starts here, then Gets "a": its use must protect it even though
+	// it was the least recently used at the mark.
+	mark := e.mark()
+	if _, ok := e.lookup("a"); !ok {
+		t.Fatal("lookup a: not found")
+	}
+
+	for _, en := range e.evictIdle(mark, 0) {
+		if en.hash == "a" {
+			t.Fatal("evicted a, which was used after the mark")
+		}
+	}
+	if _, ok := e.entries["a"]; !ok {
+		t.Error("entry a is gone but was used after the mark")
+	}
+}
+
+func TestEvictIdleIgnoresOtherPrefixes(t *testing.T) {
+	e := newEngine()
+	newEntry(e, "manager/default", "m")
+	newEntry(e, "connection/ns", "c")
+	newEntry(e, "workload/ns/w", "w")
+
+	evicted := e.evictIdle(e.mark(), 0)
+	if len(evicted) != 1 || evicted[0].hash != "w" {
+		t.Fatalf("evicted %v, want just the workload entry", evicted)
+	}
+	for _, h := range []string{"m", "c"} {
+		if _, ok := e.entries[h]; !ok {
+			t.Errorf("entry %s was evicted but only workload/ entries are candidates", h)
+		}
+	}
+}
+
+// An evicted entry is destroyed, so the final teardown must not see it again.
+func TestEvictIdleDropsEntryFromTeardownSequence(t *testing.T) {
+	e := newEngine()
+	newEntry(e, "workload/ns/a", "a")
+	newEntry(e, "workload/ns/b", "b")
+
+	e.evictIdle(e.mark(), 1)
+	for _, en := range e.snapshot() {
+		if en.hash == "a" {
+			t.Fatal("evicted entry a is still in the teardown sequence")
+		}
+	}
+	if len(e.snapshot()) != 1 {
+		t.Errorf("teardown sequence has %d entries, want 1", len(e.snapshot()))
+	}
+}
+
+func TestEvictIdleKeepsAllWhenUnderCap(t *testing.T) {
+	e := newEngine()
+	newEntry(e, "workload/ns/a", "a")
+	newEntry(e, "workload/ns/b", "b")
+
+	if evicted := e.evictIdle(e.mark(), 5); evicted != nil {
+		t.Fatalf("evicted %v with a cap above the entry count, want none", evicted)
+	}
+}

--- a/regression_test/framework/rt/fixture_workload.go
+++ b/regression_test/framework/rt/fixture_workload.go
@@ -56,7 +56,7 @@ func (w *Workload) ServiceURLNamed(name string) (url string, ok bool) {
 func WorkloadFixture(ns string, tpl workloads.Template) *Fixture[*Workload] {
 	h := sha256.Sum256([]byte(workloadKey(ns, tpl)))
 	hash := hex.EncodeToString(h[:])
-	name := fmt.Sprintf("workload/%s/%s", ns, tpl.Name)
+	name := fmt.Sprintf("%s%s/%s", workloadFixturePrefix, ns, tpl.Name)
 	return &Fixture[*Workload]{
 		Name: name,
 		Hash: hash,

--- a/regression_test/framework/rt/registry.go
+++ b/regression_test/framework/rt/registry.go
@@ -202,7 +202,9 @@ func RunArea(t *testing.T, area string) {
 				return
 			}
 			r.Infof("[rtest] suite %s: start", reg.name)
+			mark := r.engine.mark()
 			suite.Run(t, reg.suite)
+			r.evictIdleWorkloads(mark)
 		})
 	}
 }


### PR DESCRIPTION
The regression job's first CI run ([#4229](https://github.com/telepresenceio/telepresence/pull/4229)) failed four tests, none of them on the code under test.

## Pod exhaustion (the three QUIC failures)

They failed with `helm upgrade: signal: killed` after the framework's two-minute invocation bound, because the traffic-manager could not be **scheduled** at all: `0/1 nodes are available: 1 Too many pods`.

That is fixture accumulation, not a slow runner. From the run's own logs:

| Measurement | Value |
|---|---|
| Distinct workload fixtures | 89 |
| Workload provision events | 90 |
| First workload provisioned | 15:03:49 |
| First workload destroyed | 15:42:31 |
| Pods in the manager namespace, whole run | ~16 |

A memo entry lives until the run ends, so every workload any suite ever touched is still running when the last suites execute — ~90 pods, which together with the manager, quic-forwarder, route-controller and kube-system crosses kubelet's default cap of 110. The QUIC suites are simply late in the order. `WorkloadFixture` already carried a comment about marching the node toward the pod limit, but `AlwaysDestroy` only bounds accumulation *across* runs, not within one.

Raising `kubelet.max-pods` would hide this and buy a ceiling that moves out again with every suite added, so instead the engine now bounds what it keeps: each entry is stamped with a clock reading on every `Get`, and a suite boundary evicts workload entries untouched since that suite began, past `maxLiveWorkloads` (25, comfortably above any one suite's usage, so a neighbouring suite's reuse is still served from the memo).

Comparing against the mark taken *before* the suite ran is what makes eviction safe: anything the suite touched is stamped at or after it, so a fixture in use is never a candidate. Suites run serially, so no other suite can hold one either. Evicted entries also leave the teardown sequence, since eviction has already destroyed the resource. Unit tests cover recency ordering, the used-since-mark guarantee, prefix confinement, and sequence removal.

## Missing images

The job built three images but loaded only `tel2`, so route-controller pods sat in `ErrImageNeverPull`. `make load-images` covers all three, the way `build_and_test` already does.

## Transient connect (the Docker/Coexist failure)

A connect landing while the user daemon's root-daemon client is absent reports "root daemon is reconnecting". The fixture already retried the neighbouring transient ("failed to connect to root daemon"); this extends that retry to cover it.