### PR TITLE
Wait for workload rollouts before continuing pod eviction

### DIFF
--- a/cmd/traffic/cmd/manager/mutator/eviction.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+	argoRollouts "github.com/datawire/argo-rollouts-go-client/pkg/apis/rollouts/v1alpha1"
 	"github.com/puzpuzpuz/xsync/v4"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/policy/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,46 +81,133 @@ func (c *configWatcher) EvictAllPodsWithAgentConfig(ctx context.Context, namespa
 	return errs
 }
 
+func (c *configWatcher) evictAllPodsWithAgentConfigAndWait(ctx context.Context, namespace string) error {
+	c.agentConfigs.Delete(namespace)
+	failedWorkloads := make(map[WorkloadKey]struct{})
+	var errs error
+	for {
+		evictMap, err := podList(ctx, namespace)
+		if err != nil {
+			return errors.Join(errs, err)
+		}
+
+		foundAgent := false
+		for key, wp := range evictMap {
+			if _, failed := failedWorkloads[key]; failed {
+				continue
+			}
+			pods := podsWithAgentConfigMismatch(ctx, wp.pods, "")
+			if len(pods) == 0 {
+				continue
+			}
+			foundAgent = true
+			if err = c.evictPods(ctx, wp.wl, pods); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("unable to evict agents from %s: %w", wp.wl, err))
+				failedWorkloads[key] = struct{}{}
+				continue
+			}
+
+			recoveryCtx := ctx
+			cancel := func() {}
+			if timeout := managerutil.GetEnv(ctx).AgentArrivalTimeout; timeout > 0 {
+				recoveryCtx, cancel = context.WithTimeout(ctx, timeout)
+			}
+			err = waitForWorkloadRecovery(recoveryCtx, wp.wl)
+			cancel()
+			if err != nil {
+				errs = errors.Join(errs, err)
+				failedWorkloads[key] = struct{}{}
+			}
+		}
+		if !foundAgent {
+			return errs
+		}
+	}
+}
+
 func (c *configWatcher) evictPodsWithAgentConfigMismatch(ctx context.Context, wl k8sapi.Workload, pods []*core.Pod, cfgJSON string) error {
-	pods = slices.DeleteFunc(pods, func(pod *core.Pod) bool {
+	return c.evictPods(ctx, wl, podsWithAgentConfigMismatch(ctx, pods, cfgJSON))
+}
+
+func podsWithAgentConfigMismatch(ctx context.Context, pods []*core.Pod, cfgJSON string) []*core.Pod {
+	return slices.DeleteFunc(slices.Clone(pods), func(pod *core.Pod) bool {
+		if podIsManuallyInjected(ctx, pod) {
+			clog.Tracef(ctx, "Keeping pod %s because it is managed manually", pod.Name)
+			return true
+		}
 		if pod.Annotations[annotation.Config] == cfgJSON {
 			clog.Tracef(ctx, "Keeping pod %s because its config is still valid", pod.Name)
 			return true
 		}
 		return false
 	})
-	return c.evictPods(ctx, wl, pods)
 }
 
+func podIsManuallyInjected(ctx context.Context, pod *core.Pod) bool {
+	v := annotation.GetAnnotation(ctx, pod.Annotations, annotation.ManuallyInjected, annotation.LegacyManuallyInjected)
+	return v == "true"
+}
+
+type podEvictionResult uint8
+
+const (
+	podEvictionGone podEvictionResult = iota
+	podEvictionStarted
+	podEvictionDeferred
+)
+
 func (c *configWatcher) evictPods(ctx context.Context, wl k8sapi.Workload, pods []*core.Pod) (err error) {
-	didRollout := false
-	counter := 0
+	var evictionState *workloadEvictionState
+	if wl != nil {
+		key := WorkloadKey{Kind: wl.GetKind(), Name: wl.GetName(), Namespace: wl.GetNamespace()}
+		evictionState = c.lockEvictionState(key)
+		defer evictionState.Unlock()
+
+		wl, err = refreshWorkload(ctx, wl)
+		if err != nil {
+			return err
+		}
+		if !workloadUpdateInProgress(wl) {
+			evictionState.replacementPending = false
+		}
+		if evictionState.replacementPending || workloadRolloutInProgress(wl) {
+			clog.Debugf(ctx, "Deferring pod eviction because %s is already updating", wl)
+			return nil
+		}
+	}
+
 	for _, pod := range pods {
 		podID := pod.UID
 		if c.isEvicted(podID) {
 			clog.Debugf(ctx, "Skipping pod %s because it is already deleted", pod.Name)
 			continue
 		}
-		v := annotation.GetAnnotation(ctx, pod.Annotations, annotation.ManuallyInjected, annotation.LegacyManuallyInjected)
-		if v == "true" {
+		if podIsManuallyInjected(ctx, pod) {
 			clog.Tracef(ctx, "Skipping pod %s because it is managed manually", pod.Name)
 			continue
 		}
+		result := podEvictionGone
 		c.inactivePods.Compute(podID, func(v inactivation, loaded bool) (inactivation, xsync.ComputeOp) {
 			if loaded && v.deleted {
 				return v, xsync.CancelOp
 			}
-			if !didRollout {
-				didRollout, err = evictOrRollout(ctx, wl, pod, counter)
-				if err != nil {
-					return v, xsync.CancelOp
-				}
-				counter++
+			result, err = evictOrRollout(ctx, wl, pod)
+			if err != nil || result == podEvictionDeferred {
+				return v, xsync.CancelOp
 			}
 			return inactivation{Time: time.Now(), deleted: true}, xsync.UpdateOp
 		})
 		if err != nil {
 			return err
+		}
+		switch result {
+		case podEvictionDeferred:
+			return nil
+		case podEvictionStarted:
+			if evictionState != nil {
+				evictionState.replacementPending = true
+				return nil
+			}
 		}
 	}
 	return nil
@@ -133,40 +224,161 @@ func (e disruptionBudgetError) Error() string {
 	return fmt.Sprintf("cannot evict pod %s as it would violate the pod's disruption budget", e.podName)
 }
 
-func evictOrRollout(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, counter int) (didRollout bool, err error) {
-	err = evictPod(ctx, pod)
+func evictOrRollout(ctx context.Context, wl k8sapi.Workload, pod *core.Pod) (podEvictionResult, error) {
+	if wl != nil {
+		refreshed, err := refreshWorkload(ctx, wl)
+		if err != nil {
+			return podEvictionGone, err
+		}
+		wl = refreshed
+		if workloadRolloutInProgress(wl) {
+			// Do not consume disruption budget while another rollout is already replacing pods.
+			clog.Debugf(ctx, "Deferring eviction of %s because %s is already updating", pod.Name, wl)
+			return podEvictionDeferred, nil
+		}
+	}
+
+	evicted, err := evictPod(ctx, pod)
 	if err == nil {
-		return false, nil
+		if !evicted {
+			return podEvictionGone, nil
+		}
+		if wl == nil {
+			return podEvictionStarted, nil
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if waitErr := waitForWorkloadUpdateStart(waitCtx, wl); waitErr != nil {
+			return podEvictionStarted, fmt.Errorf("workload update was not observed after evicting %s: %w", pod.Name, waitErr)
+		}
+		return podEvictionStarted, nil
 	}
 	if wl == nil || !errors.As(err, &disruptionBudgetError{}) {
-		return false, fmt.Errorf("failed to evict pod %s: %v", pod.Name, err)
+		return podEvictionGone, fmt.Errorf("failed to evict pod %s: %v", pod.Name, err)
 	}
 	clog.Debug(ctx, err.Error())
-	if counter > 0 {
-		// Other pod siblings were evicted successfully, which means that an attachment will be able to
-		// proceed, Wait for the previous eviction(s) to trigger pod recreation, so the disruption budget
-		// can be satisfied even though this pod is evicted.
-		go func() {
-			clog.Debugf(ctx, "Waiting for other %s pods to be recreated so that the disruption budget can be satisfied when evicting %s", wl.GetNamespace(), pod.Name)
-			evictCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), managerutil.GetEnv(ctx).AgentArrivalTimeout)
-			defer cancel()
-			_ = retryEvictPod(evictCtx, wl, pod, wl.Replicas())
-		}()
-		return false, nil
+	refreshedWorkload, refreshErr := refreshWorkload(ctx, wl)
+	if refreshErr != nil {
+		return podEvictionGone, refreshErr
+	}
+	wl = refreshedWorkload
+	if workloadRolloutInProgress(wl) {
+		// A previous restart patch or an unrelated workload update is already replacing these pods.
+		// Patching restartedAt again resets slow rollouts and can keep them permanently below their
+		// disruption budget. Informer reconciliation will retry once the update finishes.
+		clog.Debugf(ctx, "Deferring eviction of %s because %s is already updating", pod.Name, wl)
+		return podEvictionDeferred, nil
 	}
 	switch wl.GetKind() {
 	case k8sapi.StatefulSetKind, k8sapi.ReplicaSetKind:
-		return false, triggerScalingEviction(ctx, wl, pod)
+		if err := triggerScalingEviction(ctx, wl, pod); err != nil {
+			return podEvictionGone, err
+		}
 	default:
 		clog.Debugf(ctx, "Patching %s to trigger pod recreation", wl)
 		restartAnnotation := generateRestartAnnotationPatch(wl.GetPodTemplate().Annotations)
-		if err = wl.Patch(ctx, types.JSONPatchType, []byte(restartAnnotation)); err != nil {
-			return false, fmt.Errorf("unable to patch %s: %v", wl, err)
+		if err := wl.Patch(ctx, types.JSONPatchType, []byte(restartAnnotation)); err != nil {
+			return podEvictionGone, fmt.Errorf("unable to patch %s: %v", wl, err)
 		}
 		clog.Debugf(ctx, "Successfully patched %s", wl)
 	}
 	// Rollout applies to all pods for the workload, so we're done here
-	return true, nil
+	return podEvictionStarted, nil
+}
+
+func workloadUpdateInProgress(wl k8sapi.Workload) bool {
+	return !wl.Updated(wl.GetGeneration())
+}
+
+func workloadRolloutInProgress(wl k8sapi.Workload) bool {
+	desiredReplicas := k8sapi.DesiredReplicas(wl)
+	switch wl.GetKind() {
+	case k8sapi.DeploymentKind:
+		deployment, ok := k8sapi.DeploymentImpl(wl)
+		if !ok {
+			break
+		}
+		if deployment.Status.ObservedGeneration != deployment.Generation ||
+			deployment.Status.Replicas != desiredReplicas ||
+			deployment.Status.UpdatedReplicas != desiredReplicas {
+			return true
+		}
+		for _, condition := range deployment.Status.Conditions {
+			if condition.Type == apps.DeploymentProgressing && condition.Status == core.ConditionTrue {
+				return condition.Reason != "NewReplicaSetAvailable"
+			}
+		}
+		return false
+	case k8sapi.RolloutKind:
+		rollout, ok := k8sapi.RolloutImpl(wl)
+		if !ok {
+			break
+		}
+		return rollout.Status.ObservedGeneration != strconv.FormatInt(rollout.Generation, 10) ||
+			rollout.Status.Replicas != desiredReplicas ||
+			rollout.Status.UpdatedReplicas != desiredReplicas ||
+			rollout.Status.ReadyReplicas != desiredReplicas ||
+			rollout.Status.AvailableReplicas != desiredReplicas ||
+			rollout.Status.Phase != argoRollouts.RolloutPhaseHealthy
+	case k8sapi.ReplicaSetKind:
+		replicaSet, ok := k8sapi.ReplicaSetImpl(wl)
+		if !ok {
+			break
+		}
+		return replicaSet.Status.ObservedGeneration != replicaSet.Generation ||
+			replicaSet.Status.Replicas != desiredReplicas
+	case k8sapi.StatefulSetKind:
+		statefulSet, ok := k8sapi.StatefulSetImpl(wl)
+		if !ok {
+			break
+		}
+		if statefulSet.Status.ObservedGeneration != statefulSet.Generation ||
+			statefulSet.Status.Replicas != desiredReplicas {
+			return true
+		}
+		if statefulSet.Spec.UpdateStrategy.Type == apps.OnDeleteStatefulSetStrategyType {
+			return false
+		}
+		expectedUpdatedReplicas := desiredReplicas
+		if rollingUpdate := statefulSet.Spec.UpdateStrategy.RollingUpdate; rollingUpdate != nil && rollingUpdate.Partition != nil {
+			expectedUpdatedReplicas = max(0, desiredReplicas-*rollingUpdate.Partition)
+		}
+		return statefulSet.Status.UpdatedReplicas < expectedUpdatedReplicas
+	}
+	return workloadUpdateInProgress(wl)
+}
+
+func refreshWorkload(ctx context.Context, wl k8sapi.Workload) (k8sapi.Workload, error) {
+	var refreshed k8sapi.Workload
+	err := backoff.Retry(func() error {
+		var refreshErr error
+		refreshed, refreshErr = k8sapi.GetWorkload(ctx, wl.GetName(), wl.GetNamespace(), wl.GetKind())
+		if refreshErr != nil && workloadRefreshErrorIsTerminal(refreshErr) {
+			return backoff.Permanent(refreshErr)
+		}
+		return refreshErr
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(200*time.Millisecond), 10), ctx))
+	if err != nil {
+		return nil, fmt.Errorf("unable to refresh %s before pod eviction: %w", wl, err)
+	}
+	return refreshed, nil
+}
+
+func workloadRefreshErrorIsTerminal(err error) bool {
+	return k8sErrors.IsNotFound(err) ||
+		k8sErrors.IsForbidden(err) ||
+		k8sErrors.IsUnauthorized(err) ||
+		k8sErrors.IsBadRequest(err) ||
+		k8sErrors.IsInvalid(err) ||
+		k8sErrors.IsMethodNotSupported(err)
+}
+
+func refreshedWorkloadUpdateInProgress(ctx context.Context, wl k8sapi.Workload) (k8sapi.Workload, bool, error) {
+	refreshed, err := refreshWorkload(ctx, wl)
+	if err != nil {
+		return nil, false, err
+	}
+	return refreshed, workloadUpdateInProgress(refreshed), nil
 }
 
 func retryEvictPod(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, replicas int) error {
@@ -176,7 +388,7 @@ func retryEvictPod(ctx context.Context, wl k8sapi.Workload, pod *core.Pod, repli
 		return err
 	}
 	for {
-		err = evictPod(ctx, pod)
+		_, err = evictPod(ctx, pod)
 		if err == nil || !errors.As(err, &disruptionBudgetError{}) {
 			clog.Error(ctx, err)
 			return err
@@ -229,6 +441,44 @@ func waitForReplicaCount(ctx context.Context, wl k8sapi.Workload, count int) err
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%s never scaled to %d", wl, count)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func waitForWorkloadUpdateStart(ctx context.Context, wl k8sapi.Workload) error {
+	for {
+		refreshed, updating, err := refreshedWorkloadUpdateInProgress(ctx, wl)
+		if err != nil {
+			return err
+		}
+		if updating {
+			return nil
+		}
+		wl = refreshed
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s did not start updating: %w", wl, ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func waitForWorkloadRecovery(ctx context.Context, wl k8sapi.Workload) error {
+	for {
+		refreshed, err := refreshWorkload(ctx, wl)
+		if err != nil {
+			return err
+		}
+		desiredReplicas := k8sapi.DesiredReplicas(refreshed)
+		if k8sapi.ReadyReplicas(refreshed) >= desiredReplicas &&
+			!workloadRolloutInProgress(refreshed) {
+			return nil
+		}
+		wl = refreshed
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s did not recover %d ready replicas: %w", wl, desiredReplicas, ctx.Err())
 		case <-time.After(300 * time.Millisecond):
 		}
 	}
@@ -244,7 +494,7 @@ func scaleIt(ctx context.Context, wl k8sapi.Workload, replicas int) error {
 	return err
 }
 
-func triggerScalingEviction(ctx context.Context, wl k8sapi.Workload, pod *core.Pod) error {
+func triggerScalingEviction(ctx context.Context, wl k8sapi.Workload, pod *core.Pod) (err error) {
 	// Rollout of a replicatset/statefulset will not recreate the pods. For that to happen, the
 	// set must be scaled up to replicas+1 and then the pod must be evicted before the replicas
 	// are scaled back down.
@@ -253,36 +503,44 @@ func triggerScalingEviction(ctx context.Context, wl k8sapi.Workload, pod *core.P
 		return err
 	}
 	defer func() {
-		// Ensure that the original replica count is restored but don't wait for it.
-		go func() {
-			if err := scaleIt(context.WithoutCancel(ctx), wl, replicas); err != nil {
-				clog.Error(ctx, err)
-			}
-		}()
+		// Restore the desired count before recovery follows live replica changes. This keeps the
+		// temporary scale-up from being mistaken for an externally requested target.
+		if restoreErr := scaleIt(context.WithoutCancel(ctx), wl, replicas); restoreErr != nil {
+			err = errors.Join(err, restoreErr)
+		}
 	}()
 	return retryEvictPod(ctx, wl, pod, replicas+1)
 }
 
-func evictPod(ctx context.Context, pod *core.Pod) error {
+func evictPod(ctx context.Context, pod *core.Pod) (bool, error) {
 	clog.Debugf(ctx, "Attempting to evict pod %s", pod.Name)
+	uid := pod.UID
 	err := k8sapi.GetK8sInterface(ctx).CoreV1().Pods(pod.Namespace).EvictV1(ctx, &v1.Eviction{
 		ObjectMeta: meta.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace},
+		DeleteOptions: &meta.DeleteOptions{
+			Preconditions: &meta.Preconditions{UID: &uid},
+		},
 	})
-	switch {
-	case err == nil:
-		clog.Debugf(ctx, "Successfully evicted pod %s", pod.Name)
-	case k8sErrors.IsNotFound(err):
-		// The pod is already gone, which is the objective of the eviction.
-		clog.Debugf(ctx, "Pod %s no longer exists", pod.Name)
-	default:
-		if strings.Contains(err.Error(), "disruption budget") {
-			err = disruptionBudgetError{error: err, podName: pod.Name}
+	if err == nil || k8sErrors.IsNotFound(err) {
+		store := informer.GetK8sFactory(ctx, pod.Namespace).Core().V1().Pods().Informer().GetStore()
+		if cached, exists, getErr := store.Get(pod); getErr == nil && exists {
+			if cachedPod, ok := cached.(*core.Pod); ok && cachedPod.UID == pod.UID {
+				_ = store.Delete(cachedPod)
+			}
 		}
-		return err
+		clog.Debugf(ctx, "Pod %s was evicted or already replaced", pod.Name)
+		return err == nil, nil
 	}
-	store := informer.GetK8sFactory(ctx, pod.Namespace).Core().V1().Pods().Informer().GetStore()
-	_ = store.Delete(pod)
-	return nil
+	if k8sErrors.IsConflict(err) {
+		// The name now belongs to a different UID. Leave the informer entry intact so the
+		// replacement remains visible to subsequent reconciliation.
+		clog.Debugf(ctx, "Pod %s was already replaced", pod.Name)
+		return false, nil
+	}
+	if strings.Contains(err.Error(), "disruption budget") {
+		err = disruptionBudgetError{error: err, podName: pod.Name}
+	}
+	return false, err
 }
 
 func podIsPendingOrRunning(pod *core.Pod) bool {

--- a/cmd/traffic/cmd/manager/mutator/eviction_test.go
+++ b/cmd/traffic/cmd/manager/mutator/eviction_test.go
@@ -3,7 +3,10 @@ package mutator
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	argorollouts "github.com/datawire/argo-rollouts-go-client/pkg/apis/rollouts/v1alpha1"
 	argorolloutsfake "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
@@ -11,14 +14,18 @@ import (
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/telepresenceio/clog/testutil"
 	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/annotation"
 	"github.com/telepresenceio/telepresence/v2/pkg/informer"
 	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
 )
@@ -61,7 +68,7 @@ func TestEvictPod(t *testing.T) {
 			})
 			ctx = k8sapi.WithJoinedClientSetInterface(ctx, ci, argorolloutsfake.NewSimpleClientset())
 			ctx = informer.WithFactory(ctx, "")
-			err := evictPod(ctx, &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "echo-1", Namespace: "ns"}})
+			_, err := evictPod(ctx, &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "echo-1", Namespace: "ns"}})
 			if tt.expectErr == "" {
 				require.NoError(t, err)
 			} else {
@@ -212,4 +219,575 @@ func TestWorkloadPodsFindsRolloutPodsWhenReplicaSetsAreDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pods, 1)
 	assert.Equal(t, pod.Name, pods[0].Name)
+}
+
+func TestWorkloadUpdateInProgress(t *testing.T) {
+	replicas := int32(6)
+	deployment := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Generation: 12},
+		Spec:       apps.DeploymentSpec{Replicas: &replicas},
+		Status: apps.DeploymentStatus{
+			ObservedGeneration: 12,
+			Replicas:           6,
+			UpdatedReplicas:    6,
+			AvailableReplicas:  6,
+		},
+	}
+
+	assert.False(t, workloadUpdateInProgress(k8sapi.Deployment(deployment)))
+
+	deployment.Status.Replicas = 8
+	deployment.Status.UpdatedReplicas = 3
+	deployment.Status.AvailableReplicas = 5
+	assert.True(t, workloadUpdateInProgress(k8sapi.Deployment(deployment)))
+
+	deployment.Status.ObservedGeneration = 11
+	deployment.Status.Replicas = 6
+	deployment.Status.UpdatedReplicas = 6
+	deployment.Status.AvailableReplicas = 6
+	assert.True(t, workloadUpdateInProgress(k8sapi.Deployment(deployment)))
+}
+
+func TestWorkloadRolloutInProgress(t *testing.T) {
+	replicas := int32(6)
+	deployment := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Generation: 12},
+		Spec:       apps.DeploymentSpec{Replicas: &replicas},
+		Status: apps.DeploymentStatus{
+			ObservedGeneration: 12,
+			Replicas:           6,
+			UpdatedReplicas:    6,
+			AvailableReplicas:  5,
+			Conditions: []apps.DeploymentCondition{{
+				Type:   apps.DeploymentProgressing,
+				Status: core.ConditionTrue,
+				Reason: "NewReplicaSetAvailable",
+			}},
+		},
+	}
+	assert.False(t, workloadRolloutInProgress(k8sapi.Deployment(deployment)), "steady unavailable replica")
+
+	deployment.Status.Conditions[0].Reason = "ReplicaSetUpdated"
+	assert.True(t, workloadRolloutInProgress(k8sapi.Deployment(deployment)), "rollout awaiting availability")
+
+	replicaSet := &apps.ReplicaSet{
+		ObjectMeta: meta.ObjectMeta{Generation: 4},
+		Spec:       apps.ReplicaSetSpec{Replicas: &replicas},
+		Status: apps.ReplicaSetStatus{
+			ObservedGeneration: 4,
+			Replicas:           6,
+			AvailableReplicas:  5,
+		},
+	}
+	assert.False(t, workloadRolloutInProgress(k8sapi.ReplicaSet(replicaSet)), "steady unavailable replica")
+	replicaSet.Status.Replicas = 5
+	assert.True(t, workloadRolloutInProgress(k8sapi.ReplicaSet(replicaSet)), "scale in progress")
+
+	statefulSet := &apps.StatefulSet{
+		ObjectMeta: meta.ObjectMeta{Generation: 8},
+		Spec: apps.StatefulSetSpec{
+			Replicas: &replicas,
+			UpdateStrategy: apps.StatefulSetUpdateStrategy{
+				Type: apps.OnDeleteStatefulSetStrategyType,
+			},
+		},
+		Status: apps.StatefulSetStatus{
+			ObservedGeneration: 8,
+			Replicas:           6,
+			UpdatedReplicas:    0,
+		},
+	}
+	assert.False(t, workloadRolloutInProgress(k8sapi.StatefulSet(statefulSet)), "OnDelete revision mismatch")
+	statefulSet.Status.Replicas = 5
+	assert.True(t, workloadRolloutInProgress(k8sapi.StatefulSet(statefulSet)), "OnDelete scale in progress")
+
+	partition := int32(3)
+	statefulSet.Status.Replicas = 6
+	statefulSet.Spec.UpdateStrategy = apps.StatefulSetUpdateStrategy{
+		Type:          apps.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: &apps.RollingUpdateStatefulSetStrategy{Partition: &partition},
+	}
+	statefulSet.Status.UpdatedReplicas = 3
+	assert.False(t, workloadRolloutInProgress(k8sapi.StatefulSet(statefulSet)), "completed partitioned rollout")
+	statefulSet.Status.UpdatedReplicas = 2
+	assert.True(t, workloadRolloutInProgress(k8sapi.StatefulSet(statefulSet)), "partitioned rollout in progress")
+
+	rollout := &argorollouts.Rollout{
+		ObjectMeta: meta.ObjectMeta{Generation: 12},
+		Spec:       argorollouts.RolloutSpec{Replicas: &replicas},
+		Status: argorollouts.RolloutStatus{
+			ObservedGeneration: "12",
+			Replicas:           6,
+			UpdatedReplicas:    6,
+			ReadyReplicas:      6,
+			AvailableReplicas:  6,
+			Phase:              argorollouts.RolloutPhaseHealthy,
+		},
+	}
+	assert.False(t, workloadRolloutInProgress(k8sapi.Rollout(rollout)), "healthy rollout")
+	rollout.Status.Phase = argorollouts.RolloutPhaseProgressing
+	assert.True(t, workloadRolloutInProgress(k8sapi.Rollout(rollout)), "analysis in progress")
+	rollout.Status.Phase = argorollouts.RolloutPhaseHealthy
+	rollout.Status.ReadyReplicas = 5
+	assert.True(t, workloadRolloutInProgress(k8sapi.Rollout(rollout)), "rollout awaiting readiness")
+}
+
+func TestEvictOrRolloutDoesNotRestartUpdatingWorkload(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		status            apps.DeploymentStatus
+		wantEvictionCount int
+		wantPatchCount    int
+		wantResult        podEvictionResult
+	}{
+		{
+			name: "stable workload",
+			status: apps.DeploymentStatus{
+				ObservedGeneration: 12,
+				Replicas:           6,
+				UpdatedReplicas:    6,
+				AvailableReplicas:  6,
+			},
+			wantEvictionCount: 1,
+			wantPatchCount:    1,
+			wantResult:        podEvictionStarted,
+		},
+		{
+			name: "stable workload with unavailable replica",
+			status: apps.DeploymentStatus{
+				ObservedGeneration: 12,
+				Replicas:           6,
+				UpdatedReplicas:    6,
+				AvailableReplicas:  5,
+				Conditions: []apps.DeploymentCondition{{
+					Type:   apps.DeploymentProgressing,
+					Status: core.ConditionTrue,
+					Reason: "NewReplicaSetAvailable",
+				}},
+			},
+			wantEvictionCount: 1,
+			wantPatchCount:    1,
+			wantResult:        podEvictionStarted,
+		},
+		{
+			name: "update in progress",
+			status: apps.DeploymentStatus{
+				ObservedGeneration: 12,
+				Replicas:           8,
+				UpdatedReplicas:    3,
+				AvailableReplicas:  5,
+			},
+			wantResult: podEvictionDeferred,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			replicas := int32(6)
+			deployment := &apps.Deployment{
+				ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default", Generation: 12},
+				Spec:       apps.DeploymentSpec{Replicas: &replicas},
+				Status:     tc.status,
+			}
+			pod := &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "echo-old", Namespace: "default", UID: types.UID("echo-old")}}
+			client := fake.NewSimpleClientset(deployment.DeepCopy(), pod.DeepCopy())
+			evictionCount := 0
+			client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() != "eviction" {
+					return false, nil, nil
+				}
+				evictionCount++
+				return true, nil, k8sErrors.NewTooManyRequests("eviction would violate the pod's disruption budget", 0)
+			})
+
+			ctx := k8sapi.WithK8sInterface(context.Background(), client)
+			ctx = managerutil.WithEnv(ctx, &managerutil.Env{})
+			result, err := evictOrRollout(ctx, k8sapi.Deployment(deployment), pod)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantResult, result)
+			assert.Equal(t, tc.wantEvictionCount, evictionCount)
+
+			patchCount := 0
+			for _, action := range client.Actions() {
+				if action.GetVerb() == "patch" && action.GetResource().Resource == "deployments" {
+					patchCount++
+				}
+			}
+			assert.Equal(t, tc.wantPatchCount, patchCount)
+		})
+	}
+}
+
+func TestPodsWithAgentConfigMismatchIgnoresManualInjection(t *testing.T) {
+	pod := &core.Pod{ObjectMeta: meta.ObjectMeta{
+		Name: "echo",
+		Annotations: map[string]string{
+			annotation.Config:           "stale",
+			annotation.ManuallyInjected: "true",
+		},
+	}}
+	assert.Empty(t, podsWithAgentConfigMismatch(context.Background(), []*core.Pod{pod}, ""))
+}
+
+func TestDeferredEvictionIsNotMarkedDeleted(t *testing.T) {
+	replicas := int32(2)
+	stable := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default", Generation: 3},
+		Spec:       apps.DeploymentSpec{Replicas: &replicas},
+		Status: apps.DeploymentStatus{
+			ObservedGeneration: 3,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+		},
+	}
+	updating := stable.DeepCopy()
+	updating.Status.Replicas = 3
+	updating.Status.UpdatedReplicas = 1
+	pod := &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "echo-old", Namespace: "default", UID: "old"}}
+	client := fake.NewSimpleClientset(stable.DeepCopy(), pod.DeepCopy())
+	getCount := 0
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCount++
+		if getCount == 1 {
+			return true, stable.DeepCopy(), nil
+		}
+		return true, updating.DeepCopy(), nil
+	})
+
+	ctx := k8sapi.WithK8sInterface(context.Background(), client)
+	cw := NewWatcher().(*configWatcher)
+	require.NoError(t, cw.evictPods(ctx, k8sapi.Deployment(stable), []*core.Pod{pod}))
+	assert.False(t, cw.isEvicted(pod.UID))
+}
+
+func TestAbsentPodDoesNotConsumeSuccessfulEvictionCount(t *testing.T) {
+	replicas := int32(2)
+	deployment := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default", Generation: 3},
+		Spec: apps.DeploymentSpec{
+			Replicas: &replicas,
+			Template: core.PodTemplateSpec{ObjectMeta: meta.ObjectMeta{Annotations: map[string]string{}}},
+		},
+		Status: apps.DeploymentStatus{
+			ObservedGeneration: 3,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+		},
+	}
+	oldPods := []*core.Pod{
+		{ObjectMeta: meta.ObjectMeta{Name: "echo-gone", Namespace: "default", UID: "gone"}},
+		{ObjectMeta: meta.ObjectMeta{Name: "echo-blocked", Namespace: "default", UID: "blocked"}},
+	}
+	client := fake.NewSimpleClientset(deployment.DeepCopy())
+	evictionCount := 0
+	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		evictionCount++
+		if evictionCount == 1 {
+			return true, nil, k8sErrors.NewNotFound(core.Resource("pods"), oldPods[0].Name)
+		}
+		return true, nil, k8sErrors.NewTooManyRequests("eviction would violate the pod's disruption budget", 0)
+	})
+
+	ctx := k8sapi.WithK8sInterface(context.Background(), client)
+	ctx = informer.WithFactory(ctx, "")
+	store := informer.GetK8sFactory(ctx, "default").Core().V1().Pods().Informer().GetStore()
+	for _, pod := range oldPods {
+		require.NoError(t, store.Add(pod.DeepCopy()))
+	}
+	cw := NewWatcher().(*configWatcher)
+	require.NoError(t, cw.evictPods(ctx, k8sapi.Deployment(deployment), oldPods))
+	assert.Equal(t, 2, evictionCount)
+	assert.Equal(t, 1, countActions(client.Actions(), "patch", "deployments"))
+}
+
+func TestEvictPodConflictPreservesReplacementInStore(t *testing.T) {
+	oldPod := &core.Pod{ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default", UID: "old"}}
+	replacement := oldPod.DeepCopy()
+	replacement.UID = "new"
+	client := fake.NewSimpleClientset(replacement.DeepCopy())
+	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "eviction" {
+			return true, nil, k8sErrors.NewConflict(core.Resource("pods"), oldPod.Name, fmt.Errorf("UID precondition failed"))
+		}
+		return false, nil, nil
+	})
+
+	ctx := k8sapi.WithK8sInterface(context.Background(), client)
+	ctx = informer.WithFactory(ctx, "")
+	store := informer.GetK8sFactory(ctx, "default").Core().V1().Pods().Informer().GetStore()
+	require.NoError(t, store.Add(replacement.DeepCopy()))
+	evicted, err := evictPod(ctx, oldPod)
+	require.NoError(t, err)
+	assert.False(t, evicted)
+	cached, exists, err := store.Get(oldPod)
+	require.NoError(t, err)
+	require.True(t, exists)
+	assert.Equal(t, replacement.UID, cached.(*core.Pod).UID)
+}
+
+func TestWaitForWorkloadRecoveryFollowsDesiredReplicaChanges(t *testing.T) {
+	oldReplicas := int32(3)
+	newReplicas := int32(4)
+	original := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default", Generation: 1},
+		Spec:       apps.DeploymentSpec{Replicas: &oldReplicas},
+	}
+	rescaled := original.DeepCopy()
+	rescaled.Spec.Replicas = &newReplicas
+	rescaled.Status = apps.DeploymentStatus{
+		ObservedGeneration: 1,
+		Replicas:           4,
+		UpdatedReplicas:    4,
+		ReadyReplicas:      4,
+		AvailableReplicas:  4,
+	}
+	client := fake.NewSimpleClientset(rescaled)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = k8sapi.WithK8sInterface(ctx, client)
+	require.NoError(t, waitForWorkloadRecovery(ctx, k8sapi.Deployment(original)))
+}
+
+func TestTeardownContinuesAfterWorkloadFailure(t *testing.T) {
+	const namespace = "default"
+	replicas := int32(1)
+	objects := make([]runtime.Object, 0, 4)
+	for _, name := range []string{"echo-one", "echo-two"} {
+		selector := map[string]string{"app": name}
+		objects = append(objects,
+			&apps.ReplicaSet{
+				ObjectMeta: meta.ObjectMeta{Name: name, Namespace: namespace, Generation: 1},
+				Spec: apps.ReplicaSetSpec{
+					Replicas: &replicas,
+					Selector: &meta.LabelSelector{MatchLabels: selector},
+				},
+				Status: apps.ReplicaSetStatus{
+					ObservedGeneration:   1,
+					Replicas:             1,
+					ReadyReplicas:        1,
+					AvailableReplicas:    1,
+					FullyLabeledReplicas: 1,
+				},
+			},
+			&core.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      name + "-old",
+					Namespace: namespace,
+					UID:       types.UID(name + "-old"),
+					Labels: map[string]string{
+						"app":                         name,
+						agentconfig.WorkloadNameLabel: name,
+						agentconfig.WorkloadKindLabel: string(k8sapi.ReplicaSetKind),
+					},
+					Annotations: map[string]string{annotation.Config: "stale"},
+				},
+				Status: core.PodStatus{Phase: core.PodRunning},
+			},
+		)
+	}
+
+	client := fake.NewSimpleClientset(objects...)
+	attempted := make(map[string]bool)
+	client.PrependReactor("get", "replicasets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		name := action.(k8stesting.GetAction).GetName()
+		attempted[name] = true
+		return true, nil, k8sErrors.NewForbidden(apps.Resource("replicasets"), name, fmt.Errorf("denied"))
+	})
+
+	ctx := k8sapi.WithJoinedClientSetInterface(context.Background(), client, argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.ReplicaSetKind}})
+	factory := informer.GetK8sFactory(ctx, namespace)
+	podStore := factory.Core().V1().Pods().Informer().GetStore()
+	replicaSetStore := factory.Apps().V1().ReplicaSets().Informer().GetStore()
+	for _, object := range objects {
+		switch object := object.(type) {
+		case *core.Pod:
+			require.NoError(t, podStore.Add(object.DeepCopy()))
+		case *apps.ReplicaSet:
+			require.NoError(t, replicaSetStore.Add(object.DeepCopy()))
+		}
+	}
+
+	cw := NewWatcher().(*configWatcher)
+	require.Error(t, cw.evictAllPodsWithAgentConfigAndWait(ctx, namespace))
+	assert.Equal(t, map[string]bool{"echo-one": true, "echo-two": true}, attempted)
+}
+
+func TestEvictionStateIsReclaimed(t *testing.T) {
+	cw := NewWatcher().(*configWatcher)
+	key := WorkloadKey{Name: "echo", Namespace: "default", Kind: k8sapi.DeploymentKind}
+	state := cw.lockEvictionState(key)
+	state.Unlock()
+	require.Equal(t, 1, cw.evictionStates.Size())
+	cw.deleteEvictionState(key)
+	assert.Zero(t, cw.evictionStates.Size())
+}
+
+func countActions(actions []k8stesting.Action, verb, resource string) int {
+	count := 0
+	for _, action := range actions {
+		if action.GetVerb() == verb && action.GetResource().Resource == resource {
+			count++
+		}
+	}
+	return count
+}
+
+func TestRefreshWorkloadRetriesTransientError(t *testing.T) {
+	replicas := int32(1)
+	deployment := &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: "echo", Namespace: "default"},
+		Spec:       apps.DeploymentSpec{Replicas: &replicas},
+	}
+	client := fake.NewSimpleClientset(deployment.DeepCopy())
+	getCount := 0
+	client.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCount++
+		if getCount == 1 {
+			return true, nil, k8sErrors.NewServiceUnavailable("temporary API server failure")
+		}
+		return false, nil, nil
+	})
+
+	ctx := k8sapi.WithK8sInterface(context.Background(), client)
+	refreshed, err := refreshWorkload(ctx, k8sapi.Deployment(deployment))
+	require.NoError(t, err)
+	assert.Equal(t, "echo", refreshed.GetName())
+	assert.Equal(t, 2, getCount)
+}
+
+func TestDeleteMapsAndRolloutNamespaceWaitsForAllEvictions(t *testing.T) {
+	const (
+		namespace = "default"
+		name      = "echo"
+	)
+	replicas := int32(3)
+	selector := map[string]string{"app": name}
+	replicaSet := &apps.ReplicaSet{
+		ObjectMeta: meta.ObjectMeta{Name: name, Namespace: namespace, Generation: 1},
+		Spec: apps.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &meta.LabelSelector{MatchLabels: selector},
+		},
+		Status: apps.ReplicaSetStatus{
+			ObservedGeneration:   1,
+			Replicas:             replicas,
+			ReadyReplicas:        replicas,
+			AvailableReplicas:    replicas,
+			FullyLabeledReplicas: replicas,
+		},
+	}
+	objects := []runtime.Object{replicaSet}
+	for i := range int(replicas) {
+		objects = append(objects, &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      fmt.Sprintf("echo-old-%d", i),
+				Namespace: namespace,
+				UID:       types.UID(fmt.Sprintf("echo-old-%d", i)),
+				Labels: map[string]string{
+					"app":                         name,
+					agentconfig.WorkloadNameLabel: name,
+					agentconfig.WorkloadKindLabel: string(k8sapi.ReplicaSetKind),
+				},
+				Annotations: map[string]string{annotation.Config: "stale"},
+			},
+			Status: core.PodStatus{Phase: core.PodRunning},
+		})
+	}
+
+	client := fake.NewSimpleClientset(objects...)
+	tracker := client.Tracker()
+	podsResource := core.SchemeGroupVersion.WithResource("pods")
+	replicaSetsResource := apps.SchemeGroupVersion.WithResource("replicasets")
+	replacementName := ""
+	evictionCount := 0
+	var informerCancelled atomic.Bool
+	var cancelledBeforeEviction atomic.Bool
+	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		if informerCancelled.Load() {
+			cancelledBeforeEviction.Store(true)
+		}
+		eviction := action.(k8stesting.CreateAction).GetObject().(*policy.Eviction)
+		require.NoError(t, tracker.Delete(podsResource, namespace, eviction.Name))
+		evictionCount++
+		replacementName = fmt.Sprintf("echo-new-%d", evictionCount)
+		obj, err := tracker.Get(replicaSetsResource, namespace, name)
+		require.NoError(t, err)
+		updated := obj.(*apps.ReplicaSet).DeepCopy()
+		updated.Status.Replicas = replicas - 1
+		updated.Status.ReadyReplicas = replicas - 1
+		updated.Status.AvailableReplicas = replicas - 1
+		updated.Status.FullyLabeledReplicas = replicas - 1
+		require.NoError(t, tracker.Update(replicaSetsResource, updated, namespace))
+		return true, nil, nil
+	})
+	client.PrependReactor("get", "replicasets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if replacementName == "" {
+			return false, nil, nil
+		}
+		obj, err := tracker.Get(replicaSetsResource, namespace, name)
+		require.NoError(t, err)
+		updating := obj.(*apps.ReplicaSet).DeepCopy()
+		replacement := &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:      replacementName,
+				Namespace: namespace,
+				UID:       types.UID(replacementName),
+				Labels: map[string]string{
+					"app":                         name,
+					agentconfig.WorkloadNameLabel: name,
+					agentconfig.WorkloadKindLabel: string(k8sapi.ReplicaSetKind),
+				},
+			},
+			Status: core.PodStatus{Phase: core.PodRunning},
+		}
+		require.NoError(t, tracker.Create(podsResource, replacement, namespace))
+		recovered := updating.DeepCopy()
+		recovered.Status.Replicas = replicas
+		recovered.Status.ReadyReplicas = replicas
+		recovered.Status.AvailableReplicas = replicas
+		recovered.Status.FullyLabeledReplicas = replicas
+		require.NoError(t, tracker.Update(replicaSetsResource, recovered, namespace))
+		replacementName = ""
+		return true, updating, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = k8sapi.WithJoinedClientSetInterface(ctx, client, argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		AgentArrivalTimeout:  2 * time.Second,
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.ReplicaSetKind},
+	})
+	factory := informer.GetK8sFactory(ctx, namespace)
+	podStore := factory.Core().V1().Pods().Informer().GetStore()
+	replicaSetStore := factory.Apps().V1().ReplicaSets().Informer().GetStore()
+	for _, object := range objects {
+		switch object := object.(type) {
+		case *core.Pod:
+			require.NoError(t, podStore.Add(object.DeepCopy()))
+		case *apps.ReplicaSet:
+			require.NoError(t, replicaSetStore.Add(object.DeepCopy()))
+		}
+	}
+	evictMap, err := podList(ctx, namespace)
+	require.NoError(t, err)
+	require.Len(t, evictMap, 1)
+
+	cw := NewWatcher().(*configWatcher)
+	iwc := &informersWithCancel{cancel: func() { informerCancelled.Store(true) }}
+	cw.informers.Store(namespace, iwc)
+	cw.deleteMapsAndRolloutNS(ctx, namespace, iwc)
+
+	assert.Equal(t, int(replicas), evictionCount)
+	assert.True(t, informerCancelled.Load())
+	assert.False(t, cancelledBeforeEviction.Load())
 }

