### PR TITLE
Add Breland Miley to the maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ Maintainers are listed in alphabetical order.
 | Maintainer      | GitHub ID                                 | Affiliation |
 |-----------------|-------------------------------------------|-------------|
 | Blazej Gruszka  | [bgruszka](https://github.com/bgruszka)   | Displate    |
+| Breland Miley   | [breland-openai](https://github.com/breland-openai) | OpenAI |
 | Nick Powell     | [njayp](https://github.com/njayp)         |             |
 | Thomas Hallgren | [thallgren](https://github.com/thallgren) | Polar Sky   |
 


### PR DESCRIPTION
Breland Miley (@breland-openai, OpenAI) has accepted the invitation to become a Telepresence maintainer.