### PR TITLE
Support Service intercepts across multiple workloads

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -44,6 +44,20 @@ items:
           pod creation cannot corrupt the cached config or block a workload
           rollout.
       - type: feature
+        title: HTTP intercepts can follow every workload selected by one Service
+        body: >-
+          A Kubernetes Service can route requests to more than one workload,
+          such as stable and canary Deployments, while an intercept previously
+          followed only the workload named by the user. HTTP intercepts
+          without <code>--replace</code> now let each selected workload
+          participate in one logical intercept, so filtered traffic reaches
+          the same local handler regardless of which selected workload
+          receives it. If the selected workloads or their traffic-agents
+          cannot support shared interception, Telepresence warns and keeps
+          the historical single-workload behavior instead of failing the
+          intercept.
+        docs: reference/attachments/cli
+      - type: feature
         title: Guided traffic-manager setup with telepresence setup
         body: >-
           The new <code>telepresence setup</code> command analyzes the

--- a/cmd/traffic/cmd/agent/agent.go
+++ b/cmd/traffic/cmd/agent/agent.go
@@ -260,6 +260,50 @@ func TalkToManagerLoop(ctx context.Context, s State, info *rpc.AgentInfo) {
 	}
 }
 
+func advertisedInterceptTargets(ac *agentconfig.Sidecar) []*rpc.AgentInfo_InterceptTarget {
+	interceptTargets := make([]*rpc.AgentInfo_InterceptTarget, 0)
+	seenTargets := make(map[string]struct{})
+	for _, cn := range ac.Containers {
+		for _, ic := range cn.Intercepts {
+			if ic.ServiceUID == "" {
+				continue
+			}
+			key := fmt.Sprintf("%s/%d/%s/%s/%d",
+				ic.ServiceUID, ic.ServicePort, ic.Protocol, cn.Name, ic.ContainerPort)
+			if _, ok := seenTargets[key]; ok {
+				continue
+			}
+			seenTargets[key] = struct{}{}
+			interceptTargets = append(interceptTargets, &rpc.AgentInfo_InterceptTarget{
+				ServiceUid:      string(ic.ServiceUID),
+				ServiceName:     ic.ServiceName,
+				ServicePortName: ic.ServicePortName,
+				ServicePort:     int32(ic.ServicePort),
+				Protocol:        ic.Protocol.String(),
+				ContainerName:   cn.Name,
+				ContainerPort:   int32(ic.ContainerPort),
+			})
+		}
+	}
+	sort.Slice(interceptTargets, func(i, j int) bool {
+		a, b := interceptTargets[i], interceptTargets[j]
+		if a.ServiceUid != b.ServiceUid {
+			return a.ServiceUid < b.ServiceUid
+		}
+		if a.ServicePort != b.ServicePort {
+			return a.ServicePort < b.ServicePort
+		}
+		if a.Protocol != b.Protocol {
+			return a.Protocol < b.Protocol
+		}
+		if a.ContainerName != b.ContainerName {
+			return a.ContainerName < b.ContainerName
+		}
+		return a.ContainerPort < b.ContainerPort
+	})
+	return interceptTargets
+}
+
 func StartServices(g log.Group, config Config, srv State) (*rpc.AgentInfo, error) {
 	ac := config.AgentConfig()
 
@@ -340,6 +384,7 @@ func StartServices(g log.Group, config Config, srv State) (*rpc.AgentInfo, error
 			Mounts:      appMounts.ToRPC(),
 		}
 	}
+	interceptTargets := advertisedInterceptTargets(ac)
 
 	return &rpc.AgentInfo{
 		Name:      ac.AgentName,
@@ -367,7 +412,8 @@ func StartServices(g log.Group, config Config, srv State) (*rpc.AgentInfo, error
 				Version: version.Version,
 			},
 		},
-		Containers: containers,
+		Containers:       containers,
+		InterceptTargets: interceptTargets,
 	}, nil
 }
 

--- a/cmd/traffic/cmd/agent/fwdstate.go
+++ b/cmd/traffic/cmd/agent/fwdstate.go
@@ -86,12 +86,23 @@ func (pm *ProviderMux) CreateClientStream(ctx context.Context, tag tunnel.Tag, s
 	return pm.AgentProvider.CreateClientStream(ctx, tag, sessionID, id, roundTripLatency, dialTimeout)
 }
 