--- a/cmd/traffic/cmd/manager/mutator/service.go
+++ b/cmd/traffic/cmd/manager/mutator/service.go
@@ -135,10 +135,21 @@ type NodeAgentReaper func(ctx context.Context) error
 // logged rather than surfaced to the caller -- the hook already treats the
 // request as best-effort (`|| exit 0`).
 func uninstallHandler(ai AgentInjector, reap NodeAgentReaper) http.HandlerFunc {
+	return uninstallHandlerWithContext(nil, ai, reap) //nolint:staticcheck // nil keeps teardown bound to the request context
+}
+
+// uninstallHandlerWithContext keeps teardown attached to managerCtx when it
+// is provided. The Helm hook can disconnect before sidecars finish rolling
+// back, and request cancellation must not abandon that reconciliation.
+func uninstallHandlerWithContext(managerCtx context.Context, ai AgentInjector, reap NodeAgentReaper) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		clog.Debug(ctx, "Received uninstall request...")
-		statusCode, err := serveRequest(ctx, r, http.MethodDelete, func(ctx context.Context) {
+		requestCtx := r.Context()
+		actionCtx := requestCtx
+		if managerCtx != nil {
+			actionCtx = managerCtx
+		}
+		clog.Debug(requestCtx, "Received uninstall request...")
+		statusCode, err := serveRequest(actionCtx, r, http.MethodDelete, func(ctx context.Context) {
 			if ai != nil {
 				ai.Uninstall(ctx)
 			}
@@ -149,11 +160,11 @@ func uninstallHandler(ai AgentInjector, reap NodeAgentReaper) http.HandlerFunc {
 			}
 		})
 		if err != nil {
-			clog.Errorf(ctx, "error handling uninstall request: %v", err)
+			clog.Errorf(requestCtx, "error handling uninstall request: %v", err)
 			w.WriteHeader(statusCode)
 			_, _ = w.Write([]byte(err.Error()))
 		} else {
-			clog.Debug(ctx, "uninstall request handled successfully")
+			clog.Debug(requestCtx, "uninstall request handled successfully")
 			w.WriteHeader(http.StatusOK)
 		}
 	}
@@ -184,7 +195,7 @@ func ServeMutator(ctx context.Context, g log.Group, injectorCertGetter InjectorC
 			clog.Errorf(ctx, "could not write response: %v", err)
 		}
 	})
