### PR TITLE
Keep unsupported FTP from stopping userd

### DIFF
--- a/pkg/client/remotefs/fuseftp_docker.go
+++ b/pkg/client/remotefs/fuseftp_docker.go
@@ -26,7 +26,7 @@ func (s *fuseFtpMgr) LinkedFTP() bool {
 }
 
 func (s *fuseFtpMgr) DeferInit(context.Context) error {
-	return errors.New("fuseftp client is not available")
+	return errors.New("FTP remote mounts are unavailable because this Telepresence client was built without fuseftp support")
 }
 
 func (s *fuseFtpMgr) GetFuseFTPClient(context.Context) rpc.FuseFTPClient {

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -97,6 +97,7 @@ func newService(ctx context.Context, cancel context.CancelFunc, cfg client.Confi
 		fuseFtpMgr:     remotefs.NewFuseFTPManager(),
 		sessionRunning: make(chan struct{}),
 	}
+	s.initFTPServer(ctx, cfg)
 	close(s.sessionRunning)
 	s.quit = func(sessionIsLocked bool) {
 		cancel()
@@ -326,16 +327,6 @@ func internalRun(c context.Context, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	if cfg.Intercept().UseFtp && !s.fuseFtpMgr.LinkedFTP() {
-		g.Go("fuseftp-server", func(c context.Context) error {
-			if err := s.InitFTPServer(c); err != nil {
-				return err
-			}
-			<-c.Done()
-			return nil
-		})
-	}
-
 	g.Go("config-reload", s.configReload)
 	if !rootSessionInProc {
 		// User daemon process survives multiple sessions.
@@ -355,6 +346,19 @@ func internalRun(c context.Context, flags *pflag.FlagSet) error {
 
 func (s *service) LinkedFTP() bool {
 	return s.fuseFtpMgr.LinkedFTP()
+}
+
+// initFTPServer records an unavailable FTP implementation as a mount capability
+// error. Some builds intentionally omit fuseftp, while ordinary clients can
+// still have intercept.useFtp configured.
+func (s *service) initFTPServer(ctx context.Context, cfg client.Config) {
+	if !cfg.Intercept().UseFtp || s.fuseFtpMgr.LinkedFTP() {
+		return
+	}
+	if err := s.InitFTPServer(ctx); err != nil {
+		s.fuseFTPError = err
+		clog.Warnf(ctx, "FTP remote mounts are unavailable: %v", err)
+	}
 }
 
 func (s *service) InitFTPServer(ctx context.Context) error {

--- a/pkg/client/userd/daemon/service_docker_test.go
+++ b/pkg/client/userd/daemon/service_docker_test.go
@@ -1,0 +1,38 @@
+//go:build docker
+
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	empty "google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/proc"
+)
+
+func TestDockerBuildRejectsFTPWithoutStoppingUserDaemon(t *testing.T) {
+	cfg := client.GetDefaultConfig()
+	cfg.Intercept().UseFtp = true
+	ctx := client.WithConfig(context.Background(), cfg)
+
+	svc := newService(ctx, func() {}, cfg, nil)
+	ftpErr := svc.FuseFTPError()
+	if ftpErr == nil {
+		t.Fatal("expected docker build to report unavailable FTP mounts")
+	}
+	if !strings.Contains(ftpErr.Error(), "built without fuseftp support") {
+		t.Fatalf("unexpected FTP availability error: %v", ftpErr)
+	}
+
+	wasContainerized := proc.RunningInContainer()
+	proc.SetRunningInContainer(false)
+	t.Cleanup(func() { proc.SetRunningInContainer(wasContainerized) })
+	if _, err := svc.RemoteMountAvailability(ctx, &empty.Empty{}); err == nil {
+		t.Fatal("expected FTP mount availability check to fail")
+	} else if !strings.Contains(err.Error(), "built without fuseftp support") {
+		t.Fatalf("unexpected mount availability error: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Some client builds intentionally do not include fuseftp support. When FTP mounts are still enabled in config, that expected unsupported error currently bubbles out of startup and stops userd.

This records the unavailable FTP capability on the service instead, so userd can keep running and report a useful mount-availability error. Other startup paths are unchanged. I added a Docker-tagged regression test for the unavailable implementation.

LMK if you find this useful, this is not "strictly" required. 

Tested with `GOEXPERIMENT=jsonv2 go test -tags docker ./pkg/client/userd/daemon ./pkg/client/remotefs`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.