### PR TITLE
Add useful context when sessions or intercept paths stall

### DIFF
--- a/cmd/traffic/cmd/agent/fwd/http.go
+++ b/cmd/traffic/cmd/agent/fwd/http.go
@@ -12,6 +12,8 @@ import (
 	"net/http/httputil"
 	"net/netip"
 	"net/url"
+	"sync/atomic"
+	"time"
 
 	"golang.org/x/net/http2"
 
@@ -21,6 +23,41 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/matcher"
 	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
 )
+
+const (
+	httpInterceptSlowAfter = 2 * time.Second
+	httpInterceptVerySlow  = 10 * time.Second
+)
+
+type observedResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	bytes      int64
+}
+
+func (w *observedResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+
+func (w *observedResponseWriter) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *observedResponseWriter) Write(p []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes += int64(n)
+	return n, err
+}
+
+func (w *observedResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
 
 func (f *tcp) protocols(ctx context.Context, plainText bool) *http.Protocols {
 	pr := new(http.Protocols)
@@ -237,6 +274,33 @@ func (f *tcp) serveHTTPIntercept(
 	f.mu.Lock()
 	sp := f.streamProvider
 	f.mu.Unlock()
+	requestID := f.httpRequestID.Add(1)
+	requestStart := time.Now()
+	method := request.Method
+	path := request.URL.RequestURI()
+	if path == "" {
+		path = request.URL.Path
+	}
+	host := request.Host
+	var slowLogged atomic.Bool
+	slowTimer := time.AfterFunc(httpInterceptSlowAfter, func() {
+		slowLogged.Store(true)
+		clog.Warnf(
+			ctx,
+			"HTTP selected intercept request still active after %s: request=%d intercept=%s clientSession=%s method=%s host=%q path=%q src=%s target=%s:%d",
+			time.Since(requestStart).Round(time.Millisecond),
+			requestID,
+			ii.Id,
+			ii.ClientSession.SessionId,
+			method,
+			host,
+			path,
+			src,
+			spec.TargetHost,
+			spec.TargetPort,
+		)
+	})
+	defer slowTimer.Stop()
 
 	metricsEnabled := sp != nil && sp.MetricsEnabled()
 	var ingressBytes, egressBytes *tunnel.CounterProbe
@@ -287,14 +351,43 @@ func (f *tcp) serveHTTPIntercept(
 	targetProxy := httputil.NewSingleHostReverseProxy(trg)
 	targetProxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
 		if errors.Is(err, errClientStream) {
-			clog.Warnf(ctx, "Intercept tunnel unavailable for %s %s; failing open to app container: %v", req.Method, req.URL.Path, err)
+			clog.Warnf(ctx, "HTTP selected intercept tunnel unavailable for request=%d %s %s; failing open to app container: %v", requestID, req.Method, req.URL.Path, err)
 			defaultHandler.ServeHTTP(rw, req)
 			return
 		}
+		clog.Warnf(ctx, "HTTP selected intercept proxy error for request=%d %s %s: %v", requestID, req.Method, req.URL.Path, err)
 		proxyErrorHandler(rw, req, err)
 	}
 	targetProxy.Transport = trn
-	targetProxy.ServeHTTP(writer, request)
+	observedWriter := &observedResponseWriter{ResponseWriter: writer}
+	targetProxy.ServeHTTP(observedWriter, request)
+
+	duration := time.Since(requestStart)
+	statusCode := observedWriter.statusCode
+	if statusCode == 0 {
+		statusCode = -1
+	}
+	if slowLogged.Load() || duration > httpInterceptSlowAfter || statusCode == -1 {
+		logFn := clog.Infof
+		if duration > httpInterceptVerySlow || statusCode == -1 {
+			logFn = clog.Warnf
+		}
+		logFn(
+			ctx,
+			"HTTP selected intercept request finished after %s: request=%d intercept=%s clientSession=%s method=%s host=%q path=%q src=%s target=%s status=%d responseBytes=%d",
+			duration.Round(time.Millisecond),
+			requestID,
+			ii.Id,
+			ii.ClientSession.SessionId,
+			method,
+			host,
+			path,
+			src,
+			trg,
+			statusCode,
+			observedWriter.bytes,
+		)
+	}
 
 	if metricsEnabled {
 		clog.Debugf(ctx, "Connection to %s ended. IngressBytes: %d, egressBytes: %d", trg, ingressBytes.GetValue(), egressBytes.GetValue())

--- a/cmd/traffic/cmd/agent/fwd/http_test.go
+++ b/cmd/traffic/cmd/agent/fwd/http_test.go
@@ -127,6 +127,20 @@ func TestHTTPInterceptor_noFilters(t *testing.T) {
 	assert.True(t, result)
 }
 
+func TestObservedResponseWriterTracksStatusAndBytes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writer := &observedResponseWriter{ResponseWriter: rec}
+
+	writer.WriteHeader(http.StatusCreated)
+	n, err := writer.Write([]byte("hello"))
+
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, http.StatusCreated, writer.statusCode)
+	require.EqualValues(t, 5, writer.bytes)
+	require.Same(t, rec, writer.Unwrap())
+}
+
 // fakeTapStream is a minimal tunnel.Stream that records everything sent to it.
 type fakeTapStream struct {
 	mu   sync.Mutex

--- a/cmd/traffic/cmd/agent/fwd/tcp.go
+++ b/cmd/traffic/cmd/agent/fwd/tcp.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/telepresenceio/clog"
@@ -24,6 +25,7 @@ type tcp struct {
 	*interceptor
 	tlsManager     tls.Manager
 	listenerSwitch ListenerSwitch
+	httpRequestID  atomic.Uint64
 }
 
 func NewTCPInterceptor(ctx context.Context, listenPort types.PortAndProto, tag tunnel.Tag, tlsManager tls.Manager, target netip.AddrPort, opts ...forwarder.Option) Interceptor {
@@ -191,9 +193,37 @@ func (f *tcp) createStream(ctx context.Context, src netip.AddrPort, ii *manager.
 	f.mu.Lock()
 	sp := f.streamProvider
 	f.mu.Unlock()
+	start := time.Now()
 	s, err := sp.CreateClientStream(ctx, tunnel.AgentToClient, clientSession, id, latency, timeout)
 	if err != nil {
+		clog.Warnf(
+			ctx,
+			"failed to create agent-to-client intercept stream after %s: intercept=%s clientSession=%s conn=%s src=%s dst=%s target=%s:%d error=%v",
+			time.Since(start).Round(time.Millisecond),
+			ii.Id,
+			clientSession,
+			id,
+			src,
+			dst,
+			spec.TargetHost,
+			spec.TargetPort,
+			err,
+		)
 		return nil, fmt.Errorf("%w: %w", errClientStream, err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		clog.Warnf(
+			ctx,
+			"created agent-to-client intercept stream slowly after %s: intercept=%s clientSession=%s conn=%s src=%s dst=%s target=%s:%d",
+			elapsed.Round(time.Millisecond),
+			ii.Id,
+			clientSession,
+			id,
+			src,
+			dst,
+			spec.TargetHost,
+			spec.TargetPort,
+		)
 	}
 	return s, nil
 }

--- a/cmd/traffic/cmd/agent/server.go
+++ b/cmd/traffic/cmd/agent/server.go
@@ -27,6 +27,11 @@ type awaitingForward struct {
 	doneCh   <-chan struct{}
 }
 
+const (
+	clientTunnelSlowAfter       = time.Second
+	clientTunnelStillWaitingLog = 5 * time.Second
+)
+
 func (s *state) Version(context.Context, *emptypb.Empty) (*rpc.VersionInfo2, error) {
 	return &rpc.VersionInfo2{Name: DisplayName, Version: version.Version}, nil
 }
@@ -113,8 +118,11 @@ func (s *state) WatchDial(session *rpc.SessionInfo, server agent.Agent_WatchDial
 	if err != nil {
 		return err
 	}
-	clog.Debugf(ctx, "WatchDial called from client %s", session.SessionId)
-	defer clog.Debugf(ctx, "WatchDial ended from client %s", session.SessionId)
+	started := time.Now()
+	clog.Infof(ctx, "WatchDial called from client %s", session.SessionId)
+	defer func() {
+		clog.Infof(ctx, "WatchDial ended from client %s after %s: context=%v", session.SessionId, time.Since(started).Round(time.Millisecond), ctx.Err())
+	}()
 	drCh := make(chan *rpc.DialRequest)
 
 	// Displacement policy: a verified caller always takes over the slot, even from a
@@ -167,6 +175,7 @@ func (s *state) WatchDial(session *rpc.SessionInfo, server agent.Agent_WatchDial
 func (s *state) CreateClientStream(ctx context.Context, _ tunnel.Tag, sessionID tunnel.SessionID, id tunnel.ConnID, roundTripLatency, dialTimeout time.Duration,
 ) (tunnel.Stream, error) {
 	clog.Debugf(ctx, "Creating tunnel to client %s for id %s", sessionID, id)
+	createStart := time.Now()
 	var drCh chan<- *rpc.DialRequest
 	var stCh <-chan tunnel.Stream
 
@@ -192,18 +201,39 @@ func (s *state) CreateClientStream(ctx context.Context, _ tunnel.Tag, sessionID 
 		return fmt.Errorf("unable to create tunnel to client %s for id %s: no dial watcher", sessionID, id)
 	}, backoff.WithContext(backoff.NewConstantBackOff(20*time.Millisecond), ctx))
 	if err != nil {
+		clog.Warnf(ctx, "unable to create tunnel to client %s for id %s after %s: %v", sessionID, id, time.Since(createStart).Round(time.Millisecond), err)
 		return nil, err
 	}
 
+	requestStart := time.Now()
 	drCh <- &rpc.DialRequest{ConnId: []byte(id), DialTimeout: int64(dialTimeout), RoundtripLatency: int64(roundTripLatency)}
 
-	select {
-	case <-ctx.Done():
-		clog.Errorf(ctx, "unable to create tunnel to client %s for id %s: %v", sessionID, id, ctx.Done())
-		return nil, ctx.Err()
-	case stream := <-stCh:
-		clog.Debugf(ctx, "Created tunnel to client %s for id %s", sessionID, id)
-		return stream, nil
+	waitLog := time.NewTimer(clientTunnelSlowAfter)
+	defer waitLog.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			clog.Errorf(ctx, "unable to create tunnel to client %s for id %s after %s: %v", sessionID, id, time.Since(requestStart).Round(time.Millisecond), ctx.Err())
+			return nil, ctx.Err()
+		case stream := <-stCh:
+			if elapsed := time.Since(requestStart); elapsed > clientTunnelSlowAfter {
+				clog.Warnf(ctx, "created tunnel to client %s for id %s slowly in %s", sessionID, id, elapsed.Round(time.Millisecond))
+			} else {
+				clog.Debugf(ctx, "Created tunnel to client %s for id %s in %s", sessionID, id, elapsed)
+			}
+			return stream, nil
+		case <-waitLog.C:
+			clog.Warnf(
+				ctx,
+				"still waiting for client tunnel after %s: clientSession=%s conn=%s dialTimeout=%s roundtripLatency=%s",
+				time.Since(requestStart).Round(time.Millisecond),
+				sessionID,
+				id,
+				dialTimeout,
+				roundTripLatency,
+			)
+			waitLog.Reset(clientTunnelStillWaitingLog)
+		}
 	}
 }
 

--- a/pkg/client/agentpf/clients.go
+++ b/pkg/client/agentpf/clients.go
@@ -92,11 +92,16 @@ func (ac *client) Tunnel(ctx context.Context, opts ...grpc.CallOption) (tunnel.G
 	if err != nil {
 		return nil, err
 	}
+	start := time.Now()
 	clog.Tracef(ctx, "%s(%s) creating Tunnel over gRPC", ac, net.IP(ac.info.PodIp))
 	tc, err := cli.Tunnel(ctx, opts...)
+	elapsed := time.Since(start)
 	if err != nil {
-		clog.Tracef(ctx, "%s(%s) failed to create Tunnel over gRPC: %v", ac, net.IP(ac.info.PodIp), err)
+		clog.Warnf(ctx, "%s(%s) failed to create Tunnel over gRPC after %s: %v", ac, net.IP(ac.info.PodIp), elapsed.Round(time.Millisecond), err)
 		return nil, err
+	}
+	if elapsed > time.Second {
+		clog.Warnf(ctx, "%s(%s) created Tunnel over gRPC slowly in %s", ac, net.IP(ac.info.PodIp), elapsed.Round(time.Millisecond))
 	}
 	atomic.AddInt32(&ac.tunnelCount, 1)
 	clog.Tracef(ctx, "%s(%s) have %d active tunnels", ac, net.IP(ac.info.PodIp), atomic.LoadInt32(&ac.tunnelCount))
@@ -798,7 +803,7 @@ func (s *clients) teardown() {
 		}
 		return true
 	})
-	clog.Debugf(s, "WatchAgentPods ending with %d clients still active", activeCount)
+	clog.Infof(s, "WatchAgentPods ending with %d clients still active", activeCount)
 	s.disabled.Store(true)
 }
 

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -2,6 +2,8 @@ package rootd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"time"
 
@@ -96,11 +98,11 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 		return nil, err
 	}
 
-	sessionCtx, sessionCancel := context.WithCancel(s)
+	sessionCtx, sessionCancel := context.WithCancelCause(s)
 	var sn *session
 	sn, err = createSession(client.WithConfig(sessionCtx, cfg), ctx, info, s.activity, dns.CleanupRouting)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to create root daemon session: %w", err))
 		return nil, err
 	}
 	if !s.managed {
@@ -120,7 +122,7 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 	sessionRunning := make(chan struct{})
 	go func() {
 		defer func() {
-			sessionCancel()
+			sessionCancel(context.Canceled)
 			if !s.managed {
 				// Restore log level from service config after session ends.
 				client.ReloadLogLevel(s)
@@ -136,18 +138,24 @@ func (s *service) Connect(ctx context.Context, info *rpc.NetworkConfig) (reply *
 		return nil, status.Error(codes.Canceled, "session canceled")
 	case <-ctx.Done():
 		// gRPC context was canceled, probably by the caller.
-		sessionCancel()
+		sessionCancel(errors.New("root daemon Connect call canceled"))
 		return nil, status.Error(codes.Canceled, "connect call canceled")
 	case err = <-initErrCh:
 		if err != nil {
 			// Session failed to initialize.
-			sessionCancel()
+			sessionCancel(fmt.Errorf("root daemon session initialization failed: %w", err))
 			return nil, err
 		}
 		// Session initialized successfully.
 	}
 	s.session = sn
-	s.sessionCancel = sessionCancel
+	s.sessionCancel = func(cause error) {
+		if cause == nil {
+			cause = context.Canceled
+		}
+		clog.Infof(sn, "canceling root daemon session: %v", cause)
+		sessionCancel(cause)
+	}
 	s.sessionRunning = sessionRunning
 	return reply, nil
 }
@@ -170,7 +178,7 @@ func (s *service) cancelSession(ctx context.Context) {
 	// We must use a shared read lock when cancelling to avoid a deadlock.
 	var oldSession *session
 	err := s.withSession(ctx, func(_ context.Context, session *session) error {
-		s.sessionCancel()
+		s.sessionCancel(errors.New("root daemon Disconnect request"))
 		oldSession = session
 		return nil
 	})

--- a/pkg/client/rootd/service.go
+++ b/pkg/client/rootd/service.go
@@ -53,7 +53,7 @@ type service struct {
 	// sessionLock protects the session, sessionCancel, and sessionRunning fields.
 	sessionLock   sync.RWMutex
 	session       *session
-	sessionCancel context.CancelFunc
+	sessionCancel func(error)
 
 	// sessionRunning is closed when the session is done running.
 	sessionRunning chan struct{}
@@ -256,7 +256,7 @@ func runAliveAndCancellation(g log.Group, daemonPort uint16, cancel context.Canc
 		return il.WatchInfos(func(ctx context.Context) error {
 			ok, err := il.InfoExists(daemon.InfoFileName)
 			if err == nil && !ok {
-				clog.Debugf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemon.InfoFileName)
+				clog.Warnf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemon.InfoFileName)
 				cancel()
 			}
 			return err

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -1437,6 +1437,7 @@ func (s *session) hasPodConnectivity(info *manager.ClusterInfo) bool {
 }
 
 func (s *session) run(initErrs chan<- error) {
+	started := time.Now()
 	defer func() {
 		clog.Info(s, "-- session ended")
 	}()
@@ -1448,8 +1449,14 @@ func (s *session) run(initErrs chan<- error) {
 	}
 	close(initErrs)
 	err := g.Wait()
-	if err != nil {
-		clog.Errorf(s, "session ended with error: %v", err)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	switch {
+	case err != nil:
+		clog.Errorf(s, "session ended after %s with error: %v context=%v cause=%v", elapsed, err, s.Err(), context.Cause(s))
+	case s.Err() != nil:
+		clog.Infof(s, "session context ended after %s: context=%v cause=%v", elapsed, s.Err(), context.Cause(s))
+	default:
+		clog.Infof(s, "session services stopped cleanly after %s", elapsed)
 	}
 }
 

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -93,10 +93,10 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 	// Obtain the kubeconfig from the request parameters so that we can determine
 	// what kubernetes context that will be used.
 	var kubeConfig *k8s.Kubeconfig
-	sessionCtx, sessionCancel := context.WithCancel(s.Context)
+	sessionCtx, sessionCancel := context.WithCancelCause(s.Context)
 	kubeConfig, err = k8s.DaemonKubeconfig(client.WithConfig(sessionCtx, cfg), cr)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to obtain kubeconfig: %w", err))
 		if s.rootSessionInProc {
 			s.quit(true)
 		}
@@ -124,7 +124,7 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 	var session userd.Session
 	session, result, err = trafficmgr.NewSession(s, server.NewCombinedContext(s, ctx), cr, kubeConfig, wg)
 	if err != nil {
-		sessionCancel()
+		sessionCancel(fmt.Errorf("failed to create user daemon session: %w", err))
 		if s.rootSessionInProc {
 			// Simplified session management. The daemon handles one session, then exits.
 			s.quit(true)
@@ -132,11 +132,15 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 		return nil, err
 	}
 	client.ReloadLogLevel(session)
-	s.sessionCancel = func() {
+	s.sessionCancel = func(cause error) {
+		if cause == nil {
+			cause = context.Canceled
+		}
+		clog.Infof(session, "canceling user daemon session: %v", cause)
 		if err := session.ClearIngestsAndIntercepts(); err != nil {
 			clog.Errorf(ctx, "failed to clear intercepts: %v", err)
 		}
-		sessionCancel()
+		sessionCancel(cause)
 	}
 	sessionRunning := make(chan struct{})
 	s.session = session
@@ -155,7 +159,10 @@ func (s *service) Connect(ctx context.Context, cr *rpc.ConnectRequest) (result *
 		s.clearSession(session)
 	}()
 	if s.rootSessionInProc {
-		go runAliveAndCancellationSession(session, s.sessionCancel, daemonID, wg)
+		cancelUserSession := s.sessionCancel
+		go runAliveAndCancellationSession(session, func() {
+			cancelUserSession(errors.New("session daemon info file disappeared"))
+		}, daemonID, wg)
 	}
 	return result, err
 }
@@ -176,7 +183,7 @@ func (s *service) cancelSession(ctx context.Context, disconnectRoot bool) {
 	var oldSession userd.Session
 	err := s.withSession(ctx, func(_ context.Context, session userd.Session) error {
 		oldSession = session
-		s.sessionCancel()
+		s.sessionCancel(errors.New("connector Disconnect request"))
 		return nil
 	})
 	if err == nil && s.clearSession(oldSession) {

--- a/pkg/client/userd/daemon/service.go
+++ b/pkg/client/userd/daemon/service.go
@@ -60,7 +60,7 @@ type service struct {
 
 	sessionLock    sync.RWMutex
 	session        userd.Session
-	sessionCancel  context.CancelFunc
+	sessionCancel  func(error)
 	sessionRunning chan struct{}
 
 	fuseFtpMgr remotefs.FuseFTPManager
@@ -214,7 +214,7 @@ func runAliveAndCancellation(g log.Group, cancel context.CancelFunc, daemonInfoF
 		return il.WatchInfos(func(ctx context.Context) error {
 			ok, err := il.InfoExists(daemonInfoFile)
 			if err == nil && !ok {
-				clog.Debugf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemonInfoFile)
+				clog.Warnf(ctx, "info-watcher cancels everything because daemon info %s does not exist", daemonInfoFile)
 				cancel()
 			}
 			return err

--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -301,6 +301,7 @@ func (s *session) GetService() userd.Service {
 //     Services, and
 //   - (4) mount the appropriate remote volumes.
 func (s *session) Run() {
+	started := time.Now()
 	g := log.NewGroup(s)
 	defer func() {
 		_ = s.WithRootClient(context.WithoutCancel(s), func(ctx context.Context, rd rootdRpc.DaemonClient) error {
@@ -312,8 +313,14 @@ func (s *session) Run() {
 	}()
 	s.startServices(g)
 	err := g.Wait()
-	if err != nil {
-		clog.Errorf(s, "session ended with error: %v", err)
+	elapsed := time.Since(started).Round(time.Millisecond)
+	switch {
+	case err != nil:
+		clog.Errorf(s, "session ended after %s with error: %v context=%v cause=%v", elapsed, err, s.Err(), context.Cause(s))
+	case s.Err() != nil:
+		clog.Infof(s, "session context ended after %s: context=%v cause=%v", elapsed, s.Err(), context.Cause(s))
+	default:
+		clog.Infof(s, "session services stopped cleanly after %s", elapsed)
 	}
 }
 

--- a/pkg/log/group.go
+++ b/pkg/log/group.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -35,5 +36,22 @@ func NewGroup(ctx context.Context) Group {
 
 // Go runs the given function in a goroutine where the context logger uses the given name as a group prefix.
 func (g group) Go(name string, f func(context.Context) error) {
-	g.Group.Go(func() error { return f(clog.WithGroup(g.Context, name)) })
+	g.Group.Go(func() (err error) {
+		ctx := clog.WithGroup(g.Context, name)
+		started := time.Now()
+		defer func() {
+			elapsed := time.Since(started).Round(time.Millisecond)
+			ctxErr := ctx.Err()
+			cause := context.Cause(ctx)
+			switch {
+			case err != nil:
+				clog.Errorf(ctx, "service goroutine ended after %s: err=%v context=%v cause=%v", elapsed, err, ctxErr, cause)
+			case ctxErr != nil:
+				clog.Debugf(ctx, "service goroutine stopped after %s: context=%v cause=%v", elapsed, ctxErr, cause)
+			default:
+				clog.Debugf(ctx, "service goroutine completed after %s", elapsed)
+			}
+		}()
+		return f(ctx)
+	})
 }

--- a/pkg/tunnel/dialer.go
+++ b/pkg/tunnel/dialer.go
@@ -30,6 +30,7 @@ const (
 	tcpConnTTL       = 2 * time.Hour // Default tcp_keepalive_time on Linux
 	udpConnTTL       = 2 * time.Second
 	localDialTimeout = 2 * time.Second
+	slowDialResponse = 2 * time.Second
 )
 
 // Limit selected-intercept dial responders so bursty workloads cannot create
@@ -497,6 +498,15 @@ func DialWaitLoop(
 func dialRespond(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.DialRequest, sessionID SessionID, metrics DialMetrics) {
 	id := ConnID(dr.ConnId)
 	ctx, cancel := context.WithCancel(ctx)
+	respondStart := time.Now()
+	var slowLogged atomic.Bool
+	slowTimer := time.AfterFunc(slowDialResponse, func() {
+		slowLogged.Store(true)
+		clog.Warnf(ctx, "!! %s %s, dial response still active after %s for session %s", tag, id, time.Since(respondStart).Round(time.Millisecond), sessionID)
+	})
+	defer slowTimer.Stop()
+
+	tunnelStart := time.Now()
 	mt, err := tunnelProvider.Tunnel(ctx)
 	if err != nil {
 		clog.Errorf(ctx, "!! %s %s, call to manager Tunnel failed: %v", tag, id, err)
@@ -506,6 +516,13 @@ func dialRespond(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.
 		cancel()
 		return
 	}
+	tunnelDuration := time.Since(tunnelStart)
+	if tunnelDuration > time.Second {
+		clog.Warnf(ctx, "   %s %s, Tunnel stream established slowly in %s", tag, id, tunnelDuration.Round(time.Millisecond))
+	} else if tunnelDuration > 100*time.Millisecond {
+		clog.Debugf(ctx, "   %s %s, Tunnel stream established in %s", tag, id, tunnelDuration)
+	}
+	streamStart := time.Now()
 	s, err := NewClientStream(ctx, tag, mt, id, sessionID, time.Duration(dr.RoundtripLatency), time.Duration(dr.DialTimeout))
 	if err != nil {
 		clog.Error(ctx, err)
@@ -515,7 +532,29 @@ func dialRespond(ctx context.Context, tag Tag, tunnelProvider Provider, dr *rpc.
 		cancel()
 		return
 	}
-	d := NewDialer(s, cancel, nil, nil)
+	streamDuration := time.Since(streamStart)
+	if streamDuration > time.Second {
+		clog.Warnf(ctx, "   %s %s, client stream handshake completed slowly in %s", tag, id, streamDuration.Round(time.Millisecond))
+	} else if streamDuration > 100*time.Millisecond {
+		clog.Debugf(ctx, "   %s %s, client stream handshake completed in %s", tag, id, streamDuration)
+	}
+	ingressBytes := NewCounterProbe("FromClientBytes")
+	egressBytes := NewCounterProbe("ToClientBytes")
+	d := NewDialer(s, cancel, ingressBytes, egressBytes)
 	d.Start(ctx)
 	<-d.Done()
+	if elapsed := time.Since(respondStart); slowLogged.Load() || elapsed > slowDialResponse {
+		clog.Warnf(
+			ctx,
+			"!! %s %s, dial response ended after %s for session %s: ingressBytes=%d egressBytes=%d context=%v cause=%v",
+			tag,
+			id,
+			elapsed.Round(time.Millisecond),
+			sessionID,
+			ingressBytes.GetValue(),
+			egressBytes.GetValue(),
+			ctx.Err(),
+			context.Cause(ctx),
+		)
+	}
 }


### PR DESCRIPTION
## Description

This is the diagnostics portion of #4126, rebuilt separately from the reconnect and transport-reuse changes.

When a daemon session stops or a selected HTTP intercept stalls, the current logs often say that something ended without preserving why, or stay quiet until the useful context is gone. That makes it hard to tell whether the stop came from cancellation, a service goroutine, a local endpoint, a client tunnel, or the agent response path.

This keeps cancellation causes and session-exit timing visible, and adds request IDs plus slow-path summaries around selected HTTP requests, client stream creation, dial watchers, and dial responses. Normal long-lived tunnels stay out of the warning path.

Tested with focused `pkg/log`, rootd, agentpf, traffic-agent, tunnel, and HTTP forwarder tests, plus full `go test ./pkg/client/userd/daemon ./pkg/client/userd/trafficmgr` under `GOEXPERIMENT=jsonv2`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.