### PR TITLE
Add local client redirect commands

### DIFF
--- a/docs/reference/cli/telepresence.md
+++ b/docs/reference/cli/telepresence.md
@@ -56,6 +56,7 @@ result in a password prompt.
 | [list](telepresence_list) | List current intercepts |
 | [list-contexts](telepresence_list-contexts) | Show all contexts |
 | [list-namespaces](telepresence_list-namespaces) | Show all namespaces |
+| [local-client-redirect](telepresence_local-client-redirect) | Manage local client redirects |
 | [loglevel](telepresence_loglevel) | Temporarily change the log-level of the traffic-manager, traffic-agent, and user and root daemons |
 | [mcp](telepresence_mcp) | MCP server management |
 | [quit](telepresence_quit) | Tell telepresence daemons to quit |

--- a/docs/reference/cli/telepresence_local-client-redirect.md
+++ b/docs/reference/cli/telepresence_local-client-redirect.md
@@ -1,0 +1,34 @@
+---
+title: telepresence local-client-redirect
+description: Manage local client redirects
+hide_table_of_contents: true
+---
+
+Manage local client redirects
+
+### Usage:
+```
+  telepresence local-client-redirect [command] [flags]
+```
+
+### Available Commands:
+| Command | Description |
+|---------|-------------|
+| [add](telepresence_local-client-redirect_add) | Redirect client traffic for a remote host and port to localhost |
+| [list](telepresence_local-client-redirect_list) | List local client redirects |
+| [remove](telepresence_local-client-redirect_remove) | Remove a local client redirect |
+
+### Flags:
+```
+  -h, --help   help for local-client-redirect
+```
+
+### Global Flags:
+```
+      --config string     Path to the Telepresence configuration file
+      --format string     Set the output format, supported values are 'json', 'yaml', 'json-stream', and 'default' (default &quot;default&quot;)
+      --progress string   Set type of progress output (auto, tty, plain, json, quiet) (default &quot;auto&quot;)
+      --use string        Match expression that uniquely identifies the daemon container
+```
+
+Use `telepresence local-client-redirect [command] --help` for more information about a command.

--- a/docs/reference/cli/telepresence_local-client-redirect_add.md
+++ b/docs/reference/cli/telepresence_local-client-redirect_add.md
@@ -1,0 +1,25 @@
+---
+title: telepresence local-client-redirect add
+description: Redirect client traffic for a remote host and port to localhost
+hide_table_of_contents: true
+---
+
+Redirect client traffic for a remote host and port to localhost
+
+### Usage:
+```
+  telepresence local-client-redirect add &lt;host&gt;:&lt;port&gt;:&lt;local-port&gt;[/{tcp,udp}] [flags]
+```
+
+### Flags:
+```
+  -h, --help   help for add
+```
+
+### Global Flags:
+```
+      --config string     Path to the Telepresence configuration file
+      --format string     Set the output format, supported values are 'json', 'yaml', 'json-stream', and 'default' (default &quot;default&quot;)
+      --progress string   Set type of progress output (auto, tty, plain, json, quiet) (default &quot;auto&quot;)
+      --use string        Match expression that uniquely identifies the daemon container
+```

--- a/docs/reference/cli/telepresence_local-client-redirect_list.md
+++ b/docs/reference/cli/telepresence_local-client-redirect_list.md
@@ -1,0 +1,28 @@
+---
+title: telepresence local-client-redirect list
+description: List local client redirects
+hide_table_of_contents: true
+---
+
+List local client redirects
+
+### Usage:
+```
+  telepresence local-client-redirect list [flags]
+```
+
+### Aliases:
+  list, ls
+
+### Flags:
+```
+  -h, --help   help for list
+```
+
+### Global Flags:
+```
+      --config string     Path to the Telepresence configuration file
+      --format string     Set the output format, supported values are 'json', 'yaml', 'json-stream', and 'default' (default &quot;default&quot;)
+      --progress string   Set type of progress output (auto, tty, plain, json, quiet) (default &quot;auto&quot;)
+      --use string        Match expression that uniquely identifies the daemon container
+```

--- a/docs/reference/cli/telepresence_local-client-redirect_remove.md
+++ b/docs/reference/cli/telepresence_local-client-redirect_remove.md
@@ -1,0 +1,28 @@
+---
+title: telepresence local-client-redirect remove
+description: Remove a local client redirect
+hide_table_of_contents: true
+---
+
+Remove a local client redirect
+
+### Usage:
+```
+  telepresence local-client-redirect remove &lt;host&gt;:&lt;port&gt;[/{tcp,udp}] [flags]
+```
+
+### Aliases:
+  remove, rm, delete
+
+### Flags:
+```
+  -h, --help   help for remove
+```
+
+### Global Flags:
+```
+      --config string     Path to the Telepresence configuration file
+      --format string     Set the output format, supported values are 'json', 'yaml', 'json-stream', and 'default' (default &quot;default&quot;)
+      --progress string   Set type of progress output (auto, tty, plain, json, quiet) (default &quot;auto&quot;)
+      --use string        Match expression that uniquely identifies the daemon container
+```

--- a/pkg/client/cli/cmd/local_client_redirect.go
+++ b/pkg/client/cli/cmd/local_client_redirect.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/ann"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/connect"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/daemon"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/output"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/cli/progress"
+)
+
+type localClientRedirectInfo struct {
+	Remote string `json:"remote"`
+	Local  string `json:"local"`
+}
+
+func localClientRedirectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "local-client-redirect",
+		Args:  OnlySubcommands,
+		Short: "Manage local client redirects",
+		RunE:  RunSubcommands,
+		ValidArgsFunction: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			return []string{"add", "list", "remove"}, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	cmd.AddCommand(localClientRedirectAddCmd(), localClientRedirectListCmd(), localClientRedirectRemoveCmd())
+	return cmd
+}
+
+func localClientRedirectAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <host>:<port>:<local-port>[/{tcp,udp}]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Redirect client traffic for a remote host and port to localhost",
+		Annotations: map[string]string{
+			ann.Session: ann.Required,
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := connect.InitCommand(cmd); err != nil {
+				return err
+			}
+			defer progress.Stop(cmd.Context())
+			ctx := cmd.Context()
+			if err := connect.ResolveLocalClientRedirect(ctx, daemon.MustGetSession(ctx), args[0]); err != nil {
+				return err
+			}
+			if output.WantsFormatted(cmd) {
+				output.Object(ctx, map[string]string{"redirect": args[0]}, false)
+				return nil
+			}
+			_, err := fmt.Fprintf(output.Out(ctx), "Added local client redirect %s\n", args[0])
+			return err
+		},
+		ValidArgsFunction: cobra.NoFileCompletions,
+	}
+}
+
+func localClientRedirectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Short:   "List local client redirects",
+		Annotations: map[string]string{
+			ann.Session: ann.Required,
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := connect.InitCommand(cmd); err != nil {
+				return err
+			}
+			defer progress.Stop(cmd.Context())
+			ctx := cmd.Context()
+			redirects, err := getLocalClientRedirectInfos(ctx, daemon.MustGetSession(ctx))
+			if err != nil {
+				return err
+			}
+			if output.WantsFormatted(cmd) {
+				output.Object(ctx, redirects, false)
+				return nil
+			}
+			if len(redirects) == 0 {
+				_, err = fmt.Fprintln(output.Out(ctx), "No local client redirects")
+				return err
+			}
+			for _, redirect := range redirects {
+				if _, err = fmt.Fprintf(output.Out(ctx), "%s -> %s\n", redirect.Remote, redirect.Local); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		ValidArgsFunction: cobra.NoFileCompletions,
+	}
+}
+
+func localClientRedirectRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <host>:<port>[/{tcp,udp}]",
+		Aliases: []string{"rm", "delete"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "Remove a local client redirect",
+		Annotations: map[string]string{
+			ann.Session: ann.Required,
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := connect.InitCommand(cmd); err != nil {
+				return err
+			}
+			defer progress.Stop(cmd.Context())
+			ctx := cmd.Context()
+			if err := connect.RemoveLocalClientRedirect(ctx, daemon.MustGetSession(ctx), args[0]); err != nil {
+				return err
+			}
+			if output.WantsFormatted(cmd) {
+				output.Object(ctx, map[string]string{"remote": args[0]}, false)
+				return nil
+			}
+			_, err := fmt.Fprintf(output.Out(ctx), "Removed local client redirect %s\n", args[0])
+			return err
+		},
+		ValidArgsFunction: cobra.NoFileCompletions,
+	}
+}
+
+func getLocalClientRedirectInfos(ctx context.Context, session *daemon.Session) ([]localClientRedirectInfo, error) {
+	redirects, err := connect.ListLocalClientRedirects(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]localClientRedirectInfo, 0, len(redirects))
+	for _, redirect := range redirects {
+		infos = append(infos, localClientRedirectInfo{
+			Remote: redirect.Remote.String(),
+			Local:  fmt.Sprintf("127.0.0.1:%d", redirect.LocalPort),
+		})
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		if infos[i].Remote == infos[j].Remote {
+			return infos[i].Local < infos[j].Local
+		}
+		return infos[i].Remote < infos[j].Remote
+	})
+	return infos, nil
+}

--- a/pkg/client/cli/cmd/telepresence.go
+++ b/pkg/client/cli/cmd/telepresence.go
@@ -170,6 +170,7 @@ func WithSubCommands(ctx context.Context) context.Context {
 		leaveCmd(),
 		list(),
 		listContexts(),
+		localClientRedirectCmd(),
 		revokeCmd(),
 		listNamespaces(),
 		loglevel(),

--- a/pkg/client/cli/connect/connector.go
+++ b/pkg/client/cli/connect/connector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"math"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -43,6 +44,11 @@ import (
 	"github.com/telepresenceio/telepresence/v2/pkg/proc"
 	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
+
+type LocalClientRedirect struct {
+	Remote    types.AddrPortProto
+	LocalPort uint16
+}
 
 //nolint:gochecknoglobals // extension point
 var QuitDaemonFuncs = []func(context.Context){
@@ -226,6 +232,7 @@ func EnsureSession(ctx context.Context, useLine string, required bool) (context.
 			return ctx, err
 		}
 	}
+
 	return daemon.WithSession(ctx, s), nil
 }
 
@@ -275,6 +282,75 @@ func ResolveRemoteReroute(ctx context.Context, ds *daemon.Session, pm string) (e
 		SrcPort:     uint32(newPort.Port),
 	})
 	return tpGrpc.FromGRPC(err)
