### PR TITLE
Bound the traffic-agent manager handshake

### DIFF
--- a/cmd/traffic/cmd/agent/client.go
+++ b/cmd/traffic/cmd/agent/client.go
@@ -44,6 +44,23 @@ func (is interceptsStringer) String() string {
 
 var NewExtendedManagerClient func(conn *grpc.ClientConn, ossManager rpc.ManagerClient) rpc.ManagerClient //nolint:gochecknoglobals // extension point
 
+// managerHandshakeTimeout bounds the initial unary RPCs made before the agent
+// can enter its reconnecting watch loops. Without a timeout, a manager that
+// accepts the transport but stops servicing unary RPCs can leave the agent
+// stuck forever before /tmp/agent/ready is created.
+var managerHandshakeTimeout = 10 * time.Second //nolint:gochecknoglobals // overridden by tests
+
+const agentSessionIDPrefix = "agent:"
+
+// Agent session IDs are deterministic from the pod UID. Older managers can
+// return an empty ID when a retried arrival finds the first call already
+// committed, so recover the same ID before opening session streams.
+func recoverAgentSessionID(info *rpc.AgentInfo, session *rpc.SessionInfo) {
+	if session.GetSessionId() == "" && info.GetPodUid() != "" {
+		session.SessionId = agentSessionIDPrefix + info.GetPodUid()
+	}
+}
+
 func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, state State) error {
 	// processCtx outlives this single manager session: it bounds the QUIC listener
 	// RefreshQuicAgentListener may start below, which must survive the reconnects
@@ -73,9 +90,11 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 		manager = NewExtendedManagerClient(conn, manager)
 	}
 
-	ver, err := manager.Version(ctx, &empty.Empty{})
+	handshakeCtx, handshakeCancel := context.WithTimeout(ctx, managerHandshakeTimeout)
+	ver, err := manager.Version(handshakeCtx, &empty.Empty{})
+	handshakeCancel()
 	if err != nil {
-		return err
+		return fmt.Errorf("get manager version: %w", err)
 	}
 
 	verStr := strings.TrimPrefix(ver.Version, "v")
@@ -85,10 +104,13 @@ func TalkToManager(ctx context.Context, address string, info *rpc.AgentInfo, sta
 		return fmt.Errorf("failed to parse manager version %q: %s", verStr, err)
 	}
 
-	session, err := manager.ArriveAsAgent(ctx, info)
+	handshakeCtx, handshakeCancel = context.WithTimeout(ctx, managerHandshakeTimeout)
+	session, err := manager.ArriveAsAgent(handshakeCtx, info)
+	handshakeCancel()
 	if err != nil {
-		return err
+		return fmt.Errorf("arrive as agent: %w", err)
 	}
+	recoverAgentSessionID(info, session)
 
 	state.SetManager(session, manager, mgrVer)
 