-	mux.HandleFunc("/uninstall", uninstallHandler(ai, reapNodeAgentJobs))
+	mux.HandleFunc("/uninstall", uninstallHandlerWithContext(ctx, ai, reapNodeAgentJobs))
 	mux.HandleFunc("/healthz", healthzHandler)
 
 	port := managerutil.GetEnv(ctx).MutatorWebhookPort
@@ -228,7 +239,7 @@ func ServeMutator(ctx context.Context, g log.Group, injectorCertGetter InjectorC
 // regardless of which mode created the listening process).
 func ServeNodeAgentUninstall(ctx context.Context, reapNodeAgentJobs NodeAgentReaper) error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/uninstall", uninstallHandler(nil, reapNodeAgentJobs))
+	mux.HandleFunc("/uninstall", uninstallHandlerWithContext(ctx, nil, reapNodeAgentJobs))
 	mux.HandleFunc("/healthz", healthzHandler)
 
 	port := managerutil.GetEnv(ctx).MutatorWebhookPort

--- a/cmd/traffic/cmd/manager/mutator/service_test.go
+++ b/cmd/traffic/cmd/manager/mutator/service_test.go
@@ -1,15 +1,31 @@
 package mutator
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admission "k8s.io/api/admission/v1"
 
 	"github.com/telepresenceio/telepresence/v2/pkg/errcat"
 )
