### PR TITLE
Give connect phases independent timeout budgets

### DIFF
--- a/pkg/client/userd/trafficmgr/session.go
+++ b/pkg/client/userd/trafficmgr/session.go
@@ -240,10 +240,10 @@ func NewSession(
 	}
 	cfg := client.GetConfig(cluster)
 	tos := cfg.Timeouts()
-	ctx, cancel := tos.TimeoutContext(ctx, client.TimeoutTrafficManagerConnect)
-	defer cancel()
+	managerCtx, managerCancel := tos.TimeoutContext(ctx, client.TimeoutTrafficManagerConnect)
 
-	tmgr, err := connectMgr(ctx, service, cluster, installID, cr)
+	tmgr, err := connectMgr(managerCtx, service, cluster, installID, cr)
+	managerCancel()
 	if err != nil {
 		clog.Errorf(config, "Unable to connect to session: %s", err)
 		return nil, nil, err
@@ -252,7 +252,9 @@ func NewSession(
 		return nil, nil,
 			fmt.Errorf("traffic manager version %s is too old. Minimum supported version is 2.21.0, please upgrade", tmgr.managerVersion)
 	}
-	tmgr.updateClientConfig(ctx, cr.MappedNamespaces)
+	configCtx, configCancel := tos.TimeoutContext(ctx, client.TimeoutTrafficManagerConnect)
+	tmgr.updateClientConfig(configCtx, cr.MappedNamespaces)
+	configCancel()
 
 	oi := tmgr.getNetworkInfo(cr)
 	if !service.RootSessionInProcess() {
@@ -276,7 +278,11 @@ func NewSession(
 
 	tmgr.Context = tunnel.WithSyntheticIPResolver(tmgr.Context, tmgr)
 
-	if err = tmgr.connectRootDaemon(ctx, oi, wg, cr.IsPodDaemon); err != nil {
+	// The root daemon establishes its own manager connection, so give that phase
+	// a fresh timeout instead of reusing the budget spent by the user daemon.
+	rootCtx, rootCancel := tos.TimeoutContext(ctx, client.TimeoutTrafficManagerConnect)
+	defer rootCancel()
+	if err = tmgr.connectRootDaemon(rootCtx, oi, wg, cr.IsPodDaemon); err != nil {
 		tmgr.managerConn.Close()
 		return nil, nil, err
 	}
@@ -285,7 +291,7 @@ func NewSession(
 	clog.Debug(tmgr, "Finished connecting to traffic manager")
 
 	tmgr.AddNamespaceEventHandler(tmgr.updateDaemonNamespaces)
-	ci, err := tmgr.status(ctx, true)
+	ci, err := tmgr.status(rootCtx, true)
 	return tmgr, ci, err
 }
 


### PR DESCRIPTION
## Description

A connect currently shares one `trafficManagerConnect` timeout across traffic-manager discovery, remote configuration, and the root-daemon handoff. On a slower API path, an earlier successful phase can consume most of that budget and make the next phase fail even though it would succeed on its own.

Give each phase a fresh timeout budget. This keeps the existing per-phase limit while avoiding a startup race between otherwise independent phases.

Tested with `GOEXPERIMENT=jsonv2 go test ./pkg/client/userd/trafficmgr`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.