+// containerForIntercept returns the local container that should review and
+// serve an intercept. A service-scoped intercept can be shared by workloads
+// whose matching containers have different names, so the matched forwarder
+// target wins over the primary workload's container name in that case.
+func (fs *fwdState) containerForIntercept(spec *manager.InterceptSpec) string {
+	if spec.ServiceUid != "" && fs.intercept.MatchForSpec(spec) {
+		return fs.container
+	}
+	if spec.ContainerName != "" {
+		return spec.ContainerName
+	}
+	return fs.container
+}
+
 // processWiretapIntercept handles wiretap intercepts which can always be active alongside others.
 func (fs *fwdState) processWiretapIntercept(ii *manager.InterceptInfo) *manager.ReviewInterceptRequest {
-	container := ii.Spec.ContainerName
-	if container == "" {
-		container = fs.container
-	}
+	container := fs.containerForIntercept(ii.Spec)
 	cs := fs.containerStates[container]
 	if cs == nil {
 		return &manager.ReviewInterceptRequest{
@@ -158,10 +169,7 @@ func (fs *fwdState) processRegularIntercept(
 	}
 
 	// No conflict detected, allow this intercept to become active
-	container := ii.Spec.ContainerName
-	if container == "" {
-		container = fs.container
-	}
+	container := fs.containerForIntercept(ii.Spec)
 	cs := fs.containerStates[container]
 	if cs == nil {
 		return &manager.ReviewInterceptRequest{

--- a/cmd/traffic/cmd/agent/fwdstate_test.go
+++ b/cmd/traffic/cmd/agent/fwdstate_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
+)
+
+func TestContainerForInterceptUsesMatchedServiceTarget(t *testing.T) {
+	fs := &fwdState{
+		intercept: agentconfig.NewInterceptTarget([]*agentconfig.Intercept{{
+			ServiceUID:    k8sTypes.UID("service-uid"),
+			ServicePort:   80,
+			Protocol:      types.ProtoTCP,
+			ContainerPort: 8080,
+		}}),
+		container: "canary-app",
+	}
+
+	require.Equal(t, "canary-app", fs.containerForIntercept(&rpc.InterceptSpec{
+		ServiceUid:    "service-uid",
+		ServicePort:   80,
+		Protocol:      "TCP",
+		ContainerName: "primary-app",
+	}))
+	require.Equal(t, "primary-app", fs.containerForIntercept(&rpc.InterceptSpec{
+		ContainerName: "primary-app",
+	}))
+}

--- a/cmd/traffic/cmd/agent/service_targets_test.go
+++ b/cmd/traffic/cmd/agent/service_targets_test.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
+)
+
+func TestAdvertisedInterceptTargets(t *testing.T) {
+	ac := &agentconfig.Sidecar{Containers: []*agentconfig.Container{{
+		Name: "app",
+		Intercepts: []*agentconfig.Intercept{
+			{
+				ServiceUID:      k8sTypes.UID("shared-service"),
+				ServiceName:     "app",
+				ServicePortName: "http",
+				ServicePort:     80,
+				Protocol:        types.ProtoTCP,
+				ContainerPort:   8080,
+			},
+			{
+				// Duplicates are intentionally omitted from AgentInfo.
+				ServiceUID:      k8sTypes.UID("shared-service"),
+				ServiceName:     "app",
+				ServicePortName: "http",
+				ServicePort:     80,
+				Protocol:        types.ProtoTCP,
+				ContainerPort:   8080,
+			},
+			{
+				// Container-only targets are still workload-scoped.
+				Protocol:      types.ProtoTCP,
+				ContainerPort: 9090,
+			},
+		},
+	}}}
+
+	require.Equal(t, []*rpc.AgentInfo_InterceptTarget{{
+		ServiceUid:      "shared-service",
+		ServiceName:     "app",
+		ServicePortName: "http",
+		ServicePort:     80,
+		Protocol:        "TCP",
+		ContainerName:   "app",
+		ContainerPort:   8080,
+	}}, advertisedInterceptTargets(ac))
+}

--- a/cmd/traffic/cmd/manager/service.go
+++ b/cmd/traffic/cmd/manager/service.go
@@ -696,7 +696,7 @@ func (s *service) watchAgentPods(ctx context.Context, namespaces []string, strea
 				Namespace:    a.Namespace,
 				PodIp:        aip.AsSlice(),
 				ApiPort:      a.ApiPort,
-				Intercepted:  s.state.IsInterceptedBy(a.Name, a.Namespace, clientSessionID),
+				Intercepted:  s.state.IsInterceptedBy(a, clientSessionID),
 				NodeAgent:    a.NodeAgent,
 				QuicSni:      quicSNIForAgent(a.QuicPort, a.PodUid),
 			}
@@ -797,7 +797,7 @@ func (p *agentPodProjection) run(ctx context.Context, sessionDone <-chan struct{
 						Namespace:    a.Namespace,
 						PodIp:        aip.AsSlice(),
 						ApiPort:      a.ApiPort,
-						Intercepted:  p.s.state.IsInterceptedBy(a.Name, a.Namespace, p.clientSessionID),
+						Intercepted:  p.s.state.IsInterceptedBy(a, p.clientSessionID),
 						NodeAgent:    a.NodeAgent,
 						QuicSni:      quicSNIForAgent(a.QuicPort, a.PodUid),
 						Version:      a.Version,
@@ -820,7 +820,8 @@ func (p *agentPodProjection) refreshIntercepted() {
 		if p.m.IsInactive(types.UID(a.PodId)) {
 			return true
 		}
-		intercepted := p.s.state.IsInterceptedBy(a.WorkloadName, a.Namespace, p.clientSessionID)
+		agent := p.s.state.GetAgent(tunnel.SessionID(state.AgentSessionIDPrefix + a.PodId))
+		intercepted := p.s.state.IsInterceptedBy(agent, p.clientSessionID)
 		p.agentPodInfos.Compute(k, func(a *rpc.AgentPodInfo, loaded bool) (*rpc.AgentPodInfo, xsync.ComputeOp) {
 			if loaded && a.Intercepted != intercepted {
 				a := proto.Clone(a).(*rpc.AgentPodInfo)
@@ -974,10 +975,75 @@ func (s *service) WatchAgentsDelta(session *rpc.SessionInfo, stream grpc.ServerS
 	}
 }
 
+// filterInterceptDeltas keeps a per-subscriber view of matching intercepts.
+// Unlike cache.Map's stateless filter, it emits a removal when an updated
+// intercept stops matching, which is required when a Service selector prunes
+// a participant that previously received the intercept.
+func filterInterceptDeltas(
+	ctx context.Context,
+	source <-chan cache.Delta[string, *state.Intercept],
+	include func(string, *state.Intercept) bool,
+) <-chan cache.Delta[string, *state.Intercept] {
+	filtered := make(chan cache.Delta[string, *state.Intercept], 1)
+	go func() {
+		defer close(filtered)
+		included := make(map[string]*state.Intercept)
+		initialized := false
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case delta, ok := <-source:
+				if !ok {
+					return
+				}
+				next := cache.Delta[string, *state.Intercept]{}
+				for id := range delta.Removals {
+					if previous, exists := included[id]; exists {
+						if next.Removals == nil {
+							next.Removals = make(map[string]*state.Intercept)
+						}
+						next.Removals[id] = previous
+						delete(included, id)
+					}
+				}
+				for id, intercept := range delta.Upserts {
+					if include == nil || include(id, intercept) {
+						if next.Upserts == nil {
+							next.Upserts = make(map[string]*state.Intercept)
+						}
+						next.Upserts[id] = intercept
+						included[id] = intercept
+						continue
+					}
+					if previous, exists := included[id]; exists {
+						if next.Removals == nil {
+							next.Removals = make(map[string]*state.Intercept)
+						}
+						next.Removals[id] = previous
+						delete(included, id)
+					}
+				}
+				if initialized && len(next.Upserts) == 0 && len(next.Removals) == 0 {
+					continue
+				}
+				initialized = true
+				select {
+				case <-ctx.Done():
+					return
+				case filtered <- next:
+				}
+			}
+		}
+	}()
+	return filtered
+}
+
 func (s *service) watchIntercepts(ctx context.Context, session *rpc.SessionInfo) (<-chan cache.Delta[string, *state.Intercept], <-chan struct{}, error) {
 	sessionID := tunnel.SessionID(session.GetSessionId())
 	var sessionDone <-chan struct{}
 	var filter func(id string, info *state.Intercept) bool
+	participantAwareFilter := false
 	if sessionID == "" {
 		filter = func(id string, info *state.Intercept) bool {
 			return info.Disposition != rpc.InterceptDispositionType_REMOVED && !state.IsChildIntercept(info.Spec)
@@ -993,7 +1059,7 @@ func (s *service) watchIntercepts(ctx context.Context, session *rpc.SessionInfo)
 				return nil, nil, err
 			}
 			filter = func(id string, info *state.Intercept) bool {
-				if info.Spec.Namespace != agent.Namespace || info.Spec.Agent != agent.Name {
+				if !state.AgentMatchesInterceptInfo(agent.AgentInfo, info) {
 					// Don't return intercepts for different agents.
 					return false
 				}
@@ -1015,6 +1081,7 @@ func (s *service) watchIntercepts(ctx context.Context, session *rpc.SessionInfo)
 					return false
 				}
 			}
+			participantAwareFilter = true
 		} else {
 			// sessionID refers to a client session.
 			client := s.state.GetClient(sessionID)
@@ -1032,6 +1099,9 @@ func (s *service) watchIntercepts(ctx context.Context, session *rpc.SessionInfo)
 		}
 	}
 
+	if participantAwareFilter {
+		return filterInterceptDeltas(ctx, s.state.WatchIntercepts(ctx, nil), filter), sessionDone, nil
+	}
 	return s.state.WatchIntercepts(ctx, filter), sessionDone, nil
 }
 
@@ -1394,31 +1464,7 @@ func (s *service) ReviewIntercept(ctx context.Context, rIReq *rpc.ReviewIntercep
 
 	s.removeExcludedEnvVars(rIReq.Environment)
 
-	intercept := s.state.UpdateIntercept(ceptID, func(intercept *state.Intercept) {
-		// Sanity check: The reviewing agent must be an agent for the intercept.
-		if intercept.Spec.Namespace != agent.Namespace || intercept.Spec.Agent != agent.Name {
-			return
-		}
-		if mutator.GetMap(ctx).IsInactive(types.UID(agent.PodUid)) {
-			clog.Debugf(ctx, "Pod %s(%s) is blacklisted", agent.PodName, agent.PodIp)
-			return
-		}
-
-		// Only update intercepts in the waiting or no agent states.  Agents race to review an intercept, but we
-		// expect they will always produce compatible answers.
-		if intercept.Disposition == rpc.InterceptDispositionType_NO_AGENT || intercept.Disposition == rpc.InterceptDispositionType_WAITING {
-			intercept.Disposition = rIReq.Disposition
-			intercept.Message = rIReq.Message
-			intercept.PodIp = rIReq.PodIp
-			intercept.PodName = agent.PodName
-			intercept.FtpPort = rIReq.FtpPort
-			intercept.SftpPort = rIReq.SftpPort
-			intercept.MountPoint = rIReq.MountPoint
-			intercept.MechanismArgsDesc = rIReq.MechanismArgsDesc
-			intercept.Environment = rIReq.Environment
-			intercept.Mounts = rIReq.Mounts
-		}
-	})
+	intercept := s.state.ApplyAgentReview(ctx, ceptID, agent, rIReq)
 
 	if intercept == nil {
 		return nil, status.Errorf(codes.NotFound, "Intercept with ID %q not found for this session", ceptID)

--- a/cmd/traffic/cmd/manager/service_intercept_filter_test.go
+++ b/cmd/traffic/cmd/manager/service_intercept_filter_test.go
@@ -1,0 +1,44 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/state"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
+)
+
+func TestFilterInterceptDeltasRemovesInterceptThatStopsMatching(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	source := make(chan cache.Delta[string, *state.Intercept], 2)
+	filtered := filterInterceptDeltas(ctx, source, func(_ string, intercept *state.Intercept) bool {
+		return intercept.Spec.Agent == "selected"
+	})
+	selected := &state.Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:   "client:intercept",
+		Spec: &rpc.InterceptSpec{Agent: "selected"},
+	}}
+	source <- cache.Delta[string, *state.Intercept]{
+		Upserts: map[string]*state.Intercept{selected.Id: selected},
+	}
+	first := <-filtered
+	require.Contains(t, first.Upserts, selected.Id)
+	require.Empty(t, first.Removals)
+
+	dropped := &state.Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:   selected.Id,
+		Spec: &rpc.InterceptSpec{Agent: "dropped"},
+	}}
+	source <- cache.Delta[string, *state.Intercept]{
+		Upserts: map[string]*state.Intercept{dropped.Id: dropped},
+	}
+	second := <-filtered
+	require.Empty(t, second.Upserts)
+	require.Contains(t, second.Removals, selected.Id)
+	require.Same(t, selected, second.Removals[selected.Id])
+}

--- a/cmd/traffic/cmd/manager/service_sessionevents_test.go
+++ b/cmd/traffic/cmd/manager/service_sessionevents_test.go
@@ -289,6 +289,7 @@ func TestWatchSessionEvents_InterceptedFlipsOnActiveIntercept(t *testing.T) {
 			Mechanism: "tcp",
 		},
 		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		PodIp:         helloAgent.PodIp,
 		ClientSession: aliceSess,
 	}
 	mgr.State().RestoreIntercepts(svcCtx, []*rpc.InterceptInfo{aliceIntercept}, time.Now())

--- a/cmd/traffic/cmd/manager/state/intercept.go
+++ b/cmd/traffic/cmd/manager/state/intercept.go
@@ -249,6 +249,364 @@ func serviceIPs(ctx context.Context, serviceName, namespace string) (ips [][]byt
 	return ips
 }
 
+func servicePodIsRelevant(pod *core.Pod) bool {
+	// The shared pod informer deliberately strips Status.Conditions. Service
+	// discovery still needs every selector-matching pod that has not started
+	// deleting so it can detect pod-only labels and resolve current owners.
+	return pod.DeletionTimestamp == nil
+}
+
+func sidecarClaimsService(sc *agentconfig.Sidecar, spec *rpc.InterceptSpec) bool {
+	for _, container := range sc.Containers {
+		for _, target := range container.Intercepts {
+			if string(target.ServiceUID) != spec.ServiceUid || target.Protocol.String() != spec.Protocol {
+				continue
+			}
+			if spec.ServicePort > 0 && int32(target.ServicePort) == spec.ServicePort {
+				return true
+			}
+			if spec.ServicePort == 0 && spec.ServicePortName != "" && target.ServicePortName == spec.ServicePortName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sortedServiceWorkloads(workloads map[string]k8sapi.Workload) []k8sapi.Workload {
+	keys := make([]string, 0, len(workloads))
+	for key := range workloads {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]k8sapi.Workload, len(keys))
+	for i, key := range keys {
+		result[i] = workloads[key]
+	}
+	return result
+}
+
+func addServiceWorkload(workloads map[string]k8sapi.Workload, workload k8sapi.Workload) {
+	workloads[participantKey(workload.GetNamespace(), string(workload.GetKind()), workload.GetName())] = workload
+}
+
+var (
+	errServicePodOnlySelection        = errors.New("service selects only individual pods from a workload")
+	errServicePodOwnerUnrepresentable = errors.New("service selects a pod without a supported workload owner")
+	errServiceIdentityChanged         = errors.New("service is missing or changed identity")
+	errServiceSelectorless            = errors.New("service has no selector")
+)
+
+// discoverServiceWorkloads finds both selector-matching workload templates
+// and current selected pod owners. The former keeps scaled-to-zero and
+// starting workloads from escaping when they later become ready. A workload
+// selected only by labels on one of its pods cannot be expanded safely,
+// because agent configuration is shared by every pod in that workload.
+func discoverServiceWorkloads(ctx context.Context, spec *rpc.InterceptSpec) ([]k8sapi.Workload, bool, error) {
+	if !serviceScopedIntercept(spec) || spec.ServiceName == "" {
+		return nil, false, nil
+	}
+
+	f := informer.GetFactory(ctx, spec.Namespace)
+	if f == nil {
+		return nil, false, nil
+	}
+	kf := f.GetK8sInformerFactory()
+	svc, err := kf.Core().V1().Services().Lister().Services(spec.Namespace).Get(spec.ServiceName)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return nil, true, fmt.Errorf("%w: service %s.%s no longer exists",
+				errServiceIdentityChanged, spec.ServiceName, spec.Namespace)
+		}
+		return nil, true, err
+	}
+	if string(svc.UID) != spec.ServiceUid {
+		return nil, true, fmt.Errorf("%w: service %s.%s changed identity while preparing intercept",
+			errServiceIdentityChanged, spec.ServiceName, spec.Namespace)
+	}
+	if len(svc.Spec.Selector) == 0 {
+		return nil, true, fmt.Errorf("%w: service %s.%s has no selector",
+			errServiceSelectorless, spec.ServiceName, spec.Namespace)
+	}
+
+	selector := labels.SelectorFromSet(svc.Spec.Selector)
+	enabledKinds := managerutil.GetEnv(ctx).EnabledWorkloadKinds
+	workloads := make(map[string]k8sapi.Workload)
+	addTemplate := func(workload k8sapi.Workload) {
+		if hasValidReplicasetOwner(workload, enabledKinds) {
+			return
+		}
+		if workload.GetKind() == k8sapi.DeploymentKind &&
+			agentmap.TrafficManagerSelector.Matches(labels.Set(workload.GetLabels())) {
+			return
+		}
+		if selector.Matches(labels.Set(workload.GetPodTemplate().Labels)) {
+			addServiceWorkload(workloads, workload)
+		}
+	}
+
+	ai := kf.Apps().V1()
+	for _, kind := range enabledKinds {
+		switch kind {
+		case k8sapi.DeploymentKind:
+			deployments, err := ai.Deployments().Lister().Deployments(spec.Namespace).List(labels.Everything())
+			if err != nil {
+				return nil, true, err
+			}
+			for _, deployment := range deployments {
+				addTemplate(k8sapi.Deployment(deployment))
+			}
+		case k8sapi.ReplicaSetKind:
+			replicaSets, err := ai.ReplicaSets().Lister().ReplicaSets(spec.Namespace).List(labels.Everything())
+			if err != nil {
+				return nil, true, err
+			}
+			for _, replicaSet := range replicaSets {
+				addTemplate(k8sapi.ReplicaSet(replicaSet))
+			}
+		case k8sapi.StatefulSetKind:
+			statefulSets, err := ai.StatefulSets().Lister().StatefulSets(spec.Namespace).List(labels.Everything())
+			if err != nil {
+				return nil, true, err
+			}
+			for _, statefulSet := range statefulSets {
+				addTemplate(k8sapi.StatefulSet(statefulSet))
+			}
+		case k8sapi.RolloutKind:
+			ri := f.GetArgoRolloutsInformerFactory().Argoproj().V1alpha1().Rollouts()
+			rollouts, err := ri.Lister().Rollouts(spec.Namespace).List(labels.Everything())
+			if err != nil {
+				return nil, true, err
+			}
+			for _, rollout := range rollouts {
+				addTemplate(k8sapi.Rollout(rollout))
+			}
+		}
+	}
+
+	pods, err := kf.Core().V1().Pods().Lister().Pods(spec.Namespace).List(selector)
+	if err != nil {
+		return nil, true, err
+	}
+	for _, pod := range pods {
+		if !servicePodIsRelevant(pod) {
+			continue
+		}
+		workload, err := agentmap.FindOwnerWorkload(ctx, k8sapi.Pod(pod), enabledKinds)
+		if err != nil {
+			var ownerNotFound *agentmap.WorkloadOwnerNotFoundError
+			if errors.As(err, &ownerNotFound) {
+				return nil, true, fmt.Errorf("%w: service endpoint pod %s.%s has no supported workload owner: %v",
+					errServicePodOwnerUnrepresentable, pod.Name, pod.Namespace, err)
+			}
+			return nil, true, fmt.Errorf("unable to resolve workload owner for service endpoint pod %s.%s: %w", pod.Name, pod.Namespace, err)
+		}
+		if !selector.Matches(labels.Set(workload.GetPodTemplate().Labels)) {
+			return nil, true, fmt.Errorf("%w: service endpoint pod %s.%s belongs to %s whose pod template does not match the Service selector",
+				errServicePodOnlySelection, pod.Name, pod.Namespace, workload)
+		}
+		addServiceWorkload(workloads, workload)
+	}
+	return sortedServiceWorkloads(workloads), true, nil
+}
+
+// serviceWorkloads keeps the explicitly requested workload when informer
+// state is unavailable, preserving single-workload interception.
+func serviceWorkloads(ctx context.Context, spec *rpc.InterceptSpec, primary k8sapi.Workload) ([]k8sapi.Workload, error) {
+	workloads := map[string]k8sapi.Workload{
+		participantKey(primary.GetNamespace(), string(primary.GetKind()), primary.GetName()): primary,
+	}
+	discovered, known, err := discoverServiceWorkloads(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if !known {
+		return sortedServiceWorkloads(workloads), nil
+	}
+	for _, workload := range discovered {
+		addServiceWorkload(workloads, workload)
+	}
+	return sortedServiceWorkloads(workloads), nil
+}
+
+// checkServiceWorkloadConflicts resolves the target container for a
+// secondary workload without changing its stored agent config. This must run
+// before shared-Service expansion changes ReplacePolicyContainer to
+// ReplacePolicyIntercept and restarts pods.
+func (s *State) checkServiceWorkloadConflicts(
+	ctx context.Context,
+	spec *rpc.InterceptSpec,
+	workload k8sapi.Workload,
+	client *ClientSession,
+) error {
+	return s.checkServiceWorkloadConflictsIgnoring(ctx, spec, workload, client, "")
+}
+
+func (s *State) checkServiceWorkloadConflictsIgnoring(
+	ctx context.Context,
+	spec *rpc.InterceptSpec,
+	workload k8sapi.Workload,
+	client *ClientSession,
+	ignoredInterceptID string,
+) error {
+	if client == nil {
+		return fmt.Errorf("client session is unavailable")
+	}
+	agentImage := managerutil.GetAgentImage(ctx)
+	if err := s.ValidateAgentImage(agentImage, s.isExtended(spec)); err != nil {
+		return err
+	}
+	var config *agentconfig.Sidecar
+	if mm := mutator.GetMap(ctx); mm != nil {
+		config = mm.Get(workload.GetName(), workload.GetNamespace())
+	}
+	if config == nil || !sidecarClaimsService(config, spec) {
+		var err error
+		config, err = s.createAgentConfig(ctx, workload, agentImage)
+		if err != nil {
+			return err
+		}
+	}
+	secondarySpec := proto.Clone(spec).(*rpc.InterceptSpec)
+	// Different selected workloads can use different container names for the
+	// same Service target. Resolve the secondary workload's own container.
+	secondarySpec.ContainerName = ""
+	_, ic, err := config.FindIntercept(
+		secondarySpec.ServiceName,
+		secondarySpec.ContainerName,
+		types.PortIdentifier(secondarySpec.PortIdentifier),
+	)
+	if err != nil {
+		return err
+	}
+	_, containerPorts, err := checkPortConsistency(config, nil, ic, secondarySpec)
+	if err != nil {
+		return err
+	}
+	conflictSpec := proto.Clone(secondarySpec).(*rpc.InterceptSpec)
+	conflictSpec.ServiceUid = string(ic.ServiceUID)
+	conflictSpec.ServicePortName = ic.ServicePortName
+	conflictSpec.ServicePort = int32(ic.ServicePort)
+	conflictSpec.Protocol = ic.Protocol.String()
+	conflictSpec.ContainerPort = int32(ic.ContainerPort)
+	return s.checkInterceptConflictsIgnoring(config, client, containerPorts, conflictSpec, ignoredInterceptID)
+}
+
+func serviceWorkloadInfos(workloads []k8sapi.Workload) []*rpc.InterceptWorkload {
+	infos := make([]*rpc.InterceptWorkload, len(workloads))
+	for i, workload := range workloads {
+		infos[i] = &rpc.InterceptWorkload{
+			Namespace:    workload.GetNamespace(),
+			WorkloadKind: string(workload.GetKind()),
+			WorkloadName: workload.GetName(),
+		}
+	}
+	return infos
+}
+
+func fallbackToSingleWorkload(ctx context.Context, spec *rpc.InterceptSpec, reason string) {
+	clog.Warnf(ctx, "Shared-Service expansion for %q is unavailable: %s; using only requested workload %q",
+		spec.ServiceName, reason, spec.Agent)
+	spec.ServiceUid = ""
+	spec.ServicePortName = ""
+	spec.ServicePort = 0
+}
+
+func (s *State) ensureServiceWorkloads(
+	ctx context.Context,
+	spec *rpc.InterceptSpec,
+	primary k8sapi.Workload,
+	primaryConfig *agentconfig.Sidecar,
+	primaryAgents []*AgentSession,
+	rp agentconfig.ReplacePolicy,
+	client *ClientSession,
+) []*rpc.InterceptWorkload {
+	if !serviceScopedIntercept(spec) {
+		return nil
+	}
+	if spec.Replace || spec.Mechanism != "http" {
+		fallbackToSingleWorkload(ctx, spec, "shared interception requires the http mechanism without --replace")
+		return nil
+	}
+
+	workloads, err := serviceWorkloads(ctx, spec, primary)
+	if err != nil {
+		fallbackToSingleWorkload(ctx, spec, err.Error())
+		return nil
+	}
+	if len(workloads) <= 1 {
+		return serviceWorkloadInfos(workloads)
+	}
+
+	configWorkloads := make(map[string]k8sapi.Workload, len(workloads))
+	for _, workload := range workloads {
+		if workload.GetName() == primary.GetName() && workload.GetKind() == primary.GetKind() {
+			continue
+		}
+		if err = s.checkServiceWorkloadConflicts(ctx, spec, workload, client); err != nil {
+			fallbackToSingleWorkload(ctx, spec,
+				fmt.Sprintf("workload %s conflicts with an existing intercept: %v", workload, err))
+			return nil
+		}
+		configWorkloads[participantKey(workload.GetNamespace(), string(workload.GetKind()), workload.GetName())] = workload
+	}
+
+	for _, workload := range workloads {
+		config := primaryConfig
+		agents := primaryAgents
+		if workload.GetName() != primary.GetName() || workload.GetKind() != primary.GetKind() {
+			configWorkload := configWorkloads[participantKey(workload.GetNamespace(), string(workload.GetKind()), workload.GetName())]
+			if k8sapi.ReadyReplicas(workload) == 0 {
+				config, err = s.getOrCreateAgentConfig(ctx, configWorkload, s.isExtended(spec), false, spec, rp)
+				if err == nil {
+					err = mutator.GetMap(ctx).EvictPodsWithAgentConfigMismatch(ctx, workload, config)
+				}
+				agents = nil
+			} else {
+				config, agents, err = s.ensureAgent(ctx, configWorkload, s.isExtended(spec), false, spec, rp)
+			}
+			if err != nil {
+				fallbackToSingleWorkload(ctx, spec,
+					fmt.Sprintf("unable to ensure agent for workload %s: %v", workload, err))
+				return nil
+			}
+		}
+		if !sidecarClaimsService(config, spec) {
+			fallbackToSingleWorkload(ctx, spec,
+				fmt.Sprintf("agent config for workload %s does not claim the selected Service target", workload))
+			return nil
+		}
+		currentAgents := s.LoadMatchingAgents(func(_ tunnel.SessionID, agent *AgentSession) bool {
+			return agent.Namespace == workload.GetNamespace() &&
+				agent.Kind == string(workload.GetKind()) &&
+				agent.Name == workload.GetName()
+		})
+		if len(currentAgents) > 0 {
+			agents = agents[:0]
+			for _, agent := range currentAgents {
+				agents = append(agents, agent)
+			}
+			sortAgents(agents)
+		}
+		if len(agents) == 0 && k8sapi.ReadyReplicas(workload) == 0 {
+			continue
+		}
+		allClaim := len(agents) > 0
+		for _, agent := range agents {
+			if !agentClaimsService(agent.AgentInfo, spec) {
+				allClaim = false
+				break
+			}
+		}
+		if !allClaim {
+			fallbackToSingleWorkload(ctx, spec,
+				fmt.Sprintf("not every agent for workload %s advertises the selected Service target", workload))
+			return nil
+		}
+	}
+	return serviceWorkloadInfos(workloads)
+}
+
 func prepareAllContainerPorts(cn *agentconfig.Container, pi *rpc.PreparedIntercept) {
 	pics := agentconfig.PortUniqueIntercepts(cn)
 	if ni := len(pics); ni > 0 {
@@ -303,7 +661,13 @@ func (s *State) checkInterceptConsistency(
 	if err != nil {
 		return err
 	}
-	err = s.checkInterceptConflicts(ac, client, containerPorts, spec)
+	conflictSpec := proto.Clone(spec).(*rpc.InterceptSpec)
+	conflictSpec.ServiceUid = string(ic.ServiceUID)
+	conflictSpec.ServicePortName = ic.ServicePortName
+	conflictSpec.ServicePort = int32(ic.ServicePort)
+	conflictSpec.Protocol = ic.Protocol.String()
+	conflictSpec.ContainerPort = int32(ic.ContainerPort)
+	err = s.checkInterceptConflicts(ac, client, containerPorts, conflictSpec)
 	if err != nil {
 		return err
 	}
@@ -366,13 +730,115 @@ func checkPortConsistency(
 }
 
 func (s *State) checkInterceptConflicts(ac *agentconfig.Sidecar, client *ClientSession, containerPorts []types.PortAndProto, spec *rpc.InterceptSpec) error {
+	return s.checkInterceptConflictsIgnoring(ac, client, containerPorts, spec, "")
+}
+
+// serviceParticipantPotentialConflict reports whether an existing shared
+// Service intercept occupies one of the requested ports in this sidecar's
+// workload. The logical intercept stores the primary workload's resolved
+// container port, but a secondary workload can route the same Service port to
+// a different container port.
+func serviceParticipantPotentialConflict(
+	ac *agentconfig.Sidecar,
+	containerPorts []types.PortAndProto,
+	intercept *Intercept,
+) bool {
+	if !serviceScopedIntercept(intercept.Spec) || intercept.Spec.Wiretap {
+		return false
+	}
+	switch intercept.Disposition {
+	case rpc.InterceptDispositionType_ACTIVE, rpc.InterceptDispositionType_WAITING, rpc.InterceptDispositionType_NO_AGENT:
+	default:
+		return false
+	}
+
+	workloadName := ac.WorkloadName
+	if workloadName == "" {
+		workloadName = ac.AgentName
+	}
+	workloadKind := string(ac.WorkloadKind)
+	matchesWorkload := func(namespace, kind, name string) bool {
+		return namespace == ac.Namespace && name == workloadName &&
+			(workloadKind == "" || kind == "" || kind == workloadKind)
+	}
+	participant := false
+	if len(intercept.participants) > 0 {
+		for _, candidate := range intercept.participants {
+			if matchesWorkload(candidate.namespace, candidate.kind, candidate.name) {
+				participant = true
+				break
+			}
+		}
+	} else {
+		for _, candidate := range intercept.ServiceWorkloads {
+			if candidate != nil && matchesWorkload(candidate.Namespace, candidate.WorkloadKind, candidate.WorkloadName) {
+				participant = true
+				break
+			}
+		}
+	}
+	if !participant {
+		return false
+	}
+
+	portName := intercept.Spec.ServicePortName
+	if portName == "" && intercept.Spec.ServicePort > 0 {
+		portName = fmt.Sprintf("%d", intercept.Spec.ServicePort)
+	}
+	portID, err := types.NewPortIdentifier(
+		types.FromK8sProtocol(core.Protocol(intercept.Spec.Protocol)),
+		portName,
+	)
+	if err != nil {
+		return false
+	}
+	_, target, err := ac.FindIntercept(intercept.Spec.ServiceName, "", portID)
+	if err != nil {
+		return false
+	}
+	if !servicePortMatches(&rpc.AgentInfo_InterceptTarget{
+		ServiceUid:      string(target.ServiceUID),
+		ServicePortName: target.ServicePortName,
+		ServicePort:     int32(target.ServicePort),
+		Protocol:        target.Protocol.String(),
+	}, intercept.Spec) {
+		return false
+	}
+	targetPort := types.PortAndProto{Proto: target.Protocol, Port: target.ContainerPort}
+	for _, containerPort := range containerPorts {
+		if containerPort == targetPort {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *State) checkInterceptConflictsIgnoring(
+	ac *agentconfig.Sidecar,
+	client *ClientSession,
+	containerPorts []types.PortAndProto,
+	spec *rpc.InterceptSpec,
+	ignoredInterceptID string,
+) error {
 	if spec.Wiretap {
 		// A wiretap intercept is never in conflict with any other intercept.
 		return nil
 	}
 
 	// Validate that there's no port conflict with other intercepts using the same agent.
-	potentialConflicts := s.intercepts.LoadMatching(func(s string, info *Intercept) bool {
+	potentialConflicts := s.intercepts.LoadMatching(func(id string, info *Intercept) bool {
+		if id == ignoredInterceptID {
+			return false
+		}
+		if serviceScopesOverlap(spec, info.Spec) {
+			switch info.Disposition {
+			case rpc.InterceptDispositionType_ACTIVE, rpc.InterceptDispositionType_WAITING, rpc.InterceptDispositionType_NO_AGENT:
+				return !info.Spec.Wiretap
+			}
+		}
+		if serviceParticipantPotentialConflict(ac, containerPorts, info) {
+			return true
+		}
 		return icept.PotentialConflict(ac.AgentName, ac.Namespace, containerPorts, info.InterceptInfo)
 	})
 	if len(potentialConflicts) == 0 {
@@ -414,6 +880,16 @@ func (s *State) checkInterceptConflicts(ac *agentconfig.Sidecar, client *ClientS
 	return nil
 }
 
+func serviceScopesOverlap(a, b *rpc.InterceptSpec) bool {
+	if !serviceScopedIntercept(a) || !serviceScopedIntercept(b) || a.ServiceUid != b.ServiceUid || a.Protocol != b.Protocol {
+		return false
+	}
+	if a.ServicePort > 0 && b.ServicePort > 0 {
+		return a.ServicePort == b.ServicePort
+	}
+	return a.ServicePortName != "" && a.ServicePortName == b.ServicePortName
+}
+
 func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptRequest) (*ClientSession, *rpc.InterceptInfo, error) {
 	clientSession := cir.Session
 	sessionID := tunnel.SessionID(clientSession.SessionId)
@@ -438,6 +914,9 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 	if spec.Replace {
 		rp = agentconfig.ReplacePolicyContainer
 	}
+	var primaryConfig *agentconfig.Sidecar
+	var primaryAgents []*AgentSession
+	var serviceWorkloads []*rpc.InterceptWorkload
 	if spec.NodeAgent {
 		// PrepareIntercept already provisioned the node-agent Job. Running
 		// the injecting ensureAgent here would inject a sidecar and restart
@@ -448,14 +927,22 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		if _, err = s.waitForNodeAgent(ctx, wl.GetName(), wl.GetNamespace()); err != nil {
 			return nil, nil, err
 		}
+		if serviceScopedIntercept(spec) {
+			// Node-agent intercepts target the pod selected during
+			// PrepareIntercept. They cannot provision the other workloads
+			// behind a shared Service, so don't let existing sidecars make
+			// this intercept appear partially service-scoped.
+			fallbackToSingleWorkload(ctx, spec, "node-agent intercepts target only the requested workload")
+		}
 	} else {
-		_, _, err = s.ensureAgent(ctx, wl, s.isExtended(spec), false, spec, rp)
+		primaryConfig, primaryAgents, err = s.ensureAgent(ctx, wl, s.isExtended(spec), false, spec, rp)
 		if err != nil {
 			return nil, nil, err
 		}
+		serviceWorkloads = s.ensureServiceWorkloads(ctx, spec, wl, primaryConfig, primaryAgents, rp, client)
 	}
 
-	is, err := s.addIntercept(interceptID, cir)
+	is, err := s.addIntercept(interceptID, cir, serviceWorkloads)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -488,7 +975,7 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		pmSpec.Client = fmt.Sprintf("child %s %s %s", pm, spec.Name, spec.Client)
 
 		pmInterceptID := fmt.Sprintf("%s:%s", sessionID, pmSpec.Name)
-		_, err = s.addIntercept(pmInterceptID, pmCir)
+		_, err = s.addIntercept(pmInterceptID, pmCir, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -520,6 +1007,9 @@ func (s *State) AddIntercept(ctx context.Context, cir *rpc.CreateInterceptReques
 		// has stored it.
 		s.startNodeAgentPodWatch(spec.Agent, spec.Namespace)
 	}
+	if serviceScopedIntercept(spec) {
+		s.startServiceInterceptWatch(interceptID)
+	}
 
 	agentType := "sidecar"
 	if spec.NodeAgent {
@@ -541,8 +1031,10 @@ func (s *State) GetParentIntercept(sessionID tunnel.SessionID, spec *rpc.Interce
 	return s.intercepts.Load(fmt.Sprintf("%s:%s", sessionID, childCols[2]))
 }
 
-func (s *State) addIntercept(id string, cir *rpc.CreateInterceptRequest) (*Intercept, error) {
+func (s *State) addIntercept(id string, cir *rpc.CreateInterceptRequest, serviceWorkloads []*rpc.InterceptWorkload) (*Intercept, error) {
 	is := s.NewInterceptInfo(id, cir)
+	is.ServiceWorkloads = serviceWorkloads
+	s.initializeParticipants(is)
 
 	// Wrap each potential-state-change in an
 	//
@@ -870,13 +1362,18 @@ func (s *State) GetOrGenerateAgentConfig(ctx context.Context, name, namespace st
 	return s.getOrCreateAgentConfig(ctx, wl, false, true, nil, agentconfig.ReplacePolicyInactive)
 }
 
-func (s *State) createAgentConfig(ctx context.Context, wl k8sapi.Workload, agentImage string) (*agentconfig.Sidecar, error) {
+func (s *State) generateAgentConfig(
+	ctx context.Context,
+	wl k8sapi.Workload,
+	agentImage string,
+	existing *agentconfig.Sidecar,
+) (*agentconfig.Sidecar, error) {
 	gc, err := managerutil.GetEnv(ctx).GeneratorConfig(agentImage)
 	if err != nil {
 		return nil, err
 	}
 	clog.Debugf(ctx, "generating new agent config for %s", wl)
-	sc, err := gc.Generate(ctx, wl, nil)
+	sc, err := gc.Generate(ctx, wl, existing)
 	if err != nil {
 		return nil, err
 	}
@@ -884,6 +1381,10 @@ func (s *State) createAgentConfig(ctx context.Context, wl k8sapi.Workload, agent
 		return nil, err
 	}
 	return sc, nil
+}
+
+func (s *State) createAgentConfig(ctx context.Context, wl k8sapi.Workload, agentImage string) (*agentconfig.Sidecar, error) {
+	return s.generateAgentConfig(ctx, wl, agentImage, nil)
 }
 
 func (s *State) getOrCreateAgentConfig(
@@ -920,6 +1421,12 @@ func (s *State) getOrCreateAgentConfig(
 			// If the agentImage has changed, and the extended image is requested, then update
 			if sc.AgentImage != agentImage {
 				sc.AgentImage = agentImage
+			}
+			if serviceScopedIntercept(spec) && !sidecarClaimsService(sc, spec) {
+				sc, err = s.generateAgentConfig(ctx, wl, agentImage, sc)
+				if err != nil {
+					return nil, err
+				}
 			}
 			clog.Debugf(ctx, "found existing agent config for %s", wl)
 		} else {

--- a/cmd/traffic/cmd/manager/state/intercept_test.go
+++ b/cmd/traffic/cmd/manager/state/intercept_test.go
@@ -724,8 +724,10 @@ func TestWaitForAgents_AccumulatesToExpectedCount(t *testing.T) {
 }
 
 // TestAddIntercept_NodeAgent_ReportsAttach verifies that a successful
-// node-agent AddIntercept emits a "manager.attach" usage report carrying
-// agent.type=node and the intercept's mechanism.
+// node-agent AddIntercept stays scoped to its requested workload even when
+// PrepareIntercept supplied a shared-Service target, and emits a
+// "manager.attach" usage report carrying agent.type=node and the intercept's
+// mechanism.
 func TestAddIntercept_NodeAgent_ReportsAttach(t *testing.T) {
 	t.Parallel()
 
@@ -781,25 +783,38 @@ func TestAddIntercept_NodeAgent_ReportsAttach(t *testing.T) {
 
 	// The node-agent Job's own agent session is already registered by the
 	// time AddIntercept waits for it, mirroring waitForAgents' immediate-wait
-	// property exercised elsewhere in this file.
-	s.agents.Store(sessionID, &AgentSession{AgentInfo: &rpc.AgentInfo{
-		Name: "test-agent", Namespace: ns, NodeAgent: true, PodUid: "uid-1", PodName: "test-agent-abc123",
-	}})
+	// property exercised elsewhere in this file. A sidecar for another
+	// workload already claims the same Service target; it must not join this
+	// requested-workload-only node-agent intercept.
+	nodeAgent := serviceAgent("test-agent", "test-agent-abc123", "10.0.0.1")
+	nodeAgent.NodeAgent = true
+	s.agents.Store(sessionID, nodeAgent)
+	sibling := serviceAgent("test-agent-canary", "test-agent-canary-abc123", "10.0.0.2")
+	s.agents.Store(tunnel.SessionID("sibling"), sibling)
 
 	cir := &rpc.CreateInterceptRequest{
 		Session: &rpc.SessionInfo{SessionId: string(sessionID)},
 		InterceptSpec: &rpc.InterceptSpec{
 			Name: "ic1", Client: "userA@hostA", Agent: "test-agent", Namespace: ns,
-			WorkloadKind: string(k8sapi.DeploymentKind), NodeAgent: true, Wiretap: true, Mechanism: "tcp",
+			WorkloadKind: string(k8sapi.DeploymentKind), NodeAgent: true, Wiretap: true, Mechanism: "http",
+			ServiceUid: "shared-service-uid", ServiceName: "example-service", ServicePort: 80, Protocol: "TCP",
 		},
 	}
 	_, ii, err := s.AddIntercept(ctx, cir)
 	require.NoError(t, err)
 	require.NotNil(t, ii)
+	require.False(t, serviceScopedIntercept(ii.Spec))
+	require.Empty(t, ii.Spec.ServiceUid)
+	require.Zero(t, ii.Spec.ServicePort)
+	require.Empty(t, ii.Spec.ServicePortName)
+	require.Equal(t, "example-service", ii.Spec.ServiceName)
+	require.Empty(t, ii.ServiceWorkloads)
+	require.True(t, AgentMatchesIntercept(nodeAgent.AgentInfo, ii.Spec))
+	require.False(t, AgentMatchesIntercept(sibling.AgentInfo, ii.Spec))
 
 	reports := sink.Drain(0)
 	require.Len(t, reports, 1)
 	assert.Equal(t, "manager.attach", reports[0].Topic)
 	assert.Equal(t, "node", reports[0].Entries["agent.type"])
-	assert.Equal(t, "tcp", reports[0].Entries["mechanism"])
+	assert.Equal(t, "http", reports[0].Entries["mechanism"])
 }

--- a/cmd/traffic/cmd/manager/state/service_intercept.go
+++ b/cmd/traffic/cmd/manager/state/service_intercept.go
@@ -1,0 +1,550 @@
+package state
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/telepresenceio/clog"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+)
+
+// interceptParticipant tracks one workload that must approve a service-scoped
+// intercept before the logical intercept can become active. A workload may
+// have many agent pods, but one approving pod is sufficient because all pods
+// receive the active intercept snapshot.
+type interceptParticipant struct {
+	namespace string
+	kind      string
+	name      string
+	podName   string
+	review    *rpc.ReviewInterceptRequest
+}
+
+func (p *interceptParticipant) clone() *interceptParticipant {
+	cp := &interceptParticipant{
+		namespace: p.namespace,
+		kind:      p.kind,
+		name:      p.name,
+		podName:   p.podName,
+	}
+	if p.review != nil {
+		cp.review = proto.Clone(p.review).(*rpc.ReviewInterceptRequest)
+	}
+	return cp
+}
+
+func participantKey(namespace, kind, name string) string {
+	return namespace + "/" + kind + "/" + name
+}
+
+func agentParticipantKey(agent *rpc.AgentInfo) string {
+	return participantKey(agent.Namespace, agent.Kind, agent.Name)
+}
+
+func serviceScopedIntercept(spec *rpc.InterceptSpec) bool {
+	return spec != nil && spec.ServiceUid != "" && (spec.ServicePort > 0 || spec.ServicePortName != "")
+}
+
+func servicePortMatches(target *rpc.AgentInfo_InterceptTarget, spec *rpc.InterceptSpec) bool {
+	if target.ServiceUid != spec.ServiceUid || target.Protocol != spec.Protocol {
+		return false
+	}
+	if spec.ServicePort > 0 {
+		return target.ServicePort == spec.ServicePort
+	}
+	return target.ServicePortName == spec.ServicePortName
+}
+
+func agentClaimsService(agent *rpc.AgentInfo, spec *rpc.InterceptSpec) bool {
+	for _, target := range agent.InterceptTargets {
+		if servicePortMatches(target, spec) {
+			return true
+		}
+	}
+	return false
+}
+
+func allAgentsMatchIntercept(agents []*rpc.AgentInfo, spec *rpc.InterceptSpec) bool {
+	for _, agent := range agents {
+		if !AgentMatchesIntercept(agent, spec) {
+			return false
+		}
+	}
+	return true
+}
+
+// AgentMatchesIntercept reports whether an agent is eligible to receive and
+// review an intercept. Workload-scoped intercepts match by requested workload
+// name. Service-backed intercepts match advertised Service UID and port claims.
+func AgentMatchesIntercept(agent *rpc.AgentInfo, spec *rpc.InterceptSpec) bool {
+	if agent == nil || spec == nil || agent.Namespace != spec.Namespace {
+		return false
+	}
+	if !serviceScopedIntercept(spec) {
+		return agent.Name == spec.Agent
+	}
+	if agentClaimsService(agent, spec) {
+		return true
+	}
+	// Agents with no advertised targets match only the requested workload.
+	return len(agent.InterceptTargets) == 0 && agent.Name == spec.Agent
+}
+
+// AgentMatchesInterceptInfo reports whether an agent both matches an
+// intercept's target and belongs to its current participant set. Service
+// selectors can drop a workload while an old agent still advertises the
+// Service target, so delivery must use the participant-aware predicate.
+func AgentMatchesInterceptInfo(agent *rpc.AgentInfo, intercept *Intercept) bool {
+	if intercept == nil || !AgentMatchesIntercept(agent, intercept.Spec) {
+		return false
+	}
+	if !serviceScopedIntercept(intercept.Spec) {
+		return true
+	}
+	_, ok := intercept.participants[agentParticipantKey(agent)]
+	return ok
+}
+
+func participantsEqual(a, b map[string]*interceptParticipant) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, ap := range a {
+		bp, ok := b[key]
+		if !ok || ap.namespace != bp.namespace || ap.kind != bp.kind || ap.name != bp.name ||
+			ap.podName != bp.podName || !proto.Equal(ap.review, bp.review) {
+			return false
+		}
+	}
+	return true
+}
+
+func (is *Intercept) cloneParticipants() map[string]*interceptParticipant {
+	if len(is.participants) == 0 {
+		return nil
+	}
+	participants := make(map[string]*interceptParticipant, len(is.participants))
+	for key, participant := range is.participants {
+		participants[key] = participant.clone()
+	}
+	return participants
+}
+
+func (s *State) initializeParticipants(intercept *Intercept) {
+	if !serviceScopedIntercept(intercept.Spec) {
+		return
+	}
+	intercept.participants = make(map[string]*interceptParticipant)
+	// Restored intercepts already carry the workload identities that took
+	// part before the manager restarted. Seed those first so a reconnecting
+	// client cannot observe an empty participant set while agents are
+	// arriving again.
+	for _, workload := range intercept.ServiceWorkloads {
+		if workload == nil || workload.WorkloadName == "" {
+			continue
+		}
+		key := participantKey(workload.Namespace, workload.WorkloadKind, workload.WorkloadName)
+		intercept.participants[key] = &interceptParticipant{
+			namespace: workload.Namespace,
+			kind:      workload.WorkloadKind,
+			name:      workload.WorkloadName,
+		}
+	}
+	persistedKeys := make([]string, 0, len(intercept.participants))
+	for key := range intercept.participants {
+		persistedKeys = append(persistedKeys, key)
+	}
+	// Persisted intercepts may not carry ServiceWorkloads. The
+	// explicitly requested workload is safe to restore, but newly observed
+	// secondary workloads must wait for watcher preflight before joining.
+	primaryKey := participantKey(intercept.Spec.Namespace, intercept.Spec.WorkloadKind, intercept.Spec.Agent)
+	if _, ok := intercept.participants[primaryKey]; !ok {
+		intercept.participants[primaryKey] = &interceptParticipant{
+			namespace: intercept.Spec.Namespace,
+			kind:      intercept.Spec.WorkloadKind,
+			name:      intercept.Spec.Agent,
+		}
+	}
+	// On restore, RestoreAgents runs before RestoreIntercepts, so use the
+	// recorded pod to reconnect the published review to its workload before
+	// current selection can prune it. Without a matching restored agent, only
+	// a single persisted participant (or a snapshot with none) is safe
+	// to infer; otherwise wait for fresh reviews instead of guessing.
+	hasPublishedPod := intercept.PodName != "" || intercept.PodIp != ""
+	publishedKey := ""
+	if hasPublishedPod {
+		s.EachAgent(func(_ tunnel.SessionID, agent *AgentSession) bool {
+			if agent.Namespace != intercept.Spec.Namespace ||
+				(intercept.PodName != "" && agent.PodName != intercept.PodName) ||
+				(intercept.PodName == "" && intercept.PodIp != "" && agent.PodIp != intercept.PodIp) {
+				return true
+			}
+			key := agentParticipantKey(agent.AgentInfo)
+			if _, ok := intercept.participants[key]; ok {
+				publishedKey = key
+			}
+			return true
+		})
+		if publishedKey == "" {
+			switch len(persistedKeys) {
+			case 0:
+				publishedKey = primaryKey
+			case 1:
+				publishedKey = persistedKeys[0]
+			}
+		}
+	} else if published := intercept.publishedServiceParticipant(); published != nil {
+		publishedKey = participantKey(published.namespace, published.kind, published.name)
+	}
+	publishedUnknown := hasPublishedPod && publishedKey == ""
+	prunedPublished := false
+	for _, key := range s.staleServiceParticipantKeys(intercept) {
+		prunedPublished = prunedPublished || key == publishedKey
+		delete(intercept.participants, key)
+	}
+	if !prunedPublished && !publishedUnknown && intercept.PodName != "" {
+		if participant, ok := intercept.participants[publishedKey]; ok {
+			participant.podName = intercept.PodName
+		}
+	}
+	intercept.syncServiceWorkloads()
+	if prunedPublished || publishedUnknown {
+		intercept.reselectServiceReview()
+	}
+}
+
+func (is *Intercept) addParticipant(agent *rpc.AgentInfo) *interceptParticipant {
+	key := agentParticipantKey(agent)
+	if participant, ok := is.participants[key]; ok {
+		return participant
+	}
+	participant := &interceptParticipant{
+		namespace: agent.Namespace,
+		kind:      agent.Kind,
+		name:      agent.Name,
+	}
+	if is.participants == nil {
+		is.participants = make(map[string]*interceptParticipant)
+	}
+	is.participants[key] = participant
+	is.syncServiceWorkloads()
+	return participant
+}
+
+func (is *Intercept) syncServiceWorkloads() {
+	if len(is.participants) == 0 {
+		is.ServiceWorkloads = nil
+		return
+	}
+	keys := is.participantKeys()
+	workloads := make([]*rpc.InterceptWorkload, 0, len(keys))
+	for _, key := range keys {
+		participant := is.participants[key]
+		workloads = append(workloads, &rpc.InterceptWorkload{
+			Namespace:    participant.namespace,
+			WorkloadKind: participant.kind,
+			WorkloadName: participant.name,
+		})
+	}
+	is.ServiceWorkloads = workloads
+}
+
+func (is *Intercept) pendingParticipants() []string {
+	pending := make([]string, 0, len(is.participants))
+	for _, participant := range is.participants {
+		if participant.review == nil {
+			pending = append(pending, participant.name)
+		}
+	}
+	sort.Strings(pending)
+	return pending
+}
+
+func (is *Intercept) participantKeys() []string {
+	keys := make([]string, 0, len(is.participants))
+	for key := range is.participants {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *State) agentsByParticipant(intercept *Intercept) map[string][]*rpc.AgentInfo {
+	groups := make(map[string][]*rpc.AgentInfo)
+	if !serviceScopedIntercept(intercept.Spec) {
+		key := participantKey(intercept.Spec.Namespace, intercept.Spec.WorkloadKind, intercept.Spec.Agent)
+		s.EachAgent(func(_ tunnel.SessionID, agent *AgentSession) bool {
+			if AgentMatchesIntercept(agent.AgentInfo, intercept.Spec) {
+				groups[key] = append(groups[key], agent.AgentInfo)
+			}
+			return true
+		})
+		return groups
+	}
+
+	for key := range intercept.participants {
+		groups[key] = nil
+	}
+	s.EachAgent(func(_ tunnel.SessionID, agent *AgentSession) bool {
+		key := agentParticipantKey(agent.AgentInfo)
+		if _, ok := intercept.participants[key]; ok {
+			groups[key] = append(groups[key], agent.AgentInfo)
+		}
+		return true
+	})
+	return groups
+}
+
+func serviceParticipantsFromWorkloads(workloads []k8sapi.Workload) map[string]*interceptParticipant {
+	selected := make(map[string]*interceptParticipant)
+	for _, workload := range workloads {
+		key := participantKey(workload.GetNamespace(), string(workload.GetKind()), workload.GetName())
+		selected[key] = &interceptParticipant{
+			namespace: workload.GetNamespace(),
+			kind:      string(workload.GetKind()),
+			name:      workload.GetName(),
+		}
+	}
+	return selected
+}
+
+func (s *State) selectedServiceParticipants(intercept *Intercept) (map[string]*interceptParticipant, bool) {
+	workloads, known, err := discoverServiceWorkloads(s.backgroundCtx, intercept.Spec)
+	if err != nil {
+		clog.Debugf(s.backgroundCtx, "Unable to reconcile participants for intercept %q: %v", intercept.Id, err)
+		return nil, false
+	}
+	if !known {
+		return nil, false
+	}
+	return serviceParticipantsFromWorkloads(workloads), true
+}
+
+// staleServiceParticipantKeys retains zero-agent workloads only while their
+// templates still match the Service selector.
+func (s *State) staleServiceParticipantKeys(intercept *Intercept) []string {
+	if !serviceScopedIntercept(intercept.Spec) || len(intercept.participants) == 0 {
+		return nil
+	}
+	selected, selectionKnown := s.selectedServiceParticipants(intercept)
+	return s.staleServiceParticipantKeysWithSelection(intercept, selected, selectionKnown)
+}
+
+func (s *State) staleServiceParticipantKeysWithSelection(
+	intercept *Intercept,
+	selected map[string]*interceptParticipant,
+	selectionKnown bool,
+) []string {
+	if !serviceScopedIntercept(intercept.Spec) || len(intercept.participants) == 0 {
+		return nil
+	}
+	present := make(map[string]bool)
+	matching := make(map[string]bool)
+	s.EachAgent(func(_ tunnel.SessionID, agent *AgentSession) bool {
+		key := agentParticipantKey(agent.AgentInfo)
+		if _, ok := intercept.participants[key]; !ok {
+			return true
+		}
+		present[key] = true
+		if AgentMatchesIntercept(agent.AgentInfo, intercept.Spec) {
+			matching[key] = true
+		}
+		return true
+	})
+
+	stale := make(map[string]struct{})
+	for key := range intercept.participants {
+		if selectionKnown {
+			if _, ok := selected[key]; !ok {
+				stale[key] = struct{}{}
+			}
+			continue
+		}
+		if present[key] && !matching[key] {
+			stale[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(stale))
+	for key := range stale {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// reconcileServiceParticipants prunes workloads that no longer belong to the
+// Service. Newly selected workloads are added only by the Service watcher
+// after it has preflighted the exact selection snapshot.
+func (s *State) reconcileServiceParticipants(interceptID string, intercept *Intercept) *Intercept {
+	selected, selectionKnown := s.selectedServiceParticipants(intercept)
+	return s.reconcileServiceParticipantsWithSelection(interceptID, intercept, selected, selectionKnown, false)
+}
+
+func (s *State) reconcileServiceParticipantsWithSelection(
+	interceptID string,
+	intercept *Intercept,
+	selected map[string]*interceptParticipant,
+	selectionKnown bool,
+	allowAdds bool,
+) *Intercept {
+	stale := s.staleServiceParticipantKeysWithSelection(intercept, selected, selectionKnown)
+	missing := false
+	if allowAdds && selectionKnown {
+		for key := range selected {
+			if _, ok := intercept.participants[key]; !ok {
+				missing = true
+				break
+			}
+		}
+	}
+	if !missing && len(stale) == 0 {
+		return intercept
+	}
+	return s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+		added := false
+		published := intercept.publishedServiceParticipant()
+		publishedKey := ""
+		if published != nil {
+			publishedKey = participantKey(published.namespace, published.kind, published.name)
+		}
+		if allowAdds && selectionKnown {
+			for key, participant := range selected {
+				if _, ok := intercept.participants[key]; !ok {
+					intercept.participants[key] = participant
+					added = true
+				}
+			}
+		}
+		prunedPublished := false
+		for _, key := range s.staleServiceParticipantKeysWithSelection(intercept, selected, selectionKnown) {
+			prunedPublished = prunedPublished || key == publishedKey
+			delete(intercept.participants, key)
+		}
+		intercept.syncServiceWorkloads()
+		if prunedPublished {
+			intercept.reselectServiceReview()
+		} else if added && intercept.Disposition == rpc.InterceptDispositionType_ACTIVE {
+			intercept.Disposition = rpc.InterceptDispositionType_WAITING
+			intercept.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s",
+				strings.Join(intercept.pendingParticipants(), ", "))
+		}
+	})
+}
+
+func (is *Intercept) publishedServiceParticipant() *interceptParticipant {
+	if is.PodName != "" {
+		for _, participant := range is.participants {
+			if participant.podName == is.PodName {
+				return participant
+			}
+		}
+	}
+	if is.PodIp != "" {
+		for _, participant := range is.participants {
+			if participant.review != nil && participant.review.PodIp == is.PodIp {
+				return participant
+			}
+		}
+	}
+	if is.Disposition == rpc.InterceptDispositionType_ACTIVE {
+		return is.primaryParticipant()
+	}
+	return nil
+}
+
+func clearPublishedReview(intercept *Intercept) {
+	intercept.PodIp = ""
+	intercept.PodName = ""
+	intercept.ApiPort = 0
+	intercept.FtpPort = 0
+	intercept.SftpPort = 0
+	intercept.MountPoint = ""
+	intercept.MechanismArgsDesc = ""
+	intercept.Environment = nil
+	intercept.Mounts = nil
+}
+
+func (is *Intercept) reselectServiceReview() {
+	pending := is.pendingParticipants()
+	if len(pending) > 0 {
+		clearPublishedReview(is)
+		is.Disposition = rpc.InterceptDispositionType_WAITING
+		is.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s", strings.Join(pending, ", "))
+		return
+	}
+	primary := is.primaryParticipant()
+	if primary == nil || primary.review == nil {
+		clearPublishedReview(is)
+		is.Disposition = rpc.InterceptDispositionType_WAITING
+		is.Message = "Waiting for primary workload Agent approval"
+		return
+	}
+	applyReview(is, primary.review)
+	is.PodName = primary.podName
+	is.Disposition = rpc.InterceptDispositionType_ACTIVE
+	is.Message = ""
+}
+
+func (is *Intercept) primaryParticipant() *interceptParticipant {
+	var first *interceptParticipant
+	for _, participant := range is.participants {
+		if first == nil || participantKey(participant.namespace, participant.kind, participant.name) <
+			participantKey(first.namespace, first.kind, first.name) {
+			first = participant
+		}
+		if participant.namespace == is.Spec.Namespace && participant.name == is.Spec.Agent &&
+			(is.Spec.WorkloadKind == "" || participant.kind == is.Spec.WorkloadKind) {
+			return participant
+		}
+	}
+	return first
+}
+
+func applyReview(intercept *Intercept, review *rpc.ReviewInterceptRequest) {
+	intercept.Disposition = review.Disposition
+	intercept.Message = review.Message
+	intercept.PodIp = review.PodIp
+	intercept.PodName = ""
+	intercept.FtpPort = review.FtpPort
+	intercept.SftpPort = review.SftpPort
+	intercept.MountPoint = review.MountPoint
+	intercept.MechanismArgsDesc = review.MechanismArgsDesc
+	intercept.Environment = review.Environment
+	intercept.Mounts = review.Mounts
+}
+
+func (is *Intercept) applyServiceReview(agent *rpc.AgentInfo, review *rpc.ReviewInterceptRequest) {
+	participant := is.addParticipant(agent)
+	if review.Disposition != rpc.InterceptDispositionType_ACTIVE {
+		applyReview(is, review)
+		if is.Message == "" {
+			is.Message = fmt.Sprintf("Workload %q rejected the intercept", participant.name)
+		}
+		return
+	}
+
+	participant.review = proto.Clone(review).(*rpc.ReviewInterceptRequest)
+	participant.podName = agent.PodName
+	pending := is.pendingParticipants()
+	if len(pending) > 0 {
+		is.Disposition = rpc.InterceptDispositionType_WAITING
+		is.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s", strings.Join(pending, ", "))
+		return
+	}
+
+	primary := is.primaryParticipant()
+	if primary == nil || primary.review == nil {
+		is.Disposition = rpc.InterceptDispositionType_WAITING
+		is.Message = "Waiting for primary workload Agent approval"
+		return
+	}
+	applyReview(is, primary.review)
+	is.PodName = primary.podName
+	is.Disposition = rpc.InterceptDispositionType_ACTIVE
+	is.Message = ""
+}

--- a/cmd/traffic/cmd/manager/state/service_intercept_test.go
+++ b/cmd/traffic/cmd/manager/state/service_intercept_test.go
@@ -1,0 +1,1559 @@
+package state
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/kubernetes/fake"
+
+	argorolloutsfake "github.com/datawire/argo-rollouts-go-client/pkg/client/clientset/versioned/fake"
+	"github.com/telepresenceio/clog"
+	"github.com/telepresenceio/clog/testutil"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/managerutil"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/cache"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/k8sapi"
+	"github.com/telepresenceio/telepresence/v2/pkg/log"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
+)
+
+func newServiceInterceptState(t *testing.T) (context.Context, *State) {
+	t.Helper()
+	ctx := testutil.NewContext(t, false)
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	return ctx, &State{
+		backgroundCtx:            ctx,
+		intercepts:               cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+		agents:                   cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, time.Millisecond),
+		clients:                  xsync.NewMap[tunnel.SessionID, *ClientSession](),
+		workloadWatchers:         xsync.NewMap[string, Watcher](),
+		serviceInterceptWatchers: xsync.NewMap[string, struct{}](),
+		timedLogLevel:            log.NewTimedLevel(slog.LevelDebug, clog.SetTreeLevel),
+		llSubs:                   newLoglevelSubscribers(),
+	}
+}
+
+func serviceAgent(name, podName, podIP string) *AgentSession {
+	return &AgentSession{AgentInfo: &rpc.AgentInfo{
+		Name:      name,
+		Kind:      "Deployment",
+		Namespace: "default",
+		PodName:   podName,
+		PodIp:     podIP,
+		PodUid:    podName + "-uid",
+		Mechanisms: []*rpc.AgentInfo_Mechanism{{
+			Name:    "http",
+			Product: "telepresence",
+			Version: "v2.29.2",
+		}},
+		InterceptTargets: []*rpc.AgentInfo_InterceptTarget{{
+			ServiceUid:  "shared-service-uid",
+			ServiceName: "example-service",
+			ServicePort: 80,
+			Protocol:    "TCP",
+		}},
+	}}
+}
+
+func sharedServiceSpec() *rpc.InterceptSpec {
+	return &rpc.InterceptSpec{
+		Name:         "example-service",
+		Client:       "alice",
+		Agent:        "example-service",
+		WorkloadKind: "Deployment",
+		Namespace:    "default",
+		Mechanism:    "http",
+		ServiceUid:   "shared-service-uid",
+		ServiceName:  "example-service",
+		ServicePort:  80,
+		Protocol:     "TCP",
+	}
+}
+
+func sharedServiceWorkloads(names ...string) []*rpc.InterceptWorkload {
+	workloads := make([]*rpc.InterceptWorkload, len(names))
+	for i, name := range names {
+		workloads[i] = &rpc.InterceptWorkload{
+			Namespace:    "default",
+			WorkloadKind: "Deployment",
+			WorkloadName: name,
+		}
+	}
+	return workloads
+}
+
+func serviceDeployment(name string, labels map[string]string) *apps.Deployment {
+	return &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: apps.DeploymentSpec{
+			Selector: &meta.LabelSelector{MatchLabels: labels},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{Labels: labels},
+				Spec: core.PodSpec{Containers: []core.Container{{
+					Name:  "app",
+					Ports: []core.ContainerPort{{ContainerPort: 8080}},
+				}}},
+			},
+		},
+	}
+}
+
+func serviceDiscoveryContext(t *testing.T, svc *core.Service, deployments ...*apps.Deployment) context.Context {
+	t.Helper()
+	ctx := testutil.NewContext(t, false)
+	ctx = k8sapi.WithJoinedClientSetInterface(ctx, fake.NewSimpleClientset(), argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		ManagerNamespace:     "ambassador",
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind},
+	})
+	f := informer.GetK8sFactory(ctx, "")
+	require.NoError(t, f.Core().V1().Services().Informer().GetStore().Add(svc.DeepCopy()))
+	for _, deployment := range deployments {
+		require.NoError(t, f.Apps().V1().Deployments().Informer().GetStore().Add(deployment.DeepCopy()))
+	}
+	return ctx
+}
+
+func servicePod(name, workload string, labels map[string]string) *core.Pod {
+	controller := true
+	return &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+			OwnerReferences: []meta.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       workload,
+				Controller: &controller,
+			}},
+		},
+	}
+}
+
+func serviceWatchContext(t *testing.T, objects ...runtime.Object) (context.Context, *fake.Clientset) {
+	t.Helper()
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	ctx, cancel := context.WithCancel(testutil.NewContext(t, false))
+	t.Cleanup(cancel)
+	client := fake.NewSimpleClientset(objects...)
+	ctx = k8sapi.WithJoinedClientSetInterface(ctx, client, argorolloutsfake.NewSimpleClientset())
+	ctx = informer.WithFactory(ctx, "")
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		ManagerNamespace:     "ambassador",
+		EnabledWorkloadKinds: k8sapi.Kinds{k8sapi.DeploymentKind},
+	})
+	f := informer.GetK8sFactory(ctx, "")
+	f.Core().V1().Services().Informer()
+	f.Core().V1().Pods().Informer()
+	f.Apps().V1().Deployments().Informer()
+	f.Start(ctx.Done())
+	f.WaitForCacheSync(ctx.Done())
+	return ctx, client
+}
+
+func activeServiceIntercept(t *testing.T, ctx context.Context, st *State, stable, canary *AgentSession) *Intercept {
+	t.Helper()
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_WAITING,
+		ClientSession:    &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name, canary.Name),
+	}}
+	st.initializeParticipants(intercept)
+	st.intercepts.Store(intercept.Id, intercept)
+	intercept = st.ApplyAgentReview(ctx, intercept.Id, stable, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       stable.PodIp,
+	})
+	intercept = st.ApplyAgentReview(ctx, intercept.Id, canary, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       canary.PodIp,
+	})
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, intercept.Disposition)
+	return intercept
+}
+
+func TestCountActiveInterceptsForServiceParticipantWorkload(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+
+	canaryKey := &mutator.WorkloadKey{
+		Name:      canary.Name,
+		Namespace: canary.Namespace,
+		Kind:      k8sapi.DeploymentKind,
+	}
+	require.Equal(t, 1, st.CountActiveInterceptsForWorkload(canaryKey))
+	require.Zero(t, st.CountActiveInterceptsForWorkload(&mutator.WorkloadKey{
+		Name:      "unrelated",
+		Namespace: canary.Namespace,
+		Kind:      k8sapi.DeploymentKind,
+	}))
+
+	st.UpdateIntercept(intercept.Id, func(intercept *Intercept) {
+		intercept.Disposition = rpc.InterceptDispositionType_WAITING
+	})
+	require.Zero(t, st.CountActiveInterceptsForWorkload(canaryKey))
+}
+
+func TestServiceWorkloadsIncludesSelectedTemplateWithoutReadyPod(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+	}
+	ctx := serviceDiscoveryContext(t, svc, stable, canary)
+
+	workloads, err := serviceWorkloads(ctx, sharedServiceSpec(), k8sapi.Deployment(stable))
+	require.NoError(t, err)
+	require.Len(t, workloads, 2)
+	require.Equal(t, "example-service", workloads[0].GetName())
+	require.Equal(t, "example-service-canary", workloads[1].GetName())
+}
+
+func TestServiceInterceptPrunesDroppedSelectorParticipantWithoutAgent(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"track": "stable"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stable, canary), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	stableAgent := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	st.agents.Store("stable", stableAgent)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:   "client:example-service",
+		Spec: sharedServiceSpec(),
+	}}
+	intercept.participants = map[string]*interceptParticipant{
+		participantKey("default", "Deployment", "example-service"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service",
+		},
+		participantKey("default", "Deployment", "example-service-canary"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service-canary",
+		},
+	}
+	intercept.syncServiceWorkloads()
+	st.intercepts.Store(intercept.Id, intercept)
+
+	updated := st.reconcileServiceParticipants(intercept.Id, intercept)
+	require.Len(t, updated.participants, 1)
+	require.Contains(t, updated.participants, participantKey("default", "Deployment", "example-service"))
+	require.NotContains(t, updated.participants, participantKey("default", "Deployment", "example-service-canary"))
+	require.Len(t, updated.ServiceWorkloads, 1)
+}
+
+func TestServiceInterceptFallsBackWhenServiceIdentityChanges(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		delete bool
+	}{
+		{name: "deleted", delete: true},
+		{name: "recreated"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+			canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+			svc := &core.Service{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "example-service",
+					Namespace: "default",
+					UID:       k8sTypes.UID("shared-service-uid"),
+				},
+				Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+			}
+			ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+			_, st := newServiceInterceptState(t)
+			st.backgroundCtx = ctx
+			stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+			canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+			intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+			require.True(t, st.IsInterceptedBy(canary, "client"))
+
+			serviceStore := informer.GetK8sFactory(ctx, "").Core().V1().Services().Informer().GetStore()
+			if tt.delete {
+				require.NoError(t, serviceStore.Delete(svc.DeepCopy()))
+			} else {
+				recreated := svc.DeepCopy()
+				recreated.UID = k8sTypes.UID("replacement-service-uid")
+				require.NoError(t, serviceStore.Update(recreated))
+			}
+
+			st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+			updated, ok := st.intercepts.Load(intercept.Id)
+			require.True(t, ok)
+			require.False(t, serviceScopedIntercept(updated.Spec))
+			require.Empty(t, updated.Spec.ServiceUid)
+			require.Empty(t, updated.participants)
+			require.Empty(t, updated.ServiceWorkloads)
+			require.False(t, st.IsInterceptedBy(canary, "client"))
+		})
+	}
+}
+
+func TestServiceInterceptFallsBackWhenServiceBecomesSelectorless(t *testing.T) {
+	stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+	require.True(t, st.IsInterceptedBy(canary, "client"))
+
+	selectorless := svc.DeepCopy()
+	selectorless.Spec.Selector = nil
+	serviceStore := informer.GetK8sFactory(ctx, "").Core().V1().Services().Informer().GetStore()
+	require.NoError(t, serviceStore.Update(selectorless))
+
+	st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.False(t, serviceScopedIntercept(updated.Spec))
+	require.Empty(t, updated.Spec.ServiceUid)
+	require.Empty(t, updated.participants)
+	require.Empty(t, updated.ServiceWorkloads)
+	require.True(t, st.IsInterceptedBy(stable, "client"))
+	require.False(t, st.IsInterceptedBy(canary, "client"))
+}
+
+func TestServiceInterceptFallbackRequeuesHealthyPrimary(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		disposition rpc.InterceptDispositionType
+	}{
+		{name: "no agent", disposition: rpc.InterceptDispositionType_NO_AGENT},
+		{name: "agent error", disposition: rpc.InterceptDispositionType_AGENT_ERROR},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+			canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+			svc := &core.Service{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "example-service",
+					Namespace: "default",
+					UID:       k8sTypes.UID("shared-service-uid"),
+				},
+				Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+			}
+			ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+			_, st := newServiceInterceptState(t)
+			st.backgroundCtx = ctx
+			stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+			canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+			intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+			st.UpdateIntercept(intercept.Id, func(intercept *Intercept) {
+				intercept.Disposition = tt.disposition
+				intercept.Message = "Secondary workload did not approve"
+			})
+
+			selectorless := svc.DeepCopy()
+			selectorless.Spec.Selector = nil
+			serviceStore := informer.GetK8sFactory(ctx, "").Core().V1().Services().Informer().GetStore()
+			require.NoError(t, serviceStore.Update(selectorless))
+
+			st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+			updated, ok := st.intercepts.Load(intercept.Id)
+			require.True(t, ok)
+			require.False(t, serviceScopedIntercept(updated.Spec))
+			require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+			require.Equal(t, "Waiting for Agent approval", updated.Message)
+			require.True(t, AgentMatchesInterceptInfo(stable.AgentInfo, updated))
+			require.False(t, AgentMatchesInterceptInfo(canary.AgentInfo, updated))
+
+			updated = st.ApplyAgentReview(ctx, intercept.Id, stable, &rpc.ReviewInterceptRequest{
+				Disposition: rpc.InterceptDispositionType_ACTIVE,
+				PodIp:       stable.PodIp,
+			})
+			require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+		})
+	}
+}
+
+func TestServiceInterceptReselectsReviewWhenPublishedParticipantIsPruned(t *testing.T) {
+	stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+	require.Equal(t, stable.PodName, intercept.PodName)
+
+	updatedService := svc.DeepCopy()
+	updatedService.Spec.Selector = map[string]string{"track": "canary"}
+	f := informer.GetK8sFactory(ctx, "")
+	require.NoError(t, f.Core().V1().Services().Informer().GetStore().Update(updatedService))
+
+	updated := st.reconcileServiceParticipants(intercept.Id, intercept)
+	require.Len(t, updated.participants, 1)
+	require.NotContains(t, updated.participants, agentParticipantKey(stable.AgentInfo))
+	require.Contains(t, updated.participants, agentParticipantKey(canary.AgentInfo))
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+	require.Equal(t, canary.PodIp, updated.PodIp)
+	require.Equal(t, canary.PodName, updated.PodName)
+	require.False(t, AgentMatchesInterceptInfo(stable.AgentInfo, updated))
+	require.False(t, st.IsInterceptedBy(stable, "client"))
+	require.True(t, AgentMatchesInterceptInfo(canary.AgentInfo, updated))
+	require.True(t, st.IsInterceptedBy(canary, "client"))
+
+	staleStable := serviceAgent("example-service", "stable-pod-2", "10.0.0.3")
+	_, err := st.RestoreAgent(ctx, "stale-stable", staleStable.AgentInfo, nil, time.Now())
+	require.NoError(t, err)
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.NotContains(t, updated.participants, agentParticipantKey(staleStable.AgentInfo))
+}
+
+func TestRestoreAgentWaitsForServiceWatchBeforeAddingSelectedParticipant(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stable, canary), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	stableAgent := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canaryAgent := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stableAgent)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:          "client:example-service",
+		Spec:        sharedServiceSpec(),
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+	}}
+	intercept.participants = map[string]*interceptParticipant{
+		participantKey("default", "Deployment", "example-service"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service",
+		},
+	}
+	intercept.syncServiceWorkloads()
+	st.intercepts.Store(intercept.Id, intercept)
+
+	_, err := st.RestoreAgent(ctx, "canary", canaryAgent.AgentInfo, nil, time.Now())
+	require.NoError(t, err)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.NotContains(t, updated.participants, participantKey("default", "Deployment", "example-service-canary"))
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+}
+
+func TestServiceInterceptProvisionsWorkloadSelectedAfterCreation(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"app": "example-service"},
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	ctx := serviceDiscoveryContext(t, svc, stable, canary)
+	ctx = managerutil.WithResolvedAgentImageRetriever(ctx, managerutil.ImageFromEnv("ghcr.io/telepresenceio/tel2:2.99.0"))
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	st.agents.Store("stable", serviceAgent("example-service", "stable-pod", "10.0.0.1"))
+	st.clients.Store("client", newClientSessionState(ctx, "client", &rpc.ClientInfo{Name: "alice"}, time.Now()))
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+	}}
+	intercept.participants = map[string]*interceptParticipant{
+		participantKey("default", "Deployment", "example-service"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service",
+		},
+	}
+	intercept.syncServiceWorkloads()
+	st.intercepts.Store(intercept.Id, intercept)
+
+	st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Contains(t, updated.participants, participantKey("default", "Deployment", "example-service-canary"))
+	require.Equal(t, rpc.InterceptDispositionType_NO_AGENT, updated.Disposition)
+	config := mutator.GetMap(ctx).Get("example-service-canary", "default")
+	require.NotNil(t, config)
+	require.True(t, sidecarClaimsService(config, updated.Spec))
+}
+
+func TestServiceInterceptFallsBackForPodOnlySelectionAtCreation(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"app": "example-service"},
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	pod := servicePod("canary-pod", canary.Name, map[string]string{
+		"app":   "example-service",
+		"track": "canary",
+	})
+	require.Empty(t, pod.Status.Conditions)
+	ctx, _ := serviceWatchContext(t, svc, stable, canary, pod)
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+
+	spec := sharedServiceSpec()
+	workloads := st.ensureServiceWorkloads(
+		ctx,
+		spec,
+		k8sapi.Deployment(stable),
+		nil,
+		nil,
+		agentconfig.ReplacePolicyIntercept,
+		nil,
+	)
+
+	require.Nil(t, workloads)
+	require.False(t, serviceScopedIntercept(spec))
+	require.Nil(t, mutator.GetMap(ctx).Get(canary.Name, canary.Namespace))
+}
+
+func TestServiceInterceptFallsBackForWorkloadSelectedByPodRelabel(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"app": "example-service"},
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	pod := servicePod("canary-pod", canary.Name, map[string]string{"track": "canary"})
+	ctx, client := serviceWatchContext(t, svc, stable, canary, pod)
+	ctx = managerutil.WithResolvedAgentImageRetriever(ctx, managerutil.ImageFromEnv("ghcr.io/telepresenceio/tel2:2.99.0"))
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	serviceSpec := sharedServiceSpec()
+	st.agents.Store("stable", serviceAgent("example-service", "stable-pod", "10.0.0.1"))
+	st.clients.Store("client", newClientSessionState(ctx, "client", &rpc.ClientInfo{Name: "alice"}, time.Now()))
+	existingConfig, err := st.getOrCreateAgentConfig(
+		ctx,
+		k8sapi.Deployment(canary),
+		false,
+		false,
+		nil,
+		agentconfig.ReplacePolicyInactive,
+	)
+	require.NoError(t, err)
+	require.False(t, sidecarClaimsService(existingConfig, serviceSpec))
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+	}}
+	intercept.participants = map[string]*interceptParticipant{
+		participantKey("default", "Deployment", "example-service"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service",
+		},
+	}
+	intercept.syncServiceWorkloads()
+	st.intercepts.Store(intercept.Id, intercept)
+	st.startServiceInterceptWatch(intercept.Id)
+	require.Eventually(t, func() bool {
+		return st.workloadWatchers.Size() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.False(t, sidecarClaimsService(mutator.GetMap(ctx).Get(canary.Name, canary.Namespace), intercept.Spec))
+
+	currentPod, err := client.CoreV1().Pods("default").Get(ctx, pod.Name, meta.GetOptions{})
+	require.NoError(t, err)
+	currentPod.Labels["app"] = "example-service"
+	_, err = client.CoreV1().Pods("default").Update(ctx, currentPod, meta.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		updated, ok := st.intercepts.Load(intercept.Id)
+		if !ok || serviceScopedIntercept(updated.Spec) || len(updated.participants) != 0 ||
+			len(updated.ServiceWorkloads) != 0 {
+			return false
+		}
+		config := mutator.GetMap(ctx).Get(canary.Name, canary.Namespace)
+		return config != nil && !sidecarClaimsService(config, serviceSpec)
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestServiceInterceptFallsBackForUnrepresentableServicePodOwner(t *testing.T) {
+	controller := true
+	for _, tt := range []struct {
+		name            string
+		ownerReferences []meta.OwnerReference
+	}{
+		{name: "bare pod"},
+		{
+			name: "unsupported owner",
+			ownerReferences: []meta.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+				Name:       "example-job",
+				Controller: &controller,
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+			canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+			svc := &core.Service{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "example-service",
+					Namespace: "default",
+					UID:       k8sTypes.UID("shared-service-uid"),
+				},
+				Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+			}
+			pod := &core.Pod{ObjectMeta: meta.ObjectMeta{
+				Name:            "unowned-pod",
+				Namespace:       "default",
+				Labels:          map[string]string{"app": "example-service"},
+				OwnerReferences: tt.ownerReferences,
+			}}
+			ctx, _ := serviceWatchContext(t, svc, stableDeployment, canaryDeployment, pod)
+			ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+			_, st := newServiceInterceptState(t)
+			st.backgroundCtx = ctx
+			stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+			canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+			intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+			require.True(t, st.IsInterceptedBy(canary, "client"))
+
+			st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+			updated, ok := st.intercepts.Load(intercept.Id)
+			require.True(t, ok)
+			require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+			require.False(t, serviceScopedIntercept(updated.Spec))
+			require.Empty(t, updated.participants)
+			require.Empty(t, updated.ServiceWorkloads)
+			require.True(t, st.IsInterceptedBy(stable, "client"))
+			require.False(t, st.IsInterceptedBy(canary, "client"))
+		})
+	}
+}
+
+func TestServiceInterceptChecksSecondaryConflictsBeforeChangingConfig(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"app": "example-service"},
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	ctx := serviceDiscoveryContext(t, svc, stable, canary)
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		ManagerNamespace:              "ambassador",
+		EnabledWorkloadKinds:          k8sapi.Kinds{k8sapi.DeploymentKind},
+		InterceptInactiveBlockTimeout: time.Hour,
+	})
+	ctx = managerutil.WithResolvedAgentImageRetriever(ctx, managerutil.ImageFromEnv("ghcr.io/telepresenceio/tel2:2.99.0"))
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+
+	spec := sharedServiceSpec()
+	primaryConfig, err := st.getOrCreateAgentConfig(
+		ctx,
+		k8sapi.Deployment(stable),
+		false,
+		true,
+		spec,
+		agentconfig.ReplacePolicyIntercept,
+	)
+	require.NoError(t, err)
+	canaryConfig, err := st.getOrCreateAgentConfig(
+		ctx,
+		k8sapi.Deployment(canary),
+		false,
+		false,
+		nil,
+		agentconfig.ReplacePolicyInactive,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, canaryConfig.Containers)
+	canaryConfig.Containers[0].Replace = agentconfig.ReplacePolicyContainer
+
+	otherClient := newClientSessionState(ctx, "bob", &rpc.ClientInfo{Name: "bob"}, time.Now())
+	st.clients.Store("bob", otherClient)
+	st.intercepts.Store("bob:replace", &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id: "bob:replace",
+		Spec: &rpc.InterceptSpec{
+			Name:          "replace",
+			Client:        "bob",
+			Agent:         canary.Name,
+			WorkloadKind:  "Deployment",
+			Namespace:     "default",
+			Mechanism:     "http",
+			Replace:       true,
+			ContainerName: "app",
+			ContainerPort: 8080,
+			Protocol:      "TCP",
+		},
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "bob"},
+	}})
+	client := newClientSessionState(ctx, "alice", &rpc.ClientInfo{Name: "alice"}, time.Now())
+
+	workloads := st.ensureServiceWorkloads(
+		ctx,
+		spec,
+		k8sapi.Deployment(stable),
+		primaryConfig,
+		nil,
+		agentconfig.ReplacePolicyIntercept,
+		client,
+	)
+
+	require.Nil(t, workloads)
+	require.False(t, serviceScopedIntercept(spec))
+	config := mutator.GetMap(ctx).Get(canary.Name, canary.Namespace)
+	require.NotNil(t, config)
+	require.Equal(t, agentconfig.ReplacePolicyContainer, config.Containers[0].Replace)
+}
+
+func TestServiceInterceptChecksExistingSecondaryConfigConflictsBeforeJoining(t *testing.T) {
+	stable := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canary := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"app": "example-service"},
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	ctx := serviceDiscoveryContext(t, svc, stable, canary)
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{
+		ManagerNamespace:              "ambassador",
+		EnabledWorkloadKinds:          k8sapi.Kinds{k8sapi.DeploymentKind},
+		InterceptInactiveBlockTimeout: time.Hour,
+	})
+	ctx = managerutil.WithResolvedAgentImageRetriever(ctx, managerutil.ImageFromEnv("ghcr.io/telepresenceio/tel2:2.99.0"))
+	ctx = mutator.WithMap(ctx, mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+
+	serviceSpec := sharedServiceSpec()
+	canaryConfig, err := st.getOrCreateAgentConfig(
+		ctx,
+		k8sapi.Deployment(canary),
+		false,
+		false,
+		serviceSpec,
+		agentconfig.ReplacePolicyIntercept,
+	)
+	require.NoError(t, err)
+	require.True(t, sidecarClaimsService(canaryConfig, serviceSpec))
+
+	otherClient := newClientSessionState(ctx, "bob", &rpc.ClientInfo{Name: "bob"}, time.Now())
+	st.clients.Store("bob", otherClient)
+	st.intercepts.Store("bob:replace", &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id: "bob:replace",
+		Spec: &rpc.InterceptSpec{
+			Name:          "replace",
+			Client:        "bob",
+			Agent:         canary.Name,
+			WorkloadKind:  "Deployment",
+			Namespace:     "default",
+			Mechanism:     "http",
+			Replace:       true,
+			ContainerName: "app",
+			ContainerPort: 8080,
+			Protocol:      "TCP",
+		},
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "bob"},
+	}})
+	client := newClientSessionState(ctx, "alice", &rpc.ClientInfo{Name: "alice"}, time.Now())
+	st.clients.Store("client", client)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+	}}
+	intercept.participants = map[string]*interceptParticipant{
+		participantKey("default", "Deployment", "example-service"): {
+			namespace: "default",
+			kind:      "Deployment",
+			name:      "example-service",
+		},
+	}
+	intercept.syncServiceWorkloads()
+	st.intercepts.Store(intercept.Id, intercept)
+
+	st.reconcileServiceInterceptWorkloads(ctx, intercept.Id)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.False(t, serviceScopedIntercept(updated.Spec))
+	require.Empty(t, updated.participants)
+	require.Empty(t, updated.ServiceWorkloads)
+	require.True(t, sidecarClaimsService(mutator.GetMap(ctx).Get(canary.Name, canary.Namespace), serviceSpec))
+}
+
+func TestServiceInterceptParticipantBlocksLaterContainerConflict(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	ctx = managerutil.WithEnv(ctx, &managerutil.Env{InterceptInactiveBlockTimeout: time.Hour})
+	st.backgroundCtx = ctx
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	existing := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id: "bob:shared",
+		Spec: &rpc.InterceptSpec{
+			Name:          "shared",
+			Client:        "bob",
+			Agent:         stable.Name,
+			WorkloadKind:  "Deployment",
+			Namespace:     "default",
+			Mechanism:     "http",
+			ServiceUid:    "shared-service-uid",
+			ServiceName:   "example-service",
+			ServicePort:   80,
+			ContainerPort: 8080,
+			Protocol:      "TCP",
+		},
+		Disposition:      rpc.InterceptDispositionType_ACTIVE,
+		ClientSession:    &rpc.SessionInfo{SessionId: "bob"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name, canary.Name),
+	}}
+	st.initializeParticipants(existing)
+	st.intercepts.Store(existing.Id, existing)
+	st.clients.Store("bob", newClientSessionState(ctx, "bob", &rpc.ClientInfo{Name: "bob"}, time.Now()))
+	client := newClientSessionState(ctx, "alice", &rpc.ClientInfo{Name: "alice"}, time.Now())
+
+	// The same Service port resolves to a different physical container port in
+	// the secondary workload. Conflict detection must use this config, not the
+	// primary workload's persisted ContainerPort.
+	ac := &agentconfig.Sidecar{
+		AgentName:    canary.Name,
+		WorkloadName: canary.Name,
+		WorkloadKind: k8sapi.DeploymentKind,
+		Namespace:    canary.Namespace,
+		Containers: []*agentconfig.Container{{
+			Name: "app",
+			Intercepts: []*agentconfig.Intercept{{
+				ServiceName:   "example-service",
+				ServiceUID:    k8sTypes.UID("shared-service-uid"),
+				ServicePort:   80,
+				ContainerPort: 9090,
+				Protocol:      types.ProtoTCP,
+			}},
+		}},
+	}
+	newSpec := &rpc.InterceptSpec{
+		Name:          "replace",
+		Client:        "alice",
+		Agent:         canary.Name,
+		WorkloadKind:  "Deployment",
+		Namespace:     canary.Namespace,
+		Mechanism:     "http",
+		Replace:       true,
+		ContainerName: "app",
+		ContainerPort: 9090,
+		Protocol:      "TCP",
+	}
+
+	err := st.checkInterceptConflicts(ac, client, []types.PortAndProto{{Proto: types.ProtoTCP, Port: 9090}}, newSpec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflict with intercept")
+
+	newSpec.ContainerPort = 9091
+	err = st.checkInterceptConflicts(ac, client, []types.PortAndProto{{Proto: types.ProtoTCP, Port: 9091}}, newSpec)
+	require.NoError(t, err)
+}
+
+func TestServiceInterceptRejectsMixedTargetClaims(t *testing.T) {
+	_, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	legacyCanary := serviceAgent("example-service-canary", "canary-pod-2", "10.0.0.3")
+	legacyCanary.InterceptTargets = nil
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+	st.agents.Store("legacy-canary", legacyCanary)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_WAITING,
+		ClientSession:    &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name, canary.Name),
+	}}
+	st.initializeParticipants(intercept)
+
+	code, message := st.checkAgentsForIntercept(intercept)
+	require.Equal(t, rpc.InterceptDispositionType_NO_AGENT, code)
+	require.Contains(t, message, "Not every agent")
+}
+
+func TestServiceInterceptWaitsForEveryWorkload(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_WAITING,
+		ClientSession:    &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name, canary.Name),
+	}}
+	st.initializeParticipants(intercept)
+	require.Len(t, intercept.participants, 2)
+	require.Len(t, intercept.ServiceWorkloads, 2)
+	require.Equal(t, "example-service", intercept.ServiceWorkloads[0].WorkloadName)
+	require.Equal(t, "example-service-canary", intercept.ServiceWorkloads[1].WorkloadName)
+	st.intercepts.Store(intercept.Id, intercept)
+
+	stableReview := &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       stable.PodIp,
+		Environment: map[string]string{"TRACK": "stable"},
+	}
+	updated := st.ApplyAgentReview(ctx, intercept.Id, stable, stableReview)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+	require.Contains(t, updated.Message, "example-service-canary")
+
+	updated = st.ApplyAgentReview(ctx, intercept.Id, canary, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       canary.PodIp,
+		Environment: map[string]string{"TRACK": "canary"},
+	})
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+	require.Equal(t, stable.PodIp, updated.PodIp)
+	require.Equal(t, stable.PodName, updated.PodName)
+	require.Equal(t, map[string]string{"TRACK": "stable"}, updated.Environment)
+	require.True(t, st.IsInterceptedBy(stable, "client"))
+	require.True(t, st.IsInterceptedBy(canary, "client"))
+}
+
+func TestServiceInterceptPublishesLateWorkload(t *testing.T) {
+	_, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+	}}
+	st.initializeParticipants(intercept)
+	require.Len(t, intercept.ServiceWorkloads, 1)
+	require.Equal(t, "example-service", intercept.ServiceWorkloads[0].WorkloadName)
+
+	intercept.addParticipant(canary.AgentInfo)
+	require.Len(t, intercept.ServiceWorkloads, 2)
+	require.Equal(t, "example-service", intercept.ServiceWorkloads[0].WorkloadName)
+	require.Equal(t, "example-service-canary", intercept.ServiceWorkloads[1].WorkloadName)
+}
+
+func TestLateServiceParticipantReturnsActiveInterceptToWaiting(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		PodIp:         stable.PodIp,
+		PodName:       stable.PodName,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+	}}
+	st.initializeParticipants(intercept)
+	stableParticipant := intercept.participants[agentParticipantKey(stable.AgentInfo)]
+	require.NotNil(t, stableParticipant)
+	stableParticipant.review = &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       stable.PodIp,
+	}
+	stableParticipant.podName = stable.PodName
+	st.intercepts.Store(intercept.Id, intercept)
+
+	_, err := st.RestoreAgent(ctx, "canary", canary.AgentInfo, nil, time.Now())
+	require.NoError(t, err)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+	require.Contains(t, updated.Message, "example-service-canary")
+	require.Len(t, updated.participants, 2)
+	require.Nil(t, updated.participants[agentParticipantKey(canary.AgentInfo)].review)
+	require.False(t, st.IsInterceptedBy(stable, "client"))
+	require.False(t, st.IsInterceptedBy(canary, "client"))
+
+	updated = st.ApplyAgentReview(ctx, intercept.Id, canary, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       canary.PodIp,
+	})
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+}
+
+func TestRestoreInterceptsRebuildsServiceParticipants(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	ctx = k8sapi.WithK8sInterface(ctx, fake.NewSimpleClientset())
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+
+	restored := &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: []*rpc.InterceptWorkload{
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: "example-service"},
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: "example-service-canary"},
+		},
+	}
+
+	st.RestoreIntercepts(ctx, []*rpc.InterceptInfo{restored}, time.Now())
+	intercept, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Len(t, intercept.participants, 2)
+	require.Len(t, intercept.ServiceWorkloads, 2)
+	code, message := st.checkAgentsForIntercept(intercept)
+	require.Equal(t, rpc.InterceptDispositionType_UNSPECIFIED, code)
+	require.Empty(t, message)
+}
+
+func TestRestoreInterceptsWaitsForWatcherBeforeAddingNewSelectedParticipant(t *testing.T) {
+	stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"app": "example-service"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	// Keep this test on the restore path itself; the watcher is what may add
+	// the new canary after it has preflighted the selection.
+	st.serviceInterceptWatchers = nil
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+
+	restored := &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_ACTIVE,
+		ClientSession:    &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name),
+	}
+	st.RestoreIntercepts(ctx, []*rpc.InterceptInfo{restored}, time.Now())
+
+	intercept, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Len(t, intercept.participants, 1)
+	require.NotContains(t, intercept.participants, agentParticipantKey(canary.AgentInfo))
+	require.False(t, AgentMatchesInterceptInfo(canary.AgentInfo, intercept))
+	require.False(t, st.IsInterceptedBy(canary, "client"))
+}
+
+func TestRestoreInterceptsRequeuesWhenSelectorDropsPublishedParticipant(t *testing.T) {
+	stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"track": "canary"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	// Keep this test on the restore path itself. The watcher would see the
+	// already-pruned selection and cannot repair stale published metadata.
+	st.serviceInterceptWatchers = nil
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+
+	restored := &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		PodIp:         stable.PodIp,
+		PodName:       stable.PodName,
+		MountPoint:    "/tmp/stale-mount",
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: []*rpc.InterceptWorkload{
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: stable.Name},
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: canary.Name},
+		},
+	}
+
+	st.RestoreIntercepts(ctx, []*rpc.InterceptInfo{restored}, time.Now())
+
+	intercept, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, intercept.Disposition)
+	require.Empty(t, intercept.PodIp)
+	require.Empty(t, intercept.PodName)
+	require.Empty(t, intercept.MountPoint)
+	require.Len(t, intercept.participants, 1)
+	require.NotContains(t, intercept.participants, agentParticipantKey(stable.AgentInfo))
+	require.Contains(t, intercept.participants, agentParticipantKey(canary.AgentInfo))
+	require.Equal(t, sharedServiceWorkloads(canary.Name), intercept.ServiceWorkloads)
+}
+
+func TestRestoreInterceptsRequeuesWhenSelectorDropsUnrestoredPublishedParticipant(t *testing.T) {
+	stableDeployment := serviceDeployment("example-service", map[string]string{"app": "example-service", "track": "stable"})
+	canaryDeployment := serviceDeployment("example-service-canary", map[string]string{"app": "example-service", "track": "canary"})
+	svc := &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "example-service",
+			Namespace: "default",
+			UID:       k8sTypes.UID("shared-service-uid"),
+		},
+		Spec: core.ServiceSpec{Selector: map[string]string{"track": "stable"}},
+	}
+	ctx := mutator.WithMap(serviceDiscoveryContext(t, svc, stableDeployment, canaryDeployment), mutator.NewWatcher())
+	_, st := newServiceInterceptState(t)
+	st.backgroundCtx = ctx
+	st.serviceInterceptWatchers = nil
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	// The published canary pod disappeared before the restore snapshot, so
+	// only the still-selected primary agent is available to restore.
+	st.agents.Store("stable", stable)
+
+	restored := &rpc.InterceptInfo{
+		Id:            "client:example-service",
+		Spec:          sharedServiceSpec(),
+		Disposition:   rpc.InterceptDispositionType_ACTIVE,
+		PodIp:         canary.PodIp,
+		PodName:       canary.PodName,
+		MountPoint:    "/tmp/stale-mount",
+		ClientSession: &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: []*rpc.InterceptWorkload{
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: canary.Name},
+		},
+	}
+
+	st.RestoreIntercepts(ctx, []*rpc.InterceptInfo{restored}, time.Now())
+
+	intercept, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, intercept.Disposition)
+	require.Empty(t, intercept.PodIp)
+	require.Empty(t, intercept.PodName)
+	require.Empty(t, intercept.MountPoint)
+	require.Len(t, intercept.participants, 1)
+	require.Contains(t, intercept.participants, agentParticipantKey(stable.AgentInfo))
+	require.NotContains(t, intercept.participants, agentParticipantKey(canary.AgentInfo))
+	require.Equal(t, sharedServiceWorkloads(stable.Name), intercept.ServiceWorkloads)
+}
+
+func TestInitializeParticipantsRestoresUnambiguousWaitingPublishedPod(t *testing.T) {
+	_, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_WAITING,
+		PodIp:            stable.PodIp,
+		PodName:          stable.PodName,
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name),
+	}}
+
+	st.initializeParticipants(intercept)
+
+	participant := intercept.participants[agentParticipantKey(stable.AgentInfo)]
+	require.NotNil(t, participant)
+	require.Equal(t, stable.PodName, participant.podName)
+	require.Equal(t, stable.PodIp, intercept.PodIp)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, intercept.Disposition)
+}
+
+func TestRestoredServiceInterceptRequeuesWhenRecordedPodLeaves(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	ctx = k8sapi.WithK8sInterface(ctx, fake.NewSimpleClientset())
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	stableSibling := serviceAgent("example-service", "stable-pod-2", "10.0.0.3")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	st.agents.Store("stable", stable)
+	st.agents.Store("stable-sibling", stableSibling)
+	st.agents.Store("canary", canary)
+
+	restored := &rpc.InterceptInfo{
+		Id:          "client:example-service",
+		Spec:        sharedServiceSpec(),
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       stable.PodIp,
+		PodName:     stable.PodName,
+		ClientSession: &rpc.SessionInfo{
+			SessionId: "client",
+		},
+		ServiceWorkloads: []*rpc.InterceptWorkload{
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: "example-service"},
+			{Namespace: "default", WorkloadKind: "Deployment", WorkloadName: "example-service-canary"},
+		},
+	}
+	st.RestoreIntercepts(ctx, []*rpc.InterceptInfo{restored}, time.Now())
+	intercept, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Equal(t, stable.PodName, intercept.participants[agentParticipantKey(stable.AgentInfo)].podName)
+
+	st.agents.Delete("stable")
+	st.consolidateAgentSessionIntercepts(stable)
+
+	updated, ok := st.intercepts.Load(restored.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+	require.Nil(t, updated.participants[agentParticipantKey(stable.AgentInfo)].review)
+	require.Empty(t, updated.participants[agentParticipantKey(stable.AgentInfo)].podName)
+}
+
+func TestServiceInterceptRemovalClearsOnlyRemovedParticipantReview(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	canaryReplacement := serviceAgent("example-service-canary", "canary-pod-2", "10.0.0.3")
+	st.agents.Store("stable", stable)
+	st.agents.Store("canary", canary)
+	st.agents.Store("canary-replacement", canaryReplacement)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:               "client:example-service",
+		Spec:             sharedServiceSpec(),
+		Disposition:      rpc.InterceptDispositionType_WAITING,
+		ClientSession:    &rpc.SessionInfo{SessionId: "client"},
+		ServiceWorkloads: sharedServiceWorkloads(stable.Name, canary.Name),
+	}}
+	st.initializeParticipants(intercept)
+	st.intercepts.Store(intercept.Id, intercept)
+	intercept = st.ApplyAgentReview(ctx, intercept.Id, stable, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       stable.PodIp,
+	})
+	intercept = st.ApplyAgentReview(ctx, intercept.Id, canary, &rpc.ReviewInterceptRequest{
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       canary.PodIp,
+	})
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, intercept.Disposition)
+
+	st.agents.Delete("canary")
+	st.consolidateAgentSessionIntercepts(canary)
+
+	intercept, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, intercept.Disposition)
+	require.Equal(t, stable.PodIp, intercept.PodIp)
+	require.Equal(t, stable.PodName, intercept.PodName)
+	participant := intercept.participants[agentParticipantKey(canary.AgentInfo)]
+	require.NotNil(t, participant)
+	require.Nil(t, participant.review)
+	require.Empty(t, participant.podName)
+}
+
+func TestServiceInterceptPrunesParticipantAfterTargetClaimDisappears(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	replacement := serviceAgent("example-service-canary", "canary-pod-2", "10.0.0.3")
+	replacement.InterceptTargets = nil
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+
+	// The replacement is already present when the old claiming pod leaves.
+	st.agents.Store("canary-replacement", replacement)
+	st.agents.Delete("canary")
+	st.consolidateAgentSessionIntercepts(canary)
+
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, updated.Disposition)
+	require.Len(t, updated.participants, 1)
+	require.NotContains(t, updated.participants, agentParticipantKey(canary.AgentInfo))
+	require.Len(t, updated.ServiceWorkloads, 1)
+	require.Equal(t, "example-service", updated.ServiceWorkloads[0].WorkloadName)
+	code, message := st.checkAgentsForIntercept(updated)
+	require.Equal(t, rpc.InterceptDispositionType_UNSPECIFIED, code)
+	require.Empty(t, message)
+}
+
+func TestServiceInterceptPrunesParticipantWhenNonClaimingReplacementArrives(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	replacement := serviceAgent("example-service-canary", "canary-pod-2", "10.0.0.3")
+	replacement.InterceptTargets = nil
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+
+	// If the claiming pod disappears first, the intercept briefly has no
+	// agent for this participant. The later replacement proves that the
+	// workload no longer claims the Service target and must unblock it.
+	st.agents.Delete("canary")
+	st.consolidateAgentSessionIntercepts(canary)
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_NO_AGENT, updated.Disposition)
+
+	_, err := st.RestoreAgent(ctx, "canary-replacement", replacement.AgentInfo, nil, time.Now())
+	require.NoError(t, err)
+
+	updated, ok = st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+	require.Len(t, updated.participants, 1)
+	require.NotContains(t, updated.participants, agentParticipantKey(canary.AgentInfo))
+	require.Len(t, updated.ServiceWorkloads, 1)
+	require.Equal(t, "example-service", updated.ServiceWorkloads[0].WorkloadName)
+	code, message := st.checkAgentsForIntercept(updated)
+	require.Equal(t, rpc.InterceptDispositionType_UNSPECIFIED, code)
+	require.Empty(t, message)
+}
+
+func TestServiceInterceptRequeuesWhenNonClaimingParticipantLeaves(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	stable := serviceAgent("example-service", "stable-pod", "10.0.0.1")
+	canary := serviceAgent("example-service-canary", "canary-pod", "10.0.0.2")
+	legacyCanary := serviceAgent("example-service-canary", "canary-pod-2", "10.0.0.3")
+	legacyCanary.InterceptTargets = nil
+	intercept := activeServiceIntercept(t, ctx, st, stable, canary)
+
+	_, err := st.RestoreAgent(ctx, "legacy-canary", legacyCanary.AgentInfo, nil, time.Now())
+	require.NoError(t, err)
+	updated, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_NO_AGENT, updated.Disposition)
+
+	st.RemoveSession(ctx, "legacy-canary")
+
+	updated, ok = st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_WAITING, updated.Disposition)
+	require.Len(t, updated.participants, 2)
+	require.NotNil(t, updated.participants[agentParticipantKey(stable.AgentInfo)].review)
+	require.NotNil(t, updated.participants[agentParticipantKey(canary.AgentInfo)].review)
+	code, message := st.checkAgentsForIntercept(updated)
+	require.Equal(t, rpc.InterceptDispositionType_UNSPECIFIED, code)
+	require.Empty(t, message)
+}
+
+func TestNonServiceSiblingRemovalDoesNotResetActiveIntercept(t *testing.T) {
+	_, st := newServiceInterceptState(t)
+	recorded := serviceAgent("demo", "recorded-pod", "10.0.0.1")
+	sibling := serviceAgent("demo", "sibling-pod", "10.0.0.2")
+	st.agents.Store("recorded", recorded)
+
+	intercept := &Intercept{InterceptInfo: &rpc.InterceptInfo{
+		Id:          "client:demo",
+		Spec:        &rpc.InterceptSpec{Agent: "demo", Namespace: "default", WorkloadKind: "Deployment", Mechanism: "tcp"},
+		Disposition: rpc.InterceptDispositionType_ACTIVE,
+		PodIp:       recorded.PodIp,
+		PodName:     recorded.PodName,
+		ClientSession: &rpc.SessionInfo{
+			SessionId: "client",
+		},
+	}}
+	st.intercepts.Store(intercept.Id, intercept)
+
+	st.consolidateAgentSessionIntercepts(sibling)
+
+	intercept, ok := st.intercepts.Load(intercept.Id)
+	require.True(t, ok)
+	require.Equal(t, rpc.InterceptDispositionType_ACTIVE, intercept.Disposition)
+	require.Equal(t, recorded.PodIp, intercept.PodIp)
+	require.Equal(t, recorded.PodName, intercept.PodName)
+}
+
+func TestAgentMatchesServiceInterceptByClaim(t *testing.T) {
+	spec := sharedServiceSpec()
+	require.True(t, AgentMatchesIntercept(serviceAgent("example-service-canary", "pod", "10.0.0.2").AgentInfo, spec))
+
+	agent := serviceAgent("example-service-canary", "pod", "10.0.0.2").AgentInfo
+	agent.InterceptTargets[0].ServiceUid = "other-service"
+	require.False(t, AgentMatchesIntercept(agent, spec))
+
+	legacyPrimary := serviceAgent("example-service", "pod", "10.0.0.1").AgentInfo
+	legacyPrimary.InterceptTargets = nil
+	require.True(t, AgentMatchesIntercept(legacyPrimary, spec))
+
+	legacyCanary := serviceAgent("example-service-canary", "pod", "10.0.0.2").AgentInfo
+	legacyCanary.InterceptTargets = nil
+	require.False(t, AgentMatchesIntercept(legacyCanary, spec))
+}
+
+func TestServiceScopesOverlap(t *testing.T) {
+	spec := sharedServiceSpec()
+	same := sharedServiceSpec()
+	same.Agent = "example-service-canary"
+	require.True(t, serviceScopesOverlap(spec, same))
+
+	otherPort := sharedServiceSpec()
+	otherPort.ServicePort = 81
+	require.False(t, serviceScopesOverlap(spec, otherPort))
+
+	otherUID := sharedServiceSpec()
+	otherUID.ServiceUid = "other-service"
+	require.False(t, serviceScopesOverlap(spec, otherUID))
+}
+
+func TestServicePodIsRelevant(t *testing.T) {
+	pod := &core.Pod{}
+	require.True(t, servicePodIsRelevant(pod))
+
+	pod.Status.Conditions = []core.PodCondition{{
+		Type:   core.PodReady,
+		Status: core.ConditionFalse,
+	}}
+	require.True(t, servicePodIsRelevant(pod))
+
+	now := meta.Now()
+	pod.DeletionTimestamp = &now
+	require.False(t, servicePodIsRelevant(pod))
+}
+
+func TestUnsupportedSharedServiceModeFallsBackToRequestedWorkload(t *testing.T) {
+	ctx, st := newServiceInterceptState(t)
+	spec := sharedServiceSpec()
+	spec.Mechanism = "tcp"
+
+	st.ensureServiceWorkloads(ctx, spec, nil, nil, nil, agentconfig.ReplacePolicyIntercept, nil)
+
+	require.False(t, serviceScopedIntercept(spec))
+	require.Empty(t, spec.ServiceUid)
+	require.Zero(t, spec.ServicePort)
+	require.Empty(t, spec.ServicePortName)
+	require.Equal(t, "example-service", spec.ServiceName)
+}

