### PR TITLE
Share one workload watcher across a cluster-wide manager's clients

### DIFF
--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -221,6 +221,10 @@ func (s *State) pruneWorkloadWatchers(ctx context.Context) {
 		return
 	}
 	s.workloadWatchers.Range(func(ns string, ww Watcher) bool {
+		if ns == "" {
+			// The cluster-wide watcher lives as long as the process.
+			return true
+		}
 		if !slices.Contains(nss, ns) {
 			s.workloadWatchers.Delete(ns)
 			ww.Close()
@@ -697,14 +701,22 @@ func (s *State) WatchAgents(
 }
 
 func (s *State) WatchWorkloads(ctx context.Context, ns string) (ch <-chan []Event, err error) {
-	ww, _ := s.workloadWatchers.LoadOrCompute(ns, func() (ww Watcher, rm bool) {
-		ww, err = NewWatcher(s.backgroundCtx, ns, managerutil.GetEnv(ctx).EnabledWorkloadKinds)
+	// Cluster-wide scope: informers are already cluster-wide (informer.GetFactory
+	// returns the "" factory for every namespace), so one watcher and one handler
+	// set serves every subscription; each subscription filters to its own
+	// namespace at delivery time (see watcher.go).
+	key := ns
+	if namespaces.Get(ctx) == nil {
+		key = ""
+	}
+	ww, _ := s.workloadWatchers.LoadOrCompute(key, func() (ww Watcher, rm bool) {
+		ww, err = NewWatcher(s.backgroundCtx, key, managerutil.GetEnv(ctx).EnabledWorkloadKinds)
 		return ww, err != nil // delete if error.
 	})
 	if err != nil {
 		return nil, err
 	}
-	return ww.Subscribe(ctx), nil
+	return ww.Subscribe(ctx, ns), nil
 }
 
 // UpdateIntercept applies a given mutator function to the stored intercept with interceptID;

--- a/cmd/traffic/cmd/manager/state/watcher.go
+++ b/cmd/traffic/cmd/manager/state/watcher.go
@@ -51,7 +51,7 @@ func (e EventType) String() string {
 }
 
 type Watcher interface {
-	Subscribe(ctx context.Context) <-chan []Event
+	Subscribe(ctx context.Context, namespace string) <-chan []Event
 	// Close removes the watcher's informer event handlers and stops its
 	// delivery timer. Subscribers are not signaled; they stop on their own
 	// context.
@@ -65,10 +65,24 @@ type handlerReg struct {
 	reg      cache.ResourceEventHandlerRegistration
 }
 
+// subscriptionBacklog is the event-channel buffer of one subscription. The
+// receiver drains promptly, so more than one slot is rarely occupied; the
+// depth exists so that deliveries racing an unsubscribe land in the buffer
+// instead of parking a delivery goroutine, and so the end sentinel almost
+// always fits.
+const subscriptionBacklog = 8
+
+// subscription is a single Subscribe call: the channel events are delivered
+// on, and the namespace they're filtered to.
+type subscription struct {
+	ch        chan<- []Event
+	namespace string
+}
+
 type watcher struct {
 	sync.Mutex
 	namespace            string
-	subscriptions        map[uuid.UUID]chan<- []Event
+	subscriptions        map[uuid.UUID]subscription
 	timer                *time.Timer
 	events               []Event
 	enabledWorkloadKinds k8sapi.Kinds
@@ -76,14 +90,18 @@ type watcher struct {
 	regs []handlerReg
 }
 
+// NewWatcher creates a watcher backed by the informer factory for ns: a
+// namespace-scoped factory for a scoped watcher, or the cluster-wide factory
+// when ns is "". Namespace selection for a subscriber is not decided here;
+// see Subscribe.
 func NewWatcher(ctx context.Context, ns string, enabledWorkloadKinds k8sapi.Kinds) (Watcher, error) {
 	w := new(watcher)
 	w.namespace = ns
 	w.enabledWorkloadKinds = enabledWorkloadKinds
-	w.subscriptions = make(map[uuid.UUID]chan<- []Event)
+	w.subscriptions = make(map[uuid.UUID]subscription)
 	w.timer = time.AfterFunc(time.Duration(math.MaxInt64), func() {
 		w.Lock()
-		ss := make([]chan<- []Event, len(w.subscriptions))
+		ss := make([]subscription, len(w.subscriptions))
 		i := 0
 		for _, sub := range w.subscriptions {
 			ss[i] = sub
@@ -93,15 +111,24 @@ func NewWatcher(ctx context.Context, ns string, enabledWorkloadKinds k8sapi.Kind
 		w.events = nil
 		w.Unlock()
 		for _, s := range ss {
+			var filtered []Event
+			for _, e := range events {
+				if e.Workload.GetNamespace() == s.namespace {
+					filtered = append(filtered, e)
+				}
+			}
+			if len(filtered) == 0 {
+				continue
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case s <- events:
+			case s.ch <- events:
 			}
 		}
 	})
 
-	err := w.addEventHandler(ctx, ns)
+	err := w.addEventHandler(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -121,15 +148,22 @@ func hasValidReplicasetOwner(wl k8sapi.Workload, enabledKinds k8sapi.Kinds) bool
 	return false
 }
 
-func (w *watcher) Subscribe(ctx context.Context) <-chan []Event {
-	ch := make(chan []Event, 1)
+// Subscribe registers a subscriber scoped to namespace and returns its event
+// channel, seeded with an initial snapshot of the currently known workloads
+// in that namespace. The watcher's own factory (w.namespace) may be the
+// cluster-wide informer; namespace is only used to scope this subscription's
+// listing and delivery, and is never empty.
+func (w *watcher) Subscribe(ctx context.Context, namespace string) <-chan []Event {
+	ch := make(chan []Event, subscriptionBacklog)
+	// Deliberately non-nil even when empty: nil on this channel is the
+	// end-of-subscription sentinel.
 	initialEvents := make([]Event, 0, 100)
 	id := uuid.New()
 	kf := informer.GetFactory(ctx, w.namespace)
 	ai := kf.GetK8sInformerFactory().Apps().V1()
-	clog.Debugf(ctx, "workload.Watcher producing initial events for namespace %s", w.namespace)
+	clog.Debugf(ctx, "workload.Watcher producing initial events for namespace %s", namespace)
 	if w.enabledWorkloadKinds.Contains(k8sapi.DeploymentKind) {
-		if dps, err := ai.Deployments().Lister().Deployments(w.namespace).List(labels.Everything()); err == nil {
+		if dps, err := ai.Deployments().Lister().Deployments(namespace).List(labels.Everything()); err == nil {
 			for _, obj := range dps {
 				if wl, ok := workload.FromAny(obj); ok && !hasValidReplicasetOwner(wl, w.enabledWorkloadKinds) && !agentmap.TrafficManagerSelector.Matches(labels.Set(obj.Labels)) {
 					initialEvents = append(initialEvents, Event{
@@ -141,7 +175,7 @@ func (w *watcher) Subscribe(ctx context.Context) <-chan []Event {
 		}
 	}
 	if w.enabledWorkloadKinds.Contains(k8sapi.ReplicaSetKind) {
-		if rps, err := ai.ReplicaSets().Lister().ReplicaSets(w.namespace).List(labels.Everything()); err == nil {
+		if rps, err := ai.ReplicaSets().Lister().ReplicaSets(namespace).List(labels.Everything()); err == nil {
 			for _, obj := range rps {
 				if wl, ok := workload.FromAny(obj); ok && !hasValidReplicasetOwner(wl, w.enabledWorkloadKinds) {
 					initialEvents = append(initialEvents, Event{
@@ -153,7 +187,7 @@ func (w *watcher) Subscribe(ctx context.Context) <-chan []Event {
 		}
 	}
 	if w.enabledWorkloadKinds.Contains(k8sapi.StatefulSetKind) {
-		if sps, err := ai.StatefulSets().Lister().StatefulSets(w.namespace).List(labels.Everything()); err == nil {
+		if sps, err := ai.StatefulSets().Lister().StatefulSets(namespace).List(labels.Everything()); err == nil {
 			for _, obj := range sps {
 				if wl, ok := workload.FromAny(obj); ok && !hasValidReplicasetOwner(wl, w.enabledWorkloadKinds) {
 					initialEvents = append(initialEvents, Event{
@@ -166,7 +200,7 @@ func (w *watcher) Subscribe(ctx context.Context) <-chan []Event {
 	}
 	if w.enabledWorkloadKinds.Contains(k8sapi.RolloutKind) {
 		ri := kf.GetArgoRolloutsInformerFactory().Argoproj().V1alpha1()
-		if sps, err := ri.Rollouts().Lister().Rollouts(w.namespace).List(labels.Everything()); err == nil {
+		if sps, err := ri.Rollouts().Lister().Rollouts(namespace).List(labels.Everything()); err == nil {
 			for _, obj := range sps {
 				if wl, ok := workload.FromAny(obj); ok && !hasValidReplicasetOwner(wl, w.enabledWorkloadKinds) {
 					initialEvents = append(initialEvents, Event{
@@ -180,14 +214,22 @@ func (w *watcher) Subscribe(ctx context.Context) <-chan []Event {
 	ch <- initialEvents
 
 	w.Lock()
-	w.subscriptions[id] = ch
+	w.subscriptions[id] = subscription{ch: ch, namespace: namespace}
 	w.Unlock()
 	go func() {
 		<-ctx.Done()
-		close(ch)
 		w.Lock()
 		delete(w.subscriptions, id)
 		w.Unlock()
+		// A nil batch tells the receiver the subscription has ended. The
+		// send is a best-effort courtesy -- the receiver's own context is
+		// already done -- so a full backlog just skips it; the channel is
+		// never closed, keeping an in-flight delivery free of any
+		// send-on-closed hazard.
+		select {
+		case ch <- nil:
+		default:
+		}
 	}()
 	return ch
 }
@@ -225,27 +267,32 @@ func (w *watcher) Close() {
 	w.timer.Stop()
 }
 
-func (w *watcher) watch(ix cache.SharedIndexInformer, ns string, hasValidController func(k8sapi.Workload) bool) error {
+// watch registers an event handler on ix that forwards every add/update/
+// delete of a workload without a valid replicaset owner. The informer is
+// already scoped to whatever namespace this watcher covers (a single
+// namespace, or the whole cluster), so no namespace check is needed here;
+// per-subscription namespace filtering happens at delivery time.
+func (w *watcher) watch(ix cache.SharedIndexInformer, hasValidController func(k8sapi.Workload) bool) error {
 	reg, err := ix.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
-				if wl, ok := workload.FromAny(obj); ok && ns == wl.GetNamespace() && !hasValidController(wl) {
+				if wl, ok := workload.FromAny(obj); ok && !hasValidController(wl) {
 					w.handleEvent(Event{Type: EventTypeAdd, Workload: wl})
 				}
 			},
 			DeleteFunc: func(obj any) {
 				if wl, ok := workload.FromAny(obj); ok {
-					if ns == wl.GetNamespace() && !hasValidController(wl) {
+					if !hasValidController(wl) {
 						w.handleEvent(Event{Type: EventTypeDelete, Workload: wl})
 					}
 				} else if dfsu, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
-					if wl, ok = workload.FromAny(dfsu.Obj); ok && ns == wl.GetNamespace() && !hasValidController(wl) {
+					if wl, ok = workload.FromAny(dfsu.Obj); ok && !hasValidController(wl) {
 						w.handleEvent(Event{Type: EventTypeDelete, Workload: wl})
 					}
 				}
 			},
 			UpdateFunc: func(oldObj, newObj any) {
-				if wl, ok := workload.FromAny(newObj); ok && ns == wl.GetNamespace() && !hasValidController(wl) {
+				if wl, ok := workload.FromAny(newObj); ok && !hasValidController(wl) {
 					if oldWl, ok := workload.FromAny(oldObj); ok {
 						if cmp.Equal(wl, oldWl, compareOptions()...) {
 							return
@@ -268,8 +315,8 @@ func (w *watcher) watch(ix cache.SharedIndexInformer, ns string, hasValidControl
 	return err
 }
 
-func (w *watcher) addEventHandler(ctx context.Context, ns string) error {
-	kf := informer.GetFactory(ctx, ns)
+func (w *watcher) addEventHandler(ctx context.Context) error {
+	kf := informer.GetFactory(ctx, w.namespace)
 	hvc := func(wl k8sapi.Workload) bool {
 		return hasValidReplicasetOwner(wl, w.enabledWorkloadKinds)
 	}
@@ -291,7 +338,7 @@ func (w *watcher) addEventHandler(ctx context.Context, ns string) error {
 			continue
 		}
 
-		if err := w.watch(ssi, ns, hvc); err != nil {
+		if err := w.watch(ssi, hvc); err != nil {
 			return err
 		}
 	}

--- a/cmd/traffic/cmd/manager/state/watcher_test.go
+++ b/cmd/traffic/cmd/manager/state/watcher_test.go
@@ -1,0 +1,220 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fakeargorollouts "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/telepresenceio/clog/testutil"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/namespaces"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/pkg/labels"
+)
+
+func newTestDeployment(name, ns string) *apps.Deployment {
+	return &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+}
+
+// newWatcherTestContext returns a context wired with a fake clientset seeded
+// with objs and an informer factory for ns (the cluster-wide factory when ns
+// is ""), with the Deployments informer started and synced. The returned
+// cancel func stops the informer and any watcher goroutines started against
+// this context; it's registered with t.Cleanup by the caller.
+func newWatcherTestContext(t *testing.T, ns string, objs ...runtime.Object) (context.Context, *fake.Clientset) {
+	t.Helper()
+	// The fake clientset's watch doesn't emit the bookmark event this client
+	// feature waits for, which would otherwise hang WaitForCacheSync.
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	ctx, cancel := context.WithCancel(testutil.NewContext(t, false))
+	t.Cleanup(cancel)
+
+	fakeClient := fake.NewClientset(objs...)
+	ctx = k8sapi.WithJoinedClientSetInterface(ctx, fakeClient, fakeargorollouts.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, ns)
+
+	f := informer.GetK8sFactory(ctx, ns)
+	f.Apps().V1().Deployments().Informer()
+	f.Start(ctx.Done())
+	f.WaitForCacheSync(ctx.Done())
+	return ctx, fakeClient
+}
+
+// eventNames extracts the workload names from a batch of events, for
+// order-independent comparisons.
+func eventNames(evs []Event) []string {
+	names := make([]string, len(evs))
+	for i, e := range evs {
+		names[i] = e.Workload.GetName()
+	}
+	return names
+}
+
+func receiveWithTimeout(t *testing.T, ch <-chan []Event, timeout time.Duration) ([]Event, bool) {
+	t.Helper()
+	select {
+	case evs := <-ch:
+		return evs, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// drainSettle discards batches on ch until quiet has passed with nothing
+// arriving. A SharedIndexInformer replays an Add for every object already in
+// its store to any handler added after the fact, so the handler NewWatcher
+// registers for an already-synced informer re-delivers the same workloads
+// Subscribe's initial listing already produced. That replay is harmless
+// (downstream consumers dedupe repeat adds) but would otherwise land in the
+// same timer-batched delivery as a subsequent, genuinely new event and make
+// these tests flaky; settle it out first.
+func drainSettle(ch <-chan []Event, quiet time.Duration) {
+	for {
+		select {
+		case <-ch:
+		case <-time.After(quiet):
+			return
+		}
+	}
+}
+
+// TestWatcher_ClusterWide_SubscriptionsFilterByNamespace verifies that a
+// single cluster-wide watcher (ns == "") serves subscriptions for different
+// namespaces correctly: each subscriber's initial snapshot only contains its
+// own namespace's workloads, and a subsequent add in one namespace is
+// delivered only to that namespace's subscriber.
+func TestWatcher_ClusterWide_SubscriptionsFilterByNamespace(t *testing.T) {
+	depA := newTestDeployment("dep-a", "ns-a")
+	depB := newTestDeployment("dep-b", "ns-b")
+	ctx, fakeClient := newWatcherTestContext(t, "", depA, depB)
+
+	kinds := k8sapi.Kinds{k8sapi.DeploymentKind}
+	w, err := NewWatcher(ctx, "", kinds)
+	require.NoError(t, err)
+	defer w.Close()
+
+	chA := w.Subscribe(ctx, "ns-a")
+	chB := w.Subscribe(ctx, "ns-b")
+
+	initialA := <-chA
+	initialB := <-chB
+	assert.ElementsMatch(t, []string{"dep-a"}, eventNames(initialA), "ns-a subscriber's initial batch must contain only ns-a workloads")
+	assert.ElementsMatch(t, []string{"dep-b"}, eventNames(initialB), "ns-b subscriber's initial batch must contain only ns-b workloads")
+	drainSettle(chA, 300*time.Millisecond)
+	drainSettle(chB, 300*time.Millisecond)
+
+	// Adding a Deployment in ns-a must be delivered only to the ns-a subscriber.
+	depA2 := newTestDeployment("dep-a2", "ns-a")
+	_, err = fakeClient.AppsV1().Deployments("ns-a").Create(ctx, depA2, meta.CreateOptions{})
+	require.NoError(t, err)
+
+	evs, ok := receiveWithTimeout(t, chA, 2*time.Second)
+	require.True(t, ok, "ns-a subscriber must receive a delta for the new ns-a Deployment")
+	assert.ElementsMatch(t, []string{"dep-a2"}, eventNames(evs))
+
+	_, ok = receiveWithTimeout(t, chB, 500*time.Millisecond)
+	assert.False(t, ok, "ns-b subscriber must not receive anything for an event in ns-a")
+}
+
+// TestWatcher_Scoped_BehavesAsBefore verifies scoped-mode parity: a watcher
+// created for a specific namespace, backed by a factory scoped to that
+// namespace, still delivers an initial snapshot and a delta on add exactly
+// as it did before subscriptions gained their own namespace.
+func TestWatcher_Scoped_BehavesAsBefore(t *testing.T) {
+	dep := newTestDeployment("dep-a", "ns-a")
+	ctx, fakeClient := newWatcherTestContext(t, "ns-a", dep)
+
+	kinds := k8sapi.Kinds{k8sapi.DeploymentKind}
+	w, err := NewWatcher(ctx, "ns-a", kinds)
+	require.NoError(t, err)
+	defer w.Close()
+
+	ch := w.Subscribe(ctx, "ns-a")
+	initial := <-ch
+	assert.ElementsMatch(t, []string{"dep-a"}, eventNames(initial))
+	drainSettle(ch, 300*time.Millisecond)
+
+	dep2 := newTestDeployment("dep-a2", "ns-a")
+	_, err = fakeClient.AppsV1().Deployments("ns-a").Create(ctx, dep2, meta.CreateOptions{})
+	require.NoError(t, err)
+
+	evs, ok := receiveWithTimeout(t, ch, 2*time.Second)
+	require.True(t, ok, "subscriber must receive a delta for the new Deployment")
+	assert.ElementsMatch(t, []string{"dep-a2"}, eventNames(evs))
+}
+
+// TestState_WatchWorkloads_KeyFollowsScope pins the watcher-map keying:
+// cluster-wide scope shares one watcher under "", and selector scope keys by
+// the subscription's namespace.
+func TestState_WatchWorkloads_KeyFollowsScope(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	newScopeState := func(ctx context.Context) *State {
+		return &State{
+			backgroundCtx:    ctx,
+			workloadWatchers: xsync.NewMap[string, Watcher](),
+		}
+	}
+	hasKey := func(s *State, key string) bool {
+		_, ok := s.workloadWatchers.Load(key)
+		return ok
+	}
+
+	t.Run("cluster-wide", func(t *testing.T) {
+		// No namespaces handle in the context: namespaces.Get returns nil.
+		ctx, _ := newWatcherTestContext(t, "", newTestDeployment("dep", "ns-a"))
+		ctx = managerutil.WithEnv(ctx, &managerutil.Env{EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind}})
+		s := newScopeState(ctx)
+
+		_, err := s.WatchWorkloads(ctx, "ns-a")
+		require.NoError(t, err)
+		assert.True(t, hasKey(s, ""), "cluster-wide scope must share the \"\" watcher")
+		assert.False(t, hasKey(s, "ns-a"), "cluster-wide scope must not key by namespace")
+
+		_, err = s.WatchWorkloads(ctx, "ns-b")
+		require.NoError(t, err)
+		assert.False(t, hasKey(s, "ns-b"), "every namespace shares the \"\" watcher")
+	})
+
+	t.Run("selector-scoped", func(t *testing.T) {
+		ctx, _ := newWatcherTestContext(t, "", newTestDeployment("dep", "ns-a"))
+		ctx = managerutil.WithEnv(ctx, &managerutil.Env{EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind}})
+
+		// A static name-in selector makes namespaces.Get return its names
+		// without watching the cluster.
+		selCh := make(chan *labels.Selector, 1)
+		selCh <- &labels.Selector{
+			MatchExpressions: []*labels.Requirement{{
+				Key:      labels.NameLabelKey,
+				Operator: labels.OperatorIn,
+				Values:   []string{"ns-a"},
+			}},
+		}
+		ctx, err := namespaces.InitContext(ctx, selCh)
+		require.NoError(t, err)
+
+		s := newScopeState(ctx)
+		_, err = s.WatchWorkloads(ctx, "ns-a")
+		require.NoError(t, err)
+		assert.True(t, hasKey(s, "ns-a"), "selector scope must key by namespace")
+		assert.False(t, hasKey(s, ""), "selector scope must not create the cluster-wide watcher")
+	})
+}

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -88,8 +88,11 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStre
 		case <-sessionDone:
 			return nil
 		case wes, ok := <-workloadsCh:
-			if !ok {
-				clog.Debug(ctx, "Workloads channel closed")
+			// A nil batch is the subscription's end sentinel (see
+			// Subscribe); the channel itself is never closed, but the ok
+			// check stays as a guard against a future closer.
+			if !ok || wes == nil {
+				clog.Debug(ctx, "Workloads subscription ended")
 				return nil
 			}
 			wf.handleWorkloadEvents(ctx, wes, initial)


### PR DESCRIPTION
A cluster-wide traffic-manager now runs one workload watcher over its cluster-wide informers, shared by every client, instead of one watcher per namespace a client ever touched. Namespace selection moved to the subscription: each `WatchWorkloads` stream gets its own initial snapshot and delivery filtered to its namespace.

Previously every stream registered its own event-handler set on the shared informers — client-go invokes all registered handlers for every event, so per-event cost grew with the namespaces clients touched, and since nothing prunes in cluster-wide scope, namespaces deleted from the cluster left their handlers behind until the pod restarted. Selector- and static-scoped managers keep their per-namespace watchers and the pruning introduced in #4232.

No wire, chart, or client changes.
