### PR TITLE
Avoid rewriting unchanged intercepts

### DIFF
--- a/cmd/traffic/cmd/manager/state/state.go
+++ b/cmd/traffic/cmd/manager/state/state.go
@@ -720,8 +720,9 @@ func (s *State) WatchWorkloads(ctx context.Context, ns string) (ch <-chan []Even
 }
 
 // UpdateIntercept applies a given mutator function to the stored intercept with interceptID;
-// storing and returning the result.  If the given intercept does not exist, then the mutator
-// function is not run, and nil is returned.
+// storing and returning the result. If the mutator leaves the intercept semantically unchanged,
+// the current value is returned without updating ModifiedAt. If the given intercept does not
+// exist, then the mutator function is not run, and nil is returned.
 //
 // This does not lock; but instead uses CAS and may therefore call the mutator function multiple
 // times.  So: it is safe to perform blocking operations in your mutator function, but you must take
@@ -736,6 +737,9 @@ func (s *State) UpdateIntercept(interceptID string, apply func(*Intercept)) *Int
 
 		newInfo := cur.Clone()
 		apply(newInfo)
+		if interceptEqual(cur, newInfo) {
+			return cur
+		}
 		newInfo.ModifiedAt = timestamppb.Now()
 
 		swapped := s.intercepts.CompareAndSwap(newInfo.Id, cur, newInfo)

--- a/cmd/traffic/cmd/manager/state/state_test.go
+++ b/cmd/traffic/cmd/manager/state/state_test.go
@@ -254,6 +254,42 @@ func TestIsInterceptedBy(t *testing.T) {
 	require.False(t, st.IsInterceptedBy("queued", "default", clientID))
 }
 
+func TestUpdateInterceptSkipsSemanticNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.NewContext(t, false)
+	st := &State{
+		backgroundCtx: ctx,
+		intercepts:    cache.NewMap[string, *Intercept](interceptEqual, time.Millisecond),
+	}
+	current := &Intercept{InterceptInfo: &manager.InterceptInfo{
+		Id:          "client:demo",
+		Disposition: manager.InterceptDispositionType_ACTIVE,
+		Spec:        &manager.InterceptSpec{Name: "demo"},
+	}}
+	st.intercepts.Store(current.Id, current)
+
+	applyCalls := 0
+	updated := st.UpdateIntercept(current.Id, func(intercept *Intercept) {
+		applyCalls++
+		intercept.Disposition = manager.InterceptDispositionType_ACTIVE
+	})
+
+	require.Equal(t, 1, applyCalls)
+	require.Same(t, current, updated)
+	stored, ok := st.GetIntercept(current.Id)
+	require.True(t, ok)
+	require.Same(t, current, stored)
+	require.Nil(t, stored.ModifiedAt)
+
+	updated = st.UpdateIntercept(current.Id, func(intercept *Intercept) {
+		intercept.Message = "updated"
+	})
+
+	require.NotSame(t, current, updated)
+	require.NotNil(t, updated.ModifiedAt)
+}
+
 func TestSuiteState(testing *testing.T) {
 	suite.Run(testing, new(suiteState))
 }


### PR DESCRIPTION
## Description

Some intercept updates run through a mutator that can leave the stored value semantically unchanged. Rewriting that value anyway refreshes `ModifiedAt` and adds an unnecessary compare-and-swap cycle.

This returns the current intercept when the mutation is a no-op, while real changes still get a fresh timestamp and stored value.

Tested with `GOEXPERIMENT=jsonv2 go test ./cmd/traffic/cmd/manager/state -count=1`.

## Checklist

 - [ ] I made sure to update `./CHANGELOG.yml` (our release notes are generated from this file).
 - [ ] I made sure to add any documentation changes required for my change.
 - [x] My change is adequately tested.
 - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
 - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.