+}
+
+func ResolveLocalClientRedirect(ctx context.Context, ds *daemon.Session, pm string) (err error) {
+	ix := strings.LastIndexByte(pm, ':')
+	if ix < 3 {
+		return fmt.Errorf("invalid local client redirect %s", pm)
+	}
+	localPort, err := types.ParsePortAndProto(pm[ix+1:])
+	if err != nil {
+		return fmt.Errorf("invalid local client redirect %s: local port %w", pm, err)
+	}
+	hostPort, err := resolveHostPort(ctx, ds, localPort.Proto, pm[:ix])
+	if err != nil {
+		return err
+	}
+	hpb, err := hostPort.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	_, err = ds.AddLocalClientRedirect(ctx, &daemonRpc.ReroutePortRequest{
+		DstHostPort: hpb,
+		SrcPort:     uint32(localPort.Port),
+	})
+	return tpGrpc.FromGRPC(err)
+}
+
+func RemoveLocalClientRedirect(ctx context.Context, ds *daemon.Session, hp string) (err error) {
+	proto := types.ProtoTCP
+	if ix := strings.LastIndexByte(hp, types.ProtoSeparator); ix > 0 {
+		proto, err = types.ParseProto(hp[ix+1:])
+		if err != nil {
+			return fmt.Errorf("invalid local client redirect %s: protocol %w", hp, err)
+		}
+		hp = hp[:ix]
+	}
+	hostPort, err := resolveHostPort(ctx, ds, proto, hp)
+	if err != nil {
+		return err
+	}
+	hpb, err := hostPort.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	_, err = ds.RemoveLocalClientRedirect(ctx, &daemonRpc.ReroutePortRequest{
+		DstHostPort: hpb,
+	})
+	return tpGrpc.FromGRPC(err)
+}
+
+func ListLocalClientRedirects(ctx context.Context, ds *daemon.Session) ([]LocalClientRedirect, error) {
+	rsp, err := ds.ListLocalClientRedirects(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, tpGrpc.FromGRPC(err)
+	}
+	redirects := make([]LocalClientRedirect, 0, len(rsp.Redirects))
+	for _, redirect := range rsp.Redirects {
+		var remote types.AddrPortProto
+		if err := remote.UnmarshalBinary(redirect.DstHostPort); err != nil {
+			return nil, err
+		}
+		if redirect.LocalPort > math.MaxUint16 {
+			return nil, fmt.Errorf("invalid local client redirect local port %d", redirect.LocalPort)
+		}
+		redirects = append(redirects, LocalClientRedirect{
+			Remote:    remote,
+			LocalPort: uint16(redirect.LocalPort),
+		})
+	}
+	return redirects, nil
 }
 
 func resolveHostPort(ctx context.Context, ds *daemon.Session, proto types.Proto, hostPortStr string) (hostPort types.AddrPortProto, err error) {

--- a/pkg/client/rootd/grpc.go
+++ b/pkg/client/rootd/grpc.go
@@ -290,6 +290,38 @@ func (s *service) WatchAgentPods(stream rpc.Daemon_WatchAgentPodsServer) error {
 	}
 }
 
