### PR TITLE
Let warning watches stop when delivery is canceled

### DIFF
--- a/pkg/eventwatch/eventwatch.go
+++ b/pkg/eventwatch/eventwatch.go
@@ -98,7 +98,11 @@ func WatchWarnings(ctx context.Context, ki kubernetes.Interface, namespace, name
 					!strings.HasPrefix(e.Note, combinedNotePrefix) &&
 					regardingMatches(e, name, nd) {
 					clog.Infof(ctx, "%s %s %s", e.Type, e.Reason, e.Note)
-					ec <- e
+					select {
+					case <-ctx.Done():
+						return
+					case ec <- e:
+					}
 				}
 			}
 		}

--- a/pkg/eventwatch/eventwatch_test.go
+++ b/pkg/eventwatch/eventwatch_test.go
@@ -3,15 +3,72 @@ package eventwatch
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	events "k8s.io/api/events/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+type recordingWatch struct {
+	result   chan watch.Event
+	stopped  chan struct{}
+	stopOnce sync.Once
+}
+
+func newRecordingWatch() *recordingWatch {
+	return &recordingWatch{
+		result:  make(chan watch.Event, 1),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (w *recordingWatch) Stop() {
+	w.stopOnce.Do(func() { close(w.stopped) })
+}
+
+func (w *recordingWatch) ResultChan() <-chan watch.Event {
+	return w.result
+}
+
+func TestWatchWarningsStopsWhenDeliveryIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := newRecordingWatch()
+	ki := fake.NewSimpleClientset()
+	ki.PrependWatchReactor("events", func(k8stesting.Action) (bool, watch.Interface, error) {
+		return true, w, nil
+	})
+
+	_, err := WatchWarnings(ctx, ki, "default", "echo")
+	require.NoError(t, err)
+
+	// Do not receive from the returned channel. This reproduces waitForAgents
+	// returning while a matching event is in flight.
+	w.result <- watch.Event{Type: watch.Added, Object: &events.Event{
+		ObjectMeta: meta.ObjectMeta{CreationTimestamp: meta.Now()},
+		Regarding:  core.ObjectReference{Name: "echo"},
+		Type:       "Warning",
+		Reason:     "FailedCreate",
+		Note:       "quota exceeded",
+	}}
+	require.Eventually(t, func() bool { return len(w.result) == 0 }, time.Second, time.Millisecond)
+
+	cancel()
+	select {
+	case <-w.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("underlying watch was not stopped after cancellation")
+	}
+}
 
 func TestIsTerminal(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

`WatchWarnings` can block while delivering an event to a slow consumer. If the context is canceled at that point, the goroutine cannot unwind and the underlying Kubernetes watch stays alive.

This makes event delivery cancellation-aware, so the watch stops promptly even when nobody is receiving from the returned channel. I added a regression test that cancels while a matching warning is blocked in delivery.

Tested with `GOEXPERIMENT=jsonv2 go test ./pkg/eventwatch`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.