### PR TITLE
Only evict pods owned by the workload being reconciled

### DIFF
--- a/cmd/traffic/cmd/manager/mutator/eviction.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction.go
@@ -320,14 +320,7 @@ func podList(ctx context.Context, namespace string) (wlPodMap, error) {
 		if !podIsPendingOrRunning(pod) {
 			continue
 		}
-		var wl k8sapi.Workload
-		if podKind, ok := pod.Labels[agentconfig.WorkloadKindLabel]; ok && !enabledWorkloads.Contains(k8sapi.Kind(podKind)) {
-			// Pod's label indicates a workload kind that has been disabled. As such, it will not be present in the
-			// shared informer cache.
-			wl, err = k8sapi.GetWorkload(ctx, pod.Labels[agentconfig.WorkloadNameLabel], pod.Namespace, k8sapi.Kind(podKind))
-		} else {
-			wl, err = agentmap.FindOwnerWorkload(ctx, k8sapi.Pod(pod), enabledWorkloads)
-		}
+		wl, err := podOwnerWorkload(ctx, pod, enabledWorkloads)
 		if err != nil {
 			if k8sErrors.IsNotFound(err) {
 				continue
@@ -337,6 +330,35 @@ func podList(ctx context.Context, namespace string) (wlPodMap, error) {
 		podMap.add(wl, pod)
 	}
 	return podMap, nil
+}
+
+func podOwnerWorkload(ctx context.Context, pod *core.Pod, enabledWorkloads k8sapi.Kinds) (k8sapi.Workload, error) {
+	if podKind, ok := pod.Labels[agentconfig.WorkloadKindLabel]; ok {
+		if !enabledWorkloads.Contains(k8sapi.Kind(podKind)) {
+			// Pod's label indicates a workload kind that has been disabled. As such, it will not be present in the
+			// shared informer cache.
+			return k8sapi.GetWorkload(ctx, pod.Labels[agentconfig.WorkloadNameLabel], pod.Namespace, k8sapi.Kind(podKind))
+		}
+		return agentmap.FindOwnerWorkload(ctx, k8sapi.Pod(pod), enabledWorkloads)
+	}
+	if enabledWorkloads.Contains(k8sapi.RolloutKind) && !enabledWorkloads.Contains(k8sapi.ReplicaSetKind) {
+		// Rollout pods are owned by ReplicaSets even when ReplicaSets are not enabled as workloads. Resolve
+		// through that intermediary without treating standalone ReplicaSets as eligible.
+		for _, ref := range pod.OwnerReferences {
+			if ref.Controller == nil || !*ref.Controller || ref.Kind != string(k8sapi.ReplicaSetKind) {
+				continue
+			}
+			rs, err := k8sapi.GetWorkload(ctx, ref.Name, pod.Namespace, k8sapi.ReplicaSetKind)
+			if err == nil {
+				if owner, err := agentmap.FindOwnerWorkload(ctx, rs, enabledWorkloads); err == nil &&
+					enabledWorkloads.Contains(owner.GetKind()) {
+					return owner, nil
+				}
+			}
+			break
+		}
+	}
+	return agentmap.FindOwnerWorkload(ctx, k8sapi.Pod(pod), enabledWorkloads)
 }
 
 func workloadPods(ctx context.Context, wl k8sapi.Workload) ([]*core.Pod, error) {
@@ -349,5 +371,26 @@ func workloadPods(ctx context.Context, wl k8sapi.Workload) ([]*core.Pod, error) 
 	if err != nil {
 		return nil, err
 	}
-	return slices.DeleteFunc(slices.Clone(pods), func(pod *core.Pod) bool { return !podIsPendingOrRunning(pod) }), nil
+	// A selector is not always unique to one workload. Stable and canary
+	// Deployments commonly share one and distinguish their pods only by
+	// template labels, so verify ownership before evicting a candidate pod.
+	enabledWorkloads := managerutil.GetEnv(ctx).EnabledWorkloadKinds
+	workloadKey := WorkloadKey{Kind: wl.GetKind(), Name: wl.GetName(), Namespace: wl.GetNamespace()}
+	ownedPods := make([]*core.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if !podIsPendingOrRunning(pod) {
+			continue
+		}
+		owner, err := podOwnerWorkload(ctx, pod, enabledWorkloads)
+		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if (WorkloadKey{Kind: owner.GetKind(), Name: owner.GetName(), Namespace: owner.GetNamespace()}) == workloadKey {
+			ownedPods = append(ownedPods, pod)
+		}
+	}
+	return ownedPods, nil
 }

--- a/cmd/traffic/cmd/manager/mutator/eviction_test.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction_test.go
@@ -1,10 +1,15 @@
 package mutator
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	argorollouts "github.com/datawire/argo-rollouts-go-client/pkg/apis/rollouts/v1alpha1"
+	argorolloutsfake "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,8 +17,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	argorolloutsfake "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
 	"github.com/telepresenceio/clog/testutil"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
@@ -65,4 +70,146 @@ func TestEvictPod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkloadPodsOnlyReturnsPodsOwnedByWorkload(t *testing.T) {
+	const namespace = "default"
+	controller := true
+	selector := map[string]string{"app": "example-service"}
+	stable := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "example-service", Namespace: namespace},
+		Spec: apps.DeploymentSpec{
+			Selector: &meta.LabelSelector{MatchLabels: selector},
+			Template: core.PodTemplateSpec{ObjectMeta: meta.ObjectMeta{Labels: map[string]string{
+				"app":   "example-service",
+				"track": "stable",
+			}}},
+		},
+	}
+	canary := stable.DeepCopy()
+	canary.Name = "example-service-canary"
+	canary.Spec.Template.Labels["track"] = "canary"
+
+	stableRS := &apps.ReplicaSet{ObjectMeta: meta.ObjectMeta{
+		Name:      "example-service-66dfc6c7cf",
+		Namespace: namespace,
+		OwnerReferences: []meta.OwnerReference{{
+			Kind:       string(k8sapi.DeploymentKind),
+			Name:       stable.Name,
+			Controller: &controller,
+		}},
+	}}
+	canaryRS := &apps.ReplicaSet{ObjectMeta: meta.ObjectMeta{
+		Name:      "example-service-canary-6569fd8dc4",
+		Namespace: namespace,
+		OwnerReferences: []meta.OwnerReference{{
+			Kind:       string(k8sapi.DeploymentKind),
+			Name:       canary.Name,
+			Controller: &controller,
+		}},
+	}}
+	stablePod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service-66dfc6c7cf-stable",
+			Namespace: namespace,
+			Labels:    selector,
+			OwnerReferences: []meta.OwnerReference{{
+				Kind:       string(k8sapi.ReplicaSetKind),
+				Name:       stableRS.Name,
+				Controller: &controller,
+			}},
+		},
+		Status: core.PodStatus{Phase: core.PodRunning},
+	}
+	canaryPod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service-canary-6569fd8dc4-canary",
+			Namespace: namespace,
+			Labels:    selector,
+			OwnerReferences: []meta.OwnerReference{{
+				Kind:       string(k8sapi.ReplicaSetKind),
+				Name:       canaryRS.Name,
+				Controller: &controller,
+			}},
+		},
+		Status: core.PodStatus{Phase: core.PodRunning},
+	}
+
+	client := fake.NewSimpleClientset(stable, canary, stableRS, canaryRS, stablePod, canaryPod)
+	ctx := k8sapi.WithJoinedClientSetInterface(context.Background(), client, argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind},
+	})
+	factory := informer.GetK8sFactory(ctx, namespace)
+	deploymentStore := factory.Apps().V1().Deployments().Informer().GetStore()
+	podStore := factory.Core().V1().Pods().Informer().GetStore()
+	for _, deployment := range []*apps.Deployment{stable, canary} {
+		require.NoError(t, deploymentStore.Add(deployment.DeepCopy()))
+	}
+	for _, pod := range []*core.Pod{stablePod, canaryPod} {
+		require.NoError(t, podStore.Add(pod.DeepCopy()))
+	}
+
+	pods, err := workloadPods(ctx, k8sapi.Deployment(stable))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	assert.Equal(t, stablePod.Name, pods[0].Name)
+
+	pods, err = workloadPods(ctx, k8sapi.Deployment(canary))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	assert.Equal(t, canaryPod.Name, pods[0].Name)
+}
+
+func TestWorkloadPodsFindsRolloutPodsWhenReplicaSetsAreDisabled(t *testing.T) {
+	const namespace = "default"
+	controller := true
+	selector := map[string]string{"app": "example-rollout"}
+	rollout := &argorollouts.Rollout{
+		ObjectMeta: meta.ObjectMeta{Name: "example-rollout", Namespace: namespace},
+		Spec: argorollouts.RolloutSpec{
+			Selector: &meta.LabelSelector{MatchLabels: selector},
+			Template: core.PodTemplateSpec{ObjectMeta: meta.ObjectMeta{Labels: selector}},
+		},
+	}
+	replicaSet := &apps.ReplicaSet{ObjectMeta: meta.ObjectMeta{
+		Name:      "example-rollout-66dfc6c7cf",
+		Namespace: namespace,
+		OwnerReferences: []meta.OwnerReference{{
+			Kind:       string(k8sapi.RolloutKind),
+			Name:       rollout.Name,
+			Controller: &controller,
+		}},
+	}}
+	pod := &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-rollout-66dfc6c7cf-pod",
+			Namespace: namespace,
+			Labels:    selector,
+			OwnerReferences: []meta.OwnerReference{{
+				Kind:       string(k8sapi.ReplicaSetKind),
+				Name:       replicaSet.Name,
+				Controller: &controller,
+			}},
+		},
+		Status: core.PodStatus{Phase: core.PodRunning},
+	}
+
+	client := fake.NewSimpleClientset(replicaSet, pod)
+	rolloutsClient := argorolloutsfake.NewSimpleClientset(rollout)
+	ctx := k8sapi.WithJoinedClientSetInterface(context.Background(), client, rolloutsClient)
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.RolloutKind},
+	})
+	podStore := informer.GetK8sFactory(ctx, namespace).Core().V1().Pods().Informer().GetStore()
+	rolloutStore := informer.GetArgoRolloutsFactory(ctx, namespace).Argoproj().V1alpha1().Rollouts().Informer().GetStore()
+	require.NoError(t, podStore.Add(pod.DeepCopy()))
+	require.NoError(t, rolloutStore.Add(rollout.DeepCopy()))
+
+	pods, err := workloadPods(ctx, k8sapi.Rollout(rollout))
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	assert.Equal(t, pod.Name, pods[0].Name)
 }


### PR DESCRIPTION
## Description

When two workloads share a selector, `workloadPods` currently returns every matching pod. During agent config reconciliation, that can let one workload evict pods belonging to another.

This resolves each matching pod back to its owning workload and keeps only pods owned by the workload being reconciled. It also follows Rollout pods through their owning ReplicaSet when ReplicaSets are not enabled as top-level workloads, so those pods still get reconciled.

I added regression coverage for both cases.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/mutator -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.