+
+type contextRecordingInjector struct {
+	uninstallContext context.Context
+}
+
+func (*contextRecordingInjector) Inject(context.Context, *admission.AdmissionRequest) (PatchOps, error) {
+	return nil, nil
+}
+
+func (i *contextRecordingInjector) Uninstall(ctx context.Context) {
+	i.uninstallContext = ctx
+}
 
 func TestApplyMutatorError(t *testing.T) {
 	t.Run("user error is admitted with a warning", func(t *testing.T) {
@@ -41,4 +57,20 @@ func TestApplyMutatorError(t *testing.T) {
 			assert.Equal(t, err.Error(), resp.Result.Message)
 		}
 	})
+}
+
+func TestUninstallHandlerUsesManagerContext(t *testing.T) {
+	type contextKey struct{}
+	managerCtx := context.WithValue(context.Background(), contextKey{}, "manager")
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodDelete, "/uninstall", nil).WithContext(requestCtx)
+	injector := &contextRecordingInjector{}
+
+	recorder := httptest.NewRecorder()
+	uninstallHandlerWithContext(managerCtx, injector, nil)(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, injector.uninstallContext)
+	assert.NoError(t, injector.uninstallContext.Err())
+	assert.Equal(t, "manager", injector.uninstallContext.Value(contextKey{}))
 }