+func (s *service) AddLocalClientRedirect(ctx context.Context, request *rpc.ReroutePortRequest) (rsp *emptypb.Empty, err error) {
+	err = s.withSession(ctx, func(_ context.Context, session *session) error {
+		var ap types.AddrPortProto
+		err = ap.UnmarshalBinary(request.DstHostPort)
+		if err == nil {
+			session.addLocalClientRedirect(ap, uint16(request.SrcPort))
+		}
+		return err
+	})
+	return &emptypb.Empty{}, err
+}
+
+func (s *service) RemoveLocalClientRedirect(ctx context.Context, request *rpc.ReroutePortRequest) (rsp *emptypb.Empty, err error) {
+	err = s.withSession(ctx, func(_ context.Context, session *session) error {
+		var ap types.AddrPortProto
+		err = ap.UnmarshalBinary(request.DstHostPort)
+		if err == nil {
+			session.removeLocalClientRedirect(ap)
+		}
+		return err
+	})
+	return &emptypb.Empty{}, err
+}
+
+func (s *service) ListLocalClientRedirects(ctx context.Context, _ *emptypb.Empty) (rsp *rpc.LocalClientRedirects, err error) {
+	err = s.withSession(ctx, func(_ context.Context, session *session) error {
+		rsp = &rpc.LocalClientRedirects{Redirects: session.listLocalClientRedirects()}
+		return nil
+	})
+	return rsp, err
+}
+
 func (s *service) withSession(ctx context.Context, f func(context.Context, *session) error) (err error) {
 	s.sessionLock.RLock()
 	defer s.sessionLock.RUnlock()

--- a/pkg/client/rootd/in_process.go
+++ b/pkg/client/rootd/in_process.go
@@ -114,6 +114,28 @@ func (rd *InProcSession) RerouteRemotePort(_ context.Context, request *rpc.Rerou
 	return &empty.Empty{}, nil
 }
 
+func (rd *InProcSession) AddLocalClientRedirect(_ context.Context, request *rpc.ReroutePortRequest, _ ...grpc.CallOption) (*empty.Empty, error) {
+	var ap types.AddrPortProto
+	if err := ap.UnmarshalBinary(request.DstHostPort); err != nil {
+		return nil, err
+	}
+	rd.addLocalClientRedirect(ap, uint16(request.SrcPort))
+	return &empty.Empty{}, nil
+}
+
+func (rd *InProcSession) RemoveLocalClientRedirect(_ context.Context, request *rpc.ReroutePortRequest, _ ...grpc.CallOption) (*empty.Empty, error) {
+	var ap types.AddrPortProto
+	if err := ap.UnmarshalBinary(request.DstHostPort); err != nil {
+		return nil, err
+	}
+	rd.removeLocalClientRedirect(ap)
+	return &empty.Empty{}, nil
+}
+
+func (rd *InProcSession) ListLocalClientRedirects(context.Context, *empty.Empty, ...grpc.CallOption) (*rpc.LocalClientRedirects, error) {
+	return &rpc.LocalClientRedirects{Redirects: rd.listLocalClientRedirects()}, nil
+}
+
 func (rd *InProcSession) WaitForAgentIP(ctx context.Context, request *rpc.WaitForAgentIPRequest, _ ...grpc.CallOption) (*rpc.WaitForAgentIPResponse, error) {
 	return rd.waitForAgentIP(ctx, request)
 }

--- a/pkg/client/rootd/session.go
+++ b/pkg/client/rootd/session.go
@@ -242,6 +242,9 @@ type session struct {
 	// handlers instead of being tunneled to the cluster. Nil when there are none.
 	interceptShortcuts atomic.Pointer[shortcutTable]
 
+	// Redirects a remote UDP or TCP AddrPort to a local host port.
+	localClientRedirects *xsync.Map[types.AddrPortProto, netip.AddrPort]
+
 	lookupSequencer *xsync.Map[string, clusterLookupResult]
 
 	// quicConn is the client's current QUIC connection to the traffic-manager, set
@@ -409,6 +412,7 @@ func newSession(
 		sessionStart:          time.Now(),
 		quicReprobeTrigger:    make(chan struct{}, 1),
 		quicSessionCache:      tls.NewLRUClientSessionCache(16),
+		localClientRedirects:  xsync.NewMap[types.AddrPortProto, netip.AddrPort](),
 	}
 	cfg := client.GetConfig(s)
 
@@ -553,8 +557,45 @@ func (s *session) rerouteRemotePort(ap types.AddrPortProto, newPort uint16) {
 		// Swap ports so that the port map reroutes requests for the new port to the original port.
 		toPort := ap.Port()
 		ap.AddrPort = netip.AddrPortFrom(ap.Addr(), newPort)
+		if s.l4PortMap == nil {
+			s.l4PortMap = xsync.NewMap[types.AddrPortProto, uint16]()
+		}
 		s.l4PortMap.Store(ap, toPort)
 	}
+}
+
+func (s *session) addLocalClientRedirect(ap types.AddrPortProto, localPort uint16) {
+	target := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), localPort)
+	clog.Debugf(s, "Redirecting local client traffic for %s to %s", ap, target)
+	if s.localClientRedirects == nil {
+		s.localClientRedirects = xsync.NewMap[types.AddrPortProto, netip.AddrPort]()
+	}
+	s.localClientRedirects.Store(ap, target)
+}
+
+func (s *session) removeLocalClientRedirect(ap types.AddrPortProto) {
+	clog.Debugf(s, "Removing local client redirect for %s", ap)
+	if s.localClientRedirects != nil {
+		s.localClientRedirects.Delete(ap)
+	}
+}
+
+func (s *session) listLocalClientRedirects() []*rpc.LocalClientRedirect {
+	if s.localClientRedirects == nil {
+		return nil
+	}
+	redirects := make([]*rpc.LocalClientRedirect, 0, s.localClientRedirects.Size())
+	s.localClientRedirects.Range(func(remote types.AddrPortProto, target netip.AddrPort) bool {
+		hpb, err := remote.MarshalBinary()
+		if err == nil {
+			redirects = append(redirects, &rpc.LocalClientRedirect{
+				DstHostPort: hpb,
+				LocalPort:   uint32(target.Port()),
+			})
+		}
+		return true
+	})
+	return redirects
 }
 
 type clusterLookupResult struct {

--- a/pkg/client/rootd/stream_creator.go
+++ b/pkg/client/rootd/stream_creator.go
@@ -18,6 +18,38 @@ func (s *session) isForDNS(ip netip.Addr, port uint16) bool {
 	return s.vifDNS.Addr() == ip && s.vifDNS.Port() == port
 }
 
+func (s *session) applyPortMapping(id tunnel.ConnID) tunnel.ConnID {
+	if s.l4PortMap == nil {
+		return id
+	}
+	destAddr := id.DestinationAddr()
+	if mp, ok := s.l4PortMap.Load(types.AddrPortProto{
+		AddrPort: netip.AddrPortFrom(destAddr, id.DestinationPort()),
+		Proto:    id.Protocol(),
+	}); ok {
+		return tunnel.NewConnID(id.Protocol(), id.Source(), netip.AddrPortFrom(destAddr, mp))
+	}
+	return id
+}
+
+func (s *session) localClientRedirectTarget(id tunnel.ConnID) (netip.AddrPort, bool) {
+	if s.localClientRedirects == nil {
+		return netip.AddrPort{}, false
+	}
+	return s.localClientRedirects.Load(types.AddrPortProto{
+		AddrPort: id.Destination(),
+		Proto:    id.Protocol(),
+	})
+}
+
+func (s *session) newLocalClientRedirectStream(c context.Context, id tunnel.ConnID, target netip.AddrPort) tunnel.Stream {
+	pipeID := tunnel.NewConnID(id.Protocol(), id.Source(), target)
+	clog.Debugf(c, "Redirecting local client traffic for %s to %s", id.Destination(), target)
+	from, to := tunnel.NewPipe(pipeID, tunnel.SessionID(s.session.SessionId), tunnel.LocalToTun, tunnel.TunToLocal)
+	tunnel.NewDialer(to, func() {}, nil, nil).Start(c)
+	return from
+}
+
 // checkRecursion checks that the given IP is not contained in any of the subnets
 // that the VIF is configured with. When that's the case, the VIF is somehow receiving
 // requests that originate from the cluster and dispatching it leads to infinite recursion.
@@ -70,11 +102,10 @@ func (s *session) streamCreator() tunnel.StreamCreator {
 		// tunnel attempt.
 		countAsOutbound = true
 
-		if mp, ok := s.l4PortMap.Load(types.AddrPortProto{
-			AddrPort: netip.AddrPortFrom(destAddr, id.DestinationPort()),
-			Proto:    id.Protocol(),
-		}); ok {
-			id = tunnel.NewConnID(id.Protocol(), id.Source(), netip.AddrPortFrom(destAddr, mp))
+		id = s.applyPortMapping(id)
+		destAddr = id.DestinationAddr()
+		if target, ok := s.localClientRedirectTarget(id); ok {
+			return s.newLocalClientRedirectStream(c, id, target), nil
 		}
 
 		var tp tunnel.Provider

--- a/pkg/client/rootd/stream_creator_test.go
+++ b/pkg/client/rootd/stream_creator_test.go
@@ -2,6 +2,8 @@ package rootd
 
 import (
 	"context"
+	"io"
+	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -9,7 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	rpc "github.com/telepresenceio/telepresence/rpc/v2/daemon"
+	"github.com/telepresenceio/telepresence/rpc/v2/manager"
 	"github.com/telepresenceio/telepresence/v2/pkg/client"
+	"github.com/telepresenceio/telepresence/v2/pkg/client/k8s"
+	"github.com/telepresenceio/telepresence/v2/pkg/tunnel"
+	"github.com/telepresenceio/telepresence/v2/pkg/types"
 )
 
 func TestCreateSessionCleansDNSRoutingBeforeKubeconfig(t *testing.T) {
@@ -40,4 +46,126 @@ func TestIsAlsoProxyDestination(t *testing.T) {
 	require.True(t, s.isAlsoProxyDestination(netip.MustParseAddr("fd00::1")))
 	require.False(t, s.isAlsoProxyDestination(netip.MustParseAddr("10.128.0.10")))
 	require.False(t, s.isAlsoProxyDestination(netip.MustParseAddr("2001:db8::1")))
+}
+
+func newTestStreamSession(ctx context.Context) *session {
+	return &session{
+		Cluster: &k8s.Cluster{
+			Kubeconfig: &k8s.Kubeconfig{
+				Context: ctx,
+			},
+		},
+		session: &manager.SessionInfo{SessionId: "test-session"},
+	}
+}
+
+func TestStreamCreatorRedirectsLocalClient(t *testing.T) {
+	ctx := client.WithConfig(context.Background(), client.GetDefaultConfig())
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	remote := types.AddrPortProto{
+		AddrPort: netip.MustParseAddrPort("10.0.0.10:8000"),
+		Proto:    types.ProtoTCP,
+	}
+	s := newTestStreamSession(ctx)
+	s.addLocalClientRedirect(remote, listener.Addr().(*net.TCPAddr).AddrPort().Port())
+	target, ok := s.localClientRedirectTarget(tunnel.NewConnID(
+		types.ProtoTCP,
+		netip.MustParseAddrPort("192.168.0.2:43210"),
+		remote.AddrPort,
+	))
+	require.True(t, ok)
+	require.Equal(t, listener.Addr().(*net.TCPAddr).AddrPort(), target)
+	redirects := s.listLocalClientRedirects()
+	require.Len(t, redirects, 1)
+	var listedRemote types.AddrPortProto
+	require.NoError(t, listedRemote.UnmarshalBinary(redirects[0].DstHostPort))
+	require.Equal(t, remote, listedRemote)
+	require.Equal(t, uint32(listener.Addr().(*net.TCPAddr).AddrPort().Port()), redirects[0].LocalPort)
+
+	stream, err := s.streamCreator()(ctx, tunnel.NewConnID(
+		types.ProtoTCP,
+		netip.MustParseAddrPort("192.168.0.2:43210"),
+		remote.AddrPort,
+	))
+	require.NoError(t, err)
+
+	clientConn, vifConn := net.Pipe()
+	defer clientConn.Close()
+	_ = clientConn.SetDeadline(time.Now().Add(2 * time.Second))
+	tunnel.NewConnEndpoint(stream, vifConn, cancel, nil, nil).Start(ctx)
+
+	_, err = clientConn.Write([]byte("ping"))
+	require.NoError(t, err)
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(clientConn, buf)
+	require.NoError(t, err)
+	require.Equal(t, "ping", string(buf))
+
+	s.removeLocalClientRedirect(remote)
+	_, ok = s.localClientRedirectTarget(tunnel.NewConnID(
+		types.ProtoTCP,
+		netip.MustParseAddrPort("192.168.0.2:43210"),
+		remote.AddrPort,
+	))
+	require.False(t, ok)
+	require.Empty(t, s.listLocalClientRedirects())
+}
+
+func TestStreamCreatorAppliesRemoteRerouteBeforeLocalClientRedirect(t *testing.T) {
+	ctx := client.WithConfig(context.Background(), client.GetDefaultConfig())
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	original := types.AddrPortProto{
+		AddrPort: netip.MustParseAddrPort("10.0.0.10:8000"),
+		Proto:    types.ProtoTCP,
+	}
+	s := newTestStreamSession(ctx)
+	s.rerouteRemotePort(original, 8080)
+	s.addLocalClientRedirect(original, listener.Addr().(*net.TCPAddr).AddrPort().Port())
+
+	stream, err := s.streamCreator()(ctx, tunnel.NewConnID(
+		types.ProtoTCP,
+		netip.MustParseAddrPort("192.168.0.2:43210"),
+		netip.MustParseAddrPort("10.0.0.10:8080"),
+	))
+	require.NoError(t, err)
+
+	clientConn, vifConn := net.Pipe()
+	defer clientConn.Close()
+	_ = clientConn.SetDeadline(time.Now().Add(2 * time.Second))
+	tunnel.NewConnEndpoint(stream, vifConn, cancel, nil, nil).Start(ctx)
+
+	_, err = clientConn.Write([]byte("pong"))
+	require.NoError(t, err)
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(clientConn, buf)
+	require.NoError(t, err)
+	require.Equal(t, "pong", string(buf))
 }

--- a/pkg/client/userd/daemon/grpc.go
+++ b/pkg/client/userd/daemon/grpc.go
@@ -652,6 +652,36 @@ func (s *service) RerouteRemotePort(ctx context.Context, request *daemon.Reroute
 	return rsp, err
 }
 
+func (s *service) AddLocalClientRedirect(ctx context.Context, request *daemon.ReroutePortRequest) (rsp *empty.Empty, err error) {
+	err = s.withSession(ctx, func(ctx context.Context, session userd.Session) error {
+		return session.WithRootClient(ctx, func(ctx context.Context, rd daemon.DaemonClient) (err error) {
+			rsp, err = rd.AddLocalClientRedirect(ctx, request)
+			return err
+		})
+	})
+	return rsp, err
+}
+
+func (s *service) RemoveLocalClientRedirect(ctx context.Context, request *daemon.ReroutePortRequest) (rsp *empty.Empty, err error) {
+	err = s.withSession(ctx, func(ctx context.Context, session userd.Session) error {
+		return session.WithRootClient(ctx, func(ctx context.Context, rd daemon.DaemonClient) (err error) {
+			rsp, err = rd.RemoveLocalClientRedirect(ctx, request)
+			return err
+		})
+	})
+	return rsp, err
+}
+
+func (s *service) ListLocalClientRedirects(ctx context.Context, request *empty.Empty) (rsp *daemon.LocalClientRedirects, err error) {
+	err = s.withSession(ctx, func(ctx context.Context, session userd.Session) error {
+		return session.WithRootClient(ctx, func(ctx context.Context, rd daemon.DaemonClient) (err error) {
+			rsp, err = rd.ListLocalClientRedirects(ctx, request)
+			return err
+		})
+	})
+	return rsp, err
+}
+
 func (s *service) withRootDaemon(ctx context.Context, f func(ctx context.Context, daemonClient daemon.DaemonClient) error) error {
 	s.sessionLock.RLock()
 	defer s.sessionLock.RUnlock()

--- a/rpc/connector/connector.pb.go
+++ b/rpc/connector/connector.pb.go
@@ -1996,7 +1996,7 @@ const file_connector_connector_proto_rawDesc = "" +
 	"\vresolved_ip\x18\x02 \x01(\fR\n" +
 	"resolvedIp\";\n" +
 	"\x16RevokeInterceptRequest\x12!\n" +
-	"\fintercept_id\x18\x01 \x01(\tR\vinterceptId2\x9d\x19\n" +
+	"\fintercept_id\x18\x01 \x01(\tR\vinterceptId2\xb5\x1b\n" +
 	"\tConnector\x12C\n" +
 	"\aVersion\x12\x16.google.protobuf.Empty\x1a .telepresence.common.VersionInfo\x12M\n" +
 	"\x11RootDaemonVersion\x12\x16.google.protobuf.Empty\x1a .telepresence.common.VersionInfo\x12Q\n" +
@@ -2036,7 +2036,10 @@ const file_connector_connector_proto_rawDesc = "" +
 	"\bLookupIP\x12$.telepresence.daemon.LookupIPRequest\x1a%.telepresence.daemon.LookupIPResponse\x12`\n" +
 	"\vResolvePort\x12'.telepresence.daemon.ResolvePortRequest\x1a(.telepresence.daemon.ResolvePortResponse\x12S\n" +
 	"\x10RerouteLocalPort\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12T\n" +
-	"\x11RerouteRemotePort\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.EmptyB9Z7github.com/telepresenceio/telepresence/rpc/v2/connectorb\x06proto3"
+	"\x11RerouteRemotePort\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12Y\n" +
+	"\x16AddLocalClientRedirect\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12\\\n" +
+	"\x19RemoveLocalClientRedirect\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12]\n" +
+	"\x18ListLocalClientRedirects\x12\x16.google.protobuf.Empty\x1a).telepresence.daemon.LocalClientRedirectsB9Z7github.com/telepresenceio/telepresence/rpc/v2/connectorb\x06proto3"
 
 var (
 	file_connector_connector_proto_rawDescOnce sync.Once
@@ -2110,6 +2113,7 @@ var file_connector_connector_proto_goTypes = []any{
 	(*manager.AgentConfigResponse)(nil),     // 54: telepresence.manager.AgentConfigResponse
 	(*daemon.LookupIPResponse)(nil),         // 55: telepresence.daemon.LookupIPResponse
 	(*daemon.ResolvePortResponse)(nil),      // 56: telepresence.daemon.ResolvePortResponse
+	(*daemon.LocalClientRedirects)(nil),     // 57: telepresence.daemon.LocalClientRedirects
 }
 var file_connector_connector_proto_depIdxs = []int32{
 	25, // 0: telepresence.connector.ConnectRequest.kube_flags:type_name -> telepresence.connector.ConnectRequest.KubeFlagsEntry
@@ -2175,45 +2179,51 @@ var file_connector_connector_proto_depIdxs = []int32{
 	49, // 60: telepresence.connector.Connector.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
 	50, // 61: telepresence.connector.Connector.RerouteLocalPort:input_type -> telepresence.daemon.ReroutePortRequest
 	50, // 62: telepresence.connector.Connector.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
-	32, // 63: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
-	32, // 64: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
-	32, // 65: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
-	51, // 66: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
-	38, // 67: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
-	5,  // 68: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
-	42, // 69: telepresence.connector.Connector.CheckConnect:output_type -> google.protobuf.Empty
-	42, // 70: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
-	21, // 71: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
-	5,  // 72: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
-	42, // 73: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
-	11, // 74: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
-	11, // 75: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
-	11, // 76: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
-	38, // 77: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
-	42, // 78: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
-	42, // 79: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
-	42, // 80: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
-	14, // 81: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	14, // 82: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
-	42, // 83: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
-	52, // 84: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
-	17, // 85: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
-	42, // 86: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
-	42, // 87: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
-	19, // 88: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
-	53, // 89: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
-	42, // 90: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
-	20, // 91: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
-	42, // 92: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
-	42, // 93: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
-	54, // 94: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
-	23, // 95: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
-	55, // 96: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
-	56, // 97: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
-	42, // 98: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
-	42, // 99: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
-	63, // [63:100] is the sub-list for method output_type
-	26, // [26:63] is the sub-list for method input_type
+	50, // 63: telepresence.connector.Connector.AddLocalClientRedirect:input_type -> telepresence.daemon.ReroutePortRequest
+	50, // 64: telepresence.connector.Connector.RemoveLocalClientRedirect:input_type -> telepresence.daemon.ReroutePortRequest
+	42, // 65: telepresence.connector.Connector.ListLocalClientRedirects:input_type -> google.protobuf.Empty
+	32, // 66: telepresence.connector.Connector.Version:output_type -> telepresence.common.VersionInfo
+	32, // 67: telepresence.connector.Connector.RootDaemonVersion:output_type -> telepresence.common.VersionInfo
+	32, // 68: telepresence.connector.Connector.TrafficManagerVersion:output_type -> telepresence.common.VersionInfo
+	51, // 69: telepresence.connector.Connector.AgentImageFQN:output_type -> telepresence.manager.AgentImageFQN
+	38, // 70: telepresence.connector.Connector.GetIntercept:output_type -> telepresence.manager.InterceptInfo
+	5,  // 71: telepresence.connector.Connector.Connect:output_type -> telepresence.connector.ConnectInfo
+	42, // 72: telepresence.connector.Connector.CheckConnect:output_type -> google.protobuf.Empty
+	42, // 73: telepresence.connector.Connector.Disconnect:output_type -> google.protobuf.Empty
+	21, // 74: telepresence.connector.Connector.GetClusterSubnets:output_type -> telepresence.connector.ClusterSubnets
+	5,  // 75: telepresence.connector.Connector.Status:output_type -> telepresence.connector.ConnectInfo
+	42, // 76: telepresence.connector.Connector.CanIntercept:output_type -> google.protobuf.Empty
+	11, // 77: telepresence.connector.Connector.Ingest:output_type -> telepresence.connector.IngestInfo
+	11, // 78: telepresence.connector.Connector.GetIngest:output_type -> telepresence.connector.IngestInfo
+	11, // 79: telepresence.connector.Connector.LeaveIngest:output_type -> telepresence.connector.IngestInfo
+	38, // 80: telepresence.connector.Connector.CreateIntercept:output_type -> telepresence.manager.InterceptInfo
+	42, // 81: telepresence.connector.Connector.RemoveIntercept:output_type -> google.protobuf.Empty
+	42, // 82: telepresence.connector.Connector.RevokeIntercept:output_type -> google.protobuf.Empty
+	42, // 83: telepresence.connector.Connector.Uninstall:output_type -> google.protobuf.Empty
+	14, // 84: telepresence.connector.Connector.List:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	14, // 85: telepresence.connector.Connector.WatchWorkloads:output_type -> telepresence.connector.WorkloadInfoSnapshot
+	42, // 86: telepresence.connector.Connector.SetLogLevel:output_type -> google.protobuf.Empty
+	52, // 87: telepresence.connector.Connector.Quit:output_type -> telepresence.daemon.QuitResponse
+	17, // 88: telepresence.connector.Connector.GatherLogs:output_type -> telepresence.connector.LogsResponse
+	42, // 89: telepresence.connector.Connector.AddInterceptor:output_type -> google.protobuf.Empty
+	42, // 90: telepresence.connector.Connector.RemoveInterceptor:output_type -> google.protobuf.Empty
+	19, // 91: telepresence.connector.Connector.GetNamespaces:output_type -> telepresence.connector.GetNamespacesResponse
+	53, // 92: telepresence.connector.Connector.GetKnownWorkloadKinds:output_type -> telepresence.manager.KnownWorkloadKinds
+	42, // 93: telepresence.connector.Connector.RemoteMountAvailability:output_type -> google.protobuf.Empty
+	20, // 94: telepresence.connector.Connector.GetConfig:output_type -> telepresence.connector.ClientConfig
+	42, // 95: telepresence.connector.Connector.SetDNSExcludes:output_type -> google.protobuf.Empty
+	42, // 96: telepresence.connector.Connector.SetDNSMappings:output_type -> google.protobuf.Empty
+	54, // 97: telepresence.connector.Connector.GetAgentConfig:output_type -> telepresence.manager.AgentConfigResponse
+	23, // 98: telepresence.connector.Connector.ResolveSyntheticIP:output_type -> telepresence.connector.ResolveSyntheticResponse
+	55, // 99: telepresence.connector.Connector.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
+	56, // 100: telepresence.connector.Connector.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
+	42, // 101: telepresence.connector.Connector.RerouteLocalPort:output_type -> google.protobuf.Empty
+	42, // 102: telepresence.connector.Connector.RerouteRemotePort:output_type -> google.protobuf.Empty
+	42, // 103: telepresence.connector.Connector.AddLocalClientRedirect:output_type -> google.protobuf.Empty
+	42, // 104: telepresence.connector.Connector.RemoveLocalClientRedirect:output_type -> google.protobuf.Empty
+	57, // 105: telepresence.connector.Connector.ListLocalClientRedirects:output_type -> telepresence.daemon.LocalClientRedirects
+	66, // [66:106] is the sub-list for method output_type
+	26, // [26:66] is the sub-list for method input_type
 	26, // [26:26] is the sub-list for extension type_name
 	26, // [26:26] is the sub-list for extension extendee
 	0,  // [0:26] is the sub-list for field type_name

--- a/rpc/connector/connector.proto
+++ b/rpc/connector/connector.proto
@@ -140,6 +140,15 @@ service Connector {
 
   // RerouteRemotePort makes a netip.AddrPort available on a new port on the same address.
   rpc RerouteRemotePort(daemon.ReroutePortRequest) returns (google.protobuf.Empty);
+
+  // AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+  rpc AddLocalClientRedirect(daemon.ReroutePortRequest) returns (google.protobuf.Empty);
+
+  // RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+  rpc RemoveLocalClientRedirect(daemon.ReroutePortRequest) returns (google.protobuf.Empty);
+
+  // ListLocalClientRedirects lists active local client redirects.
+  rpc ListLocalClientRedirects(google.protobuf.Empty) returns (daemon.LocalClientRedirects);
 }
 
 message Interceptor {

--- a/rpc/connector/connector_grpc.pb.go
+++ b/rpc/connector/connector_grpc.pb.go
@@ -23,43 +23,46 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Connector_Version_FullMethodName                 = "/telepresence.connector.Connector/Version"
-	Connector_RootDaemonVersion_FullMethodName       = "/telepresence.connector.Connector/RootDaemonVersion"
-	Connector_TrafficManagerVersion_FullMethodName   = "/telepresence.connector.Connector/TrafficManagerVersion"
-	Connector_AgentImageFQN_FullMethodName           = "/telepresence.connector.Connector/AgentImageFQN"
-	Connector_GetIntercept_FullMethodName            = "/telepresence.connector.Connector/GetIntercept"
-	Connector_Connect_FullMethodName                 = "/telepresence.connector.Connector/Connect"
-	Connector_CheckConnect_FullMethodName            = "/telepresence.connector.Connector/CheckConnect"
-	Connector_Disconnect_FullMethodName              = "/telepresence.connector.Connector/Disconnect"
-	Connector_GetClusterSubnets_FullMethodName       = "/telepresence.connector.Connector/GetClusterSubnets"
-	Connector_Status_FullMethodName                  = "/telepresence.connector.Connector/Status"
-	Connector_CanIntercept_FullMethodName            = "/telepresence.connector.Connector/CanIntercept"
-	Connector_Ingest_FullMethodName                  = "/telepresence.connector.Connector/Ingest"
-	Connector_GetIngest_FullMethodName               = "/telepresence.connector.Connector/GetIngest"
-	Connector_LeaveIngest_FullMethodName             = "/telepresence.connector.Connector/LeaveIngest"
-	Connector_CreateIntercept_FullMethodName         = "/telepresence.connector.Connector/CreateIntercept"
-	Connector_RemoveIntercept_FullMethodName         = "/telepresence.connector.Connector/RemoveIntercept"
-	Connector_RevokeIntercept_FullMethodName         = "/telepresence.connector.Connector/RevokeIntercept"
-	Connector_Uninstall_FullMethodName               = "/telepresence.connector.Connector/Uninstall"
-	Connector_List_FullMethodName                    = "/telepresence.connector.Connector/List"
-	Connector_WatchWorkloads_FullMethodName          = "/telepresence.connector.Connector/WatchWorkloads"
-	Connector_SetLogLevel_FullMethodName             = "/telepresence.connector.Connector/SetLogLevel"
-	Connector_Quit_FullMethodName                    = "/telepresence.connector.Connector/Quit"
-	Connector_GatherLogs_FullMethodName              = "/telepresence.connector.Connector/GatherLogs"
-	Connector_AddInterceptor_FullMethodName          = "/telepresence.connector.Connector/AddInterceptor"
-	Connector_RemoveInterceptor_FullMethodName       = "/telepresence.connector.Connector/RemoveInterceptor"
-	Connector_GetNamespaces_FullMethodName           = "/telepresence.connector.Connector/GetNamespaces"
-	Connector_GetKnownWorkloadKinds_FullMethodName   = "/telepresence.connector.Connector/GetKnownWorkloadKinds"
-	Connector_RemoteMountAvailability_FullMethodName = "/telepresence.connector.Connector/RemoteMountAvailability"
-	Connector_GetConfig_FullMethodName               = "/telepresence.connector.Connector/GetConfig"
-	Connector_SetDNSExcludes_FullMethodName          = "/telepresence.connector.Connector/SetDNSExcludes"
-	Connector_SetDNSMappings_FullMethodName          = "/telepresence.connector.Connector/SetDNSMappings"
-	Connector_GetAgentConfig_FullMethodName          = "/telepresence.connector.Connector/GetAgentConfig"
-	Connector_ResolveSyntheticIP_FullMethodName      = "/telepresence.connector.Connector/ResolveSyntheticIP"
-	Connector_LookupIP_FullMethodName                = "/telepresence.connector.Connector/LookupIP"
-	Connector_ResolvePort_FullMethodName             = "/telepresence.connector.Connector/ResolvePort"
-	Connector_RerouteLocalPort_FullMethodName        = "/telepresence.connector.Connector/RerouteLocalPort"
-	Connector_RerouteRemotePort_FullMethodName       = "/telepresence.connector.Connector/RerouteRemotePort"
+	Connector_Version_FullMethodName                   = "/telepresence.connector.Connector/Version"
+	Connector_RootDaemonVersion_FullMethodName         = "/telepresence.connector.Connector/RootDaemonVersion"
+	Connector_TrafficManagerVersion_FullMethodName     = "/telepresence.connector.Connector/TrafficManagerVersion"
+	Connector_AgentImageFQN_FullMethodName             = "/telepresence.connector.Connector/AgentImageFQN"
+	Connector_GetIntercept_FullMethodName              = "/telepresence.connector.Connector/GetIntercept"
+	Connector_Connect_FullMethodName                   = "/telepresence.connector.Connector/Connect"
+	Connector_CheckConnect_FullMethodName              = "/telepresence.connector.Connector/CheckConnect"
+	Connector_Disconnect_FullMethodName                = "/telepresence.connector.Connector/Disconnect"
+	Connector_GetClusterSubnets_FullMethodName         = "/telepresence.connector.Connector/GetClusterSubnets"
+	Connector_Status_FullMethodName                    = "/telepresence.connector.Connector/Status"
+	Connector_CanIntercept_FullMethodName              = "/telepresence.connector.Connector/CanIntercept"
+	Connector_Ingest_FullMethodName                    = "/telepresence.connector.Connector/Ingest"
+	Connector_GetIngest_FullMethodName                 = "/telepresence.connector.Connector/GetIngest"
+	Connector_LeaveIngest_FullMethodName               = "/telepresence.connector.Connector/LeaveIngest"
+	Connector_CreateIntercept_FullMethodName           = "/telepresence.connector.Connector/CreateIntercept"
+	Connector_RemoveIntercept_FullMethodName           = "/telepresence.connector.Connector/RemoveIntercept"
+	Connector_RevokeIntercept_FullMethodName           = "/telepresence.connector.Connector/RevokeIntercept"
+	Connector_Uninstall_FullMethodName                 = "/telepresence.connector.Connector/Uninstall"
+	Connector_List_FullMethodName                      = "/telepresence.connector.Connector/List"
+	Connector_WatchWorkloads_FullMethodName            = "/telepresence.connector.Connector/WatchWorkloads"
+	Connector_SetLogLevel_FullMethodName               = "/telepresence.connector.Connector/SetLogLevel"
+	Connector_Quit_FullMethodName                      = "/telepresence.connector.Connector/Quit"
+	Connector_GatherLogs_FullMethodName                = "/telepresence.connector.Connector/GatherLogs"
+	Connector_AddInterceptor_FullMethodName            = "/telepresence.connector.Connector/AddInterceptor"
+	Connector_RemoveInterceptor_FullMethodName         = "/telepresence.connector.Connector/RemoveInterceptor"
+	Connector_GetNamespaces_FullMethodName             = "/telepresence.connector.Connector/GetNamespaces"
+	Connector_GetKnownWorkloadKinds_FullMethodName     = "/telepresence.connector.Connector/GetKnownWorkloadKinds"
+	Connector_RemoteMountAvailability_FullMethodName   = "/telepresence.connector.Connector/RemoteMountAvailability"
+	Connector_GetConfig_FullMethodName                 = "/telepresence.connector.Connector/GetConfig"
+	Connector_SetDNSExcludes_FullMethodName            = "/telepresence.connector.Connector/SetDNSExcludes"
+	Connector_SetDNSMappings_FullMethodName            = "/telepresence.connector.Connector/SetDNSMappings"
+	Connector_GetAgentConfig_FullMethodName            = "/telepresence.connector.Connector/GetAgentConfig"
+	Connector_ResolveSyntheticIP_FullMethodName        = "/telepresence.connector.Connector/ResolveSyntheticIP"
+	Connector_LookupIP_FullMethodName                  = "/telepresence.connector.Connector/LookupIP"
+	Connector_ResolvePort_FullMethodName               = "/telepresence.connector.Connector/ResolvePort"
+	Connector_RerouteLocalPort_FullMethodName          = "/telepresence.connector.Connector/RerouteLocalPort"
+	Connector_RerouteRemotePort_FullMethodName         = "/telepresence.connector.Connector/RerouteRemotePort"
+	Connector_AddLocalClientRedirect_FullMethodName    = "/telepresence.connector.Connector/AddLocalClientRedirect"
+	Connector_RemoveLocalClientRedirect_FullMethodName = "/telepresence.connector.Connector/RemoveLocalClientRedirect"
+	Connector_ListLocalClientRedirects_FullMethodName  = "/telepresence.connector.Connector/ListLocalClientRedirects"
 )
 
 // ConnectorClient is the client API for Connector service.
@@ -161,6 +164,12 @@ type ConnectorClient interface {
 	RerouteLocalPort(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// RerouteRemotePort makes a netip.AddrPort available on a new port on the same address.
 	RerouteRemotePort(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+	AddLocalClientRedirect(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+	RemoveLocalClientRedirect(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ListLocalClientRedirects lists active local client redirects.
+	ListLocalClientRedirects(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*daemon.LocalClientRedirects, error)
 }
 
 type connectorClient struct {
@@ -550,6 +559,36 @@ func (c *connectorClient) RerouteRemotePort(ctx context.Context, in *daemon.Rero
 	return out, nil
 }
 
+func (c *connectorClient) AddLocalClientRedirect(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Connector_AddLocalClientRedirect_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *connectorClient) RemoveLocalClientRedirect(ctx context.Context, in *daemon.ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Connector_RemoveLocalClientRedirect_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *connectorClient) ListLocalClientRedirects(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*daemon.LocalClientRedirects, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(daemon.LocalClientRedirects)
+	err := c.cc.Invoke(ctx, Connector_ListLocalClientRedirects_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ConnectorServer is the server API for Connector service.
 // All implementations must embed UnimplementedConnectorServer
 // for forward compatibility.
@@ -649,6 +688,12 @@ type ConnectorServer interface {
 	RerouteLocalPort(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error)
 	// RerouteRemotePort makes a netip.AddrPort available on a new port on the same address.
 	RerouteRemotePort(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error)
+	// AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+	AddLocalClientRedirect(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error)
+	// RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+	RemoveLocalClientRedirect(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error)
+	// ListLocalClientRedirects lists active local client redirects.
+	ListLocalClientRedirects(context.Context, *emptypb.Empty) (*daemon.LocalClientRedirects, error)
 	mustEmbedUnimplementedConnectorServer()
 }
 
@@ -769,6 +814,15 @@ func (UnimplementedConnectorServer) RerouteLocalPort(context.Context, *daemon.Re
 }
 func (UnimplementedConnectorServer) RerouteRemotePort(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method RerouteRemotePort not implemented")
+}
+func (UnimplementedConnectorServer) AddLocalClientRedirect(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddLocalClientRedirect not implemented")
+}
+func (UnimplementedConnectorServer) RemoveLocalClientRedirect(context.Context, *daemon.ReroutePortRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveLocalClientRedirect not implemented")
+}
+func (UnimplementedConnectorServer) ListLocalClientRedirects(context.Context, *emptypb.Empty) (*daemon.LocalClientRedirects, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListLocalClientRedirects not implemented")
 }
 func (UnimplementedConnectorServer) mustEmbedUnimplementedConnectorServer() {}
 func (UnimplementedConnectorServer) testEmbeddedByValue()                   {}
@@ -1450,6 +1504,60 @@ func _Connector_RerouteRemotePort_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Connector_AddLocalClientRedirect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(daemon.ReroutePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorServer).AddLocalClientRedirect(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Connector_AddLocalClientRedirect_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorServer).AddLocalClientRedirect(ctx, req.(*daemon.ReroutePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Connector_RemoveLocalClientRedirect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(daemon.ReroutePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorServer).RemoveLocalClientRedirect(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Connector_RemoveLocalClientRedirect_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorServer).RemoveLocalClientRedirect(ctx, req.(*daemon.ReroutePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Connector_ListLocalClientRedirects_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectorServer).ListLocalClientRedirects(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Connector_ListLocalClientRedirects_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectorServer).ListLocalClientRedirects(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Connector_ServiceDesc is the grpc.ServiceDesc for Connector service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1600,6 +1708,18 @@ var Connector_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RerouteRemotePort",
 			Handler:    _Connector_RerouteRemotePort_Handler,
+		},
+		{
+			MethodName: "AddLocalClientRedirect",
+			Handler:    _Connector_AddLocalClientRedirect_Handler,
+		},
+		{
+			MethodName: "RemoveLocalClientRedirect",
+			Handler:    _Connector_RemoveLocalClientRedirect_Handler,
+		},
+		{
+			MethodName: "ListLocalClientRedirects",
+			Handler:    _Connector_ListLocalClientRedirects_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/rpc/daemon/daemon.pb.go
+++ b/rpc/daemon/daemon.pb.go
@@ -1323,6 +1323,104 @@ func (x *SetInterceptShortcutsRequest) GetShortcuts() []*InterceptShortcut {
 	return nil
 }
 
+type LocalClientRedirect struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// host_port is a iputil.ProtoAddrPort in binary format
+	DstHostPort []byte `protobuf:"bytes,1,opt,name=dst_host_port,json=dstHostPort,proto3" json:"dst_host_port,omitempty"`
+	// local_port is the port on localhost that traffic is redirected to.
+	LocalPort     uint32 `protobuf:"varint,2,opt,name=local_port,json=localPort,proto3" json:"local_port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LocalClientRedirect) Reset() {
+	*x = LocalClientRedirect{}
+	mi := &file_daemon_daemon_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LocalClientRedirect) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LocalClientRedirect) ProtoMessage() {}
+
+func (x *LocalClientRedirect) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_daemon_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LocalClientRedirect.ProtoReflect.Descriptor instead.
+func (*LocalClientRedirect) Descriptor() ([]byte, []int) {
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *LocalClientRedirect) GetDstHostPort() []byte {
+	if x != nil {
+		return x.DstHostPort
+	}
+	return nil
+}
+
+func (x *LocalClientRedirect) GetLocalPort() uint32 {
+	if x != nil {
+		return x.LocalPort
+	}
+	return 0
+}
+
+type LocalClientRedirects struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Redirects     []*LocalClientRedirect `protobuf:"bytes,1,rep,name=redirects,proto3" json:"redirects,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LocalClientRedirects) Reset() {
+	*x = LocalClientRedirects{}
+	mi := &file_daemon_daemon_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LocalClientRedirects) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LocalClientRedirects) ProtoMessage() {}
+
+func (x *LocalClientRedirects) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_daemon_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LocalClientRedirects.ProtoReflect.Descriptor instead.
+func (*LocalClientRedirects) Descriptor() ([]byte, []int) {
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *LocalClientRedirects) GetRedirects() []*LocalClientRedirect {
+	if x != nil {
+		return x.Redirects
+	}
+	return nil
+}
+
 type QuitResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Set to true when the root daemon runs as a service.
@@ -1333,7 +1431,7 @@ type QuitResponse struct {
 
 func (x *QuitResponse) Reset() {
 	*x = QuitResponse{}
-	mi := &file_daemon_daemon_proto_msgTypes[21]
+	mi := &file_daemon_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1345,7 +1443,7 @@ func (x *QuitResponse) String() string {
 func (*QuitResponse) ProtoMessage() {}
 
 func (x *QuitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[21]
+	mi := &file_daemon_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1358,7 +1456,7 @@ func (x *QuitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuitResponse.ProtoReflect.Descriptor instead.
 func (*QuitResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *QuitResponse) GetRootDaemonWillContinue() bool {
@@ -1399,7 +1497,7 @@ type Activity struct {
 
 func (x *Activity) Reset() {
 	*x = Activity{}
-	mi := &file_daemon_daemon_proto_msgTypes[22]
+	mi := &file_daemon_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1411,7 +1509,7 @@ func (x *Activity) String() string {
 func (*Activity) ProtoMessage() {}
 
 func (x *Activity) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_daemon_proto_msgTypes[22]
+	mi := &file_daemon_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1424,7 +1522,7 @@ func (x *Activity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Activity.ProtoReflect.Descriptor instead.
 func (*Activity) Descriptor() ([]byte, []int) {
-	return file_daemon_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Activity) GetActivity() *timestamppb.Timestamp {
@@ -1575,7 +1673,13 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\x0econtainer_port\x18\x05 \x01(\rR\rcontainerPort\x12\x16\n" +
 	"\x06target\x18\x06 \x01(\fR\x06target\"d\n" +
 	"\x1cSetInterceptShortcutsRequest\x12D\n" +
-	"\tshortcuts\x18\x01 \x03(\v2&.telepresence.daemon.InterceptShortcutR\tshortcuts\"I\n" +
+	"\tshortcuts\x18\x01 \x03(\v2&.telepresence.daemon.InterceptShortcutR\tshortcuts\"X\n" +
+	"\x13LocalClientRedirect\x12\"\n" +
+	"\rdst_host_port\x18\x01 \x01(\fR\vdstHostPort\x12\x1d\n" +
+	"\n" +
+	"local_port\x18\x02 \x01(\rR\tlocalPort\"^\n" +
+	"\x14LocalClientRedirects\x12F\n" +
+	"\tredirects\x18\x01 \x03(\v2(.telepresence.daemon.LocalClientRedirectR\tredirects\"I\n" +
 	"\fQuitResponse\x129\n" +
 	"\x19root_daemon_will_continue\x18\x01 \x01(\bR\x16rootDaemonWillContinue\"\xe3\x02\n" +
 	"\bActivity\x126\n" +
@@ -1586,7 +1690,7 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\x10outbound_tunnels\x18\x04 \x01(\x03R\x0foutboundTunnels\x124\n" +
 	"\x16outbound_tunnel_errors\x18\x05 \x01(\x03R\x14outboundTunnelErrors\x12%\n" +
 	"\x0eincoming_dials\x18\x06 \x01(\x03R\rincomingDials\x120\n" +
-	"\x14incoming_dial_errors\x18\a \x01(\x03R\x12incomingDialErrors2\x94\f\n" +
+	"\x14incoming_dial_errors\x18\a \x01(\x03R\x12incomingDialErrors2\xac\x0e\n" +
 	"\x06Daemon\x12C\n" +
 	"\aVersion\x12\x16.google.protobuf.Empty\x1a .telepresence.common.VersionInfo\x12C\n" +
 	"\x06Status\x12\x16.google.protobuf.Empty\x1a!.telepresence.daemon.DaemonStatus\x12A\n" +
@@ -1605,7 +1709,10 @@ const file_daemon_daemon_proto_rawDesc = "" +
 	"\bLookupIP\x12$.telepresence.daemon.LookupIPRequest\x1a%.telepresence.daemon.LookupIPResponse\x12`\n" +
 	"\vResolvePort\x12'.telepresence.daemon.ResolvePortRequest\x1a(.telepresence.daemon.ResolvePortResponse\x12T\n" +
 	"\x11RerouteRemotePort\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12b\n" +
-	"\x15SetInterceptShortcuts\x121.telepresence.daemon.SetInterceptShortcutsRequest\x1a\x16.google.protobuf.Empty\x12J\n" +
+	"\x15SetInterceptShortcuts\x121.telepresence.daemon.SetInterceptShortcutsRequest\x1a\x16.google.protobuf.Empty\x12Y\n" +
+	"\x16AddLocalClientRedirect\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12\\\n" +
+	"\x19RemoveLocalClientRedirect\x12'.telepresence.daemon.ReroutePortRequest\x1a\x16.google.protobuf.Empty\x12]\n" +
+	"\x18ListLocalClientRedirects\x12\x16.google.protobuf.Empty\x1a).telepresence.daemon.LocalClientRedirects\x12J\n" +
 	"\x0fActivityWatcher\x12\x16.google.protobuf.Empty\x1a\x1d.telepresence.daemon.Activity0\x01\x12O\n" +
 	"\x0eWatchAgentPods\x12#.telepresence.daemon.AgentPodsDelta\x1a\x16.google.protobuf.Empty(\x01B6Z4github.com/telepresenceio/telepresence/rpc/v2/daemonb\x06proto3"
 
@@ -1621,7 +1728,7 @@ func file_daemon_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_daemon_proto_rawDescData
 }
 
-var file_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_daemon_daemon_proto_goTypes = []any{
 	(*DaemonStatus)(nil),                 // 0: telepresence.daemon.DaemonStatus
 	(*TunnelTransport)(nil),              // 1: telepresence.daemon.TunnelTransport
@@ -1644,80 +1751,89 @@ var file_daemon_daemon_proto_goTypes = []any{
 	(*ReroutePortRequest)(nil),           // 18: telepresence.daemon.ReroutePortRequest
 	(*InterceptShortcut)(nil),            // 19: telepresence.daemon.InterceptShortcut
 	(*SetInterceptShortcutsRequest)(nil), // 20: telepresence.daemon.SetInterceptShortcutsRequest
-	(*QuitResponse)(nil),                 // 21: telepresence.daemon.QuitResponse
-	(*Activity)(nil),                     // 22: telepresence.daemon.Activity
-	nil,                                  // 23: telepresence.daemon.NetworkConfig.KubeFlagsEntry
-	nil,                                  // 24: telepresence.daemon.AgentPodsDelta.UpsertsEntry
-	nil,                                  // 25: telepresence.daemon.Environment.EnvEntry
-	(*common.VersionInfo)(nil),           // 26: telepresence.common.VersionInfo
-	(*durationpb.Duration)(nil),          // 27: google.protobuf.Duration
-	(*manager.SessionInfo)(nil),          // 28: telepresence.manager.SessionInfo
-	(*timestamppb.Timestamp)(nil),        // 29: google.protobuf.Timestamp
-	(*manager.AgentPodInfo)(nil),         // 30: telepresence.manager.AgentPodInfo
-	(*emptypb.Empty)(nil),                // 31: google.protobuf.Empty
-	(*manager.LogLevelRequest)(nil),      // 32: telepresence.manager.LogLevelRequest
+	(*LocalClientRedirect)(nil),          // 21: telepresence.daemon.LocalClientRedirect
+	(*LocalClientRedirects)(nil),         // 22: telepresence.daemon.LocalClientRedirects
+	(*QuitResponse)(nil),                 // 23: telepresence.daemon.QuitResponse
+	(*Activity)(nil),                     // 24: telepresence.daemon.Activity
+	nil,                                  // 25: telepresence.daemon.NetworkConfig.KubeFlagsEntry
+	nil,                                  // 26: telepresence.daemon.AgentPodsDelta.UpsertsEntry
+	nil,                                  // 27: telepresence.daemon.Environment.EnvEntry
+	(*common.VersionInfo)(nil),           // 28: telepresence.common.VersionInfo
+	(*durationpb.Duration)(nil),          // 29: google.protobuf.Duration
+	(*manager.SessionInfo)(nil),          // 30: telepresence.manager.SessionInfo
+	(*timestamppb.Timestamp)(nil),        // 31: google.protobuf.Timestamp
+	(*manager.AgentPodInfo)(nil),         // 32: telepresence.manager.AgentPodInfo
+	(*emptypb.Empty)(nil),                // 33: google.protobuf.Empty
+	(*manager.LogLevelRequest)(nil),      // 34: telepresence.manager.LogLevelRequest
 }
 var file_daemon_daemon_proto_depIdxs = []int32{
 	7,  // 0: telepresence.daemon.DaemonStatus.outbound_config:type_name -> telepresence.daemon.NetworkConfig
-	26, // 1: telepresence.daemon.DaemonStatus.version:type_name -> telepresence.common.VersionInfo
+	28, // 1: telepresence.daemon.DaemonStatus.version:type_name -> telepresence.common.VersionInfo
 	1,  // 2: telepresence.daemon.DaemonStatus.tunnel_transport:type_name -> telepresence.daemon.TunnelTransport
 	2,  // 3: telepresence.daemon.DaemonStatus.agent_transports:type_name -> telepresence.daemon.AgentTransport
 	4,  // 4: telepresence.daemon.DNSConfig.mappings:type_name -> telepresence.daemon.DNSMapping
-	27, // 5: telepresence.daemon.DNSConfig.lookup_timeout:type_name -> google.protobuf.Duration
-	28, // 6: telepresence.daemon.NetworkConfig.session:type_name -> telepresence.manager.SessionInfo
+	29, // 5: telepresence.daemon.DNSConfig.lookup_timeout:type_name -> google.protobuf.Duration
+	30, // 6: telepresence.daemon.NetworkConfig.session:type_name -> telepresence.manager.SessionInfo
 	6,  // 7: telepresence.daemon.NetworkConfig.subnet_via_workloads:type_name -> telepresence.daemon.SubnetViaWorkload
-	23, // 8: telepresence.daemon.NetworkConfig.kube_flags:type_name -> telepresence.daemon.NetworkConfig.KubeFlagsEntry
-	24, // 9: telepresence.daemon.AgentPodsDelta.upserts:type_name -> telepresence.daemon.AgentPodsDelta.UpsertsEntry
+	25, // 8: telepresence.daemon.NetworkConfig.kube_flags:type_name -> telepresence.daemon.NetworkConfig.KubeFlagsEntry
+	26, // 9: telepresence.daemon.AgentPodsDelta.upserts:type_name -> telepresence.daemon.AgentPodsDelta.UpsertsEntry
 	4,  // 10: telepresence.daemon.SetDNSMappingsRequest.mappings:type_name -> telepresence.daemon.DNSMapping
-	27, // 11: telepresence.daemon.WaitForAgentIPRequest.timeout:type_name -> google.protobuf.Duration
-	25, // 12: telepresence.daemon.Environment.env:type_name -> telepresence.daemon.Environment.EnvEntry
+	29, // 11: telepresence.daemon.WaitForAgentIPRequest.timeout:type_name -> google.protobuf.Duration
+	27, // 12: telepresence.daemon.Environment.env:type_name -> telepresence.daemon.Environment.EnvEntry
 	19, // 13: telepresence.daemon.SetInterceptShortcutsRequest.shortcuts:type_name -> telepresence.daemon.InterceptShortcut
-	29, // 14: telepresence.daemon.Activity.activity:type_name -> google.protobuf.Timestamp
-	27, // 15: telepresence.daemon.Activity.session_duration:type_name -> google.protobuf.Duration
-	30, // 16: telepresence.daemon.AgentPodsDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
-	31, // 17: telepresence.daemon.Daemon.Version:input_type -> google.protobuf.Empty
-	31, // 18: telepresence.daemon.Daemon.Status:input_type -> google.protobuf.Empty
-	31, // 19: telepresence.daemon.Daemon.Quit:input_type -> google.protobuf.Empty
-	7,  // 20: telepresence.daemon.Daemon.Connect:input_type -> telepresence.daemon.NetworkConfig
-	31, // 21: telepresence.daemon.Daemon.Disconnect:input_type -> google.protobuf.Empty
-	31, // 22: telepresence.daemon.Daemon.GetNetworkConfig:input_type -> google.protobuf.Empty
-	3,  // 23: telepresence.daemon.Daemon.SetDNSTopLevelDomains:input_type -> telepresence.daemon.Domains
-	9,  // 24: telepresence.daemon.Daemon.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
-	10, // 25: telepresence.daemon.Daemon.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
-	32, // 26: telepresence.daemon.Daemon.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
-	15, // 27: telepresence.daemon.Daemon.TranslateEnvIPs:input_type -> telepresence.daemon.Environment
-	31, // 28: telepresence.daemon.Daemon.WaitForNetwork:input_type -> google.protobuf.Empty
-	11, // 29: telepresence.daemon.Daemon.WaitForAgentIP:input_type -> telepresence.daemon.WaitForAgentIPRequest
-	13, // 30: telepresence.daemon.Daemon.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
-	16, // 31: telepresence.daemon.Daemon.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
-	18, // 32: telepresence.daemon.Daemon.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
-	20, // 33: telepresence.daemon.Daemon.SetInterceptShortcuts:input_type -> telepresence.daemon.SetInterceptShortcutsRequest
-	31, // 34: telepresence.daemon.Daemon.ActivityWatcher:input_type -> google.protobuf.Empty
-	8,  // 35: telepresence.daemon.Daemon.WatchAgentPods:input_type -> telepresence.daemon.AgentPodsDelta
-	26, // 36: telepresence.daemon.Daemon.Version:output_type -> telepresence.common.VersionInfo
-	0,  // 37: telepresence.daemon.Daemon.Status:output_type -> telepresence.daemon.DaemonStatus
-	21, // 38: telepresence.daemon.Daemon.Quit:output_type -> telepresence.daemon.QuitResponse
-	0,  // 39: telepresence.daemon.Daemon.Connect:output_type -> telepresence.daemon.DaemonStatus
-	31, // 40: telepresence.daemon.Daemon.Disconnect:output_type -> google.protobuf.Empty
-	7,  // 41: telepresence.daemon.Daemon.GetNetworkConfig:output_type -> telepresence.daemon.NetworkConfig
-	31, // 42: telepresence.daemon.Daemon.SetDNSTopLevelDomains:output_type -> google.protobuf.Empty
-	31, // 43: telepresence.daemon.Daemon.SetDNSExcludes:output_type -> google.protobuf.Empty
-	31, // 44: telepresence.daemon.Daemon.SetDNSMappings:output_type -> google.protobuf.Empty
-	31, // 45: telepresence.daemon.Daemon.SetLogLevel:output_type -> google.protobuf.Empty
-	15, // 46: telepresence.daemon.Daemon.TranslateEnvIPs:output_type -> telepresence.daemon.Environment
-	31, // 47: telepresence.daemon.Daemon.WaitForNetwork:output_type -> google.protobuf.Empty
-	12, // 48: telepresence.daemon.Daemon.WaitForAgentIP:output_type -> telepresence.daemon.WaitForAgentIPResponse
-	14, // 49: telepresence.daemon.Daemon.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
-	17, // 50: telepresence.daemon.Daemon.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
-	31, // 51: telepresence.daemon.Daemon.RerouteRemotePort:output_type -> google.protobuf.Empty
-	31, // 52: telepresence.daemon.Daemon.SetInterceptShortcuts:output_type -> google.protobuf.Empty
-	22, // 53: telepresence.daemon.Daemon.ActivityWatcher:output_type -> telepresence.daemon.Activity
-	31, // 54: telepresence.daemon.Daemon.WatchAgentPods:output_type -> google.protobuf.Empty
-	36, // [36:55] is the sub-list for method output_type
-	17, // [17:36] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	21, // 14: telepresence.daemon.LocalClientRedirects.redirects:type_name -> telepresence.daemon.LocalClientRedirect
+	31, // 15: telepresence.daemon.Activity.activity:type_name -> google.protobuf.Timestamp
+	29, // 16: telepresence.daemon.Activity.session_duration:type_name -> google.protobuf.Duration
+	32, // 17: telepresence.daemon.AgentPodsDelta.UpsertsEntry.value:type_name -> telepresence.manager.AgentPodInfo
+	33, // 18: telepresence.daemon.Daemon.Version:input_type -> google.protobuf.Empty
+	33, // 19: telepresence.daemon.Daemon.Status:input_type -> google.protobuf.Empty
+	33, // 20: telepresence.daemon.Daemon.Quit:input_type -> google.protobuf.Empty
+	7,  // 21: telepresence.daemon.Daemon.Connect:input_type -> telepresence.daemon.NetworkConfig
+	33, // 22: telepresence.daemon.Daemon.Disconnect:input_type -> google.protobuf.Empty
+	33, // 23: telepresence.daemon.Daemon.GetNetworkConfig:input_type -> google.protobuf.Empty
+	3,  // 24: telepresence.daemon.Daemon.SetDNSTopLevelDomains:input_type -> telepresence.daemon.Domains
+	9,  // 25: telepresence.daemon.Daemon.SetDNSExcludes:input_type -> telepresence.daemon.SetDNSExcludesRequest
+	10, // 26: telepresence.daemon.Daemon.SetDNSMappings:input_type -> telepresence.daemon.SetDNSMappingsRequest
+	34, // 27: telepresence.daemon.Daemon.SetLogLevel:input_type -> telepresence.manager.LogLevelRequest
+	15, // 28: telepresence.daemon.Daemon.TranslateEnvIPs:input_type -> telepresence.daemon.Environment
+	33, // 29: telepresence.daemon.Daemon.WaitForNetwork:input_type -> google.protobuf.Empty
+	11, // 30: telepresence.daemon.Daemon.WaitForAgentIP:input_type -> telepresence.daemon.WaitForAgentIPRequest
+	13, // 31: telepresence.daemon.Daemon.LookupIP:input_type -> telepresence.daemon.LookupIPRequest
+	16, // 32: telepresence.daemon.Daemon.ResolvePort:input_type -> telepresence.daemon.ResolvePortRequest
+	18, // 33: telepresence.daemon.Daemon.RerouteRemotePort:input_type -> telepresence.daemon.ReroutePortRequest
+	20, // 34: telepresence.daemon.Daemon.SetInterceptShortcuts:input_type -> telepresence.daemon.SetInterceptShortcutsRequest
+	18, // 35: telepresence.daemon.Daemon.AddLocalClientRedirect:input_type -> telepresence.daemon.ReroutePortRequest
+	18, // 36: telepresence.daemon.Daemon.RemoveLocalClientRedirect:input_type -> telepresence.daemon.ReroutePortRequest
+	33, // 37: telepresence.daemon.Daemon.ListLocalClientRedirects:input_type -> google.protobuf.Empty
+	33, // 38: telepresence.daemon.Daemon.ActivityWatcher:input_type -> google.protobuf.Empty
+	8,  // 39: telepresence.daemon.Daemon.WatchAgentPods:input_type -> telepresence.daemon.AgentPodsDelta
+	28, // 40: telepresence.daemon.Daemon.Version:output_type -> telepresence.common.VersionInfo
+	0,  // 41: telepresence.daemon.Daemon.Status:output_type -> telepresence.daemon.DaemonStatus
+	23, // 42: telepresence.daemon.Daemon.Quit:output_type -> telepresence.daemon.QuitResponse
+	0,  // 43: telepresence.daemon.Daemon.Connect:output_type -> telepresence.daemon.DaemonStatus
+	33, // 44: telepresence.daemon.Daemon.Disconnect:output_type -> google.protobuf.Empty
+	7,  // 45: telepresence.daemon.Daemon.GetNetworkConfig:output_type -> telepresence.daemon.NetworkConfig
+	33, // 46: telepresence.daemon.Daemon.SetDNSTopLevelDomains:output_type -> google.protobuf.Empty
+	33, // 47: telepresence.daemon.Daemon.SetDNSExcludes:output_type -> google.protobuf.Empty
+	33, // 48: telepresence.daemon.Daemon.SetDNSMappings:output_type -> google.protobuf.Empty
+	33, // 49: telepresence.daemon.Daemon.SetLogLevel:output_type -> google.protobuf.Empty
+	15, // 50: telepresence.daemon.Daemon.TranslateEnvIPs:output_type -> telepresence.daemon.Environment
+	33, // 51: telepresence.daemon.Daemon.WaitForNetwork:output_type -> google.protobuf.Empty
+	12, // 52: telepresence.daemon.Daemon.WaitForAgentIP:output_type -> telepresence.daemon.WaitForAgentIPResponse
+	14, // 53: telepresence.daemon.Daemon.LookupIP:output_type -> telepresence.daemon.LookupIPResponse
+	17, // 54: telepresence.daemon.Daemon.ResolvePort:output_type -> telepresence.daemon.ResolvePortResponse
+	33, // 55: telepresence.daemon.Daemon.RerouteRemotePort:output_type -> google.protobuf.Empty
+	33, // 56: telepresence.daemon.Daemon.SetInterceptShortcuts:output_type -> google.protobuf.Empty
+	33, // 57: telepresence.daemon.Daemon.AddLocalClientRedirect:output_type -> google.protobuf.Empty
+	33, // 58: telepresence.daemon.Daemon.RemoveLocalClientRedirect:output_type -> google.protobuf.Empty
+	22, // 59: telepresence.daemon.Daemon.ListLocalClientRedirects:output_type -> telepresence.daemon.LocalClientRedirects
+	24, // 60: telepresence.daemon.Daemon.ActivityWatcher:output_type -> telepresence.daemon.Activity
+	33, // 61: telepresence.daemon.Daemon.WatchAgentPods:output_type -> google.protobuf.Empty
+	40, // [40:62] is the sub-list for method output_type
+	18, // [18:40] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_daemon_daemon_proto_init() }
@@ -1732,7 +1848,7 @@ func file_daemon_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_daemon_proto_rawDesc), len(file_daemon_daemon_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   26,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/daemon/daemon.proto
+++ b/rpc/daemon/daemon.proto
@@ -65,6 +65,15 @@ service Daemon {
   // Each call replaces the previously declared set.
   rpc SetInterceptShortcuts(SetInterceptShortcutsRequest) returns (google.protobuf.Empty);
 
+  // AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+  rpc AddLocalClientRedirect(ReroutePortRequest) returns (google.protobuf.Empty);
+
+  // RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+  rpc RemoveLocalClientRedirect(ReroutePortRequest) returns (google.protobuf.Empty);
+
+  // ListLocalClientRedirects lists active local client redirects.
+  rpc ListLocalClientRedirects(google.protobuf.Empty) returns (LocalClientRedirects);
+
   rpc ActivityWatcher(google.protobuf.Empty) returns (stream Activity);
 
   // WatchAgentPods is called by the user daemon to push the agent-pod
@@ -296,6 +305,18 @@ message InterceptShortcut {
 
 message SetInterceptShortcutsRequest {
   repeated InterceptShortcut shortcuts = 1;
+}
+
+message LocalClientRedirect {
+  // host_port is a iputil.ProtoAddrPort in binary format
+  bytes dst_host_port = 1;
+
+  // local_port is the port on localhost that traffic is redirected to.
+  uint32 local_port = 2;
+}
+
+message LocalClientRedirects {
+  repeated LocalClientRedirect redirects = 1;
 }
 
 message QuitResponse {

--- a/rpc/daemon/daemon_grpc.pb.go
+++ b/rpc/daemon/daemon_grpc.pb.go
@@ -22,25 +22,28 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Daemon_Version_FullMethodName               = "/telepresence.daemon.Daemon/Version"
-	Daemon_Status_FullMethodName                = "/telepresence.daemon.Daemon/Status"
-	Daemon_Quit_FullMethodName                  = "/telepresence.daemon.Daemon/Quit"
-	Daemon_Connect_FullMethodName               = "/telepresence.daemon.Daemon/Connect"
-	Daemon_Disconnect_FullMethodName            = "/telepresence.daemon.Daemon/Disconnect"
-	Daemon_GetNetworkConfig_FullMethodName      = "/telepresence.daemon.Daemon/GetNetworkConfig"
-	Daemon_SetDNSTopLevelDomains_FullMethodName = "/telepresence.daemon.Daemon/SetDNSTopLevelDomains"
-	Daemon_SetDNSExcludes_FullMethodName        = "/telepresence.daemon.Daemon/SetDNSExcludes"
-	Daemon_SetDNSMappings_FullMethodName        = "/telepresence.daemon.Daemon/SetDNSMappings"
-	Daemon_SetLogLevel_FullMethodName           = "/telepresence.daemon.Daemon/SetLogLevel"
-	Daemon_TranslateEnvIPs_FullMethodName       = "/telepresence.daemon.Daemon/TranslateEnvIPs"
-	Daemon_WaitForNetwork_FullMethodName        = "/telepresence.daemon.Daemon/WaitForNetwork"
-	Daemon_WaitForAgentIP_FullMethodName        = "/telepresence.daemon.Daemon/WaitForAgentIP"
-	Daemon_LookupIP_FullMethodName              = "/telepresence.daemon.Daemon/LookupIP"
-	Daemon_ResolvePort_FullMethodName           = "/telepresence.daemon.Daemon/ResolvePort"
-	Daemon_RerouteRemotePort_FullMethodName     = "/telepresence.daemon.Daemon/RerouteRemotePort"
-	Daemon_SetInterceptShortcuts_FullMethodName = "/telepresence.daemon.Daemon/SetInterceptShortcuts"
-	Daemon_ActivityWatcher_FullMethodName       = "/telepresence.daemon.Daemon/ActivityWatcher"
-	Daemon_WatchAgentPods_FullMethodName        = "/telepresence.daemon.Daemon/WatchAgentPods"
+	Daemon_Version_FullMethodName                   = "/telepresence.daemon.Daemon/Version"
+	Daemon_Status_FullMethodName                    = "/telepresence.daemon.Daemon/Status"
+	Daemon_Quit_FullMethodName                      = "/telepresence.daemon.Daemon/Quit"
+	Daemon_Connect_FullMethodName                   = "/telepresence.daemon.Daemon/Connect"
+	Daemon_Disconnect_FullMethodName                = "/telepresence.daemon.Daemon/Disconnect"
+	Daemon_GetNetworkConfig_FullMethodName          = "/telepresence.daemon.Daemon/GetNetworkConfig"
+	Daemon_SetDNSTopLevelDomains_FullMethodName     = "/telepresence.daemon.Daemon/SetDNSTopLevelDomains"
+	Daemon_SetDNSExcludes_FullMethodName            = "/telepresence.daemon.Daemon/SetDNSExcludes"
+	Daemon_SetDNSMappings_FullMethodName            = "/telepresence.daemon.Daemon/SetDNSMappings"
+	Daemon_SetLogLevel_FullMethodName               = "/telepresence.daemon.Daemon/SetLogLevel"
+	Daemon_TranslateEnvIPs_FullMethodName           = "/telepresence.daemon.Daemon/TranslateEnvIPs"
+	Daemon_WaitForNetwork_FullMethodName            = "/telepresence.daemon.Daemon/WaitForNetwork"
+	Daemon_WaitForAgentIP_FullMethodName            = "/telepresence.daemon.Daemon/WaitForAgentIP"
+	Daemon_LookupIP_FullMethodName                  = "/telepresence.daemon.Daemon/LookupIP"
+	Daemon_ResolvePort_FullMethodName               = "/telepresence.daemon.Daemon/ResolvePort"
+	Daemon_RerouteRemotePort_FullMethodName         = "/telepresence.daemon.Daemon/RerouteRemotePort"
+	Daemon_SetInterceptShortcuts_FullMethodName     = "/telepresence.daemon.Daemon/SetInterceptShortcuts"
+	Daemon_AddLocalClientRedirect_FullMethodName    = "/telepresence.daemon.Daemon/AddLocalClientRedirect"
+	Daemon_RemoveLocalClientRedirect_FullMethodName = "/telepresence.daemon.Daemon/RemoveLocalClientRedirect"
+	Daemon_ListLocalClientRedirects_FullMethodName  = "/telepresence.daemon.Daemon/ListLocalClientRedirects"
+	Daemon_ActivityWatcher_FullMethodName           = "/telepresence.daemon.Daemon/ActivityWatcher"
+	Daemon_WatchAgentPods_FullMethodName            = "/telepresence.daemon.Daemon/WatchAgentPods"
 )
 
 // DaemonClient is the client API for Daemon service.
@@ -86,6 +89,12 @@ type DaemonClient interface {
 	// connects directly to local intercept handlers instead of tunneling to the cluster.
 	// Each call replaces the previously declared set.
 	SetInterceptShortcuts(ctx context.Context, in *SetInterceptShortcutsRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+	AddLocalClientRedirect(ctx context.Context, in *ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+	RemoveLocalClientRedirect(ctx context.Context, in *ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// ListLocalClientRedirects lists active local client redirects.
+	ListLocalClientRedirects(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*LocalClientRedirects, error)
 	ActivityWatcher(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Activity], error)
 	// WatchAgentPods is called by the user daemon to push the agent-pod
 	// projection it derives from its combined traffic-manager watcher. It is
@@ -273,6 +282,36 @@ func (c *daemonClient) SetInterceptShortcuts(ctx context.Context, in *SetInterce
 	return out, nil
 }
 
+func (c *daemonClient) AddLocalClientRedirect(ctx context.Context, in *ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Daemon_AddLocalClientRedirect_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonClient) RemoveLocalClientRedirect(ctx context.Context, in *ReroutePortRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Daemon_RemoveLocalClientRedirect_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonClient) ListLocalClientRedirects(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*LocalClientRedirects, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LocalClientRedirects)
+	err := c.cc.Invoke(ctx, Daemon_ListLocalClientRedirects_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *daemonClient) ActivityWatcher(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Activity], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[0], Daemon_ActivityWatcher_FullMethodName, cOpts...)
@@ -348,6 +387,12 @@ type DaemonServer interface {
 	// connects directly to local intercept handlers instead of tunneling to the cluster.
 	// Each call replaces the previously declared set.
 	SetInterceptShortcuts(context.Context, *SetInterceptShortcutsRequest) (*emptypb.Empty, error)
+	// AddLocalClientRedirect redirects traffic for a netip.AddrPort to localhost on a different port.
+	AddLocalClientRedirect(context.Context, *ReroutePortRequest) (*emptypb.Empty, error)
+	// RemoveLocalClientRedirect stops redirecting traffic for a netip.AddrPort to localhost.
+	RemoveLocalClientRedirect(context.Context, *ReroutePortRequest) (*emptypb.Empty, error)
+	// ListLocalClientRedirects lists active local client redirects.
+	ListLocalClientRedirects(context.Context, *emptypb.Empty) (*LocalClientRedirects, error)
 	ActivityWatcher(*emptypb.Empty, grpc.ServerStreamingServer[Activity]) error
 	// WatchAgentPods is called by the user daemon to push the agent-pod
 	// projection it derives from its combined traffic-manager watcher. It is
@@ -415,6 +460,15 @@ func (UnimplementedDaemonServer) RerouteRemotePort(context.Context, *ReroutePort
 }
 func (UnimplementedDaemonServer) SetInterceptShortcuts(context.Context, *SetInterceptShortcutsRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetInterceptShortcuts not implemented")
+}
+func (UnimplementedDaemonServer) AddLocalClientRedirect(context.Context, *ReroutePortRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddLocalClientRedirect not implemented")
+}
+func (UnimplementedDaemonServer) RemoveLocalClientRedirect(context.Context, *ReroutePortRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method RemoveLocalClientRedirect not implemented")
+}
+func (UnimplementedDaemonServer) ListLocalClientRedirects(context.Context, *emptypb.Empty) (*LocalClientRedirects, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListLocalClientRedirects not implemented")
 }
 func (UnimplementedDaemonServer) ActivityWatcher(*emptypb.Empty, grpc.ServerStreamingServer[Activity]) error {
 	return status.Error(codes.Unimplemented, "method ActivityWatcher not implemented")
@@ -749,6 +803,60 @@ func _Daemon_SetInterceptShortcuts_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Daemon_AddLocalClientRedirect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReroutePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServer).AddLocalClientRedirect(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Daemon_AddLocalClientRedirect_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServer).AddLocalClientRedirect(ctx, req.(*ReroutePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Daemon_RemoveLocalClientRedirect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReroutePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServer).RemoveLocalClientRedirect(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Daemon_RemoveLocalClientRedirect_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServer).RemoveLocalClientRedirect(ctx, req.(*ReroutePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Daemon_ListLocalClientRedirects_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServer).ListLocalClientRedirects(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Daemon_ListLocalClientRedirects_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServer).ListLocalClientRedirects(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Daemon_ActivityWatcher_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
@@ -841,6 +949,18 @@ var Daemon_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetInterceptShortcuts",
 			Handler:    _Daemon_SetInterceptShortcuts_Handler,
+		},
+		{
+			MethodName: "AddLocalClientRedirect",
+			Handler:    _Daemon_AddLocalClientRedirect_Handler,
+		},
+		{
+			MethodName: "RemoveLocalClientRedirect",
+			Handler:    _Daemon_RemoveLocalClientRedirect_Handler,
+		},
+		{
+			MethodName: "ListLocalClientRedirects",
+			Handler:    _Daemon_ListLocalClientRedirects_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{


### PR DESCRIPTION
## Description

Sometimes I want a local client to send one remote host and port to a localhost listener without creating or changing an intercept.

This adds `telepresence local-client-redirect add|list|remove`, carries the redirect through the user and root daemons, and checks the mapping before normal tunnel routing. The active session owns the redirect table, so it is easy to inspect and remove.

Tested with `GOEXPERIMENT=jsonv2 go test ./pkg/client/rootd ./pkg/client/cli/connect ./pkg/client/cli/cmd ./pkg/client/userd/daemon -count=1`.