### PR TITLE
Make repeated agent arrivals reuse their session

### DIFF
--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -630,7 +630,11 @@ func (s *State) RestoreAgent(ctx context.Context, id tunnel.SessionID, agent *rp
 		as.SetPrincipal(principal)
 	}
 	if _, exists := s.agents.LoadOrStore(id, as); exists {
-		return "", nil
+		as.cancel()
+		// ArriveAsAgent can be retried after the manager committed this session
+		// but the response was lost or timed out. Return the stable pod-UID based
+		// session ID so that the retry remains idempotent.
+		return id, nil
 	}
 
 	s.intercepts.Range(func(interceptID string, intercept *Intercept) bool {

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -157,6 +157,21 @@ func (s *suiteState) TestAddClient() {
 	assert.Equal(s.T(), 1, s.state.clients.Size())
 }
 
+func (s *suiteState) TestRestoreAgentIsIdempotent() {
+	s.state.backgroundCtx = mutator.WithMap(s.ctx, mutator.NewWatcher())
+	agent := testdata.GetTestAgents(s.T())["hello"]
+	id := tunnel.SessionID(AgentSessionIDPrefix + agent.PodUid)
+
+	firstID, err := s.state.RestoreAgent(s.ctx, id, agent, nil, time.Now())
+	require.NoError(s.T(), err)
+	secondID, err := s.state.RestoreAgent(s.ctx, id, agent, nil, time.Now())
+	require.NoError(s.T(), err)
+
+	assert.Equal(s.T(), id, firstID)
+	assert.Equal(s.T(), id, secondID)
+	assert.Equal(s.T(), 1, s.state.CountAgents())
+}
+
 func (s *suiteState) TestRemoveSession() {
 	// given
 	now := time.Now()


### PR DESCRIPTION
## Description

An agent can retry arrival after the manager has committed the session but before the response makes it back. The retry should get the same stable session ID instead of looking like a failed arrival.

This returns the existing pod-based session ID for a duplicate restore and cancels the unused duplicate session object.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/state -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.