--- a/cmd/traffic/cmd/manager/mutator/watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/watcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -52,13 +53,57 @@ type Map interface {
 }
 
 type configWatcher struct {
-	cancel       context.CancelFunc
-	agentConfigs *xsync.Map[string, map[string]*agentconfig.Sidecar]
-	informers    *xsync.Map[string, *informersWithCancel]
-	inactivePods *xsync.Map[types.UID, inactivation]
-	startedAt    time.Time
-	configured   atomic.Bool
-	running      atomic.Bool
+	cancel         context.CancelFunc
+	agentConfigs   *xsync.Map[string, map[string]*agentconfig.Sidecar]
+	informers      *xsync.Map[string, *informersWithCancel]
+	inactivePods   *xsync.Map[types.UID, inactivation]
+	evictionStates *xsync.Map[WorkloadKey, *workloadEvictionState]
+	startedAt      time.Time
+	configured     atomic.Bool
+	running        atomic.Bool
+}
+
+type workloadEvictionState struct {
+	sync.Mutex
+	replacementPending bool
+}
+
+func (c *configWatcher) lockEvictionState(key WorkloadKey) *workloadEvictionState {
+	for {
+		state, _ := c.evictionStates.LoadOrCompute(key, func() (*workloadEvictionState, bool) {
+			return &workloadEvictionState{}, false
+		})
+		state.Lock()
+		if current, ok := c.evictionStates.Load(key); ok && current == state {
+			return state
+		}
+		state.Unlock()
+	}
+}
+
+func (c *configWatcher) deleteEvictionState(key WorkloadKey) {
+	for {
+		state, ok := c.evictionStates.Load(key)
+		if !ok {
+			return
+		}
+		state.Lock()
+		if current, ok := c.evictionStates.Load(key); ok && current == state {
+			c.evictionStates.Delete(key)
+			state.Unlock()
+			return
+		}
+		state.Unlock()
+	}
+}
+
+func (c *configWatcher) deleteNamespaceEvictionStates(namespace string) {
+	c.evictionStates.Range(func(key WorkloadKey, _ *workloadEvictionState) bool {
+		if key.Namespace == namespace {
+			c.deleteEvictionState(key)
+		}
+		return true
+	})
 }
 
 type mapKey struct{}