--- a/cmd/traffic/cmd/manager/state/service_intercept_watch.go
+++ b/cmd/traffic/cmd/manager/state/service_intercept_watch.go
@@ -1,0 +1,295 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sCache "k8s.io/client-go/tools/cache"
+
+	"github.com/telepresenceio/clog"
+	rpc "github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/cmd/traffic/cmd/manager/mutator"
+	"github.com/telepresenceio/telepresence/v2/pkg/agentconfig"
+	"github.com/telepresenceio/telepresence/v2/pkg/informer"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+)
+
+func (s *State) startServiceInterceptWatch(interceptID string) {
+	if s.serviceInterceptWatchers == nil {
+		return
+	}
+	if _, loaded := s.serviceInterceptWatchers.LoadOrStore(interceptID, struct{}{}); loaded {
+		return
+	}
+	intercept, ok := s.intercepts.Load(interceptID)
+	if !ok || !serviceScopedIntercept(intercept.Spec) {
+		s.serviceInterceptWatchers.Delete(interceptID)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(s.backgroundCtx)
+	if err := s.AddInterceptFinalizer(interceptID, func(context.Context, *rpc.InterceptInfo) error {
+		cancel()
+		return nil
+	}); err != nil {
+		cancel()
+		s.serviceInterceptWatchers.Delete(interceptID)
+		clog.Errorf(s.backgroundCtx, "Failed to start Service intercept watcher for %s: %v", interceptID, err)
+		return
+	}
+	go func() {
+		defer cancel()
+		defer s.serviceInterceptWatchers.Delete(interceptID)
+		s.watchServiceInterceptWorkloads(ctx, interceptID)
+	}()
+}
+
+func serviceMatchesIntercept(obj any, spec *rpc.InterceptSpec) bool {
+	svc, ok := obj.(*core.Service)
+	return ok && svc.Namespace == spec.Namespace && svc.Name == spec.ServiceName
+}
+
+func podMatchesServiceSelector(obj any, svc *core.Service, spec *rpc.InterceptSpec) bool {
+	if deleted, ok := obj.(*k8sCache.DeletedFinalStateUnknown); ok {
+		obj = deleted.Obj
+	}
+	pod, ok := obj.(*core.Pod)
+	return ok && pod.Namespace == spec.Namespace && len(svc.Spec.Selector) > 0 &&
+		labels.SelectorFromSet(svc.Spec.Selector).Matches(labels.Set(pod.Labels))
+}
+
+func podUpdateMayAffectService(oldObj, newObj any, svc *core.Service, spec *rpc.InterceptSpec) bool {
+	oldPod, oldOK := oldObj.(*core.Pod)
+	newPod, newOK := newObj.(*core.Pod)
+	if !oldOK || !newOK {
+		return false
+	}
+	oldMatches := podMatchesServiceSelector(oldPod, svc, spec)
+	newMatches := podMatchesServiceSelector(newPod, svc, spec)
+	if oldMatches != newMatches {
+		return true
+	}
+	return oldMatches && servicePodIsRelevant(oldPod) != servicePodIsRelevant(newPod)
+}
+
+func (s *State) watchServiceInterceptWorkloads(ctx context.Context, interceptID string) {
+	intercept, ok := s.intercepts.Load(interceptID)
+	if !ok || !serviceScopedIntercept(intercept.Spec) {
+		return
+	}
+	spec := intercept.Spec
+	f := informer.GetK8sFactory(ctx, spec.Namespace)
+	if f == nil {
+		clog.Debugf(ctx, "No informer factory available for Service intercept %q", interceptID)
+		return
+	}
+
+	reconcileEvents := make(chan struct{}, 1)
+	signal := func() {
+		select {
+		case reconcileEvents <- struct{}{}:
+		default:
+		}
+	}
+	notifyService := func(obj any) {
+		if !serviceMatchesIntercept(obj, spec) {
+			return
+		}
+		signal()
+	}
+	reg, err := f.Core().V1().Services().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+		AddFunc: notifyService,
+		UpdateFunc: func(_, newObj any) {
+			notifyService(newObj)
+		},
+		DeleteFunc: func(obj any) {
+			if deleted, ok := obj.(*k8sCache.DeletedFinalStateUnknown); ok {
+				notifyService(deleted.Obj)
+				return
+			}
+			notifyService(obj)
+		},
+	})
+	if err != nil {
+		clog.Errorf(ctx, "Unable to watch Service changes for intercept %q: %v", interceptID, err)
+		return
+	}
+	defer func() {
+		_ = f.Core().V1().Services().Informer().RemoveEventHandler(reg)
+	}()
+
+	currentService := func() *core.Service {
+		svc, err := f.Core().V1().Services().Lister().Services(spec.Namespace).Get(spec.ServiceName)
+		if err != nil || string(svc.UID) != spec.ServiceUid {
+			return nil
+		}
+		return svc
+	}
+	notifyPod := func(obj any) {
+		if svc := currentService(); svc != nil && podMatchesServiceSelector(obj, svc, spec) {
+			signal()
+		}
+	}
+	podReg, err := f.Core().V1().Pods().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+		AddFunc: notifyPod,
+		UpdateFunc: func(oldObj, newObj any) {
+			if svc := currentService(); svc != nil && podUpdateMayAffectService(oldObj, newObj, svc, spec) {
+				signal()
+			}
+		},
+		DeleteFunc: notifyPod,
+	})
+	if err != nil {
+		clog.Errorf(ctx, "Unable to watch Pod changes for intercept %q: %v", interceptID, err)
+		return
+	}
+	defer func() {
+		_ = f.Core().V1().Pods().Informer().RemoveEventHandler(podReg)
+	}()
+
+	workloadEvents, err := s.WatchWorkloads(ctx, spec.Namespace)
+	if err != nil {
+		clog.Errorf(ctx, "Unable to watch workload changes for intercept %q: %v", interceptID, err)
+		return
+	}
+	s.reconcileServiceInterceptWorkloads(ctx, interceptID)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-reconcileEvents:
+			s.reconcileServiceInterceptWorkloads(ctx, interceptID)
+		case events := <-workloadEvents:
+			if events == nil {
+				return
+			}
+			s.reconcileServiceInterceptWorkloads(ctx, interceptID)
+		}
+	}
+}
+
+// reconcileServiceInterceptWorkloads provisions newly selected workloads
+// before waiting for their agents to join the logical intercept.
+func (s *State) reconcileServiceInterceptWorkloads(ctx context.Context, interceptID string) {
+	intercept, ok := s.intercepts.Load(interceptID)
+	if !ok || !serviceScopedIntercept(intercept.Spec) {
+		return
+	}
+	workloads, known, err := discoverServiceWorkloads(ctx, intercept.Spec)
+	if err != nil {
+		if errors.Is(err, errServicePodOnlySelection) ||
+			errors.Is(err, errServicePodOwnerUnrepresentable) ||
+			errors.Is(err, errServiceIdentityChanged) ||
+			errors.Is(err, errServiceSelectorless) {
+			s.fallbackServiceInterceptToSingleWorkload(interceptID, err.Error())
+			return
+		}
+		clog.Debugf(ctx, "Unable to discover workloads for intercept %q: %v", interceptID, err)
+		return
+	}
+	if !known {
+		return
+	}
+	selected := serviceParticipantsFromWorkloads(workloads)
+
+	mm := mutator.GetMap(ctx)
+	if mm == nil {
+		s.reconcileServiceParticipantsWithSelection(interceptID, intercept, selected, true, false)
+		return
+	}
+	var client *ClientSession
+	if intercept.ClientSession != nil {
+		client = s.GetClient(tunnel.SessionID(intercept.ClientSession.SessionId))
+	}
+	// Validate every secondary before publishing it as a participant. In
+	// particular, an existing config can already claim this Service while a
+	// different active intercept still makes the expansion unsafe.
+	for _, workload := range workloads {
+		if workload.GetName() == intercept.Spec.Agent &&
+			(intercept.Spec.WorkloadKind == "" || string(workload.GetKind()) == intercept.Spec.WorkloadKind) {
+			continue
+		}
+		if err = s.checkServiceWorkloadConflictsIgnoring(ctx, intercept.Spec, workload, client, interceptID); err != nil {
+			s.fallbackServiceInterceptToSingleWorkload(interceptID,
+				fmt.Sprintf("workload %s conflicts with an existing intercept: %v", workload, err))
+			return
+		}
+	}
+
+	intercept = s.reconcileServiceParticipantsWithSelection(interceptID, intercept, selected, true, true)
+	if intercept == nil || !serviceScopedIntercept(intercept.Spec) {
+		return
+	}
+	for _, workload := range workloads {
+		if workload.GetName() == intercept.Spec.Agent &&
+			(intercept.Spec.WorkloadKind == "" || string(workload.GetKind()) == intercept.Spec.WorkloadKind) {
+			continue
+		}
+		config := mm.Get(workload.GetName(), workload.GetNamespace())
+		if config != nil && sidecarClaimsService(config, intercept.Spec) {
+			continue
+		}
+		config, err = s.getOrCreateAgentConfig(ctx, workload, s.isExtended(intercept.Spec), false,
+			intercept.Spec, agentconfig.ReplacePolicyIntercept)
+		if err != nil {
+			clog.Errorf(ctx, "Unable to provision workload %s for intercept %q: %v", workload, interceptID, err)
+			continue
+		}
+		if !sidecarClaimsService(config, intercept.Spec) {
+			clog.Errorf(ctx, "Agent config for workload %s does not claim the selected Service target", workload)
+			continue
+		}
+		if err = mm.EvictPodsWithAgentConfigMismatch(ctx, workload, config); err != nil {
+			clog.Errorf(ctx, "Unable to refresh workload %s for intercept %q: %v", workload, interceptID, err)
+		}
+	}
+
+	intercept, ok = s.intercepts.Load(interceptID)
+	if !ok {
+		return
+	}
+	if errCode, errMsg := s.checkAgentsForIntercept(intercept); errCode != rpc.InterceptDispositionType_UNSPECIFIED {
+		s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+			intercept.Disposition = errCode
+			intercept.Message = errMsg
+		})
+	} else if intercept.Disposition == rpc.InterceptDispositionType_NO_AGENT {
+		s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+			intercept.Disposition = rpc.InterceptDispositionType_WAITING
+			intercept.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s",
+				strings.Join(intercept.pendingParticipants(), ", "))
+		})
+	}
+}
+
+// fallbackServiceInterceptToSingleWorkload stops shared-Service expansion
+// when a live Service endpoint cannot be represented safely by a
+// workload-scoped agent config. The requested workload keeps workload-scoped
+// interception, and participant-aware delivery removes the intercept from
+// any secondary agents.
+func (s *State) fallbackServiceInterceptToSingleWorkload(interceptID, reason string) {
+	s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+		if !serviceScopedIntercept(intercept.Spec) {
+			return
+		}
+		needsSingleWorkloadReview := intercept.Disposition == rpc.InterceptDispositionType_NO_AGENT ||
+			intercept.Disposition == rpc.InterceptDispositionType_AGENT_ERROR
+		fallbackToSingleWorkload(s.backgroundCtx, intercept.Spec, reason)
+		intercept.participants = nil
+		intercept.syncServiceWorkloads()
+		if !needsSingleWorkloadReview {
+			return
+		}
+		if errCode, errMsg := s.checkAgentsForIntercept(intercept); errCode != rpc.InterceptDispositionType_UNSPECIFIED {
+			intercept.Disposition = errCode
+			intercept.Message = errMsg
+			return
+		}
+		intercept.Disposition = rpc.InterceptDispositionType_WAITING
+		intercept.Message = "Waiting for Agent approval"
+	})
+}

