### PR TITLE
Point the Sponsor button at the org's sponsors listing

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [thallgren]
+github: [telepresenceio]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
The repository's Sponsor button is disabled because `.github/FUNDING.yml` names the `thallgren` user account, which has no published GitHub Sponsors listing — GitHub silently drops such entries, leaving the repository without any effective funding link.

The public listing lives on the `telepresenceio` organization (https://github.com/sponsors/telepresenceio), so the `github:` entry now points there. With this change the Sponsor button becomes active and leads to the org's sponsorship page.