### PR TITLE
Reconcile agent configs after Service selector updates

### DIFF
--- a/cmd/traffic/cmd/manager/mutator/service_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/service_watcher.go
@@ -24,7 +24,7 @@ type affectedConfig struct {
 	sc  *agentconfig.Sidecar
 }
 
-func (c *configWatcher) configsAffectedBySvc(ctx context.Context, svc *core.Service, trustUID bool) []affectedConfig {
+func (c *configWatcher) configsAffectedBySvc(ctx context.Context, svc *core.Service, includeSelectorMatches bool) []affectedConfig {
 	references := func(ac *agentconfig.Sidecar) (k8sapi.Workload, error, bool) {
 		for _, cn := range ac.Containers {
 			for _, ic := range cn.Intercepts {
@@ -33,8 +33,15 @@ func (c *configWatcher) configsAffectedBySvc(ctx context.Context, svc *core.Serv
 				}
 			}
 		}
-		if trustUID {
+		if !includeSelectorMatches {
 			// A deleted service will only affect configs that matches its UID
+			return nil, nil, false
+		}
+		if len(svc.Spec.Selector) == 0 {
+			// A selectorless Service does not select pods by label. Existing
+			// UID claimants above still need regeneration when a selector is
+			// removed, but it must not make every workload in the namespace
+			// look newly selected.
 			return nil, nil, false
 		}
 
@@ -60,8 +67,8 @@ func (c *configWatcher) configsAffectedBySvc(ctx context.Context, svc *core.Serv
 	return affected
 }
 
-func (c *configWatcher) affectedConfigs(ctx context.Context, svc *core.Service, trustUID bool) []affectedConfig {
-	return c.configsAffectedBySvc(ctx, svc, trustUID)
+func (c *configWatcher) affectedConfigs(ctx context.Context, svc *core.Service, includeSelectorMatches bool) []affectedConfig {
+	return c.configsAffectedBySvc(ctx, svc, includeSelectorMatches)
 }
 
 func (c *configWatcher) startServices(ctx context.Context, ns string) cache.SharedIndexInformer {
@@ -88,15 +95,15 @@ func (c *configWatcher) watchServices(ctx context.Context, ix cache.SharedIndexI
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
 				if svc, ok := obj.(*core.Service); ok {
-					c.updateSvc(ctx, svc, false)
+					c.updateSvc(ctx, svc, true)
 				}
 			},
 			DeleteFunc: func(obj any) {
 				if svc, ok := obj.(*core.Service); ok {
-					c.updateSvc(ctx, svc, true)
+					c.updateSvc(ctx, svc, false)
 				} else if dfsu, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
 					if svc, ok := dfsu.Obj.(*core.Service); ok {
-						c.updateSvc(ctx, svc, true)
+						c.updateSvc(ctx, svc, false)
 					}
 				}
 			},
@@ -108,7 +115,7 @@ func (c *configWatcher) watchServices(ctx context.Context, ix cache.SharedIndexI
 		})
 }
 
-func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustUID bool) {
+func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, includeSelectorMatches bool) {
 	// Does the snapshot contain workloads that we didn't find using the service's Spec.Selector?
 	// If so, include them, or if workload for the config entry isn't found, delete that entry
 	img := managerutil.GetAgentImage(ctx)
@@ -120,7 +127,7 @@ func (c *configWatcher) updateSvc(ctx context.Context, svc *core.Service, trustU
 		clog.Error(ctx, err)
 		return
 	}
-	for _, ax := range c.affectedConfigs(ctx, svc, trustUID) {
+	for _, ax := range c.affectedConfigs(ctx, svc, includeSelectorMatches) {
 		ac := ax.sc
 		wl := ax.wl
 		if wl == nil {

--- a/cmd/traffic/cmd/manager/mutator/service_watcher_test.go
+++ b/cmd/traffic/cmd/manager/mutator/service_watcher_test.go
@@ -1,0 +1,88 @@
+package mutator
+
+import (
+	"context"
+	"testing"
+
+	argorolloutsfake "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+)
+
+func TestUpdatedServiceIncludesNewlySelectedWorkload(t *testing.T) {
+	const namespace = "default"
+	stable := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "example-service", Namespace: namespace},
+		Spec: apps.DeploymentSpec{
+			Template: core.PodTemplateSpec{ObjectMeta: meta.ObjectMeta{Labels: map[string]string{
+				"app":   "example-service",
+				"track": "stable",
+			}}},
+		},
+	}
+	canary := stable.DeepCopy()
+	canary.Name = "example-service-canary"
+	canary.Spec.Template.Labels["track"] = "canary"
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{Name: "example-service", Namespace: namespace, UID: types.UID("service-uid")},
+		// Model a selector update that stopped selecting stable and now selects canary.
+		// The old stable claimant still needs regeneration so that it drops the Service.
+		Spec: core.ServiceSpec{Selector: map[string]string{"track": "canary"}},
+	}
+
+	client := fake.NewSimpleClientset(stable, canary)
+	ctx := k8sapi.WithJoinedClientSetInterface(context.Background(), client, argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	deploymentStore := informer.GetK8sFactory(ctx, namespace).Apps().V1().Deployments().Informer().GetStore()
+	for _, deployment := range []*apps.Deployment{stable, canary} {
+		require.NoError(t, deploymentStore.Add(deployment.DeepCopy()))
+	}
+
+	cw := NewWatcher().(*configWatcher)
+	cw.Store(&agentconfig.Sidecar{
+		AgentName:    stable.Name,
+		Namespace:    namespace,
+		WorkloadName: stable.Name,
+		WorkloadKind: k8sapi.DeploymentKind,
+		Containers: []*agentconfig.Container{{
+			Intercepts: []*agentconfig.Intercept{{ServiceUID: svc.UID}},
+		}},
+	})
+	cw.Store(&agentconfig.Sidecar{
+		AgentName:    canary.Name,
+		Namespace:    namespace,
+		WorkloadName: canary.Name,
+		WorkloadKind: k8sapi.DeploymentKind,
+	})
+
+	affected := cw.configsAffectedBySvc(ctx, svc, true)
+	names := make([]string, 0, len(affected))
+	for _, config := range affected {
+		names = append(names, config.sc.AgentName)
+	}
+	assert.ElementsMatch(t, []string{stable.Name, canary.Name}, names)
+
+	affected = cw.configsAffectedBySvc(ctx, svc, false)
+	names = names[:0]
+	for _, config := range affected {
+		names = append(names, config.sc.AgentName)
+	}
+	assert.Equal(t, []string{stable.Name}, names)
+
+	svc.Spec.Selector = nil
+	affected = cw.configsAffectedBySvc(ctx, svc, true)
+	names = names[:0]
+	for _, config := range affected {
+		names = append(names, config.sc.AgentName)
+	}
+	assert.Equal(t, []string{stable.Name}, names)
+}


### PR DESCRIPTION
## Description

When a Service selector changes, the watcher currently only revisits configs already tied to that Service UID. That leaves newly selected workloads stale, and a selectorless Service can accidentally look like it matches every workload.

This makes updates consider both existing claimants and newly selected workloads, while keeping selectorless Services from matching by labels. I added a focused regression test for switching a selector from one workload to another and then removing it.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/mutator -run TestUpdatedServiceIncludesNewlySelectedWorkload -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.