### PR TITLE
Avoid serializing unrelated injector workload updates

### DIFF
--- a/cmd/traffic/cmd/manager/manager.go
+++ b/cmd/traffic/cmd/manager/manager.go
@@ -84,6 +84,12 @@ func MainWithEnv(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("unable to get the Kubernetes InClusterConfig: %w", err)
 	}
+	// The manager shares one client with its informer set, admission injector, and
+	// pod-reconciliation paths. client-go's default 5 QPS / 10 burst budget is too
+	// small for clusters with many watched namespaces and can make unrelated
+	// workload reconciliation queue for longer than the webhook timeout.
+	cfg.QPS = 50
+	cfg.Burst = 100
 	ki, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("unable to create the Kubernetes Interface from InClusterConfig: %w", err)

--- a/cmd/traffic/cmd/manager/mutator/eviction.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction.go
@@ -62,7 +62,7 @@ func (c *configWatcher) EvictPodsWithAgentConfig(ctx context.Context, wl k8sapi.
 }
 
 func (c *configWatcher) EvictAllPodsWithAgentConfig(ctx context.Context, namespace string) error {
-	c.agentConfigs.Delete(namespace)
+	c.deleteNamespaceAgentConfigs(namespace)
 	evictMap, err := podList(ctx, namespace)
 	if err != nil {
 		return err

--- a/cmd/traffic/cmd/manager/mutator/service_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/service_watcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/puzpuzpuz/xsync/v4"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -54,16 +53,14 @@ func (c *configWatcher) configsAffectedBySvc(ctx context.Context, svc *core.Serv
 	}
 
 	var affected []affectedConfig
-	c.agentConfigs.Compute(svc.Namespace, func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if loaded {
-			for _, sc := range scMap {
-				if wl, err, ok := references(sc); ok {
-					affected = append(affected, affectedConfig{sc: sc, wl: wl, err: err})
-				}
+	if scMap, loaded := c.agentConfigs.Load(svc.Namespace); loaded {
+		scMap.Range(func(_ string, sc *agentconfig.Sidecar) bool {
+			if wl, err, ok := references(sc); ok {
+				affected = append(affected, affectedConfig{sc: sc, wl: wl, err: err})
 			}
-		}
-		return nil, xsync.CancelOp
-	})
+			return true
+		})
+	}
 	return affected
 }
 

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -53,7 +53,7 @@ type Map interface {
 
 type configWatcher struct {
 	cancel       context.CancelFunc
-	agentConfigs *xsync.Map[string, map[string]*agentconfig.Sidecar]
+	agentConfigs *xsync.Map[string, *xsync.Map[string, *agentconfig.Sidecar]]
 	informers    *xsync.Map[string, *informersWithCancel]
 	inactivePods *xsync.Map[types.UID, inactivation]
 	startedAt    time.Time
@@ -188,58 +188,45 @@ type inactivation struct {
 	deleted bool
 }
 
-func (c *configWatcher) Delete(name, namespace string) {
-	c.agentConfigs.Compute(namespace, func(sceMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if loaded {
-			delete(sceMap, name)
-			if len(sceMap) > 0 {
-				return sceMap, xsync.UpdateOp
-			}
-		}
-		return nil, xsync.DeleteOp
+func (c *configWatcher) namespaceAgentConfigs(namespace string) *xsync.Map[string, *agentconfig.Sidecar] {
+	scMap, _ := c.agentConfigs.LoadOrCompute(namespace, func() (*xsync.Map[string, *agentconfig.Sidecar], bool) {
+		return xsync.NewMap[string, *agentconfig.Sidecar](), false
 	})
+	return scMap
+}
+
+func (c *configWatcher) Delete(name, namespace string) {
+	if scMap, ok := c.agentConfigs.Load(namespace); ok {
+		scMap.Delete(name)
+	}
+}
+
+func (c *configWatcher) deleteNamespaceAgentConfigs(namespace string) {
+	c.agentConfigs.Delete(namespace)
 }
 
 func (c *configWatcher) Update(name, namespace string, updater func(*agentconfig.Sidecar) (*agentconfig.Sidecar, error)) (*agentconfig.Sidecar, error) {
 	var err error
 	var sc *agentconfig.Sidecar
-	c.agentConfigs.Compute(namespace, func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
+	c.namespaceAgentConfigs(namespace).Compute(name, func(existing *agentconfig.Sidecar, loaded bool) (*agentconfig.Sidecar, xsync.ComputeOp) {
 		if loaded {
-			var ok bool
-			sc, ok = scMap[name]
-			if ok {
-				sc = sc.Clone()
-			}
-			sc, err = updater(sc)
-			if err == nil {
-				if sc == nil {
-					delete(scMap, name)
-				} else {
-					scMap[name] = sc
-				}
-			}
-			return scMap, xsync.UpdateOp
-		} else {
-			sc, err = updater(nil)
-			if err == nil && sc != nil {
-				scMap = map[string]*agentconfig.Sidecar{name: sc}
-				return scMap, xsync.UpdateOp
-			}
-			return nil, xsync.CancelOp
+			sc = existing.Clone()
+		}
+		sc, err = updater(sc)
+		switch {
+		case err != nil:
+			return existing, xsync.CancelOp
+		case sc == nil:
+			return nil, xsync.DeleteOp
+		default:
+			return sc, xsync.UpdateOp
 		}
 	})
 	return sc, err
 }
 
 func (c *configWatcher) Store(sc *agentconfig.Sidecar) {
-	c.agentConfigs.Compute(sc.Namespace, func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if loaded {
-			scMap[sc.AgentName] = sc
-		} else {
-			scMap = map[string]*agentconfig.Sidecar{sc.AgentName: sc}
-		}
-		return scMap, xsync.UpdateOp
-	})
+	c.namespaceAgentConfigs(sc.Namespace).Store(sc.AgentName, sc)
 }
 
 func NewWatcher() Map {
@@ -247,7 +234,7 @@ func NewWatcher() Map {
 		cancel:       func() {},
 		informers:    xsync.NewMap[string, *informersWithCancel](),
 		inactivePods: xsync.NewMap[types.UID, inactivation](),
-		agentConfigs: xsync.NewMap[string, map[string]*agentconfig.Sidecar](),
+		agentConfigs: xsync.NewMap[string, *xsync.Map[string, *agentconfig.Sidecar]](),
 	}
 	return w
 }
@@ -336,12 +323,9 @@ func (c *configWatcher) Wait(ctx context.Context) error {
 // An error is only returned when the configmap holding the configuration could not be loaded for
 // other reasons than it did not exist.
 func (c *configWatcher) Get(key, ns string) (ac *agentconfig.Sidecar) {
-	c.agentConfigs.Compute(ns, func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if loaded {
-			ac = scMap[key]
-		}
-		return nil, xsync.CancelOp
-	})
+	if scMap, ok := c.agentConfigs.Load(ns); ok {
+		ac, _ = scMap.Load(key)
+	}
 	return ac
 }
 
@@ -384,16 +368,12 @@ func (c *configWatcher) GetOrGenerate(ctx context.Context, wl k8sapi.Workload) (
 	}
 
 	// Store the generated config, unless another goroutine generated it concurrently.
-	c.agentConfigs.Compute(wl.GetNamespace(), func(scMap map[string]*agentconfig.Sidecar, loaded bool) (map[string]*agentconfig.Sidecar, xsync.ComputeOp) {
-		if !loaded {
-			return map[string]*agentconfig.Sidecar{wl.GetName(): ac}, xsync.UpdateOp
-		}
-		if existing := scMap[wl.GetName()]; existing != nil {
+	c.namespaceAgentConfigs(wl.GetNamespace()).Compute(wl.GetName(), func(existing *agentconfig.Sidecar, loaded bool) (*agentconfig.Sidecar, xsync.ComputeOp) {
+		if loaded && existing != nil {
 			ac = existing
-			return scMap, xsync.CancelOp
+			return existing, xsync.CancelOp
 		}
-		scMap[wl.GetName()] = ac
-		return scMap, xsync.UpdateOp
+		return ac, xsync.UpdateOp
 	})
 	return ac, nil
 }

--- a/cmd/traffic/cmd/manager/mutator/watcher_test.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher_test.go
@@ -1,0 +1,49 @@
+package mutator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+)
+
+func TestAgentConfigUpdatesDoNotBlockUnrelatedWorkloads(t *testing.T) {
+	cw := NewWatcher().(*configWatcher)
+	namespace := "app-space"
+	cw.Store(&agentconfig.Sidecar{AgentName: "blocked", Namespace: namespace})
+	want := &agentconfig.Sidecar{AgentName: "ready", Namespace: namespace}
+	cw.Store(want)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(done)
+		_, err := cw.Update("blocked", namespace, func(sc *agentconfig.Sidecar) (*agentconfig.Sidecar, error) {
+			close(entered)
+			<-release
+			return sc, nil
+		})
+		errCh <- err
+	}()
+
+	<-entered
+	got := make(chan *agentconfig.Sidecar, 1)
+	go func() {
+		got <- cw.Get("ready", namespace)
+	}()
+
+	select {
+	case sc := <-got:
+		require.Equal(t, want, sc)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("unrelated workload config read blocked behind another workload update")
+	}
+
+	close(release)
+	<-done
+	require.NoError(t, <-errCh)
+}


### PR DESCRIPTION
## Description

The injector keeps every workload config for a namespace behind one map update. A slow reconciliation for one workload can therefore hold up unrelated workloads in the same namespace long enough to run into webhook timeouts.

This stores each namespace as its own concurrent map so updates serialize per workload rather than per namespace. Dropping a namespace swaps out its whole config map before eviction so stale entries are not visible during cleanup. It also gives the shared Kubernetes client a less restrictive QPS and burst budget for the informer, injector, and reconciliation paths.

The regression test blocks one workload update and verifies another can still complete.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/mutator -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.