@@ -244,10 +289,11 @@ func (c *configWatcher) Store(sc *agentconfig.Sidecar) {
 
 func NewWatcher() Map {
 	w := &configWatcher{
-		cancel:       func() {},
-		informers:    xsync.NewMap[string, *informersWithCancel](),
-		inactivePods: xsync.NewMap[types.UID, inactivation](),
-		agentConfigs: xsync.NewMap[string, map[string]*agentconfig.Sidecar](),
+		cancel:         func() {},
+		informers:      xsync.NewMap[string, *informersWithCancel](),
+		inactivePods:   xsync.NewMap[types.UID, inactivation](),
+		evictionStates: xsync.NewMap[WorkloadKey, *workloadEvictionState](),
+		agentConfigs:   xsync.NewMap[string, map[string]*agentconfig.Sidecar](),
 	}
 	return w
 }
@@ -526,19 +572,22 @@ func (c *configWatcher) DeleteMapsAndRolloutAll(ctx context.Context) {
 
 func (c *configWatcher) deleteMapsAndRolloutNS(ctx context.Context, ns string, iwc *informersWithCancel) {
 	defer func() {
+		iwc.cancel()
 		c.informers.Delete(ns)
+		c.deleteNamespaceEvictionStates(ns)
 		informer.DropFactory(ctx, ns)
 	}()
 
-	clog.Debugf(ctx, "Cancelling watchers for namespace %s", ns)
+	clog.Debugf(ctx, "Removing workload handlers for namespace %s", ns)
 	for i := 0; i < watcherMax; i++ {
 		if reg := iwc.eventRegs[i]; reg != nil {
 			_ = iwc.informers[i].RemoveEventHandler(reg)
 		}
 	}
-	iwc.cancel()
 
-	err := c.EvictAllPodsWithAgentConfig(ctx, ns)
+	// Keep the informer caches live until every replacement is ready. The normal event-driven
+	// reconciliation path is unavailable after the handlers above are removed.
+	err := c.evictAllPodsWithAgentConfigAndWait(ctx, ns)
 	if err != nil {
 		clog.Errorf(ctx, "unable to delete agents in namespace %s: %v", ns, err)
 	}

--- a/cmd/traffic/cmd/manager/mutator/workload_watcher.go
+++ b/cmd/traffic/cmd/manager/mutator/workload_watcher.go
@@ -18,6 +18,14 @@ import (
 )
 
 func (c *configWatcher) watchWorkloads(ctx context.Context, ix cache.SharedIndexInformer) (cache.ResourceEventHandlerRegistration, error) {
+	deleteWorkload := func(wl k8sapi.Workload) {
+		c.Delete(wl.GetName(), wl.GetNamespace())
+		c.deleteEvictionState(WorkloadKey{
+			Name:      wl.GetName(),
+			Namespace: wl.GetNamespace(),
+			Kind:      wl.GetKind(),
+		})
+	}
 	return ix.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
@@ -28,11 +36,11 @@ func (c *configWatcher) watchWorkloads(ctx context.Context, ix cache.SharedIndex
 			DeleteFunc: func(obj any) {
 				if wl, ok := workload.FromAny(obj); ok {
 					if len(wl.GetOwnerReferences()) == 0 {
-						c.Delete(wl.GetName(), wl.GetNamespace())
+						deleteWorkload(wl)
 					}
 				} else if dfsu, ok := obj.(*cache.DeletedFinalStateUnknown); ok {
 					if wl, ok = workload.FromAny(dfsu.Obj); ok && len(wl.GetOwnerReferences()) == 0 {
-						c.Delete(wl.GetName(), wl.GetNamespace())
+						deleteWorkload(wl)
 					}
 				}
 			},
@@ -60,7 +68,10 @@ func (c *configWatcher) updateWorkload(ctx context.Context, wl, oldWl k8sapi.Wor
 		cmpopts.IgnoreMapEntries(func(k, _ string) bool {
 			return k == annotation.RestartedAt
 		})) {
-		return
+		if !workloadUpdateInProgress(oldWl) || workloadUpdateInProgress(wl) {
+			return
+		}
+		clog.Debugf(ctx, "Reconciling agent config after %s finished updating", wl)
 	}
 
 	switch ia {


### PR DESCRIPTION
## Description

Pod eviction and agent teardown can overlap an active workload rollout. The current path can reset that rollout, start another eviction before the replacement is ready, or stop reconciliation when the original hook context is canceled.

This tracks eviction state per workload, defers eviction while a rollout is active, waits for recovery before moving to the next pod, and keeps teardown reconciliation alive long enough to finish. It also serializes eviction work so concurrent updates cannot race the same workload.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/mutator -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.