--- a/cmd/traffic/cmd/agent/client_test.go
+++ b/cmd/traffic/cmd/agent/client_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+)
+
+type handshakeManagerClient struct {
+	rpc.ManagerClient
+	version func(context.Context) (*rpc.VersionInfo2, error)
+	arrive  func(context.Context) (*rpc.SessionInfo, error)
+}
+
+func (c handshakeManagerClient) Version(ctx context.Context, _ *emptypb.Empty, _ ...grpc.CallOption) (*rpc.VersionInfo2, error) {
+	return c.version(ctx)
+}
+
+func (c handshakeManagerClient) ArriveAsAgent(ctx context.Context, _ *rpc.AgentInfo, _ ...grpc.CallOption) (*rpc.SessionInfo, error) {
+	return c.arrive(ctx)
+}
+
+func TestTalkToManagerTimesOutHandshakeRPCs(t *testing.T) {
+	oldTimeout := managerHandshakeTimeout
+	managerHandshakeTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { managerHandshakeTimeout = oldTimeout })
+
+	tests := []struct {
+		name   string
+		client handshakeManagerClient
+	}{
+		{
+			name: "version",
+			client: handshakeManagerClient{
+				version: func(ctx context.Context) (*rpc.VersionInfo2, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+				arrive: func(context.Context) (*rpc.SessionInfo, error) {
+					t.Fatal("ArriveAsAgent should not be called after Version times out")
+					return nil, nil
+				},
+			},
+		},
+		{
+			name: "arrive",
+			client: handshakeManagerClient{
+				version: func(context.Context) (*rpc.VersionInfo2, error) {
+					return &rpc.VersionInfo2{Version: "v2.29.2"}, nil
+				},
+				arrive: func(ctx context.Context) (*rpc.SessionInfo, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldClientFactory := NewExtendedManagerClient
+			NewExtendedManagerClient = func(*grpc.ClientConn, rpc.ManagerClient) rpc.ManagerClient { return tt.client }
+			t.Cleanup(func() { NewExtendedManagerClient = oldClientFactory })
+
+			start := time.Now()
+			err := TalkToManager(context.Background(), "127.0.0.1:1", &rpc.AgentInfo{}, nil)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.Less(t, time.Since(start), time.Second)
+		})
+	}
+}
+
+func TestRecoverAgentSessionID(t *testing.T) {
+	t.Run("fills empty ID from pod UID", func(t *testing.T) {
+		session := &rpc.SessionInfo{ManagerInstallId: "manager-install"}
+		recoverAgentSessionID(&rpc.AgentInfo{PodUid: "pod-uid"}, session)
+
+		require.Equal(t, "agent:pod-uid", session.SessionId)
+		require.Equal(t, "manager-install", session.ManagerInstallId)
+	})
+
+	t.Run("keeps manager-provided ID", func(t *testing.T) {
+		session := &rpc.SessionInfo{SessionId: "manager-session"}
+		recoverAgentSessionID(&rpc.AgentInfo{PodUid: "pod-uid"}, session)
+
+		require.Equal(t, "manager-session", session.SessionId)
+	})
+}

--- a/cmd/traffic/cmd/manager/service_test.go
+++ b/cmd/traffic/cmd/manager/service_test.go
@@ -427,6 +427,27 @@ func agentPrincipal(agent *rpc.AgentInfo) *auth.Principal {
 	}
 }
 
+// TestArriveAsAgentIsIdempotent covers a retry after the manager has already
+// committed the first arrival but its response did not reach the agent.
+func TestArriveAsAgentIsIdempotent(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+	ctx := testutil.NewContext(t, true)
+	testAgents := testdata.GetTestAgents(t)
+	req := require.New(t)
+
+	_, mgr, sctx := getTestClientConnAndService(ctx, t, nil)
+	agent := proto.Clone(testAgents["hello"]).(*rpc.AgentInfo)
+
+	first, err := mgr.ArriveAsAgent(sctx, agent)
+	req.NoError(err)
+	second, err := mgr.ArriveAsAgent(sctx, agent)
+	req.NoError(err)
+
+	req.NotEmpty(first.SessionId)
+	req.Equal(first.SessionId, second.SessionId)
+	req.Equal(1, mgr.State().CountAgents())
+}
+
 // TestAgentSessionBinding covers the pod-identity binding established at agent
 // arrival and enforced by ensureAgentSession on later agent-session RPCs: matching
 // claims bind the session and lock out every other identity (including no identity

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -630,7 +630,7 @@ func (s *State) RestoreAgent(ctx context.Context, id tunnel.SessionID, agent *rp
 		as.SetPrincipal(principal)
 	}
 	if _, exists := s.agents.LoadOrStore(id, as); exists {
-		return "", nil
+		return id, nil
 	}
 
 	s.intercepts.Range(func(interceptID string, intercept *Intercept) bool {


### PR DESCRIPTION
## Description

Before the traffic-agent reaches its reconnecting watch loops, it makes `Version` and `ArriveAsAgent` unary calls without deadlines. If the manager accepts the transport but stops servicing those calls, the agent can wait forever before becoming ready.

This gives each initial handshake RPC a ten-second deadline and wraps the returned error with the failed step. If a delayed arrival succeeds on the manager after the client times out, retries now keep the same deterministic session ID: new managers return the existing ID, and the agent reconstructs it when older managers reply with an empty one.

Tested with:

- `GOEXPERIMENT=jsonv2 GOTOOLCHAIN=local go test ./cmd/traffic/cmd/agent`
- `GOEXPERIMENT=jsonv2 GOTOOLCHAIN=local go test ./cmd/traffic/cmd/manager`

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.