### PR TITLE
Keep workload event sends on the watch goroutine

### DIFF
--- a/cmd/traffic/cmd/manager/state/workload_info_watcher.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher.go
@@ -46,6 +46,7 @@ func (s *State) NewWorkloadInfoWatcher(clientSession tunnel.SessionID, namespace
 
 func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStreamingServer[rpc.WorkloadEventsDelta]) error {
 	wf.start = time.Now()
+	sendCh := make(chan struct{}, 1)
 	defer func() {
 		wf.sendTimer.Stop()
 		wf.stream = nil
@@ -54,7 +55,13 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStre
 	}()
 
 	wf.sendTimer = time.AfterFunc(time.Duration(math.MaxInt64), func() {
-		wf.sendEvents(ctx, false)
+		// Keep stream.Send on the Watch goroutine. A timer callback that calls
+		// Send directly can outlive a canceled RPC while retaining its pending
+		// workload snapshot, and it can race with the initial snapshot send.
+		select {
+		case sendCh <- struct{}{}:
+		default:
+		}
 	})
 
 	wf.stream = stream
@@ -78,8 +85,8 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStre
 		return info.Spec.Namespace == wf.namespace
 	})
 
-	// Everything in this loop happens in sequence, even the firing of the timer. This means
-	// that there's no concurrency and no need for mutexes.
+	// Everything in this loop happens in sequence, including sends requested by
+	// the timer. This means that there's no concurrency and no need for mutexes.
 	initial := true
 	for {
 		select {
@@ -87,6 +94,10 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStre
 			return nil
 		case <-sessionDone:
 			return nil
+		case <-sendCh:
+			if err := wf.sendEvents(ctx, false); err != nil {
+				return err
+			}
 		case wes, ok := <-workloadsCh:
 			// A nil batch is the subscription's end sentinel (see
 			// Subscribe); the channel itself is never closed, but the ok
@@ -95,7 +106,9 @@ func (wf *workloadInfoWatcher) Watch(ctx context.Context, stream grpc.ServerStre
 				clog.Debug(ctx, "Workloads subscription ended")
 				return nil
 			}
-			wf.handleWorkloadEvents(ctx, wes, initial)
+			if err := wf.handleWorkloadEvents(ctx, wes, initial); err != nil {
+				return err
+			}
 			initial = false
 		case agentDelta := <-agentsCh:
 			wf.handleAgentDelta(ctx, agentDelta)
@@ -120,7 +133,7 @@ func (wf *workloadInfoWatcher) getIntercepts(name, namespace string) (iis []*rpc
 	return iis
 }
 
-func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) {
+func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) error {
 	// Time to send what we have
 	evz := wf.workloadEvents.Size()
 	evs := make([]*rpc.WorkloadEvent, 0, evz)
@@ -139,7 +152,7 @@ func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) {
 	wf.lastEvents = evm
 
 	if !sendEmpty && len(evs) == 0 {
-		return
+		return nil
 	}
 	clog.Debugf(ctx, "Sending %d WorkloadEvents", len(evs))
 	err := wf.stream.Send(&rpc.WorkloadEventsDelta{
@@ -148,9 +161,10 @@ func (wf *workloadInfoWatcher) sendEvents(ctx context.Context, sendEmpty bool) {
 	})
 	if err != nil {
 		clog.Warnf(ctx, "failed to send workload events delta: %v", err)
-		return
+		return err
 	}
 	wf.start = time.Now()
+	return nil
 }
 
 func (wf *workloadInfoWatcher) stopSendTimer() {
@@ -191,12 +205,11 @@ func rpcWorkload(ctx context.Context, wl k8sapi.Workload, as rpc.WorkloadInfo_Ag
 	}
 }
 
-func (wf *workloadInfoWatcher) handleWorkloadEvents(ctx context.Context, wes []Event, initial bool) {
+func (wf *workloadInfoWatcher) handleWorkloadEvents(ctx context.Context, wes []Event, initial bool) error {
 	if len(wes) == 0 {
 		if initial {
 			// The initial snapshot may be empty, but must be sent anyway.
-			wf.sendEvents(ctx, true)
-			return
+			return wf.sendEvents(ctx, true)
 		}
 	} else {
 		wf.stopSendTimer()
@@ -234,6 +247,7 @@ func (wf *workloadInfoWatcher) handleWorkloadEvents(ctx context.Context, wes []E
 			return w, xsync.UpdateOp
 		})
 	}
+	return nil
 }
 
 func (wf *workloadInfoWatcher) handleAgentDelta(ctx context.Context, delta cache.Delta[tunnel.SessionID, *AgentSession]) {

--- a/cmd/traffic/cmd/manager/state/workload_info_watcher_test.go
+++ b/cmd/traffic/cmd/manager/state/workload_info_watcher_test.go
@@ -1,0 +1,223 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	apps "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/telepresenceio/clog/testutil"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/workload"
+)
+
+type testWorkloadWatcher struct {
+	ch chan []Event
+}
+
+type initialWorkloadWatcher struct{}
+
+func (w testWorkloadWatcher) Subscribe(context.Context, string) <-chan []Event {
+	return w.ch
+}
+
+func (testWorkloadWatcher) Close() {}
+
+func (initialWorkloadWatcher) Subscribe(ctx context.Context, _ string) <-chan []Event {
+	ch := make(chan []Event, 1)
+	ch <- []Event{}
+	go func() { <-ctx.Done() }()
+	return ch
+}
+
+func (initialWorkloadWatcher) Close() {}
+
+type blockingWorkloadStream struct {
+	ctx     context.Context
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type noopWorkloadStream struct {
+	ctx context.Context
+}
+
+type errorWorkloadStream struct {
+	noopWorkloadStream
+	err error
+}
+
+func (s noopWorkloadStream) Send(*rpc.WorkloadEventsDelta) error { return nil }
+func (s noopWorkloadStream) SetHeader(metadata.MD) error         { return nil }
+func (s noopWorkloadStream) SendHeader(metadata.MD) error        { return nil }
+func (s noopWorkloadStream) SetTrailer(metadata.MD)              {}
+func (s noopWorkloadStream) Context() context.Context            { return s.ctx }
+func (s noopWorkloadStream) SendMsg(any) error                   { return nil }
+func (s noopWorkloadStream) RecvMsg(any) error                   { return nil }
+
+func (s errorWorkloadStream) Send(*rpc.WorkloadEventsDelta) error { return s.err }
+
+func (s *blockingWorkloadStream) Send(*rpc.WorkloadEventsDelta) error {
+	s.once.Do(func() { close(s.started) })
+	<-s.release
+	return nil
+}
+
+func (s *blockingWorkloadStream) SetHeader(metadata.MD) error  { return nil }
+func (s *blockingWorkloadStream) SendHeader(metadata.MD) error { return nil }
+func (s *blockingWorkloadStream) SetTrailer(metadata.MD)       {}
+func (s *blockingWorkloadStream) Context() context.Context     { return s.ctx }
+func (s *blockingWorkloadStream) SendMsg(any) error            { return nil }
+func (s *blockingWorkloadStream) RecvMsg(any) error            { return nil }
+
+func TestWorkloadInfoWatcherDoesNotDetachBlockedSend(t *testing.T) {
+	ctx, cancel := context.WithCancel(testutil.NewContext(t, false))
+	defer cancel()
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+
+	workloads := testWorkloadWatcher{ch: make(chan []Event, 1)}
+	s := &State{
+		backgroundCtx:    ctx,
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		workloadWatchers: xsync.NewMap[string, Watcher](),
+	}
+	s.workloadWatchers.Store("", workloads)
+	sessionID := tunnel.SessionID("client")
+	s.addClient(sessionID, &rpc.ClientInfo{Namespace: "default"}, nil, time.Now())
+
+	deployment := &apps.Deployment{ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default"}}
+	wl, ok := workload.FromAny(deployment)
+	require.True(t, ok)
+	workloads.ch <- []Event{{Type: EventTypeAdd, Workload: wl}}
+
+	stream := &blockingWorkloadStream{
+		ctx:     ctx,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- s.NewWorkloadInfoWatcher(sessionID, "default").Watch(ctx, stream)
+	}()
+
+	select {
+	case <-stream.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for workload stream send")
+	}
+
+	// The stream send must remain owned by Watch. A timer callback owning this
+	// blocked send lets Watch return immediately here and leaves the callback
+	// retaining the stream and its pending snapshot.
+	cancel()
+	select {
+	case err := <-result:
+		t.Fatalf("Watch returned while a detached send was still blocked: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(stream.release)
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Watch did not return after blocked send was released")
+	}
+}
+
+func TestWorkloadInfoWatcherReturnsStreamSendError(t *testing.T) {
+	ctx, cancel := context.WithCancel(testutil.NewContext(t, false))
+	defer cancel()
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+
+	workloads := testWorkloadWatcher{ch: make(chan []Event, 1)}
+	s := &State{
+		backgroundCtx:    ctx,
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		workloadWatchers: xsync.NewMap[string, Watcher](),
+	}
+	s.workloadWatchers.Store("", workloads)
+	sessionID := tunnel.SessionID("client")
+	s.addClient(sessionID, &rpc.ClientInfo{Namespace: "default"}, nil, time.Now())
+	workloads.ch <- []Event{} // An empty initial snapshot must still be sent.
+
+	wantErr := errors.New("stream closed")
+	result := make(chan error, 1)
+	go func() {
+		stream := errorWorkloadStream{noopWorkloadStream: noopWorkloadStream{ctx: ctx}, err: wantErr}
+		result <- s.NewWorkloadInfoWatcher(sessionID, "default").Watch(ctx, stream)
+	}()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, wantErr)
+	case <-time.After(time.Second):
+		t.Fatal("Watch did not return stream.Send error")
+	}
+}
+
+func TestWorkloadInfoWatcherBlockedSendChurnCleansUp(t *testing.T) {
+	ctx := mutator.WithMap(testutil.NewContext(t, false), mutator.NewWatcher())
+	s := &State{
+		backgroundCtx:    ctx,
+		intercepts:       cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:           cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		clients:          xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		workloadWatchers: xsync.NewMap[string, Watcher](),
+	}
+	s.workloadWatchers.Store("", initialWorkloadWatcher{})
+	sessionID := tunnel.SessionID("client")
+	s.addClient(sessionID, &rpc.ClientInfo{Namespace: "default"}, nil, time.Now())
+
+	baseline := runtime.NumGoroutine()
+	peak := baseline
+	for range 100 {
+		watchCtx, cancel := context.WithCancel(ctx)
+		stream := &blockingWorkloadStream{
+			ctx:     watchCtx,
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		result := make(chan error, 1)
+		go func() {
+			result <- s.NewWorkloadInfoWatcher(sessionID, "default").Watch(watchCtx, stream)
+		}()
+		select {
+		case <-stream.started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for blocked send")
+		}
+		if current := runtime.NumGoroutine(); current > peak {
+			peak = current
+		}
+		cancel()
+		close(stream.release)
+		select {
+		case err := <-result:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("Watch did not return after blocked send was released")
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+8
+	}, 2*time.Second, 10*time.Millisecond)
+	t.Logf("goroutines baseline=%d peak=%d final=%d", baseline, peak, runtime.NumGoroutine())
+}


### PR DESCRIPTION
## Description

The workload event debounce timer currently calls `stream.Send` from its callback. That can overlap the initial snapshot send, outlive a canceled RPC, and retain a pending workload snapshot after the watch is gone.

This makes the timer signal the main watch loop instead, so every send stays serialized on one goroutine and send errors can return from the RPC. The focused tests cover a blocked send, a stream error, and repeated blocked-send churn under the race detector.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/state -run "TestWorkloadInfoWatcher(DoesNotDetachBlockedSend|ReturnsStreamSendError|BlockedSendChurnCleansUp)" -count=1` and the same command with `-race`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.