### PR TITLE
Avoid cache sends racing with subscription shutdown

### DIFF
--- a/pkg/cache/map.go
+++ b/pkg/cache/map.go
@@ -39,11 +39,22 @@ func (delta *Delta[K, V]) Merge(other Delta[K, V]) {
 }
 
 type subscription[K comparable, V any] struct {
+	sync.Mutex
 	channel     chan Delta[K, V]
 	include     func(K, V) bool
-	initialized atomic.Bool
+	initialized bool
 	mark        atomic.Bool
 	doneCh      <-chan struct{}
+	closed      bool
+}
+
+func (sb *subscription[K, V]) close() {
+	sb.Lock()
+	if !sb.closed {
+		close(sb.channel)
+		sb.closed = true
+	}
+	sb.Unlock()
 }
 
 type Map[K comparable, V any] struct {
@@ -98,7 +109,7 @@ func (m *Map[K, V]) Subscribe(done <-chan struct{}, includeFilter func(K, V) boo
 		go func() {
 			<-done
 			m.subscribers.Delete(id)
-			close(ch)
+			sb.close()
 		}()
 	}
 	return ch
@@ -308,7 +319,13 @@ func (ad *allDelta[K, V]) filteredDelta(initialized bool, include func(K, V) boo
 }
 
 func (ad *allDelta[K, V]) send(sb *subscription[K, V]) {
-	initialized := sb.initialized.Swap(true)
+	sb.Lock()
+	defer sb.Unlock()
+	if sb.closed {
+		return
+	}
+	initialized := sb.initialized
+	sb.initialized = true
 	fd := ad.filteredDelta(initialized, sb.include)
 	if initialized && len(fd.Upserts) == 0 && len(fd.Removals) == 0 {
 		return

--- a/pkg/cache/map_test.go
+++ b/pkg/cache/map_test.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllDeltaSendAfterSubscriptionClose(t *testing.T) {
+	sb := &subscription[string, string]{
+		channel: make(chan Delta[string, string], 1),
+		doneCh:  make(chan struct{}),
+	}
+	sb.close()
+
+	ad := allDelta[string, string]{
+		snapshot: map[string]string{"key": "value"},
+	}
+	require.NotPanics(t, func() {
+		ad.send(sb)
+	})
+
+	_, ok := <-sb.channel
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Description

A cache update can race with subscription cleanup: one goroutine closes the subscriber channel while another is about to send a delta, which can panic with a send on a closed channel.

This guards close and send with the same subscription lock and makes late sends no-ops after closure. I added a focused regression that exercises sending after the subscription has closed, plus a repeated race run.

Tested with `GOEXPERIMENT=jsonv2 go test ./pkg/cache` and `GOEXPERIMENT=jsonv2 go test -race ./pkg/cache -run TestAllDeltaSendAfterSubscriptionClose -count=100`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.