--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -40,13 +40,15 @@ type InterceptFinalizer func(ctx context.Context, interceptInfo *rpc.InterceptIn
 
 type Intercept struct {
 	*rpc.InterceptInfo
-	finalizers []InterceptFinalizer
+	finalizers   []InterceptFinalizer
+	participants map[string]*interceptParticipant
 }
 
 func (is *Intercept) Clone() *Intercept {
 	return &Intercept{
 		InterceptInfo: proto.Clone(is.InterceptInfo).(*rpc.InterceptInfo),
 		finalizers:    slices.Clone(is.finalizers),
+		participants:  is.cloneParticipants(),
 	}
 }
 
@@ -83,6 +85,7 @@ type State struct {
 	timedLogLevel              log.TimedLevel
 	llSubs                     *loglevelSubscribers
 	workloadWatchers           *xsync.Map[string, Watcher] // workload watchers, created on demand and keyed by namespace
+	serviceInterceptWatchers   *xsync.Map[string, struct{}]
 
 	// nodeAgentPodWatchers tracks the running per-workload node-agent pod-set
 	// watchers (nodeAgentPodWatchLoop), one per name+namespace with at least
@@ -111,7 +114,7 @@ func (s *State) ManagesNamespace(ctx context.Context, ns string) bool {
 }
 
 func interceptEqual(a, b *Intercept) bool {
-	return proto.Equal(a.InterceptInfo, b.InterceptInfo)
+	return proto.Equal(a.InterceptInfo, b.InterceptInfo) && participantsEqual(a.participants, b.participants)
 }
 
 func agentsEqual(a, b *AgentSession) bool {
@@ -124,15 +127,16 @@ func NewState(ctx context.Context, g log.Group, adminCommandCh <-chan tmconfig.A
 		loglevel = slog.LevelInfo
 	}
 	s := &State{
-		backgroundCtx:        ctx,
-		intercepts:           cache.NewMap[string, *Intercept](interceptEqual, 5*time.Millisecond, xsync.WithGrowOnly()),
-		agents:               cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, 5*time.Millisecond, xsync.WithGrowOnly()),
-		clients:              xsync.NewMap[tunnel.SessionID, *ClientSession](xsync.WithGrowOnly()),
-		leases:               xsync.NewMap[leaseKey, struct{}](),
-		workloadWatchers:     xsync.NewMap[string, Watcher](),
-		nodeAgentPodWatchers: xsync.NewMap[nodeAgentWatchKey, struct{}](),
-		timedLogLevel:        log.NewTimedLevel(loglevel, clog.SetTreeLevel),
-		llSubs:               newLoglevelSubscribers(),
+		backgroundCtx:            ctx,
+		intercepts:               cache.NewMap[string, *Intercept](interceptEqual, 5*time.Millisecond, xsync.WithGrowOnly()),
+		agents:                   cache.NewMap[tunnel.SessionID, *AgentSession](agentsEqual, 5*time.Millisecond, xsync.WithGrowOnly()),
+		clients:                  xsync.NewMap[tunnel.SessionID, *ClientSession](xsync.WithGrowOnly()),
+		leases:                   xsync.NewMap[leaseKey, struct{}](),
+		workloadWatchers:         xsync.NewMap[string, Watcher](),
+		nodeAgentPodWatchers:     xsync.NewMap[nodeAgentWatchKey, struct{}](),
+		timedLogLevel:            log.NewTimedLevel(loglevel, clog.SetTreeLevel),
+		llSubs:                   newLoglevelSubscribers(),
+		serviceInterceptWatchers: xsync.NewMap[string, struct{}](),
 	}
 	g.Go("namespace-GC", s.pruneSessionGCLoop)
 	g.Go("expired-GC", s.runSessionGCLoop)
@@ -292,31 +296,37 @@ func (s *State) checkAgentsForIntercept(intercept *Intercept) (errCode rpc.Inter
 
 	// main ////////////////////////////////////////////////////////////////
 
-	var agentList []*rpc.AgentInfo
-	agentName := intercept.Spec.Agent
-	ns := intercept.Spec.Namespace
-	s.EachAgent(func(_ tunnel.SessionID, ai *AgentSession) bool {
-		if ai.Name == agentName && ai.Namespace == ns {
-			agentList = append(agentList, ai.AgentInfo)
-		}
-		return true
-	})
-
-	switch {
-	case len(agentList) == 0:
-		errCode = rpc.InterceptDispositionType_NO_AGENT
-		errMsg = fmt.Sprintf("No agent found for %q", intercept.Spec.Agent)
-	case !managerutil.AgentsAreCompatible(agentList):
-		errCode = rpc.InterceptDispositionType_NO_AGENT
-		errMsg = fmt.Sprintf("Agents for %q are not consistent", intercept.Spec.Agent)
-	case !agentHasMechanism(agentList[0], intercept.Spec.Mechanism):
-		errCode = rpc.InterceptDispositionType_NO_MECHANISM
-		errMsg = fmt.Sprintf("Agents for %q do not have mechanism %q", intercept.Spec.Agent, intercept.Spec.Mechanism)
-	default:
-		errCode = rpc.InterceptDispositionType_UNSPECIFIED
-		errMsg = ""
+	serviceScoped := serviceScopedIntercept(intercept.Spec)
+	if serviceScoped && len(intercept.participants) == 0 {
+		return rpc.InterceptDispositionType_NO_AGENT,
+			fmt.Sprintf("No agent found that claims service %q port %d", intercept.Spec.ServiceName, intercept.Spec.ServicePort)
 	}
-	return errCode, errMsg
+
+	groups := s.agentsByParticipant(intercept)
+	keys := intercept.participantKeys()
+	if !serviceScoped {
+		keys = []string{participantKey(intercept.Spec.Namespace, intercept.Spec.WorkloadKind, intercept.Spec.Agent)}
+	}
+	for _, key := range keys {
+		agentList := groups[key]
+		participantName := intercept.Spec.Agent
+		if participant := intercept.participants[key]; participant != nil {
+			participantName = participant.name
+		}
+		switch {
+		case len(agentList) == 0:
+			return rpc.InterceptDispositionType_NO_AGENT, fmt.Sprintf("No agent found for %q", participantName)
+		case serviceScoped && !allAgentsMatchIntercept(agentList, intercept.Spec):
+			return rpc.InterceptDispositionType_NO_AGENT,
+				fmt.Sprintf("Not every agent for %q advertises the selected Service target", participantName)
+		case !managerutil.AgentsAreCompatible(agentList):
+			return rpc.InterceptDispositionType_NO_AGENT, fmt.Sprintf("Agents for %q are not consistent", participantName)
+		case !agentHasMechanism(agentList[0], intercept.Spec.Mechanism):
+			return rpc.InterceptDispositionType_NO_MECHANISM,
+				fmt.Sprintf("Agents for %q do not have mechanism %q", participantName, intercept.Spec.Mechanism)
+		}
+	}
+	return rpc.InterceptDispositionType_UNSPECIFIED, ""
 }
 
 // Sessions: common ////////////////////////////////////////////////////////////////////////////////
@@ -356,21 +366,73 @@ func (s *State) removeClientSession(cs *ClientSession) {
 func (s *State) consolidateAgentSessionIntercepts(agent *AgentSession) {
 	clog.Debugf(s.backgroundCtx, "Consolidating intercepts after removal of agent %s(%s)", agent.PodName, agent.PodIp)
 	s.intercepts.Range(func(interceptID string, intercept *Intercept) bool {
-		if intercept.Disposition == rpc.InterceptDispositionType_REMOVED || agent.PodIp != intercept.PodIp {
+		serviceScoped := serviceScopedIntercept(intercept.Spec)
+		if intercept.Disposition == rpc.InterceptDispositionType_REMOVED ||
+			(!serviceScoped &&
+				(!AgentMatchesIntercept(agent.AgentInfo, intercept.Spec) || agent.PodIp != intercept.PodIp)) {
 			// Not of interest. Continue iteration.
 			return true
 		}
+		participantKey := agentParticipantKey(agent.AgentInfo)
+		if serviceScoped {
+			intercept = s.reconcileServiceParticipants(interceptID, intercept)
+			if intercept == nil {
+				return true
+			}
+			if _, ok := intercept.participants[participantKey]; !ok {
+				return true
+			}
+		}
 
-		if errCode, errMsg := s.checkAgentsForIntercept(intercept); errCode != rpc.InterceptDispositionType_UNSPECIFIED {
+		removedParticipantReview := false
+		if serviceScoped {
+			if participant := intercept.participants[participantKey]; participant != nil {
+				removedParticipantReview = participant.podName == agent.PodName
+			}
+		}
+
+		errCode, errMsg := s.checkAgentsForIntercept(intercept)
+		switch {
+		case errCode != rpc.InterceptDispositionType_UNSPECIFIED:
 			// No agents matching this intercept are available, so the intercept is now dormant or in error.
 			clog.Debugf(s.backgroundCtx, "Intercept %q no longer has available agents. Setting its disposition to %s", interceptID, errCode)
 			s.UpdateIntercept(interceptID, func(intercept *Intercept) {
-				intercept.PodIp = ""
-				intercept.PodName = ""
+				if serviceScoped {
+					if participant := intercept.participants[participantKey]; participant != nil && participant.podName == agent.PodName {
+						participant.review = nil
+						participant.podName = ""
+					}
+				} else {
+					intercept.PodIp = ""
+					intercept.PodName = ""
+				}
 				intercept.Disposition = errCode
 				intercept.Message = errMsg
 			})
-		} else if agent.PodIp == intercept.PodIp {
+		case serviceScoped && removedParticipantReview:
+			// A different pod in the same workload can keep serving traffic,
+			// but it must review the intercept before that workload is an
+			// active participant again. Preserve the primary pod recorded on
+			// the logical intercept while clearing only this workload's review.
+			clog.Debugf(s.backgroundCtx, "Intercept %q lost reviewing pod %s(%s). Setting its disposition to WAITING", interceptID, agent.PodName, agent.PodIp)
+			s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+				if participant := intercept.participants[participantKey]; participant != nil && participant.podName == agent.PodName {
+					participant.review = nil
+					participant.podName = ""
+				}
+				intercept.Disposition = rpc.InterceptDispositionType_WAITING
+				intercept.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s", strings.Join(intercept.pendingParticipants(), ", "))
+			})
+		case serviceScoped && intercept.Disposition == rpc.InterceptDispositionType_NO_AGENT:
+			// A non-claiming replica can hold a participant in NO_AGENT while
+			// it is present. Once it leaves, let the remaining agents review the
+			// intercept again if every current participant is healthy.
+			clog.Debugf(s.backgroundCtx, "Intercept %q has healthy participant agents again. Setting its disposition to WAITING", interceptID)
+			s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+				intercept.Disposition = rpc.InterceptDispositionType_WAITING
+				intercept.Message = ""
+			})
+		case !serviceScoped:
 			// The agent is about to die, but apparently more agents are present. Let some other agent pick it up then.
 			clog.Debugf(s.backgroundCtx, "Intercept %q lost its agent pod %s(%s). Setting its disposition to WAITING", interceptID, agent.PodName, agent.PodIp)
 			s.UpdateIntercept(interceptID, func(intercept *Intercept) {
@@ -485,10 +547,12 @@ func (s *State) RestoreAgents(agents []*rpc.AgentInfo, now time.Time) {
 func (s *State) RestoreIntercepts(ctx context.Context, intercepts []*rpc.InterceptInfo, now time.Time) {
 	var addedChildren []*Intercept
 	nodeAgentWatches := make(map[nodeAgentWatchKey]struct{})
+	serviceInterceptWatches := make(map[string]struct{})
 	for _, intercept := range intercepts {
 		s.intercepts.LoadOrCompute(intercept.Id, func() *Intercept {
 			spec := intercept.Spec
 			is := &Intercept{InterceptInfo: intercept}
+			s.initializeParticipants(is)
 			if IsChildIntercept(spec) {
 				// Finalizer must be added to the parent intercept, but the parent might be added after
 				// the child intercept is added, so it'll have to wait.
@@ -504,6 +568,9 @@ func (s *State) RestoreIntercepts(ctx context.Context, intercepts []*rpc.Interce
 					is.addFinalizer(s.nodeAgentReapFinalizer())
 					nodeAgentWatches[nodeAgentWatchKey{name: spec.Agent, namespace: spec.Namespace}] = struct{}{}
 				}
+				if serviceScopedIntercept(spec) {
+					serviceInterceptWatches[intercept.Id] = struct{}{}
+				}
 			}
 			return is
 		})
@@ -513,6 +580,9 @@ func (s *State) RestoreIntercepts(ctx context.Context, intercepts []*rpc.Interce
 	// already observe the claim it was started for.
 	for key := range nodeAgentWatches {
 		s.startNodeAgentPodWatch(key.name, key.namespace)
+	}
+	for interceptID := range serviceInterceptWatches {
+		s.startServiceInterceptWatch(interceptID)
 	}
 	for _, intercept := range addedChildren {
 		parent, ok := s.GetParentIntercept(tunnel.SessionID(intercept.ClientSession.SessionId), intercept.Spec)
@@ -593,24 +663,25 @@ func (s *State) CountTunnelEgress() uint64 {
 	return atomic.LoadUint64(&s.tunnelEgressCounter)
 }
 
-// IsInterceptedBy reports whether the client has an ACTIVE intercept of the
-// workload served by the agent named agentName in namespace. The answer
-// applies to every one of the workload's agent pods alike: each agent that
-// accepts an intercept redirects its own pod's traffic, regardless of
-// mechanism or filters, and can deliver a redirected connection only
-// through a dial watcher opened by the client -- so every agent pod needs
-// one, not just the pod recorded on the intercept.
-func (s *State) IsInterceptedBy(agentName, namespace string, client tunnel.SessionID) (found bool) {
+// IsInterceptedBy reports whether this agent pod is serving an ACTIVE
+// intercept owned by the given client. Every agent pod that matches an
+// intercept needs a dial watcher, regardless of mechanism or filters.
+// Service-scoped intercepts extend matching to agents that advertise the
+// selected Service target and still belong to the current participant set.
+func (s *State) IsInterceptedBy(agent *AgentSession, client tunnel.SessionID) (found bool) {
+	if agent == nil {
+		return false
+	}
 	clientSessionID := string(client)
 	s.intercepts.Range(func(id string, ii *Intercept) bool {
-		if ii.ClientSession.SessionId == clientSessionID &&
-			ii.Disposition == rpc.InterceptDispositionType_ACTIVE &&
-			ii.Spec.Namespace == namespace &&
-			ii.Spec.Agent == agentName {
-			found = true
-			return false
+		if ii.ClientSession.SessionId != clientSessionID || ii.Disposition != rpc.InterceptDispositionType_ACTIVE {
+			return true
 		}
-		return true
+		if !AgentMatchesInterceptInfo(agent.AgentInfo, ii) {
+			return true
+		}
+		found = true
+		return false
 	})
 	return found
 }
@@ -635,6 +706,49 @@ func (s *State) RestoreAgent(ctx context.Context, id tunnel.SessionID, agent *rp
 
 	s.intercepts.Range(func(interceptID string, intercept *Intercept) bool {
 		if intercept.Disposition == rpc.InterceptDispositionType_REMOVED {
+			return true
+		}
+		matches := AgentMatchesIntercept(agent, intercept.Spec)
+		if serviceScopedIntercept(intercept.Spec) {
+			participantKey := agentParticipantKey(agent)
+			wasParticipant := intercept.participants[participantKey] != nil
+			intercept = s.reconcileServiceParticipants(interceptID, intercept)
+			if intercept == nil {
+				return true
+			}
+			if !matches {
+				if !wasParticipant {
+					return true
+				}
+			} else {
+				// All pods in one workload share a participant key. Avoid entering
+				// UpdateIntercept once the workload is already represented; otherwise a
+				// burst of pods needlessly contends on the same intercept record.
+				if _, exists := intercept.participants[participantKey]; !exists {
+					if _, selectionKnown := s.selectedServiceParticipants(intercept); selectionKnown {
+						// The Service selector is authoritative when its
+						// informer state is available. An old agent can keep
+						// advertising a target after its workload was
+						// pruned, but must not rejoin the intercept.
+						return true
+					}
+					intercept = s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+						if _, exists := intercept.participants[participantKey]; exists {
+							return
+						}
+						intercept.addParticipant(agent)
+						if intercept.Disposition == rpc.InterceptDispositionType_ACTIVE {
+							intercept.Disposition = rpc.InterceptDispositionType_WAITING
+							intercept.Message = fmt.Sprintf("Waiting for Agent approval from workloads: %s",
+								strings.Join(intercept.pendingParticipants(), ", "))
+						}
+					})
+					if intercept == nil {
+						return true
+					}
+				}
+			}
+		} else if !matches {
 			return true
 		}
 		// Check whether each intercept needs to either (1) be moved in to a NO_AGENT state
@@ -744,6 +858,36 @@ func (s *State) UpdateIntercept(interceptID string, apply func(*Intercept)) *Int
 			return newInfo
 		}
 	}
+}
+
+// ApplyAgentReview applies an agent's intercept review. Service-scoped
+// intercepts wait for one approval from each participating workload before
+// they become active; workload-scoped intercepts retain the historical
+// first-review-wins behavior.
+func (s *State) ApplyAgentReview(ctx context.Context, interceptID string, agent *AgentSession, review *rpc.ReviewInterceptRequest) *Intercept {
+	return s.UpdateIntercept(interceptID, func(intercept *Intercept) {
+		if !AgentMatchesInterceptInfo(agent.AgentInfo, intercept) {
+			return
+		}
+		if mutator.GetMap(ctx).IsInactive(types.UID(agent.PodUid)) {
+			clog.Debugf(ctx, "Pod %s(%s) is blacklisted", agent.PodName, agent.PodIp)
+			return
+		}
+
+		// Agents race to review an intercept, so only reviews for waiting
+		// intercepts can change its state.
+		if intercept.Disposition != rpc.InterceptDispositionType_NO_AGENT &&
+			intercept.Disposition != rpc.InterceptDispositionType_WAITING {
+			return
+		}
+		if serviceScopedIntercept(intercept.Spec) {
+			intercept.applyServiceReview(agent.AgentInfo, review)
+			return
+		}
+
+		applyReview(intercept, review)
+		intercept.PodName = agent.PodName
+	})
 }
 
 func (s *State) RemoveIntercept(interceptID string) {
@@ -903,9 +1047,21 @@ func (s *State) allInterceptsFinalizerCall(client *ClientSession, workload *stri
 
 func (s *State) CountActiveInterceptsForWorkload(workloadKey *mutator.WorkloadKey) int {
 	intercepts := s.intercepts.LoadMatching(func(_ string, ii *Intercept) bool {
-		return ii.Disposition == rpc.InterceptDispositionType_ACTIVE &&
-			ii.Spec.Agent == workloadKey.Name &&
-			ii.Spec.Namespace == workloadKey.Namespace
+		if ii.Disposition != rpc.InterceptDispositionType_ACTIVE {
+			return false
+		}
+		if ii.Spec.Agent == workloadKey.Name && ii.Spec.Namespace == workloadKey.Namespace {
+			return true
+		}
+		for _, workload := range ii.ServiceWorkloads {
+			if workload != nil &&
+				workload.WorkloadName == workloadKey.Name &&
+				workload.Namespace == workloadKey.Namespace &&
+				workload.WorkloadKind == string(workloadKey.Kind) {
+				return true
+			}
+		}
+		return false
 	})
 	return len(intercepts)
 }

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -196,6 +196,13 @@ func TestIsInterceptedBy(t *testing.T) {
 	}
 
 	clientID := tunnel.SessionID("client")
+	agent := func(ip, name, namespace string) *AgentSession {
+		return &AgentSession{AgentInfo: &manager.AgentInfo{
+			Name:      name,
+			Namespace: namespace,
+			PodIp:     ip,
+		}}
+	}
 
 	st.intercepts.Store("http", &Intercept{InterceptInfo: &manager.InterceptInfo{
 		Id:          "http",
@@ -241,17 +248,14 @@ func TestIsInterceptedBy(t *testing.T) {
 		},
 	}})
 
-	// Any ACTIVE intercept of the workload marks it intercepted by its
-	// client, regardless of mechanism or filters.
-	require.True(t, st.IsInterceptedBy("demo", "default", clientID))
-	require.True(t, st.IsInterceptedBy("api", "default", clientID))
-
-	// A different workload, a different namespace, a different client, or a
-	// non-ACTIVE disposition does not.
-	require.False(t, st.IsInterceptedBy("other", "default", clientID))
-	require.False(t, st.IsInterceptedBy("demo", "other", clientID))
-	require.False(t, st.IsInterceptedBy("demo", "default", tunnel.SessionID("other-client")))
-	require.False(t, st.IsInterceptedBy("queued", "default", clientID))
+	require.True(t, st.IsInterceptedBy(agent("10.0.0.1", "demo", "default"), clientID))
+	require.True(t, st.IsInterceptedBy(agent("10.0.0.2", "demo", "default"), clientID))
+	require.True(t, st.IsInterceptedBy(agent("10.0.0.3", "api", "default"), clientID))
+	require.True(t, st.IsInterceptedBy(agent("10.0.0.4", "api", "default"), clientID))
+	require.False(t, st.IsInterceptedBy(agent("10.0.0.2", "other", "default"), clientID))
+	require.False(t, st.IsInterceptedBy(agent("10.0.0.2", "demo", "other"), clientID))
+	require.False(t, st.IsInterceptedBy(agent("10.0.0.1", "demo", "default"), tunnel.SessionID("other-client")))
+	require.False(t, st.IsInterceptedBy(agent("10.0.0.5", "queued", "default"), clientID))
 }
 
 func TestSuiteState(testing *testing.T) {

--- a/docs/reference/attachments/cli.md
+++ b/docs/reference/attachments/cli.md
@@ -79,6 +79,25 @@ intercepted
     Volume Mount Point     : /tmp/telfs-893700837
 ```
 
+## Intercepting a Service shared by multiple workloads
+
+A Service can select pods owned by more than one workload, such as stable and canary
+Deployments behind one traffic-splitting Service. For an HTTP intercept without
+`--replace`, Telepresence lets every selected workload participate in one logical
+intercept. Filtered requests then reach the same local handler regardless of which
+selected workload receives the request.
+
+The traffic-manager can install traffic-agents in additional selected workloads when
+they are needed for this shared intercept. Removing the intercept does not uninstall
+those agents; use the normal uninstall command when they are no longer wanted. If a
+participating workload has no available agent, for example while it is scaled to zero,
+the whole intercept moves to `NO_AGENT` until that participant returns.
+
+Shared expansion is intentionally limited to HTTP intercepts without `--replace`.
+For TCP, `--replace`, older traffic-agents that do not advertise Service targets, or
+Service selectors that cannot be resolved safely, Telepresence logs a warning and
+uses only the workload named by the user.
+
 ## Port-forwarding an intercepted container's sidecars
 
 Sidecars are containers that sit in the same pod as an application

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,12 @@ Automcompletion for <code>use</code> flag now dynamically generates completions 
 The agent injector reused a cached sidecar config across concurrent pod admissions while serializing that config temporarily cleared creation-only fields such as the traffic-agent image. A concurrent admission could observe the cleared image and produce invalid traffic-agent and init-container patches with empty image fields. Serialization now strips those fields from a local copy, so parallel pod creation cannot corrupt the cached config or block a workload rollout.
 </div>
 
+## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[HTTP intercepts can follow every workload selected by one Service](reference/attachments/cli)</div></div>
+<div style="margin-left: 15px">
+
+A Kubernetes Service can route requests to more than one workload, such as stable and canary Deployments, while an intercept previously followed only the workload named by the user. HTTP intercepts without <code>--replace</code> now let each selected workload participate in one logical intercept, so filtered traffic reaches the same local handler regardless of which selected workload receives it. If the selected workloads or their traffic-agents cannot support shared interception, Telepresence warns and keeps the historical single-workload behavior instead of failing the intercept.
+</div>
+
 ## <div style="display:flex;"><img src="images/feature.png" alt="feature" style="width:30px;height:fit-content;"/><div style="display:flex;margin-left:7px;">[Guided traffic-manager setup with telepresence setup](reference/setup)</div></div>
 <div style="margin-left: 15px">
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -21,6 +21,12 @@ The agent injector reused a cached sidecar config across concurrent pod admissio
   </Body>
 </Note>
 <Note>
+	<Title type="feature" docs="reference/attachments/cli">HTTP intercepts can follow every workload selected by one Service</Title>
+	<Body>
+A Kubernetes Service can route requests to more than one workload, such as stable and canary Deployments, while an intercept previously followed only the workload named by the user. HTTP intercepts without <code>--replace</code> now let each selected workload participate in one logical intercept, so filtered traffic reaches the same local handler regardless of which selected workload receives it. If the selected workloads or their traffic-agents cannot support shared interception, Telepresence warns and keeps the historical single-workload behavior instead of failing the intercept.
+  </Body>
+</Note>
+<Note>
 	<Title type="feature" docs="reference/setup">Guided traffic-manager setup with telepresence setup</Title>
 	<Body>
 The new <code>telepresence setup</code> command analyzes the cluster (install privileges, QUIC and node-agent viability, webhook reachability, namespace scale, routing conflicts, and any existing installation), asks only the questions the findings leave open, and then validates, writes, or applies a fully configured traffic-manager Helm install. <code>--output</code> produces a normal Helm values file for GitOps, <code>--input</code> re-runs without repeating prior decisions (and is also how every answer can be preset, keeping the command's own flag surface small), and <code>--apply</code> installs or upgrades with post-apply verification, including a real QUIC reachability check. When install privileges are missing, the report itemizes exactly what to hand to a cluster admin instead of a dead end, and <code>telepresence setup --format json</code> is a convenient attachment for bug reports.

--- a/pkg/agentconfig/intercepttarget.go
+++ b/pkg/agentconfig/intercepttarget.go
@@ -39,9 +39,28 @@ func NewInterceptTarget(ics []*Intercept) InterceptTarget {
 }
 
 func (cp InterceptTarget) MatchForSpec(spec *manager.InterceptSpec) bool {
+	proto := types.FromK8sProtocol(core.Protocol(spec.Protocol))
+	if spec.ServiceUid != "" {
+		for _, ic := range cp {
+			if string(ic.ServiceUID) != spec.ServiceUid || ic.Protocol != proto {
+				continue
+			}
+			switch {
+			case spec.ServicePort > 0:
+				if ic.ServicePort == uint16(spec.ServicePort) {
+					return true
+				}
+			case spec.ServicePortName != "":
+				if ic.ServicePortName == spec.ServicePortName {
+					return true
+				}
+			}
+		}
+		return false
+	}
 	ic := cp[0]
 	cnPort := uint16(spec.ContainerPort)
-	return cnPort == ic.ContainerPort && ic.Protocol == types.FromK8sProtocol(core.Protocol(spec.Protocol))
+	return cnPort == ic.ContainerPort && ic.Protocol == proto
 }
 
 func (cp InterceptTarget) AgentPort() uint16 {

--- a/pkg/agentconfig/intercepttarget_test.go
+++ b/pkg/agentconfig/intercepttarget_test.go
@@ -1,0 +1,49 @@
+package agentconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
+)
+
+func TestInterceptTargetMatchForServiceSpec(t *testing.T) {
+	target := NewInterceptTarget([]*Intercept{{
+		ServiceUID:      k8sTypes.UID("service-uid"),
+		ServicePortName: "http",
+		ServicePort:     80,
+		Protocol:        types.ProtoTCP,
+		ContainerPort:   8081,
+	}})
+
+	require.True(t, target.MatchForSpec(&manager.InterceptSpec{
+		ServiceUid:  "service-uid",
+		ServicePort: 80,
+		Protocol:    "TCP",
+		// The primary workload can resolve a different container port.
+		ContainerPort: 8080,
+	}))
+	require.False(t, target.MatchForSpec(&manager.InterceptSpec{
+		ServiceUid:  "other-service",
+		ServicePort: 80,
+		Protocol:    "TCP",
+	}))
+	require.False(t, target.MatchForSpec(&manager.InterceptSpec{
+		ServiceUid:  "service-uid",
+		ServicePort: 81,
+		Protocol:    "TCP",
+	}))
+}
+
+func TestInterceptTargetMatchForContainerSpec(t *testing.T) {
+	target := NewInterceptTarget([]*Intercept{{
+		Protocol:      types.ProtoTCP,
+		ContainerPort: 8080,
+	}})
+
+	require.True(t, target.MatchForSpec(&manager.InterceptSpec{ContainerPort: 8080, Protocol: "TCP"}))
+	require.False(t, target.MatchForSpec(&manager.InterceptSpec{ContainerPort: 8081, Protocol: "TCP"}))
+}

--- a/rpc/manager/manager.pb.go
+++ b/rpc/manager/manager.pb.go
@@ -169,7 +169,7 @@ func (x WorkloadInfo_Kind) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_Kind.Descriptor instead.
 func (WorkloadInfo_Kind) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58, 0}
 }
 
 type WorkloadInfo_State int32
@@ -229,7 +229,7 @@ func (x WorkloadInfo_State) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_State.Descriptor instead.
 func (WorkloadInfo_State) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57, 1}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58, 1}
 }
 
 type WorkloadInfo_AgentState int32
@@ -281,7 +281,7 @@ func (x WorkloadInfo_AgentState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadInfo_AgentState.Descriptor instead.
 func (WorkloadInfo_AgentState) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57, 2}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58, 2}
 }
 
 type WorkloadEvent_Type int32
@@ -330,7 +330,7 @@ func (x WorkloadEvent_Type) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WorkloadEvent_Type.Descriptor instead.
 func (WorkloadEvent_Type) EnumDescriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{58, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{59, 0}
 }
 
 // ClientInfo is the self-reported metadata that the on-laptop
@@ -438,9 +438,12 @@ type AgentInfo struct {
 	// UDP port of this agent's QUIC listener, reachable only through the QUIC
 	// forwarder (see docs/reference/quic-transport-architecture.md, "Agent connections
 	// over QUIC"). 0 means this agent has no QUIC listener.
-	QuicPort      int32 `protobuf:"varint,16,opt,name=quic_port,json=quicPort,proto3" json:"quic_port,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	QuicPort int32 `protobuf:"varint,16,opt,name=quic_port,json=quicPort,proto3" json:"quic_port,omitempty"`
+	// Service-backed targets advertised by this agent. Older agents leave this
+	// empty and continue to use workload-scoped intercept matching.
+	InterceptTargets []*AgentInfo_InterceptTarget `protobuf:"bytes,17,rep,name=intercept_targets,json=interceptTargets,proto3" json:"intercept_targets,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *AgentInfo) Reset() {
@@ -576,6 +579,13 @@ func (x *AgentInfo) GetQuicPort() int32 {
 		return x.QuicPort
 	}
 	return 0
+}
+
+func (x *AgentInfo) GetInterceptTargets() []*AgentInfo_InterceptTarget {
+	if x != nil {
+		return x.InterceptTargets
+	}
+	return nil
 }
 
 // PortMapping describes a mapping from a port number in the intercepted container to
@@ -966,6 +976,68 @@ func (x *InterceptSpec) GetNodeAgent() bool {
 	return false
 }
 
+// InterceptWorkload identifies one workload whose pods participate in a
+// Service-scoped intercept.
+type InterceptWorkload struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Namespace     string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	WorkloadKind  string                 `protobuf:"bytes,2,opt,name=workload_kind,json=workloadKind,proto3" json:"workload_kind,omitempty"`
+	WorkloadName  string                 `protobuf:"bytes,3,opt,name=workload_name,json=workloadName,proto3" json:"workload_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InterceptWorkload) Reset() {
+	*x = InterceptWorkload{}
+	mi := &file_manager_manager_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterceptWorkload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterceptWorkload) ProtoMessage() {}
+
+func (x *InterceptWorkload) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterceptWorkload.ProtoReflect.Descriptor instead.
+func (*InterceptWorkload) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InterceptWorkload) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *InterceptWorkload) GetWorkloadKind() string {
+	if x != nil {
+		return x.WorkloadKind
+	}
+	return ""
+}
+
+func (x *InterceptWorkload) GetWorkloadName() string {
+	if x != nil {
+		return x.WorkloadName
+	}
+	return ""
+}
+
 // InterceptInfo contains information about a live intercept in an agent
 type InterceptInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -998,14 +1070,18 @@ type InterceptInfo struct {
 	// Map of mount path -> MountPolicy
 	Mounts map[string]int32 `protobuf:"bytes,22,rep,name=mounts,proto3" json:"mounts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	// Timestamp for last modification made by traffic-manager
-	ModifiedAt    *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=modified_at,json=modifiedAt,proto3" json:"modified_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ModifiedAt *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=modified_at,json=modifiedAt,proto3" json:"modified_at,omitempty"`
+	// Workloads whose ready Service-selected pods participate in this intercept.
+	// This is populated by the manager for Service-scoped intercepts so
+	// server-side integrations can configure every participating workload.
+	ServiceWorkloads []*InterceptWorkload `protobuf:"bytes,23,rep,name=service_workloads,json=serviceWorkloads,proto3" json:"service_workloads,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *InterceptInfo) Reset() {
 	*x = InterceptInfo{}
-	mi := &file_manager_manager_proto_msgTypes[4]
+	mi := &file_manager_manager_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1017,7 +1093,7 @@ func (x *InterceptInfo) String() string {
 func (*InterceptInfo) ProtoMessage() {}
 
 func (x *InterceptInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[4]
+	mi := &file_manager_manager_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1030,7 +1106,7 @@ func (x *InterceptInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterceptInfo.ProtoReflect.Descriptor instead.
 func (*InterceptInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{4}
+	return file_manager_manager_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *InterceptInfo) GetSpec() *InterceptSpec {
@@ -1145,6 +1221,13 @@ func (x *InterceptInfo) GetModifiedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *InterceptInfo) GetServiceWorkloads() []*InterceptWorkload {
+	if x != nil {
+		return x.ServiceWorkloads
+	}
+	return nil
+}
+
 type ReconnectAgentRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Session       *SessionInfo           `protobuf:"bytes,1,opt,name=session,proto3" json:"session,omitempty"`
@@ -1155,7 +1238,7 @@ type ReconnectAgentRequest struct {
 
 func (x *ReconnectAgentRequest) Reset() {
 	*x = ReconnectAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[5]
+	mi := &file_manager_manager_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1167,7 +1250,7 @@ func (x *ReconnectAgentRequest) String() string {
 func (*ReconnectAgentRequest) ProtoMessage() {}
 
 func (x *ReconnectAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[5]
+	mi := &file_manager_manager_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1180,7 +1263,7 @@ func (x *ReconnectAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReconnectAgentRequest.ProtoReflect.Descriptor instead.
 func (*ReconnectAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{5}
+	return file_manager_manager_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ReconnectAgentRequest) GetSession() *SessionInfo {
@@ -1209,7 +1292,7 @@ type ReconnectClientRequest struct {
 
 func (x *ReconnectClientRequest) Reset() {
 	*x = ReconnectClientRequest{}
-	mi := &file_manager_manager_proto_msgTypes[6]
+	mi := &file_manager_manager_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1221,7 +1304,7 @@ func (x *ReconnectClientRequest) String() string {
 func (*ReconnectClientRequest) ProtoMessage() {}
 
 func (x *ReconnectClientRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[6]
+	mi := &file_manager_manager_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1234,7 +1317,7 @@ func (x *ReconnectClientRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReconnectClientRequest.ProtoReflect.Descriptor instead.
 func (*ReconnectClientRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{6}
+	return file_manager_manager_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ReconnectClientRequest) GetSession() *SessionInfo {
@@ -1276,7 +1359,7 @@ type SessionInfo struct {
 
 func (x *SessionInfo) Reset() {
 	*x = SessionInfo{}
-	mi := &file_manager_manager_proto_msgTypes[7]
+	mi := &file_manager_manager_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1288,7 +1371,7 @@ func (x *SessionInfo) String() string {
 func (*SessionInfo) ProtoMessage() {}
 
 func (x *SessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[7]
+	mi := &file_manager_manager_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1301,7 +1384,7 @@ func (x *SessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionInfo.ProtoReflect.Descriptor instead.
 func (*SessionInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{7}
+	return file_manager_manager_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *SessionInfo) GetSessionId() string {
@@ -1335,7 +1418,7 @@ type AgentsRequest struct {
 
 func (x *AgentsRequest) Reset() {
 	*x = AgentsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[8]
+	mi := &file_manager_manager_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1347,7 +1430,7 @@ func (x *AgentsRequest) String() string {
 func (*AgentsRequest) ProtoMessage() {}
 
 func (x *AgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[8]
+	mi := &file_manager_manager_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1360,7 +1443,7 @@ func (x *AgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentsRequest.ProtoReflect.Descriptor instead.
 func (*AgentsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{8}
+	return file_manager_manager_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *AgentsRequest) GetSession() *SessionInfo {
@@ -1386,7 +1469,7 @@ type AgentInfoSnapshot struct {
 
 func (x *AgentInfoSnapshot) Reset() {
 	*x = AgentInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[9]
+	mi := &file_manager_manager_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1398,7 +1481,7 @@ func (x *AgentInfoSnapshot) String() string {
 func (*AgentInfoSnapshot) ProtoMessage() {}
 
 func (x *AgentInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[9]
+	mi := &file_manager_manager_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1411,7 +1494,7 @@ func (x *AgentInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*AgentInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{9}
+	return file_manager_manager_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AgentInfoSnapshot) GetAgents() []*AgentInfo {
@@ -1431,7 +1514,7 @@ type AgentInfoDelta struct {
 
 func (x *AgentInfoDelta) Reset() {
 	*x = AgentInfoDelta{}
-	mi := &file_manager_manager_proto_msgTypes[10]
+	mi := &file_manager_manager_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1526,7 @@ func (x *AgentInfoDelta) String() string {
 func (*AgentInfoDelta) ProtoMessage() {}
 
 func (x *AgentInfoDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[10]
+	mi := &file_manager_manager_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1539,7 @@ func (x *AgentInfoDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentInfoDelta.ProtoReflect.Descriptor instead.
 func (*AgentInfoDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{10}
+	return file_manager_manager_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AgentInfoDelta) GetUpserts() map[string]*AgentInfo {
@@ -1482,7 +1565,7 @@ type InterceptInfoSnapshot struct {
 
 func (x *InterceptInfoSnapshot) Reset() {
 	*x = InterceptInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[11]
+	mi := &file_manager_manager_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1494,7 +1577,7 @@ func (x *InterceptInfoSnapshot) String() string {
 func (*InterceptInfoSnapshot) ProtoMessage() {}
 
 func (x *InterceptInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[11]
+	mi := &file_manager_manager_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1507,7 +1590,7 @@ func (x *InterceptInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterceptInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*InterceptInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{11}
+	return file_manager_manager_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *InterceptInfoSnapshot) GetIntercepts() []*InterceptInfo {
@@ -1527,7 +1610,7 @@ type InterceptInfoDelta struct {
 
 func (x *InterceptInfoDelta) Reset() {
 	*x = InterceptInfoDelta{}
-	mi := &file_manager_manager_proto_msgTypes[12]
+	mi := &file_manager_manager_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1539,7 +1622,7 @@ func (x *InterceptInfoDelta) String() string {
 func (*InterceptInfoDelta) ProtoMessage() {}
 
 func (x *InterceptInfoDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[12]
+	mi := &file_manager_manager_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +1635,7 @@ func (x *InterceptInfoDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterceptInfoDelta.ProtoReflect.Descriptor instead.
 func (*InterceptInfoDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{12}
+	return file_manager_manager_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *InterceptInfoDelta) GetUpserts() map[string]*InterceptInfo {
@@ -1584,7 +1667,7 @@ type SessionEventsRequest struct {
 
 func (x *SessionEventsRequest) Reset() {
 	*x = SessionEventsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1596,7 +1679,7 @@ func (x *SessionEventsRequest) String() string {
 func (*SessionEventsRequest) ProtoMessage() {}
 
 func (x *SessionEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[13]
+	mi := &file_manager_manager_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1609,7 +1692,7 @@ func (x *SessionEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionEventsRequest.ProtoReflect.Descriptor instead.
 func (*SessionEventsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{13}
+	return file_manager_manager_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SessionEventsRequest) GetSession() *SessionInfo {
@@ -1646,7 +1729,7 @@ type SessionEventsDelta struct {
 
 func (x *SessionEventsDelta) Reset() {
 	*x = SessionEventsDelta{}
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1658,7 +1741,7 @@ func (x *SessionEventsDelta) String() string {
 func (*SessionEventsDelta) ProtoMessage() {}
 
 func (x *SessionEventsDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[14]
+	mi := &file_manager_manager_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1671,7 +1754,7 @@ func (x *SessionEventsDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionEventsDelta.ProtoReflect.Descriptor instead.
 func (*SessionEventsDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{14}
+	return file_manager_manager_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SessionEventsDelta) GetAgentPods() *AgentPodInfoDelta {
@@ -1698,7 +1781,7 @@ type CreateInterceptRequest struct {
 
 func (x *CreateInterceptRequest) Reset() {
 	*x = CreateInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1710,7 +1793,7 @@ func (x *CreateInterceptRequest) String() string {
 func (*CreateInterceptRequest) ProtoMessage() {}
 
 func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[15]
+	mi := &file_manager_manager_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1723,7 +1806,7 @@ func (x *CreateInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInterceptRequest.ProtoReflect.Descriptor instead.
 func (*CreateInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{15}
+	return file_manager_manager_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CreateInterceptRequest) GetSession() *SessionInfo {
@@ -1756,7 +1839,7 @@ type EnsureAgentRequest struct {
 
 func (x *EnsureAgentRequest) Reset() {
 	*x = EnsureAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1768,7 +1851,7 @@ func (x *EnsureAgentRequest) String() string {
 func (*EnsureAgentRequest) ProtoMessage() {}
 
 func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[16]
+	mi := &file_manager_manager_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,7 +1864,7 @@ func (x *EnsureAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnsureAgentRequest.ProtoReflect.Descriptor instead.
 func (*EnsureAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{16}
+	return file_manager_manager_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *EnsureAgentRequest) GetSession() *SessionInfo {
@@ -1823,7 +1906,7 @@ type ReleaseAgentRequest struct {
 
 func (x *ReleaseAgentRequest) Reset() {
 	*x = ReleaseAgentRequest{}
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +1918,7 @@ func (x *ReleaseAgentRequest) String() string {
 func (*ReleaseAgentRequest) ProtoMessage() {}
 
 func (x *ReleaseAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[17]
+	mi := &file_manager_manager_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +1931,7 @@ func (x *ReleaseAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReleaseAgentRequest.ProtoReflect.Descriptor instead.
 func (*ReleaseAgentRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{17}
+	return file_manager_manager_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ReleaseAgentRequest) GetSession() *SessionInfo {
@@ -1895,7 +1978,7 @@ type PreparedIntercept struct {
 
 func (x *PreparedIntercept) Reset() {
 	*x = PreparedIntercept{}
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1907,7 +1990,7 @@ func (x *PreparedIntercept) String() string {
 func (*PreparedIntercept) ProtoMessage() {}
 
 func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[18]
+	mi := &file_manager_manager_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1920,7 +2003,7 @@ func (x *PreparedIntercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedIntercept.ProtoReflect.Descriptor instead.
 func (*PreparedIntercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{18}
+	return file_manager_manager_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PreparedIntercept) GetError() string {
@@ -2031,7 +2114,7 @@ type RemoveInterceptRequest2 struct {
 
 func (x *RemoveInterceptRequest2) Reset() {
 	*x = RemoveInterceptRequest2{}
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2043,7 +2126,7 @@ func (x *RemoveInterceptRequest2) String() string {
 func (*RemoveInterceptRequest2) ProtoMessage() {}
 
 func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[19]
+	mi := &file_manager_manager_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2056,7 +2139,7 @@ func (x *RemoveInterceptRequest2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveInterceptRequest2.ProtoReflect.Descriptor instead.
 func (*RemoveInterceptRequest2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{19}
+	return file_manager_manager_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RemoveInterceptRequest2) GetSession() *SessionInfo {
@@ -2083,7 +2166,7 @@ type GetInterceptRequest struct {
 
 func (x *GetInterceptRequest) Reset() {
 	*x = GetInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2095,7 +2178,7 @@ func (x *GetInterceptRequest) String() string {
 func (*GetInterceptRequest) ProtoMessage() {}
 
 func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[20]
+	mi := &file_manager_manager_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2191,7 @@ func (x *GetInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInterceptRequest.ProtoReflect.Descriptor instead.
 func (*GetInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{20}
+	return file_manager_manager_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetInterceptRequest) GetSession() *SessionInfo {
@@ -2150,7 +2233,7 @@ type ReviewInterceptRequest struct {
 
 func (x *ReviewInterceptRequest) Reset() {
 	*x = ReviewInterceptRequest{}
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2162,7 +2245,7 @@ func (x *ReviewInterceptRequest) String() string {
 func (*ReviewInterceptRequest) ProtoMessage() {}
 
 func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[21]
+	mi := &file_manager_manager_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2175,7 +2258,7 @@ func (x *ReviewInterceptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewInterceptRequest.ProtoReflect.Descriptor instead.
 func (*ReviewInterceptRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{21}
+	return file_manager_manager_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ReviewInterceptRequest) GetSession() *SessionInfo {
@@ -2265,7 +2348,7 @@ type RemainRequest struct {
 
 func (x *RemainRequest) Reset() {
 	*x = RemainRequest{}
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2277,7 +2360,7 @@ func (x *RemainRequest) String() string {
 func (*RemainRequest) ProtoMessage() {}
 
 func (x *RemainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[22]
+	mi := &file_manager_manager_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2290,7 +2373,7 @@ func (x *RemainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemainRequest.ProtoReflect.Descriptor instead.
 func (*RemainRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{22}
+	return file_manager_manager_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RemainRequest) GetSession() *SessionInfo {
@@ -2322,7 +2405,7 @@ type LogLevelRequest struct {
 
 func (x *LogLevelRequest) Reset() {
 	*x = LogLevelRequest{}
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2334,7 +2417,7 @@ func (x *LogLevelRequest) String() string {
 func (*LogLevelRequest) ProtoMessage() {}
 
 func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[23]
+	mi := &file_manager_manager_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2347,7 +2430,7 @@ func (x *LogLevelRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogLevelRequest.ProtoReflect.Descriptor instead.
 func (*LogLevelRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{23}
+	return file_manager_manager_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *LogLevelRequest) GetLogLevel() string {
@@ -2387,7 +2470,7 @@ type GetLogsRequest struct {
 
 func (x *GetLogsRequest) Reset() {
 	*x = GetLogsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2399,7 +2482,7 @@ func (x *GetLogsRequest) String() string {
 func (*GetLogsRequest) ProtoMessage() {}
 
 func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[24]
+	mi := &file_manager_manager_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2412,7 +2495,7 @@ func (x *GetLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetLogsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{24}
+	return file_manager_manager_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetLogsRequest) GetTrafficManager() bool {
@@ -2454,7 +2537,7 @@ type LogsResponse struct {
 
 func (x *LogsResponse) Reset() {
 	*x = LogsResponse{}
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2466,7 +2549,7 @@ func (x *LogsResponse) String() string {
 func (*LogsResponse) ProtoMessage() {}
 
 func (x *LogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[25]
+	mi := &file_manager_manager_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2479,7 +2562,7 @@ func (x *LogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogsResponse.ProtoReflect.Descriptor instead.
 func (*LogsResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{25}
+	return file_manager_manager_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LogsResponse) GetPodLogs() map[string]string {
@@ -2513,7 +2596,7 @@ type TelepresenceAPIInfo struct {
 
 func (x *TelepresenceAPIInfo) Reset() {
 	*x = TelepresenceAPIInfo{}
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2525,7 +2608,7 @@ func (x *TelepresenceAPIInfo) String() string {
 func (*TelepresenceAPIInfo) ProtoMessage() {}
 
 func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[26]
+	mi := &file_manager_manager_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2538,7 +2621,7 @@ func (x *TelepresenceAPIInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelepresenceAPIInfo.ProtoReflect.Descriptor instead.
 func (*TelepresenceAPIInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{26}
+	return file_manager_manager_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TelepresenceAPIInfo) GetPort() int32 {
@@ -2575,7 +2658,7 @@ type VersionInfo2 struct {
 
 func (x *VersionInfo2) Reset() {
 	*x = VersionInfo2{}
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2587,7 +2670,7 @@ func (x *VersionInfo2) String() string {
 func (*VersionInfo2) ProtoMessage() {}
 
 func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[27]
+	mi := &file_manager_manager_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2600,7 +2683,7 @@ func (x *VersionInfo2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionInfo2.ProtoReflect.Descriptor instead.
 func (*VersionInfo2) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{27}
+	return file_manager_manager_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *VersionInfo2) GetName() string {
@@ -2648,7 +2731,7 @@ type TunnelMessage struct {
 
 func (x *TunnelMessage) Reset() {
 	*x = TunnelMessage{}
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2660,7 +2743,7 @@ func (x *TunnelMessage) String() string {
 func (*TunnelMessage) ProtoMessage() {}
 
 func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[28]
+	mi := &file_manager_manager_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2673,7 +2756,7 @@ func (x *TunnelMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMessage.ProtoReflect.Descriptor instead.
 func (*TunnelMessage) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{28}
+	return file_manager_manager_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TunnelMessage) GetPayload() []byte {
@@ -2718,7 +2801,7 @@ type QuicTunnelEndpoint struct {
 
 func (x *QuicTunnelEndpoint) Reset() {
 	*x = QuicTunnelEndpoint{}
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2730,7 +2813,7 @@ func (x *QuicTunnelEndpoint) String() string {
 func (*QuicTunnelEndpoint) ProtoMessage() {}
 
 func (x *QuicTunnelEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[29]
+	mi := &file_manager_manager_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2743,7 +2826,7 @@ func (x *QuicTunnelEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicTunnelEndpoint.ProtoReflect.Descriptor instead.
 func (*QuicTunnelEndpoint) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{29}
+	return file_manager_manager_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *QuicTunnelEndpoint) GetEnabled() bool {
@@ -2821,7 +2904,7 @@ type QuicEndpointCandidate struct {
 
 func (x *QuicEndpointCandidate) Reset() {
 	*x = QuicEndpointCandidate{}
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2833,7 +2916,7 @@ func (x *QuicEndpointCandidate) String() string {
 func (*QuicEndpointCandidate) ProtoMessage() {}
 
 func (x *QuicEndpointCandidate) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[30]
+	mi := &file_manager_manager_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2846,7 +2929,7 @@ func (x *QuicEndpointCandidate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicEndpointCandidate.ProtoReflect.Descriptor instead.
 func (*QuicEndpointCandidate) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{30}
+	return file_manager_manager_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *QuicEndpointCandidate) GetHost() string {
@@ -2886,7 +2969,7 @@ type SessionCredential struct {
 
 func (x *SessionCredential) Reset() {
 	*x = SessionCredential{}
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2898,7 +2981,7 @@ func (x *SessionCredential) String() string {
 func (*SessionCredential) ProtoMessage() {}
 
 func (x *SessionCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[31]
+	mi := &file_manager_manager_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2911,7 +2994,7 @@ func (x *SessionCredential) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionCredential.ProtoReflect.Descriptor instead.
 func (*SessionCredential) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{31}
+	return file_manager_manager_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SessionCredential) GetCaPem() []byte {
@@ -2970,7 +3053,7 @@ type QuicBackend struct {
 
 func (x *QuicBackend) Reset() {
 	*x = QuicBackend{}
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2982,7 +3065,7 @@ func (x *QuicBackend) String() string {
 func (*QuicBackend) ProtoMessage() {}
 
 func (x *QuicBackend) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[32]
+	mi := &file_manager_manager_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2995,7 +3078,7 @@ func (x *QuicBackend) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicBackend.ProtoReflect.Descriptor instead.
 func (*QuicBackend) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{32}
+	return file_manager_manager_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *QuicBackend) GetIp() []byte {
@@ -3039,7 +3122,7 @@ type QuicBackendSnapshot struct {
 
 func (x *QuicBackendSnapshot) Reset() {
 	*x = QuicBackendSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3051,7 +3134,7 @@ func (x *QuicBackendSnapshot) String() string {
 func (*QuicBackendSnapshot) ProtoMessage() {}
 
 func (x *QuicBackendSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[33]
+	mi := &file_manager_manager_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3064,7 +3147,7 @@ func (x *QuicBackendSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicBackendSnapshot.ProtoReflect.Descriptor instead.
 func (*QuicBackendSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{33}
+	return file_manager_manager_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *QuicBackendSnapshot) GetBackends() []*QuicBackend {
@@ -3085,7 +3168,7 @@ type DialRequest struct {
 
 func (x *DialRequest) Reset() {
 	*x = DialRequest{}
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3097,7 +3180,7 @@ func (x *DialRequest) String() string {
 func (*DialRequest) ProtoMessage() {}
 
 func (x *DialRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[34]
+	mi := &file_manager_manager_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3110,7 +3193,7 @@ func (x *DialRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialRequest.ProtoReflect.Descriptor instead.
 func (*DialRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{34}
+	return file_manager_manager_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DialRequest) GetConnId() []byte {
@@ -3163,7 +3246,7 @@ type QuicAgentCert struct {
 
 func (x *QuicAgentCert) Reset() {
 	*x = QuicAgentCert{}
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3175,7 +3258,7 @@ func (x *QuicAgentCert) String() string {
 func (*QuicAgentCert) ProtoMessage() {}
 
 func (x *QuicAgentCert) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[35]
+	mi := &file_manager_manager_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3188,7 +3271,7 @@ func (x *QuicAgentCert) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuicAgentCert.ProtoReflect.Descriptor instead.
 func (*QuicAgentCert) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{35}
+	return file_manager_manager_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *QuicAgentCert) GetEnabled() bool {
@@ -3245,7 +3328,7 @@ type LookupRequest struct {
 
 func (x *LookupRequest) Reset() {
 	*x = LookupRequest{}
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3257,7 +3340,7 @@ func (x *LookupRequest) String() string {
 func (*LookupRequest) ProtoMessage() {}
 
 func (x *LookupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[36]
+	mi := &file_manager_manager_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3270,7 +3353,7 @@ func (x *LookupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupRequest.ProtoReflect.Descriptor instead.
 func (*LookupRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{36}
+	return file_manager_manager_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *LookupRequest) GetSession() *SessionInfo {
@@ -3297,7 +3380,7 @@ type LookupResponse struct {
 
 func (x *LookupResponse) Reset() {
 	*x = LookupResponse{}
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3309,7 +3392,7 @@ func (x *LookupResponse) String() string {
 func (*LookupResponse) ProtoMessage() {}
 
 func (x *LookupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[37]
+	mi := &file_manager_manager_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3322,7 +3405,7 @@ func (x *LookupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LookupResponse.ProtoReflect.Descriptor instead.
 func (*LookupResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{37}
+	return file_manager_manager_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *LookupResponse) GetIps() [][]byte {
@@ -3345,7 +3428,7 @@ type DNSRequest struct {
 
 func (x *DNSRequest) Reset() {
 	*x = DNSRequest{}
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3357,7 +3440,7 @@ func (x *DNSRequest) String() string {
 func (*DNSRequest) ProtoMessage() {}
 
 func (x *DNSRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[38]
+	mi := &file_manager_manager_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3370,7 +3453,7 @@ func (x *DNSRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSRequest.ProtoReflect.Descriptor instead.
 func (*DNSRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{38}
+	return file_manager_manager_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *DNSRequest) GetSession() *SessionInfo {
@@ -3406,7 +3489,7 @@ type DNSResponse struct {
 
 func (x *DNSResponse) Reset() {
 	*x = DNSResponse{}
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3418,7 +3501,7 @@ func (x *DNSResponse) String() string {
 func (*DNSResponse) ProtoMessage() {}
 
 func (x *DNSResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[39]
+	mi := &file_manager_manager_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3431,7 +3514,7 @@ func (x *DNSResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSResponse.ProtoReflect.Descriptor instead.
 func (*DNSResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{39}
+	return file_manager_manager_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DNSResponse) GetRCode() int32 {
@@ -3462,7 +3545,7 @@ type DNSAgentResponse struct {
 
 func (x *DNSAgentResponse) Reset() {
 	*x = DNSAgentResponse{}
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3474,7 +3557,7 @@ func (x *DNSAgentResponse) String() string {
 func (*DNSAgentResponse) ProtoMessage() {}
 
 func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[40]
+	mi := &file_manager_manager_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3487,7 +3570,7 @@ func (x *DNSAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSAgentResponse.ProtoReflect.Descriptor instead.
 func (*DNSAgentResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{40}
+	return file_manager_manager_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *DNSAgentResponse) GetSession() *SessionInfo {
@@ -3522,7 +3605,7 @@ type IPNet struct {
 
 func (x *IPNet) Reset() {
 	*x = IPNet{}
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3534,7 +3617,7 @@ func (x *IPNet) String() string {
 func (*IPNet) ProtoMessage() {}
 
 func (x *IPNet) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[41]
+	mi := &file_manager_manager_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3547,7 +3630,7 @@ func (x *IPNet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPNet.ProtoReflect.Descriptor instead.
 func (*IPNet) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{41}
+	return file_manager_manager_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *IPNet) GetIp() []byte {
@@ -3595,7 +3678,7 @@ type ClusterInfo struct {
 
 func (x *ClusterInfo) Reset() {
 	*x = ClusterInfo{}
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3607,7 +3690,7 @@ func (x *ClusterInfo) String() string {
 func (*ClusterInfo) ProtoMessage() {}
 
 func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[42]
+	mi := &file_manager_manager_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3620,7 +3703,7 @@ func (x *ClusterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterInfo.ProtoReflect.Descriptor instead.
 func (*ClusterInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{42}
+	return file_manager_manager_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ClusterInfo) GetServiceCidrs() [][]byte {
@@ -3704,7 +3787,7 @@ type Routing struct {
 
 func (x *Routing) Reset() {
 	*x = Routing{}
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3716,7 +3799,7 @@ func (x *Routing) String() string {
 func (*Routing) ProtoMessage() {}
 
 func (x *Routing) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[43]
+	mi := &file_manager_manager_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3729,7 +3812,7 @@ func (x *Routing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Routing.ProtoReflect.Descriptor instead.
 func (*Routing) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{43}
+	return file_manager_manager_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *Routing) GetAlsoProxySubnets() []*IPNet {
@@ -3768,7 +3851,7 @@ type DNS struct {
 
 func (x *DNS) Reset() {
 	*x = DNS{}
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3780,7 +3863,7 @@ func (x *DNS) String() string {
 func (*DNS) ProtoMessage() {}
 
 func (x *DNS) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[44]
+	mi := &file_manager_manager_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3793,7 +3876,7 @@ func (x *DNS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNS.ProtoReflect.Descriptor instead.
 func (*DNS) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{44}
+	return file_manager_manager_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *DNS) GetIncludeSuffixes() []string {
@@ -3834,7 +3917,7 @@ type CLIConfig struct {
 
 func (x *CLIConfig) Reset() {
 	*x = CLIConfig{}
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3846,7 +3929,7 @@ func (x *CLIConfig) String() string {
 func (*CLIConfig) ProtoMessage() {}
 
 func (x *CLIConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[45]
+	mi := &file_manager_manager_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3859,7 +3942,7 @@ func (x *CLIConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CLIConfig.ProtoReflect.Descriptor instead.
 func (*CLIConfig) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{45}
+	return file_manager_manager_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *CLIConfig) GetConfigYaml() []byte {
@@ -3878,7 +3961,7 @@ type AgentImageFQN struct {
 
 func (x *AgentImageFQN) Reset() {
 	*x = AgentImageFQN{}
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3890,7 +3973,7 @@ func (x *AgentImageFQN) String() string {
 func (*AgentImageFQN) ProtoMessage() {}
 
 func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[46]
+	mi := &file_manager_manager_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3903,7 +3986,7 @@ func (x *AgentImageFQN) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentImageFQN.ProtoReflect.Descriptor instead.
 func (*AgentImageFQN) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{46}
+	return file_manager_manager_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AgentImageFQN) GetFQN() string {
@@ -3938,7 +4021,7 @@ type AgentPodInfo struct {
 
 func (x *AgentPodInfo) Reset() {
 	*x = AgentPodInfo{}
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3950,7 +4033,7 @@ func (x *AgentPodInfo) String() string {
 func (*AgentPodInfo) ProtoMessage() {}
 
 func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[47]
+	mi := &file_manager_manager_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3963,7 +4046,7 @@ func (x *AgentPodInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfo.ProtoReflect.Descriptor instead.
 func (*AgentPodInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{47}
+	return file_manager_manager_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *AgentPodInfo) GetPodId() string {
@@ -4045,7 +4128,7 @@ type AgentPodInfoSnapshot struct {
 
 func (x *AgentPodInfoSnapshot) Reset() {
 	*x = AgentPodInfoSnapshot{}
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4057,7 +4140,7 @@ func (x *AgentPodInfoSnapshot) String() string {
 func (*AgentPodInfoSnapshot) ProtoMessage() {}
 
 func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[48]
+	mi := &file_manager_manager_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4070,7 +4153,7 @@ func (x *AgentPodInfoSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfoSnapshot.ProtoReflect.Descriptor instead.
 func (*AgentPodInfoSnapshot) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{48}
+	return file_manager_manager_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AgentPodInfoSnapshot) GetAgents() []*AgentPodInfo {
@@ -4090,7 +4173,7 @@ type AgentPodInfoDelta struct {
 
 func (x *AgentPodInfoDelta) Reset() {
 	*x = AgentPodInfoDelta{}
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4102,7 +4185,7 @@ func (x *AgentPodInfoDelta) String() string {
 func (*AgentPodInfoDelta) ProtoMessage() {}
 
 func (x *AgentPodInfoDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[49]
+	mi := &file_manager_manager_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4115,7 +4198,7 @@ func (x *AgentPodInfoDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentPodInfoDelta.ProtoReflect.Descriptor instead.
 func (*AgentPodInfoDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{49}
+	return file_manager_manager_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *AgentPodInfoDelta) GetUpserts() map[string]*AgentPodInfo {
@@ -4143,7 +4226,7 @@ type AgentConfigRequest struct {
 
 func (x *AgentConfigRequest) Reset() {
 	*x = AgentConfigRequest{}
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4155,7 +4238,7 @@ func (x *AgentConfigRequest) String() string {
 func (*AgentConfigRequest) ProtoMessage() {}
 
 func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[50]
+	mi := &file_manager_manager_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4168,7 +4251,7 @@ func (x *AgentConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigRequest.ProtoReflect.Descriptor instead.
 func (*AgentConfigRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{50}
+	return file_manager_manager_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *AgentConfigRequest) GetSession() *SessionInfo {
@@ -4201,7 +4284,7 @@ type AgentConfigResponse struct {
 
 func (x *AgentConfigResponse) Reset() {
 	*x = AgentConfigResponse{}
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4213,7 +4296,7 @@ func (x *AgentConfigResponse) String() string {
 func (*AgentConfigResponse) ProtoMessage() {}
 
 func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[51]
+	mi := &file_manager_manager_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4226,7 +4309,7 @@ func (x *AgentConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentConfigResponse.ProtoReflect.Descriptor instead.
 func (*AgentConfigResponse) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{51}
+	return file_manager_manager_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *AgentConfigResponse) GetData() []byte {
@@ -4249,7 +4332,7 @@ type TunnelMetrics struct {
 
 func (x *TunnelMetrics) Reset() {
 	*x = TunnelMetrics{}
-	mi := &file_manager_manager_proto_msgTypes[52]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4261,7 +4344,7 @@ func (x *TunnelMetrics) String() string {
 func (*TunnelMetrics) ProtoMessage() {}
 
 func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[52]
+	mi := &file_manager_manager_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4274,7 +4357,7 @@ func (x *TunnelMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TunnelMetrics.ProtoReflect.Descriptor instead.
 func (*TunnelMetrics) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{52}
+	return file_manager_manager_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *TunnelMetrics) GetClientSessionId() string {
@@ -4307,7 +4390,7 @@ type KnownWorkloadKinds struct {
 
 func (x *KnownWorkloadKinds) Reset() {
 	*x = KnownWorkloadKinds{}
-	mi := &file_manager_manager_proto_msgTypes[53]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4319,7 +4402,7 @@ func (x *KnownWorkloadKinds) String() string {
 func (*KnownWorkloadKinds) ProtoMessage() {}
 
 func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[53]
+	mi := &file_manager_manager_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4332,7 +4415,7 @@ func (x *KnownWorkloadKinds) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KnownWorkloadKinds.ProtoReflect.Descriptor instead.
 func (*KnownWorkloadKinds) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{53}
+	return file_manager_manager_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *KnownWorkloadKinds) GetKinds() []WorkloadInfo_Kind {
@@ -4353,7 +4436,7 @@ type ServicePort struct {
 
 func (x *ServicePort) Reset() {
 	*x = ServicePort{}
-	mi := &file_manager_manager_proto_msgTypes[54]
+	mi := &file_manager_manager_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4365,7 +4448,7 @@ func (x *ServicePort) String() string {
 func (*ServicePort) ProtoMessage() {}
 
 func (x *ServicePort) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[54]
+	mi := &file_manager_manager_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4378,7 +4461,7 @@ func (x *ServicePort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServicePort.ProtoReflect.Descriptor instead.
 func (*ServicePort) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{54}
+	return file_manager_manager_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ServicePort) GetName() string {
@@ -4424,7 +4507,7 @@ type RouteAssociation struct {
 
 func (x *RouteAssociation) Reset() {
 	*x = RouteAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[55]
+	mi := &file_manager_manager_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4436,7 +4519,7 @@ func (x *RouteAssociation) String() string {
 func (*RouteAssociation) ProtoMessage() {}
 
 func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[55]
+	mi := &file_manager_manager_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4449,7 +4532,7 @@ func (x *RouteAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteAssociation.ProtoReflect.Descriptor instead.
 func (*RouteAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{55}
+	return file_manager_manager_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *RouteAssociation) GetType() string {
@@ -4522,7 +4605,7 @@ type ServiceAssociation struct {
 
 func (x *ServiceAssociation) Reset() {
 	*x = ServiceAssociation{}
-	mi := &file_manager_manager_proto_msgTypes[56]
+	mi := &file_manager_manager_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4534,7 +4617,7 @@ func (x *ServiceAssociation) String() string {
 func (*ServiceAssociation) ProtoMessage() {}
 
 func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[56]
+	mi := &file_manager_manager_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4547,7 +4630,7 @@ func (x *ServiceAssociation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceAssociation.ProtoReflect.Descriptor instead.
 func (*ServiceAssociation) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{56}
+	return file_manager_manager_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ServiceAssociation) GetName() string {
@@ -4591,7 +4674,7 @@ type WorkloadInfo struct {
 
 func (x *WorkloadInfo) Reset() {
 	*x = WorkloadInfo{}
-	mi := &file_manager_manager_proto_msgTypes[57]
+	mi := &file_manager_manager_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4603,7 +4686,7 @@ func (x *WorkloadInfo) String() string {
 func (*WorkloadInfo) ProtoMessage() {}
 
 func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[57]
+	mi := &file_manager_manager_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4616,7 +4699,7 @@ func (x *WorkloadInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *WorkloadInfo) GetKind() WorkloadInfo_Kind {
@@ -4699,7 +4782,7 @@ type WorkloadEvent struct {
 
 func (x *WorkloadEvent) Reset() {
 	*x = WorkloadEvent{}
-	mi := &file_manager_manager_proto_msgTypes[58]
+	mi := &file_manager_manager_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4711,7 +4794,7 @@ func (x *WorkloadEvent) String() string {
 func (*WorkloadEvent) ProtoMessage() {}
 
 func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[58]
+	mi := &file_manager_manager_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4724,7 +4807,7 @@ func (x *WorkloadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadEvent) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{58}
+	return file_manager_manager_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *WorkloadEvent) GetType() WorkloadEvent_Type {
@@ -4756,7 +4839,7 @@ type WorkloadEventsDelta struct {
 
 func (x *WorkloadEventsDelta) Reset() {
 	*x = WorkloadEventsDelta{}
-	mi := &file_manager_manager_proto_msgTypes[59]
+	mi := &file_manager_manager_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4768,7 +4851,7 @@ func (x *WorkloadEventsDelta) String() string {
 func (*WorkloadEventsDelta) ProtoMessage() {}
 
 func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[59]
+	mi := &file_manager_manager_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4781,7 +4864,7 @@ func (x *WorkloadEventsDelta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsDelta.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsDelta) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{59}
+	return file_manager_manager_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *WorkloadEventsDelta) GetSince() *timestamppb.Timestamp {
@@ -4815,7 +4898,7 @@ type WorkloadEventsRequest struct {
 
 func (x *WorkloadEventsRequest) Reset() {
 	*x = WorkloadEventsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4827,7 +4910,7 @@ func (x *WorkloadEventsRequest) String() string {
 func (*WorkloadEventsRequest) ProtoMessage() {}
 
 func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[60]
+	mi := &file_manager_manager_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4840,7 +4923,7 @@ func (x *WorkloadEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadEventsRequest.ProtoReflect.Descriptor instead.
 func (*WorkloadEventsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{60}
+	return file_manager_manager_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *WorkloadEventsRequest) GetSessionInfo() *SessionInfo {
@@ -4877,7 +4960,7 @@ type UninstallAgentsRequest struct {
 
 func (x *UninstallAgentsRequest) Reset() {
 	*x = UninstallAgentsRequest{}
-	mi := &file_manager_manager_proto_msgTypes[61]
+	mi := &file_manager_manager_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4889,7 +4972,7 @@ func (x *UninstallAgentsRequest) String() string {
 func (*UninstallAgentsRequest) ProtoMessage() {}
 
 func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[61]
+	mi := &file_manager_manager_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4902,7 +4985,7 @@ func (x *UninstallAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UninstallAgentsRequest.ProtoReflect.Descriptor instead.
 func (*UninstallAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{61}
+	return file_manager_manager_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *UninstallAgentsRequest) GetSessionInfo() *SessionInfo {
@@ -4941,7 +5024,7 @@ type AgentInfo_Mechanism struct {
 
 func (x *AgentInfo_Mechanism) Reset() {
 	*x = AgentInfo_Mechanism{}
-	mi := &file_manager_manager_proto_msgTypes[62]
+	mi := &file_manager_manager_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4953,7 +5036,7 @@ func (x *AgentInfo_Mechanism) String() string {
 func (*AgentInfo_Mechanism) ProtoMessage() {}
 
 func (x *AgentInfo_Mechanism) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[62]
+	mi := &file_manager_manager_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5004,7 +5087,7 @@ type AgentInfo_ContainerInfo struct {
 
 func (x *AgentInfo_ContainerInfo) Reset() {
 	*x = AgentInfo_ContainerInfo{}
-	mi := &file_manager_manager_proto_msgTypes[63]
+	mi := &file_manager_manager_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5016,7 +5099,7 @@ func (x *AgentInfo_ContainerInfo) String() string {
 func (*AgentInfo_ContainerInfo) ProtoMessage() {}
 
 func (x *AgentInfo_ContainerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[63]
+	mi := &file_manager_manager_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5053,6 +5136,105 @@ func (x *AgentInfo_ContainerInfo) GetMounts() map[string]int32 {
 	return nil
 }
 
+// InterceptTarget describes one service-backed target that this agent can
+// handle. The traffic-manager uses these claims when a single Service
+// selects pods owned by more than one workload.
+type AgentInfo_InterceptTarget struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// .metadata.uid of the Service associated with the target.
+	ServiceUid string `protobuf:"bytes,1,opt,name=service_uid,json=serviceUid,proto3" json:"service_uid,omitempty"`
+	// Name of the Service, retained for diagnostics.
+	ServiceName string `protobuf:"bytes,2,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	// Name and number of the selected Service port.
+	ServicePortName string `protobuf:"bytes,3,opt,name=service_port_name,json=servicePortName,proto3" json:"service_port_name,omitempty"`
+	ServicePort     int32  `protobuf:"varint,4,opt,name=service_port,json=servicePort,proto3" json:"service_port,omitempty"`
+	// Protocol and local container target used by this agent.
+	Protocol      string `protobuf:"bytes,5,opt,name=protocol,proto3" json:"protocol,omitempty"`
+	ContainerName string `protobuf:"bytes,6,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
+	ContainerPort int32  `protobuf:"varint,7,opt,name=container_port,json=containerPort,proto3" json:"container_port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AgentInfo_InterceptTarget) Reset() {
+	*x = AgentInfo_InterceptTarget{}
+	mi := &file_manager_manager_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AgentInfo_InterceptTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AgentInfo_InterceptTarget) ProtoMessage() {}
+
+func (x *AgentInfo_InterceptTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_manager_manager_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AgentInfo_InterceptTarget.ProtoReflect.Descriptor instead.
+func (*AgentInfo_InterceptTarget) Descriptor() ([]byte, []int) {
+	return file_manager_manager_proto_rawDescGZIP(), []int{1, 3}
+}
+
+func (x *AgentInfo_InterceptTarget) GetServiceUid() string {
+	if x != nil {
+		return x.ServiceUid
+	}
+	return ""
+}
+
+func (x *AgentInfo_InterceptTarget) GetServiceName() string {
+	if x != nil {
+		return x.ServiceName
+	}
+	return ""
+}
+
+func (x *AgentInfo_InterceptTarget) GetServicePortName() string {
+	if x != nil {
+		return x.ServicePortName
+	}
+	return ""
+}
+
+func (x *AgentInfo_InterceptTarget) GetServicePort() int32 {
+	if x != nil {
+		return x.ServicePort
+	}
+	return 0
+}
+
+func (x *AgentInfo_InterceptTarget) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *AgentInfo_InterceptTarget) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
+}
+
+func (x *AgentInfo_InterceptTarget) GetContainerPort() int32 {
+	if x != nil {
+		return x.ContainerPort
+	}
+	return 0
+}
+
 type WorkloadInfo_Intercept struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// name of intercepting client
@@ -5063,7 +5245,7 @@ type WorkloadInfo_Intercept struct {
 
 func (x *WorkloadInfo_Intercept) Reset() {
 	*x = WorkloadInfo_Intercept{}
-	mi := &file_manager_manager_proto_msgTypes[78]
+	mi := &file_manager_manager_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5075,7 +5257,7 @@ func (x *WorkloadInfo_Intercept) String() string {
 func (*WorkloadInfo_Intercept) ProtoMessage() {}
 
 func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
-	mi := &file_manager_manager_proto_msgTypes[78]
+	mi := &file_manager_manager_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5088,7 +5270,7 @@ func (x *WorkloadInfo_Intercept) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadInfo_Intercept.ProtoReflect.Descriptor instead.
 func (*WorkloadInfo_Intercept) Descriptor() ([]byte, []int) {
-	return file_manager_manager_proto_rawDescGZIP(), []int{57, 0}
+	return file_manager_manager_proto_rawDescGZIP(), []int{58, 0}
 }
 
 func (x *WorkloadInfo_Intercept) GetClient() string {
@@ -5110,7 +5292,7 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\n" +
 	"install_id\x18\x02 \x01(\tR\tinstallId\x12\x18\n" +
 	"\aproduct\x18\x03 \x01(\tR\aproduct\x12\x18\n" +
-	"\aversion\x18\x04 \x01(\tR\aversionJ\x04\b\x05\x10\x06\"\xa7\b\n" +
+	"\aversion\x18\x04 \x01(\tR\aversionJ\x04\b\x05\x10\x06\"\x96\v\n" +
 	"\tAgentInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04kind\x18\r \x01(\tR\x04kind\x12\x1c\n" +
@@ -5132,7 +5314,8 @@ const file_manager_manager_proto_rawDesc = "" +
 	"containers\x12\x1d\n" +
 	"\n" +
 	"node_agent\x18\x0f \x01(\bR\tnodeAgent\x12\x1b\n" +
-	"\tquic_port\x18\x10 \x01(\x05R\bquicPort\x1aS\n" +
+	"\tquic_port\x18\x10 \x01(\x05R\bquicPort\x12\\\n" +
+	"\x11intercept_targets\x18\x11 \x03(\v2/.telepresence.manager.AgentInfo.InterceptTargetR\x10interceptTargets\x1aS\n" +
 	"\tMechanism\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aproduct\x18\x02 \x01(\tR\aproduct\x12\x18\n" +
@@ -5150,7 +5333,16 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\x1al\n" +
 	"\x0fContainersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12C\n" +
-	"\x05value\x18\x02 \x01(\v2-.telepresence.manager.AgentInfo.ContainerInfoR\x05value:\x028\x01J\x04\b\x06\x10\a\"1\n" +
+	"\x05value\x18\x02 \x01(\v2-.telepresence.manager.AgentInfo.ContainerInfoR\x05value:\x028\x01\x1a\x8e\x02\n" +
+	"\x0fInterceptTarget\x12\x1f\n" +
+	"\vservice_uid\x18\x01 \x01(\tR\n" +
+	"serviceUid\x12!\n" +
+	"\fservice_name\x18\x02 \x01(\tR\vserviceName\x12*\n" +
+	"\x11service_port_name\x18\x03 \x01(\tR\x0fservicePortName\x12!\n" +
+	"\fservice_port\x18\x04 \x01(\x05R\vservicePort\x12\x1a\n" +
+	"\bprotocol\x18\x05 \x01(\tR\bprotocol\x12%\n" +
+	"\x0econtainer_name\x18\x06 \x01(\tR\rcontainerName\x12%\n" +
+	"\x0econtainer_port\x18\a \x01(\x05R\rcontainerPortJ\x04\b\x06\x10\a\"1\n" +
 	"\vPortMapping\x12\x12\n" +
 	"\x04from\x18\x01 \x01(\x05R\x04from\x12\x0e\n" +
 	"\x02to\x18\x02 \x01(\x05R\x02to\"\xdf\t\n" +
@@ -5199,7 +5391,11 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\t\x10\n" +
-	"J\x04\b\v\x10\f\"\x89\a\n" +
+	"J\x04\b\v\x10\f\"{\n" +
+	"\x11InterceptWorkload\x12\x1c\n" +
+	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12#\n" +
+	"\rworkload_kind\x18\x02 \x01(\tR\fworkloadKind\x12#\n" +
+	"\rworkload_name\x18\x03 \x01(\tR\fworkloadName\"\xdf\a\n" +
 	"\rInterceptInfo\x127\n" +
 	"\x04spec\x18\x01 \x01(\v2#.telepresence.manager.InterceptSpecR\x04spec\x12\x0e\n" +
 	"\x02id\x18\x05 \x01(\tR\x02id\x12H\n" +
@@ -5219,7 +5415,8 @@ const file_manager_manager_proto_rawDesc = "" +
 	"\venvironment\x18\x11 \x03(\v24.telepresence.manager.InterceptInfo.EnvironmentEntryR\venvironment\x12G\n" +
 	"\x06mounts\x18\x16 \x03(\v2/.telepresence.manager.InterceptInfo.MountsEntryR\x06mounts\x12;\n" +
 	"\vmodified_at\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"modifiedAt\x1a>\n" +
+	"modifiedAt\x12T\n" +
+	"\x11service_workloads\x18\x17 \x03(\v2'.telepresence.manager.InterceptWorkloadR\x10serviceWorkloads\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +
@@ -5625,263 +5822,267 @@ func file_manager_manager_proto_rawDescGZIP() []byte {
 }
 
 var file_manager_manager_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 79)
+var file_manager_manager_proto_msgTypes = make([]protoimpl.MessageInfo, 81)
 var file_manager_manager_proto_goTypes = []any{
-	(InterceptDispositionType)(0),   // 0: telepresence.manager.InterceptDispositionType
-	(WorkloadInfo_Kind)(0),          // 1: telepresence.manager.WorkloadInfo.Kind
-	(WorkloadInfo_State)(0),         // 2: telepresence.manager.WorkloadInfo.State
-	(WorkloadInfo_AgentState)(0),    // 3: telepresence.manager.WorkloadInfo.AgentState
-	(WorkloadEvent_Type)(0),         // 4: telepresence.manager.WorkloadEvent.Type
-	(*ClientInfo)(nil),              // 5: telepresence.manager.ClientInfo
-	(*AgentInfo)(nil),               // 6: telepresence.manager.AgentInfo
-	(*PortMapping)(nil),             // 7: telepresence.manager.PortMapping
-	(*InterceptSpec)(nil),           // 8: telepresence.manager.InterceptSpec
-	(*InterceptInfo)(nil),           // 9: telepresence.manager.InterceptInfo
-	(*ReconnectAgentRequest)(nil),   // 10: telepresence.manager.ReconnectAgentRequest
-	(*ReconnectClientRequest)(nil),  // 11: telepresence.manager.ReconnectClientRequest
-	(*SessionInfo)(nil),             // 12: telepresence.manager.SessionInfo
-	(*AgentsRequest)(nil),           // 13: telepresence.manager.AgentsRequest
-	(*AgentInfoSnapshot)(nil),       // 14: telepresence.manager.AgentInfoSnapshot
-	(*AgentInfoDelta)(nil),          // 15: telepresence.manager.AgentInfoDelta
-	(*InterceptInfoSnapshot)(nil),   // 16: telepresence.manager.InterceptInfoSnapshot
-	(*InterceptInfoDelta)(nil),      // 17: telepresence.manager.InterceptInfoDelta
-	(*SessionEventsRequest)(nil),    // 18: telepresence.manager.SessionEventsRequest
-	(*SessionEventsDelta)(nil),      // 19: telepresence.manager.SessionEventsDelta
-	(*CreateInterceptRequest)(nil),  // 20: telepresence.manager.CreateInterceptRequest
-	(*EnsureAgentRequest)(nil),      // 21: telepresence.manager.EnsureAgentRequest
-	(*ReleaseAgentRequest)(nil),     // 22: telepresence.manager.ReleaseAgentRequest
-	(*PreparedIntercept)(nil),       // 23: telepresence.manager.PreparedIntercept
-	(*RemoveInterceptRequest2)(nil), // 24: telepresence.manager.RemoveInterceptRequest2
-	(*GetInterceptRequest)(nil),     // 25: telepresence.manager.GetInterceptRequest
-	(*ReviewInterceptRequest)(nil),  // 26: telepresence.manager.ReviewInterceptRequest
-	(*RemainRequest)(nil),           // 27: telepresence.manager.RemainRequest
-	(*LogLevelRequest)(nil),         // 28: telepresence.manager.LogLevelRequest
-	(*GetLogsRequest)(nil),          // 29: telepresence.manager.GetLogsRequest
-	(*LogsResponse)(nil),            // 30: telepresence.manager.LogsResponse
-	(*TelepresenceAPIInfo)(nil),     // 31: telepresence.manager.TelepresenceAPIInfo
-	(*VersionInfo2)(nil),            // 32: telepresence.manager.VersionInfo2
-	(*TunnelMessage)(nil),           // 33: telepresence.manager.TunnelMessage
-	(*QuicTunnelEndpoint)(nil),      // 34: telepresence.manager.QuicTunnelEndpoint
-	(*QuicEndpointCandidate)(nil),   // 35: telepresence.manager.QuicEndpointCandidate
-	(*SessionCredential)(nil),       // 36: telepresence.manager.SessionCredential
-	(*QuicBackend)(nil),             // 37: telepresence.manager.QuicBackend
-	(*QuicBackendSnapshot)(nil),     // 38: telepresence.manager.QuicBackendSnapshot
-	(*DialRequest)(nil),             // 39: telepresence.manager.DialRequest
-	(*QuicAgentCert)(nil),           // 40: telepresence.manager.QuicAgentCert
-	(*LookupRequest)(nil),           // 41: telepresence.manager.LookupRequest
-	(*LookupResponse)(nil),          // 42: telepresence.manager.LookupResponse
-	(*DNSRequest)(nil),              // 43: telepresence.manager.DNSRequest
-	(*DNSResponse)(nil),             // 44: telepresence.manager.DNSResponse
-	(*DNSAgentResponse)(nil),        // 45: telepresence.manager.DNSAgentResponse
-	(*IPNet)(nil),                   // 46: telepresence.manager.IPNet
-	(*ClusterInfo)(nil),             // 47: telepresence.manager.ClusterInfo
-	(*Routing)(nil),                 // 48: telepresence.manager.Routing
-	(*DNS)(nil),                     // 49: telepresence.manager.DNS
-	(*CLIConfig)(nil),               // 50: telepresence.manager.CLIConfig
-	(*AgentImageFQN)(nil),           // 51: telepresence.manager.AgentImageFQN
-	(*AgentPodInfo)(nil),            // 52: telepresence.manager.AgentPodInfo
-	(*AgentPodInfoSnapshot)(nil),    // 53: telepresence.manager.AgentPodInfoSnapshot
-	(*AgentPodInfoDelta)(nil),       // 54: telepresence.manager.AgentPodInfoDelta
-	(*AgentConfigRequest)(nil),      // 55: telepresence.manager.AgentConfigRequest
-	(*AgentConfigResponse)(nil),     // 56: telepresence.manager.AgentConfigResponse
-	(*TunnelMetrics)(nil),           // 57: telepresence.manager.TunnelMetrics
-	(*KnownWorkloadKinds)(nil),      // 58: telepresence.manager.KnownWorkloadKinds
-	(*ServicePort)(nil),             // 59: telepresence.manager.ServicePort
-	(*RouteAssociation)(nil),        // 60: telepresence.manager.RouteAssociation
-	(*ServiceAssociation)(nil),      // 61: telepresence.manager.ServiceAssociation
-	(*WorkloadInfo)(nil),            // 62: telepresence.manager.WorkloadInfo
-	(*WorkloadEvent)(nil),           // 63: telepresence.manager.WorkloadEvent
-	(*WorkloadEventsDelta)(nil),     // 64: telepresence.manager.WorkloadEventsDelta
-	(*WorkloadEventsRequest)(nil),   // 65: telepresence.manager.WorkloadEventsRequest
-	(*UninstallAgentsRequest)(nil),  // 66: telepresence.manager.UninstallAgentsRequest
-	(*AgentInfo_Mechanism)(nil),     // 67: telepresence.manager.AgentInfo.Mechanism
-	(*AgentInfo_ContainerInfo)(nil), // 68: telepresence.manager.AgentInfo.ContainerInfo
-	nil,                             // 69: telepresence.manager.AgentInfo.ContainersEntry
-	nil,                             // 70: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	nil,                             // 71: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	nil,                             // 72: telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	nil,                             // 73: telepresence.manager.InterceptSpec.MetadataEntry
-	nil,                             // 74: telepresence.manager.InterceptInfo.EnvironmentEntry
-	nil,                             // 75: telepresence.manager.InterceptInfo.MountsEntry
-	nil,                             // 76: telepresence.manager.AgentInfoDelta.UpsertsEntry
-	nil,                             // 77: telepresence.manager.InterceptInfoDelta.UpsertsEntry
-	nil,                             // 78: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	nil,                             // 79: telepresence.manager.ReviewInterceptRequest.MountsEntry
-	nil,                             // 80: telepresence.manager.LogsResponse.PodLogsEntry
-	nil,                             // 81: telepresence.manager.LogsResponse.PodYamlEntry
-	nil,                             // 82: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
-	(*WorkloadInfo_Intercept)(nil),  // 83: telepresence.manager.WorkloadInfo.Intercept
-	(*timestamppb.Timestamp)(nil),   // 84: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),     // 85: google.protobuf.Duration
-	(*emptypb.Empty)(nil),           // 86: google.protobuf.Empty
+	(InterceptDispositionType)(0),     // 0: telepresence.manager.InterceptDispositionType
+	(WorkloadInfo_Kind)(0),            // 1: telepresence.manager.WorkloadInfo.Kind
+	(WorkloadInfo_State)(0),           // 2: telepresence.manager.WorkloadInfo.State
+	(WorkloadInfo_AgentState)(0),      // 3: telepresence.manager.WorkloadInfo.AgentState
+	(WorkloadEvent_Type)(0),           // 4: telepresence.manager.WorkloadEvent.Type
+	(*ClientInfo)(nil),                // 5: telepresence.manager.ClientInfo
+	(*AgentInfo)(nil),                 // 6: telepresence.manager.AgentInfo
+	(*PortMapping)(nil),               // 7: telepresence.manager.PortMapping
+	(*InterceptSpec)(nil),             // 8: telepresence.manager.InterceptSpec
+	(*InterceptWorkload)(nil),         // 9: telepresence.manager.InterceptWorkload
+	(*InterceptInfo)(nil),             // 10: telepresence.manager.InterceptInfo
+	(*ReconnectAgentRequest)(nil),     // 11: telepresence.manager.ReconnectAgentRequest
+	(*ReconnectClientRequest)(nil),    // 12: telepresence.manager.ReconnectClientRequest
+	(*SessionInfo)(nil),               // 13: telepresence.manager.SessionInfo
+	(*AgentsRequest)(nil),             // 14: telepresence.manager.AgentsRequest
+	(*AgentInfoSnapshot)(nil),         // 15: telepresence.manager.AgentInfoSnapshot
+	(*AgentInfoDelta)(nil),            // 16: telepresence.manager.AgentInfoDelta
+	(*InterceptInfoSnapshot)(nil),     // 17: telepresence.manager.InterceptInfoSnapshot
+	(*InterceptInfoDelta)(nil),        // 18: telepresence.manager.InterceptInfoDelta
+	(*SessionEventsRequest)(nil),      // 19: telepresence.manager.SessionEventsRequest
+	(*SessionEventsDelta)(nil),        // 20: telepresence.manager.SessionEventsDelta
+	(*CreateInterceptRequest)(nil),    // 21: telepresence.manager.CreateInterceptRequest
+	(*EnsureAgentRequest)(nil),        // 22: telepresence.manager.EnsureAgentRequest
+	(*ReleaseAgentRequest)(nil),       // 23: telepresence.manager.ReleaseAgentRequest
+	(*PreparedIntercept)(nil),         // 24: telepresence.manager.PreparedIntercept
+	(*RemoveInterceptRequest2)(nil),   // 25: telepresence.manager.RemoveInterceptRequest2
+	(*GetInterceptRequest)(nil),       // 26: telepresence.manager.GetInterceptRequest
+	(*ReviewInterceptRequest)(nil),    // 27: telepresence.manager.ReviewInterceptRequest
+	(*RemainRequest)(nil),             // 28: telepresence.manager.RemainRequest
+	(*LogLevelRequest)(nil),           // 29: telepresence.manager.LogLevelRequest
+	(*GetLogsRequest)(nil),            // 30: telepresence.manager.GetLogsRequest
+	(*LogsResponse)(nil),              // 31: telepresence.manager.LogsResponse
+	(*TelepresenceAPIInfo)(nil),       // 32: telepresence.manager.TelepresenceAPIInfo
+	(*VersionInfo2)(nil),              // 33: telepresence.manager.VersionInfo2
+	(*TunnelMessage)(nil),             // 34: telepresence.manager.TunnelMessage
+	(*QuicTunnelEndpoint)(nil),        // 35: telepresence.manager.QuicTunnelEndpoint
+	(*QuicEndpointCandidate)(nil),     // 36: telepresence.manager.QuicEndpointCandidate
+	(*SessionCredential)(nil),         // 37: telepresence.manager.SessionCredential
+	(*QuicBackend)(nil),               // 38: telepresence.manager.QuicBackend
+	(*QuicBackendSnapshot)(nil),       // 39: telepresence.manager.QuicBackendSnapshot
+	(*DialRequest)(nil),               // 40: telepresence.manager.DialRequest
+	(*QuicAgentCert)(nil),             // 41: telepresence.manager.QuicAgentCert
+	(*LookupRequest)(nil),             // 42: telepresence.manager.LookupRequest
+	(*LookupResponse)(nil),            // 43: telepresence.manager.LookupResponse
+	(*DNSRequest)(nil),                // 44: telepresence.manager.DNSRequest
+	(*DNSResponse)(nil),               // 45: telepresence.manager.DNSResponse
+	(*DNSAgentResponse)(nil),          // 46: telepresence.manager.DNSAgentResponse
+	(*IPNet)(nil),                     // 47: telepresence.manager.IPNet
+	(*ClusterInfo)(nil),               // 48: telepresence.manager.ClusterInfo
+	(*Routing)(nil),                   // 49: telepresence.manager.Routing
+	(*DNS)(nil),                       // 50: telepresence.manager.DNS
+	(*CLIConfig)(nil),                 // 51: telepresence.manager.CLIConfig
+	(*AgentImageFQN)(nil),             // 52: telepresence.manager.AgentImageFQN
+	(*AgentPodInfo)(nil),              // 53: telepresence.manager.AgentPodInfo
+	(*AgentPodInfoSnapshot)(nil),      // 54: telepresence.manager.AgentPodInfoSnapshot
+	(*AgentPodInfoDelta)(nil),         // 55: telepresence.manager.AgentPodInfoDelta
+	(*AgentConfigRequest)(nil),        // 56: telepresence.manager.AgentConfigRequest
+	(*AgentConfigResponse)(nil),       // 57: telepresence.manager.AgentConfigResponse
+	(*TunnelMetrics)(nil),             // 58: telepresence.manager.TunnelMetrics
+	(*KnownWorkloadKinds)(nil),        // 59: telepresence.manager.KnownWorkloadKinds
+	(*ServicePort)(nil),               // 60: telepresence.manager.ServicePort
+	(*RouteAssociation)(nil),          // 61: telepresence.manager.RouteAssociation
+	(*ServiceAssociation)(nil),        // 62: telepresence.manager.ServiceAssociation
+	(*WorkloadInfo)(nil),              // 63: telepresence.manager.WorkloadInfo
+	(*WorkloadEvent)(nil),             // 64: telepresence.manager.WorkloadEvent
+	(*WorkloadEventsDelta)(nil),       // 65: telepresence.manager.WorkloadEventsDelta
+	(*WorkloadEventsRequest)(nil),     // 66: telepresence.manager.WorkloadEventsRequest
+	(*UninstallAgentsRequest)(nil),    // 67: telepresence.manager.UninstallAgentsRequest
+	(*AgentInfo_Mechanism)(nil),       // 68: telepresence.manager.AgentInfo.Mechanism
+	(*AgentInfo_ContainerInfo)(nil),   // 69: telepresence.manager.AgentInfo.ContainerInfo
+	nil,                               // 70: telepresence.manager.AgentInfo.ContainersEntry
+	(*AgentInfo_InterceptTarget)(nil), // 71: telepresence.manager.AgentInfo.InterceptTarget
+	nil,                               // 72: telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	nil,                               // 73: telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	nil,                               // 74: telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	nil,                               // 75: telepresence.manager.InterceptSpec.MetadataEntry
+	nil,                               // 76: telepresence.manager.InterceptInfo.EnvironmentEntry
+	nil,                               // 77: telepresence.manager.InterceptInfo.MountsEntry
+	nil,                               // 78: telepresence.manager.AgentInfoDelta.UpsertsEntry
+	nil,                               // 79: telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	nil,                               // 80: telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	nil,                               // 81: telepresence.manager.ReviewInterceptRequest.MountsEntry
+	nil,                               // 82: telepresence.manager.LogsResponse.PodLogsEntry
+	nil,                               // 83: telepresence.manager.LogsResponse.PodYamlEntry
+	nil,                               // 84: telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	(*WorkloadInfo_Intercept)(nil),    // 85: telepresence.manager.WorkloadInfo.Intercept
+	(*timestamppb.Timestamp)(nil),     // 86: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 87: google.protobuf.Duration
+	(*emptypb.Empty)(nil),             // 88: google.protobuf.Empty
 }
 var file_manager_manager_proto_depIdxs = []int32{
-	67,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
-	69,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
-	72,  // 2: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
-	73,  // 3: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
-	8,   // 4: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
-	12,  // 5: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
-	0,   // 6: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	74,  // 7: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
-	75,  // 8: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
-	84,  // 9: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
-	12,  // 10: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	6,   // 11: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
-	12,  // 12: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
-	5,   // 13: telepresence.manager.ReconnectClientRequest.client:type_name -> telepresence.manager.ClientInfo
-	9,   // 14: telepresence.manager.ReconnectClientRequest.intercepts:type_name -> telepresence.manager.InterceptInfo
-	6,   // 15: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
-	12,  // 16: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
-	6,   // 17: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
-	76,  // 18: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
-	9,   // 19: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
-	77,  // 20: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
-	12,  // 21: telepresence.manager.SessionEventsRequest.session:type_name -> telepresence.manager.SessionInfo
-	54,  // 22: telepresence.manager.SessionEventsDelta.agent_pods:type_name -> telepresence.manager.AgentPodInfoDelta
-	17,  // 23: telepresence.manager.SessionEventsDelta.intercepts:type_name -> telepresence.manager.InterceptInfoDelta
-	12,  // 24: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	8,   // 25: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
-	12,  // 26: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 27: telepresence.manager.ReleaseAgentRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 28: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 29: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 30: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
-	0,   // 31: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
-	78,  // 32: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
-	79,  // 33: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
-	12,  // 34: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
-	84,  // 35: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
-	85,  // 36: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
-	12,  // 37: telepresence.manager.LogLevelRequest.session:type_name -> telepresence.manager.SessionInfo
-	80,  // 38: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
-	81,  // 39: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
-	35,  // 40: telepresence.manager.QuicTunnelEndpoint.candidates:type_name -> telepresence.manager.QuicEndpointCandidate
-	84,  // 41: telepresence.manager.SessionCredential.expiry:type_name -> google.protobuf.Timestamp
-	37,  // 42: telepresence.manager.QuicBackendSnapshot.backends:type_name -> telepresence.manager.QuicBackend
-	12,  // 43: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 44: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
-	12,  // 45: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
-	43,  // 46: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
-	44,  // 47: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
-	46,  // 48: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
-	46,  // 49: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
-	48,  // 50: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
-	49,  // 51: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
-	46,  // 52: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
-	46,  // 53: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
-	46,  // 54: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
-	52,  // 55: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
-	82,  // 56: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
-	12,  // 57: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
-	1,   // 58: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
-	59,  // 59: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
-	60,  // 60: telepresence.manager.ServiceAssociation.routes:type_name -> telepresence.manager.RouteAssociation
-	1,   // 61: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
-	61,  // 62: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
-	3,   // 63: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
-	83,  // 64: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
-	2,   // 65: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
-	4,   // 66: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
-	62,  // 67: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
-	84,  // 68: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
-	63,  // 69: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
-	12,  // 70: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	84,  // 71: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
-	12,  // 72: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
-	70,  // 73: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
-	71,  // 74: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
-	68,  // 75: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
-	6,   // 76: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
-	9,   // 77: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
-	52,  // 78: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
-	86,  // 79: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
-	86,  // 80: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
-	55,  // 81: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
-	86,  // 82: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
-	86,  // 83: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
-	5,   // 84: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
-	10,  // 85: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
-	11,  // 86: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
-	6,   // 87: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
-	27,  // 88: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
-	12,  // 89: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
-	28,  // 90: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	29,  // 91: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
-	12,  // 92: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
-	12,  // 93: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
-	13,  // 94: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
-	12,  // 95: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
-	12,  // 96: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
-	12,  // 97: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
-	12,  // 98: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
-	18,  // 99: telepresence.manager.Manager.WatchSessionEvents:input_type -> telepresence.manager.SessionEventsRequest
-	65,  // 100: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
-	12,  // 101: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
-	21,  // 102: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
-	22,  // 103: telepresence.manager.Manager.ReleaseAgent:input_type -> telepresence.manager.ReleaseAgentRequest
-	20,  // 104: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	20,  // 105: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
-	24,  // 106: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
-	25,  // 107: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
-	26,  // 108: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
-	12,  // 109: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
-	41,  // 110: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
-	43,  // 111: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
-	86,  // 112: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
-	33,  // 113: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
-	12,  // 114: telepresence.manager.Manager.GetQuicTunnelEndpoint:input_type -> telepresence.manager.SessionInfo
-	12,  // 115: telepresence.manager.Manager.GetSessionCredential:input_type -> telepresence.manager.SessionInfo
-	12,  // 116: telepresence.manager.Manager.GetQuicAgentCert:input_type -> telepresence.manager.SessionInfo
-	86,  // 117: telepresence.manager.Manager.WatchQuicBackends:input_type -> google.protobuf.Empty
-	57,  // 118: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
-	66,  // 119: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
-	32,  // 120: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
-	51,  // 121: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	56,  // 122: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	50,  // 123: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
-	31,  // 124: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
-	12,  // 125: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
-	86,  // 126: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
-	86,  // 127: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
-	12,  // 128: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
-	86,  // 129: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
-	86,  // 130: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
-	86,  // 131: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
-	30,  // 132: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
-	53,  // 133: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
-	54,  // 134: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	54,  // 135: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
-	14,  // 136: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
-	15,  // 137: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
-	16,  // 138: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
-	17,  // 139: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
-	19,  // 140: telepresence.manager.Manager.WatchSessionEvents:output_type -> telepresence.manager.SessionEventsDelta
-	64,  // 141: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
-	47,  // 142: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
-	14,  // 143: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
-	86,  // 144: telepresence.manager.Manager.ReleaseAgent:output_type -> google.protobuf.Empty
-	23,  // 145: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
-	9,   // 146: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	86,  // 147: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
-	9,   // 148: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	86,  // 149: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
-	58,  // 150: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	42,  // 151: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
-	44,  // 152: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
-	28,  // 153: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
-	33,  // 154: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
-	34,  // 155: telepresence.manager.Manager.GetQuicTunnelEndpoint:output_type -> telepresence.manager.QuicTunnelEndpoint
-	36,  // 156: telepresence.manager.Manager.GetSessionCredential:output_type -> telepresence.manager.SessionCredential
-	40,  // 157: telepresence.manager.Manager.GetQuicAgentCert:output_type -> telepresence.manager.QuicAgentCert
-	38,  // 158: telepresence.manager.Manager.WatchQuicBackends:output_type -> telepresence.manager.QuicBackendSnapshot
-	86,  // 159: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
-	86,  // 160: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
-	120, // [120:161] is the sub-list for method output_type
-	79,  // [79:120] is the sub-list for method input_type
-	79,  // [79:79] is the sub-list for extension type_name
-	79,  // [79:79] is the sub-list for extension extendee
-	0,   // [0:79] is the sub-list for field type_name
+	68,  // 0: telepresence.manager.AgentInfo.mechanisms:type_name -> telepresence.manager.AgentInfo.Mechanism
+	70,  // 1: telepresence.manager.AgentInfo.containers:type_name -> telepresence.manager.AgentInfo.ContainersEntry
+	71,  // 2: telepresence.manager.AgentInfo.intercept_targets:type_name -> telepresence.manager.AgentInfo.InterceptTarget
+	74,  // 3: telepresence.manager.InterceptSpec.header_filters:type_name -> telepresence.manager.InterceptSpec.HeaderFiltersEntry
+	75,  // 4: telepresence.manager.InterceptSpec.metadata:type_name -> telepresence.manager.InterceptSpec.MetadataEntry
+	8,   // 5: telepresence.manager.InterceptInfo.spec:type_name -> telepresence.manager.InterceptSpec
+	13,  // 6: telepresence.manager.InterceptInfo.client_session:type_name -> telepresence.manager.SessionInfo
+	0,   // 7: telepresence.manager.InterceptInfo.disposition:type_name -> telepresence.manager.InterceptDispositionType
+	76,  // 8: telepresence.manager.InterceptInfo.environment:type_name -> telepresence.manager.InterceptInfo.EnvironmentEntry
+	77,  // 9: telepresence.manager.InterceptInfo.mounts:type_name -> telepresence.manager.InterceptInfo.MountsEntry
+	86,  // 10: telepresence.manager.InterceptInfo.modified_at:type_name -> google.protobuf.Timestamp
+	9,   // 11: telepresence.manager.InterceptInfo.service_workloads:type_name -> telepresence.manager.InterceptWorkload
+	13,  // 12: telepresence.manager.ReconnectAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	6,   // 13: telepresence.manager.ReconnectAgentRequest.agent:type_name -> telepresence.manager.AgentInfo
+	13,  // 14: telepresence.manager.ReconnectClientRequest.session:type_name -> telepresence.manager.SessionInfo
+	5,   // 15: telepresence.manager.ReconnectClientRequest.client:type_name -> telepresence.manager.ClientInfo
+	10,  // 16: telepresence.manager.ReconnectClientRequest.intercepts:type_name -> telepresence.manager.InterceptInfo
+	6,   // 17: telepresence.manager.ReconnectClientRequest.agents:type_name -> telepresence.manager.AgentInfo
+	13,  // 18: telepresence.manager.AgentsRequest.session:type_name -> telepresence.manager.SessionInfo
+	6,   // 19: telepresence.manager.AgentInfoSnapshot.agents:type_name -> telepresence.manager.AgentInfo
+	78,  // 20: telepresence.manager.AgentInfoDelta.upserts:type_name -> telepresence.manager.AgentInfoDelta.UpsertsEntry
+	10,  // 21: telepresence.manager.InterceptInfoSnapshot.intercepts:type_name -> telepresence.manager.InterceptInfo
+	79,  // 22: telepresence.manager.InterceptInfoDelta.upserts:type_name -> telepresence.manager.InterceptInfoDelta.UpsertsEntry
+	13,  // 23: telepresence.manager.SessionEventsRequest.session:type_name -> telepresence.manager.SessionInfo
+	55,  // 24: telepresence.manager.SessionEventsDelta.agent_pods:type_name -> telepresence.manager.AgentPodInfoDelta
+	18,  // 25: telepresence.manager.SessionEventsDelta.intercepts:type_name -> telepresence.manager.InterceptInfoDelta
+	13,  // 26: telepresence.manager.CreateInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	8,   // 27: telepresence.manager.CreateInterceptRequest.intercept_spec:type_name -> telepresence.manager.InterceptSpec
+	13,  // 28: telepresence.manager.EnsureAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 29: telepresence.manager.ReleaseAgentRequest.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 30: telepresence.manager.RemoveInterceptRequest2.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 31: telepresence.manager.GetInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 32: telepresence.manager.ReviewInterceptRequest.session:type_name -> telepresence.manager.SessionInfo
+	0,   // 33: telepresence.manager.ReviewInterceptRequest.disposition:type_name -> telepresence.manager.InterceptDispositionType
+	80,  // 34: telepresence.manager.ReviewInterceptRequest.environment:type_name -> telepresence.manager.ReviewInterceptRequest.EnvironmentEntry
+	81,  // 35: telepresence.manager.ReviewInterceptRequest.mounts:type_name -> telepresence.manager.ReviewInterceptRequest.MountsEntry
+	13,  // 36: telepresence.manager.RemainRequest.session:type_name -> telepresence.manager.SessionInfo
+	86,  // 37: telepresence.manager.RemainRequest.last_activity:type_name -> google.protobuf.Timestamp
+	87,  // 38: telepresence.manager.LogLevelRequest.duration:type_name -> google.protobuf.Duration
+	13,  // 39: telepresence.manager.LogLevelRequest.session:type_name -> telepresence.manager.SessionInfo
+	82,  // 40: telepresence.manager.LogsResponse.pod_logs:type_name -> telepresence.manager.LogsResponse.PodLogsEntry
+	83,  // 41: telepresence.manager.LogsResponse.pod_yaml:type_name -> telepresence.manager.LogsResponse.PodYamlEntry
+	36,  // 42: telepresence.manager.QuicTunnelEndpoint.candidates:type_name -> telepresence.manager.QuicEndpointCandidate
+	86,  // 43: telepresence.manager.SessionCredential.expiry:type_name -> google.protobuf.Timestamp
+	38,  // 44: telepresence.manager.QuicBackendSnapshot.backends:type_name -> telepresence.manager.QuicBackend
+	13,  // 45: telepresence.manager.LookupRequest.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 46: telepresence.manager.DNSRequest.session:type_name -> telepresence.manager.SessionInfo
+	13,  // 47: telepresence.manager.DNSAgentResponse.session:type_name -> telepresence.manager.SessionInfo
+	44,  // 48: telepresence.manager.DNSAgentResponse.request:type_name -> telepresence.manager.DNSRequest
+	45,  // 49: telepresence.manager.DNSAgentResponse.response:type_name -> telepresence.manager.DNSResponse
+	47,  // 50: telepresence.manager.ClusterInfo.service_subnet:type_name -> telepresence.manager.IPNet
+	47,  // 51: telepresence.manager.ClusterInfo.pod_subnets:type_name -> telepresence.manager.IPNet
+	49,  // 52: telepresence.manager.ClusterInfo.routing:type_name -> telepresence.manager.Routing
+	50,  // 53: telepresence.manager.ClusterInfo.dns:type_name -> telepresence.manager.DNS
+	47,  // 54: telepresence.manager.Routing.also_proxy_subnets:type_name -> telepresence.manager.IPNet
+	47,  // 55: telepresence.manager.Routing.never_proxy_subnets:type_name -> telepresence.manager.IPNet
+	47,  // 56: telepresence.manager.Routing.allow_conflicting_subnets:type_name -> telepresence.manager.IPNet
+	53,  // 57: telepresence.manager.AgentPodInfoSnapshot.agents:type_name -> telepresence.manager.AgentPodInfo
+	84,  // 58: telepresence.manager.AgentPodInfoDelta.upserts:type_name -> telepresence.manager.AgentPodInfoDelta.UpsertsEntry
+	13,  // 59: telepresence.manager.AgentConfigRequest.session:type_name -> telepresence.manager.SessionInfo
+	1,   // 60: telepresence.manager.KnownWorkloadKinds.kinds:type_name -> telepresence.manager.WorkloadInfo.Kind
+	60,  // 61: telepresence.manager.ServiceAssociation.ports:type_name -> telepresence.manager.ServicePort
+	61,  // 62: telepresence.manager.ServiceAssociation.routes:type_name -> telepresence.manager.RouteAssociation
+	1,   // 63: telepresence.manager.WorkloadInfo.kind:type_name -> telepresence.manager.WorkloadInfo.Kind
+	62,  // 64: telepresence.manager.WorkloadInfo.services:type_name -> telepresence.manager.ServiceAssociation
+	3,   // 65: telepresence.manager.WorkloadInfo.agent_state:type_name -> telepresence.manager.WorkloadInfo.AgentState
+	85,  // 66: telepresence.manager.WorkloadInfo.intercept_clients:type_name -> telepresence.manager.WorkloadInfo.Intercept
+	2,   // 67: telepresence.manager.WorkloadInfo.state:type_name -> telepresence.manager.WorkloadInfo.State
+	4,   // 68: telepresence.manager.WorkloadEvent.type:type_name -> telepresence.manager.WorkloadEvent.Type
+	63,  // 69: telepresence.manager.WorkloadEvent.workload:type_name -> telepresence.manager.WorkloadInfo
+	86,  // 70: telepresence.manager.WorkloadEventsDelta.since:type_name -> google.protobuf.Timestamp
+	64,  // 71: telepresence.manager.WorkloadEventsDelta.events:type_name -> telepresence.manager.WorkloadEvent
+	13,  // 72: telepresence.manager.WorkloadEventsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	86,  // 73: telepresence.manager.WorkloadEventsRequest.since:type_name -> google.protobuf.Timestamp
+	13,  // 74: telepresence.manager.UninstallAgentsRequest.session_info:type_name -> telepresence.manager.SessionInfo
+	72,  // 75: telepresence.manager.AgentInfo.ContainerInfo.environment:type_name -> telepresence.manager.AgentInfo.ContainerInfo.EnvironmentEntry
+	73,  // 76: telepresence.manager.AgentInfo.ContainerInfo.mounts:type_name -> telepresence.manager.AgentInfo.ContainerInfo.MountsEntry
+	69,  // 77: telepresence.manager.AgentInfo.ContainersEntry.value:type_name -> telepresence.manager.AgentInfo.ContainerInfo
+	6,   // 78: telepresence.manager.AgentInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentInfo
+	10,  // 79: telepresence.manager.InterceptInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.InterceptInfo
+	53,  // 80: telepresence.manager.AgentPodInfoDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	88,  // 81: telepresence.manager.Manager.Version:input_type -> google.protobuf.Empty
+	88,  // 82: telepresence.manager.Manager.GetAgentImageFQN:input_type -> google.protobuf.Empty
+	56,  // 83: telepresence.manager.Manager.GetAgentConfig:input_type -> telepresence.manager.AgentConfigRequest
+	88,  // 84: telepresence.manager.Manager.GetClientConfig:input_type -> google.protobuf.Empty
+	88,  // 85: telepresence.manager.Manager.GetTelepresenceAPI:input_type -> google.protobuf.Empty
+	5,   // 86: telepresence.manager.Manager.ArriveAsClient:input_type -> telepresence.manager.ClientInfo
+	11,  // 87: telepresence.manager.Manager.ReconnectAgent:input_type -> telepresence.manager.ReconnectAgentRequest
+	12,  // 88: telepresence.manager.Manager.ReconnectClient:input_type -> telepresence.manager.ReconnectClientRequest
+	6,   // 89: telepresence.manager.Manager.ArriveAsAgent:input_type -> telepresence.manager.AgentInfo
+	28,  // 90: telepresence.manager.Manager.Remain:input_type -> telepresence.manager.RemainRequest
+	13,  // 91: telepresence.manager.Manager.Depart:input_type -> telepresence.manager.SessionInfo
+	29,  // 92: telepresence.manager.Manager.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	30,  // 93: telepresence.manager.Manager.GetLogs:input_type -> telepresence.manager.GetLogsRequest
+	13,  // 94: telepresence.manager.Manager.WatchAgentPods:input_type -> telepresence.manager.SessionInfo
+	13,  // 95: telepresence.manager.Manager.WatchAgentPodsDelta:input_type -> telepresence.manager.SessionInfo
+	14,  // 96: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:input_type -> telepresence.manager.AgentsRequest
+	13,  // 97: telepresence.manager.Manager.WatchAgents:input_type -> telepresence.manager.SessionInfo
+	13,  // 98: telepresence.manager.Manager.WatchAgentsDelta:input_type -> telepresence.manager.SessionInfo
+	13,  // 99: telepresence.manager.Manager.WatchIntercepts:input_type -> telepresence.manager.SessionInfo
+	13,  // 100: telepresence.manager.Manager.WatchInterceptsDelta:input_type -> telepresence.manager.SessionInfo
+	19,  // 101: telepresence.manager.Manager.WatchSessionEvents:input_type -> telepresence.manager.SessionEventsRequest
+	66,  // 102: telepresence.manager.Manager.WatchWorkloads:input_type -> telepresence.manager.WorkloadEventsRequest
+	13,  // 103: telepresence.manager.Manager.WatchClusterInfo:input_type -> telepresence.manager.SessionInfo
+	22,  // 104: telepresence.manager.Manager.EnsureAgent:input_type -> telepresence.manager.EnsureAgentRequest
+	23,  // 105: telepresence.manager.Manager.ReleaseAgent:input_type -> telepresence.manager.ReleaseAgentRequest
+	21,  // 106: telepresence.manager.Manager.PrepareIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	21,  // 107: telepresence.manager.Manager.CreateIntercept:input_type -> telepresence.manager.CreateInterceptRequest
+	25,  // 108: telepresence.manager.Manager.RemoveIntercept:input_type -> telepresence.manager.RemoveInterceptRequest2
+	26,  // 109: telepresence.manager.Manager.GetIntercept:input_type -> telepresence.manager.GetInterceptRequest
+	27,  // 110: telepresence.manager.Manager.ReviewIntercept:input_type -> telepresence.manager.ReviewInterceptRequest
+	13,  // 111: telepresence.manager.Manager.GetKnownWorkloadKinds:input_type -> telepresence.manager.SessionInfo
+	42,  // 112: telepresence.manager.Manager.Lookup:input_type -> telepresence.manager.LookupRequest
+	44,  // 113: telepresence.manager.Manager.LookupDNS:input_type -> telepresence.manager.DNSRequest
+	88,  // 114: telepresence.manager.Manager.WatchLogLevel:input_type -> google.protobuf.Empty
+	34,  // 115: telepresence.manager.Manager.Tunnel:input_type -> telepresence.manager.TunnelMessage
+	13,  // 116: telepresence.manager.Manager.GetQuicTunnelEndpoint:input_type -> telepresence.manager.SessionInfo
+	13,  // 117: telepresence.manager.Manager.GetSessionCredential:input_type -> telepresence.manager.SessionInfo
+	13,  // 118: telepresence.manager.Manager.GetQuicAgentCert:input_type -> telepresence.manager.SessionInfo
+	88,  // 119: telepresence.manager.Manager.WatchQuicBackends:input_type -> google.protobuf.Empty
+	58,  // 120: telepresence.manager.Manager.ReportMetrics:input_type -> telepresence.manager.TunnelMetrics
+	67,  // 121: telepresence.manager.Manager.UninstallAgents:input_type -> telepresence.manager.UninstallAgentsRequest
+	33,  // 122: telepresence.manager.Manager.Version:output_type -> telepresence.manager.VersionInfo2
+	52,  // 123: telepresence.manager.Manager.GetAgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	57,  // 124: telepresence.manager.Manager.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	51,  // 125: telepresence.manager.Manager.GetClientConfig:output_type -> telepresence.manager.CLIConfig
+	32,  // 126: telepresence.manager.Manager.GetTelepresenceAPI:output_type -> telepresence.manager.TelepresenceAPIInfo
+	13,  // 127: telepresence.manager.Manager.ArriveAsClient:output_type -> telepresence.manager.SessionInfo
+	88,  // 128: telepresence.manager.Manager.ReconnectAgent:output_type -> google.protobuf.Empty
+	88,  // 129: telepresence.manager.Manager.ReconnectClient:output_type -> google.protobuf.Empty
+	13,  // 130: telepresence.manager.Manager.ArriveAsAgent:output_type -> telepresence.manager.SessionInfo
+	88,  // 131: telepresence.manager.Manager.Remain:output_type -> google.protobuf.Empty
+	88,  // 132: telepresence.manager.Manager.Depart:output_type -> google.protobuf.Empty
+	88,  // 133: telepresence.manager.Manager.SetLogLevel:output_type -> google.protobuf.Empty
+	31,  // 134: telepresence.manager.Manager.GetLogs:output_type -> telepresence.manager.LogsResponse
+	54,  // 135: telepresence.manager.Manager.WatchAgentPods:output_type -> telepresence.manager.AgentPodInfoSnapshot
+	55,  // 136: telepresence.manager.Manager.WatchAgentPodsDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	55,  // 137: telepresence.manager.Manager.WatchAgentPodsInNamespacesDelta:output_type -> telepresence.manager.AgentPodInfoDelta
+	15,  // 138: telepresence.manager.Manager.WatchAgents:output_type -> telepresence.manager.AgentInfoSnapshot
+	16,  // 139: telepresence.manager.Manager.WatchAgentsDelta:output_type -> telepresence.manager.AgentInfoDelta
+	17,  // 140: telepresence.manager.Manager.WatchIntercepts:output_type -> telepresence.manager.InterceptInfoSnapshot
+	18,  // 141: telepresence.manager.Manager.WatchInterceptsDelta:output_type -> telepresence.manager.InterceptInfoDelta
+	20,  // 142: telepresence.manager.Manager.WatchSessionEvents:output_type -> telepresence.manager.SessionEventsDelta
+	65,  // 143: telepresence.manager.Manager.WatchWorkloads:output_type -> telepresence.manager.WorkloadEventsDelta
+	48,  // 144: telepresence.manager.Manager.WatchClusterInfo:output_type -> telepresence.manager.ClusterInfo
+	15,  // 145: telepresence.manager.Manager.EnsureAgent:output_type -> telepresence.manager.AgentInfoSnapshot
+	88,  // 146: telepresence.manager.Manager.ReleaseAgent:output_type -> google.protobuf.Empty
+	24,  // 147: telepresence.manager.Manager.PrepareIntercept:output_type -> telepresence.manager.PreparedIntercept
+	10,  // 148: telepresence.manager.Manager.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	88,  // 149: telepresence.manager.Manager.RemoveIntercept:output_type -> google.protobuf.Empty
+	10,  // 150: telepresence.manager.Manager.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	88,  // 151: telepresence.manager.Manager.ReviewIntercept:output_type -> google.protobuf.Empty
+	59,  // 152: telepresence.manager.Manager.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	43,  // 153: telepresence.manager.Manager.Lookup:output_type -> telepresence.manager.LookupResponse
+	45,  // 154: telepresence.manager.Manager.LookupDNS:output_type -> telepresence.manager.DNSResponse
+	29,  // 155: telepresence.manager.Manager.WatchLogLevel:output_type -> telepresence.manager.LogLevelRequest
+	34,  // 156: telepresence.manager.Manager.Tunnel:output_type -> telepresence.manager.TunnelMessage
+	35,  // 157: telepresence.manager.Manager.GetQuicTunnelEndpoint:output_type -> telepresence.manager.QuicTunnelEndpoint
+	37,  // 158: telepresence.manager.Manager.GetSessionCredential:output_type -> telepresence.manager.SessionCredential
+	41,  // 159: telepresence.manager.Manager.GetQuicAgentCert:output_type -> telepresence.manager.QuicAgentCert
+	39,  // 160: telepresence.manager.Manager.WatchQuicBackends:output_type -> telepresence.manager.QuicBackendSnapshot
+	88,  // 161: telepresence.manager.Manager.ReportMetrics:output_type -> google.protobuf.Empty
+	88,  // 162: telepresence.manager.Manager.UninstallAgents:output_type -> google.protobuf.Empty
+	122, // [122:163] is the sub-list for method output_type
+	81,  // [81:122] is the sub-list for method input_type
+	81,  // [81:81] is the sub-list for extension type_name
+	81,  // [81:81] is the sub-list for extension extendee
+	0,   // [0:81] is the sub-list for field type_name
 }
 
 func init() { file_manager_manager_proto_init() }
@@ -5889,14 +6090,14 @@ func file_manager_manager_proto_init() {
 	if File_manager_manager_proto != nil {
 		return
 	}
-	file_manager_manager_proto_msgTypes[7].OneofWrappers = []any{}
+	file_manager_manager_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_manager_manager_proto_rawDesc), len(file_manager_manager_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   79,
+			NumMessages:   81,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/manager/manager.proto
+++ b/rpc/manager/manager.proto
@@ -82,6 +82,30 @@ message AgentInfo {
   // over QUIC"). 0 means this agent has no QUIC listener.
   int32 quic_port = 16;
 
+  // InterceptTarget describes one service-backed target that this agent can
+  // handle. The traffic-manager uses these claims when a single Service
+  // selects pods owned by more than one workload.
+  message InterceptTarget {
+    // .metadata.uid of the Service associated with the target.
+    string service_uid = 1;
+
+    // Name of the Service, retained for diagnostics.
+    string service_name = 2;
+
+    // Name and number of the selected Service port.
+    string service_port_name = 3;
+    int32 service_port = 4;
+
+    // Protocol and local container target used by this agent.
+    string protocol = 5;
+    string container_name = 6;
+    int32 container_port = 7;
+  }
+
+  // Service-backed targets advertised by this agent. Older agents leave this
+  // empty and continue to use workload-scoped intercept matching.
+  repeated InterceptTarget intercept_targets = 17;
+
   reserved 6;
 }
 
@@ -259,6 +283,14 @@ enum InterceptDispositionType {
   BAD_ARGS = 8;
 }
 
+// InterceptWorkload identifies one workload whose pods participate in a
+// Service-scoped intercept.
+message InterceptWorkload {
+  string namespace = 1;
+  string workload_kind = 2;
+  string workload_name = 3;
+}
+
 // InterceptInfo contains information about a live intercept in an agent
 message InterceptInfo {
   InterceptSpec spec = 1;
@@ -301,6 +333,11 @@ message InterceptInfo {
 
   // Timestamp for last modification made by traffic-manager
   google.protobuf.Timestamp modified_at = 21;
+
+  // Workloads whose ready Service-selected pods participate in this intercept.
+  // This is populated by the manager for Service-scoped intercepts so
+  // server-side integrations can configure every participating workload.
+  repeated InterceptWorkload service_workloads = 23;
 
   reserved 7; // was preview_domain
 


### PR DESCRIPTION
## Description

A Service can select pods owned by more than one workload, but an intercept currently follows only the explicitly requested workload. Traffic that lands on another selected workload is then left out of the intercept.

For a concrete example we currently do something like: (this is usually an envoy or something similar doing weight based random request distribution)

                         | - > "main" deployment
                         |
kube svc --->  |
                         |
                         | - > "canary" deployment

We want to be able to intercept both - so that I can not worry about cases where the request might land on either.

This lets agents advertise the Service UID and port targets they can serve, discovers every selected workload, waits for one review from each participant, and publishes the participating workload identities on the intercept. Older agents keep the historical single-workload matching path during a rolling upgrade. Shared-Service expansion is limited to HTTP intercepts without --replace, where one logical intercept can safely span the selected workloads.

It also discovers selector-matching workloads before their pods are ready, keeps the participant set aligned when the selector changes, and will not activate shared coverage while any live replica is missing the selected Service target. That keeps a scaled-zero canary or a rolling upgrade from quietly bypassing the local handler.

Restored intercepts rebuild their participants before reconciliation, each agent uses its own matched container, and unsupported expansion cases fall back to the requested workload instead of failing the intercept.

Tested with:

    GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/... -count=1
    GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/agent ./pkg/agentconfig -count=1

## Checklist

 - [x] I made sure to update ./CHANGELOG.yml (our release notes are generated from this file).
 - [x] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated CONTRIBUTING.md with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.
