### PR TITLE
Point the README sponsor link at the org's sponsors listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Thank you to the sponsors who support the development of Telepresence:
 
 - [OpenAI](https://openai.com)
 
-You can support the project too, via [GitHub Sponsors](https://github.com/sponsors/thallgren).
+You can support the project too, via [GitHub Sponsors](https://github.com/sponsors/telepresenceio).
 
 ## Contributing
 


### PR DESCRIPTION
Companion to #4235: the README's "You can support the project too" link had the same wrong target as `FUNDING.yml` — the `thallgren` user account, which has no published GitHub Sponsors listing. For anyone but the account owner, GitHub silently redirects that URL to the plain profile, leaving no way to sponsor. The link now points at the `telepresenceio` organization's public listing, matching the Sponsor button.