### PR TITLE
Run the regression shards in parallel local Vagrant VMs

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -333,6 +333,10 @@ push-client-image: client-image ## (Build) Push the client container image to $(
 load-client-image: client-image ## (Build) Load the client container image into the local cluster (kind/minikube)
 	$(call load-image,$(CLIENT_IMAGE_FQN))
 
+.PHONY: save-client-image
+save-client-image: client-image
+	docker save $(CLIENT_IMAGE_FQN) > $(BUILDDIR)/client-image.tar
+
 ROUTECONTROLLER_IMAGE_FQN=$(TELEPRESENCE_REGISTRY)/route-controller:$(TELEPRESENCE_SEMVER)
 
 .PHONY: routecontroller-image
@@ -348,6 +352,10 @@ push-routecontroller-image: routecontroller-image ## (Build) Push the route-cont
 .PHONY: load-routecontroller-image
 load-routecontroller-image: routecontroller-image ## (Build) Load the route-controller DaemonSet image into the local cluster (kind/minikube)
 	$(call load-image,$(ROUTECONTROLLER_IMAGE_FQN))
+
+.PHONY: save-routecontroller-image
+save-routecontroller-image: routecontroller-image
+	docker save $(ROUTECONTROLLER_IMAGE_FQN) > $(BUILDDIR)/routecontroller-image.tar
 
 .PHONY: push-images
 push-images: push-tel2-image push-client-image push-routecontroller-image
@@ -460,6 +468,10 @@ build-tests: build-deps ## (Test) Build (but don't run) the test suite.  Useful 
 
 shellscripts += ./packaging/homebrew-package.sh
 shellscripts += ./packaging/windows-package.sh
+shellscripts += ./build-aux/vagrant-rtest/preflight.sh
+shellscripts += ./build-aux/vagrant-rtest/provision.sh
+shellscripts += ./build-aux/vagrant-rtest/run-shard.sh
+shellscripts += ./build-aux/vagrant-rtest/run-shards.sh
 .PHONY: lint lint-rpc lint-go lint-docs
 
 lint: lint-rpc lint-go lint-docs
@@ -535,6 +547,10 @@ ifdef SHARD
 else
 	go test -count=1 -timeout=90m ./regression_test/...
 endif
+
+.PHONY: check-regression-vagrant
+check-regression-vagrant: ## (QA) Run all 3 regression shards in parallel VirtualBox VMs via Vagrant
+	build-aux/vagrant-rtest/run-shards.sh
 
 .PHONY: rtest-clean
 rtest-clean: ## (QA) Remove regression-test resources left in the cluster

--- a/build-aux/vagrant-rtest/Vagrantfile
+++ b/build-aux/vagrant-rtest/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Three self-contained VMs, one per regression-test shard. Each machine
+# gets its own copy of the repo and its own minikube cluster so the three
+# shards run concurrently without sharing a TUN device, DNS override, or
+# cluster.
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+
+  (1..3).each do |n|
+    config.vm.define "shard#{n}" do |shard|
+      shard.vm.hostname = "shard#{n}"
+
+      shard.vm.provider "virtualbox" do |vb|
+        vb.cpus = 8
+        vb.memory = 14336
+        vb.linked_clone = true
+      end
+
+      shard.vm.synced_folder "../..", "/home/vagrant/tp",
+        type: "rsync",
+        rsync__exclude: [".git/", ".claude/", ".vagrant/"]
+
+      shard.vm.provision "shell", path: "provision.sh"
+    end
+  end
+end

--- a/build-aux/vagrant-rtest/preflight.sh
+++ b/build-aux/vagrant-rtest/preflight.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Refuses to start the parallel Vagrant regression shards when the host
+# lacks the headroom to run three VirtualBox VMs (8 vCPU / 14G RAM each)
+# concurrently.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MIN_MEM_AVAILABLE_GIB=50
+MIN_MEM_HEADROOM_GIB=4
+VM_MEM_GIB=14
+MIN_DISK_FIRST_RUN_GIB=60
+MIN_DISK_WARM_RUN_GIB=25
+LOADAVG_WARN_THRESHOLD=8
+
+fail() {
+    echo "preflight: $*" >&2
+    exit 1
+}
+
+warn() {
+    echo "preflight: warning: $*" >&2
+}
+
+require_command() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || fail "'$cmd' not found on PATH"
+}
+
+check_tools() {
+    require_command vagrant
+    require_command VBoxManage
+    vagrant --version >/dev/null || fail "'vagrant --version' failed"
+    VBoxManage --version >/dev/null || fail "'VBoxManage --version' failed"
+}
+
+check_no_kvm_guests() {
+    if ! command -v virsh >/dev/null 2>&1; then
+        return 0
+    fi
+    local running
+    running="$(virsh --connect qemu:///system list --name 2>/dev/null || true)"
+    running="$(printf '%s' "$running" | sed '/^\s*$/d')"
+    if [ -n "$running" ]; then
+        fail "KVM guests are running (VirtualBox cannot share the CPU" \
+            "virtualization extensions with them): $running"
+    fi
+}
+
+machine_id() {
+    cat "$SCRIPT_DIR/.vagrant/machines/shard${1}/virtualbox/id" 2>/dev/null || true
+}
+
+# Shard VMs that are already up hold their RAM, so only the ones still to
+# be started have to fit in what is available.
+running_machine_count() {
+    local running n id count=0
+    running="$(VBoxManage list runningvms | sed -n 's/.*{\(.*\)}.*/\1/p')"
+    for n in 1 2 3; do
+        id="$(machine_id "$n")"
+        [ -n "$id" ] || continue
+        if printf '%s\n' "$running" | grep -qxF "$id"; then
+            count=$((count + 1))
+        fi
+    done
+    printf '%s' "$count"
+}
+
+check_mem_available() {
+    local mem_kib mem_gib running needed
+    mem_kib="$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)"
+    [ -n "$mem_kib" ] || fail "could not read MemAvailable from /proc/meminfo"
+    mem_gib=$((mem_kib / 1024 / 1024))
+
+    running="$(running_machine_count)"
+    needed=$((MIN_MEM_AVAILABLE_GIB - running * VM_MEM_GIB))
+    if [ "$needed" -lt "$MIN_MEM_HEADROOM_GIB" ]; then
+        needed="$MIN_MEM_HEADROOM_GIB"
+    fi
+
+    if [ "$mem_gib" -lt "$needed" ]; then
+        fail "only ${mem_gib}G RAM available, need ${needed}G with" \
+            "${running} of 3 shard VMs already running" \
+            "(close other VMs/apps and retry)"
+    fi
+}
+
+all_machines_exist() {
+    local n
+    for n in 1 2 3; do
+        [ -f "$SCRIPT_DIR/.vagrant/machines/shard${n}/virtualbox/id" ] || return 1
+    done
+    return 0
+}
+
+default_machine_folder() {
+    VBoxManage list systemproperties \
+        | awk -F': *' '/^Default machine folder:/ {print $2}'
+}
+
+check_disk_space() {
+    local folder min_gib avail_kib avail_gib
+    folder="$(default_machine_folder)"
+    [ -n "$folder" ] || fail "could not determine the VirtualBox default machine folder"
+    [ -d "$folder" ] || fail "VirtualBox default machine folder does not exist: $folder"
+
+    if all_machines_exist; then
+        min_gib="$MIN_DISK_WARM_RUN_GIB"
+    else
+        min_gib="$MIN_DISK_FIRST_RUN_GIB"
+    fi
+
+    avail_kib="$(df -Pk "$folder" | awk 'NR==2 {print $4}')"
+    [ -n "$avail_kib" ] || fail "could not determine free space on $folder"
+    avail_gib=$((avail_kib / 1024 / 1024))
+    if [ "$avail_gib" -lt "$min_gib" ]; then
+        fail "only ${avail_gib}G free on the filesystem holding $folder," \
+            "need ${min_gib}G"
+    fi
+}
+
+check_loadavg() {
+    local loadavg
+    loadavg="$(awk '{print $1}' /proc/loadavg)"
+    if awk -v l="$loadavg" -v t="$LOADAVG_WARN_THRESHOLD" \
+        'BEGIN {exit !(l > t)}'; then
+        warn "1-min load average ($loadavg) is above" \
+            "$LOADAVG_WARN_THRESHOLD; the host may be oversubscribed"
+    fi
+}
+
+check_tools
+check_no_kvm_guests
+check_mem_available
+check_disk_space
+check_loadavg
+
+echo "preflight: ok"

--- a/build-aux/vagrant-rtest/provision.sh
+++ b/build-aux/vagrant-rtest/provision.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# In-VM provisioning for a regression-shard VM: packages, kubectl,
+# minikube, and the Go toolchain. Runs once per VM lifetime, as root.
+# minikube itself is started by run-shard.sh, not here.
+set -euo pipefail
+
+KUBECTL_VERSION="v1.33.5"
+MINIKUBE_VERSION="v1.36.0"
+HELM_VERSION="v3.19.0"
+GO_VERSION="1.26.3"
+ARCH="amd64"
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    conntrack \
+    curl \
+    docker-compose-v2 \
+    docker.io \
+    gcc \
+    git \
+    jq \
+    libc6-dev \
+    libfuse-dev \
+    make \
+    rsync \
+    socat \
+    sshfs
+
+grep -q '^user_allow_other$' /etc/fuse.conf || echo 'user_allow_other' >>/etc/fuse.conf
+
+usermod -aG docker vagrant
+
+curl -fsSL -o /usr/local/bin/kubectl \
+    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+chmod +x /usr/local/bin/kubectl
+
+curl -fsSL -o /usr/local/bin/minikube \
+    "https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-${ARCH}"
+chmod +x /usr/local/bin/minikube
+
+curl -fsSL -o /tmp/helm.tar.gz \
+    "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
+tar -C /tmp -xzf /tmp/helm.tar.gz "linux-${ARCH}/helm"
+install -m 755 "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm
+rm -rf /tmp/helm.tar.gz "/tmp/linux-${ARCH}"
+
+curl -fsSL -o /tmp/go.tar.gz \
+    "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz"
+rm -rf /usr/local/go
+tar -C /usr/local -xzf /tmp/go.tar.gz
+rm -f /tmp/go.tar.gz
+
+cat > /etc/profile.d/golang.sh <<'EOF'
+export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+EOF
+chmod 644 /etc/profile.d/golang.sh
+
+# The kubelet consumes inotify instances in proportion to the pods it
+# runs, and the defaults leave too few for the root daemon's own watch.
+cat > /etc/sysctl.d/99-vagrant-rtest.conf <<'EOF'
+fs.inotify.max_user_instances = 8192
+fs.inotify.max_user_watches = 1048576
+EOF
+sysctl --system >/dev/null

--- a/build-aux/vagrant-rtest/run-shard.sh
+++ b/build-aux/vagrant-rtest/run-shard.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# In-VM entry point for one regression-test shard. Starts (or reuses) the
+# VM's own minikube cluster, loads the images built and saved on the
+# host, and runs that shard of "make check-regression". Runs as the
+# vagrant user.
+set -euo pipefail
+
+usage() {
+    echo "usage: $(basename "$0") <1|2|3>" >&2
+    exit 1
+}
+
+[ $# -eq 1 ] || usage
+case "$1" in
+    1 | 2 | 3) ;;
+    *) usage ;;
+esac
+SHARD="$1"
+
+# shellcheck source=/dev/null
+source /etc/profile.d/golang.sh
+
+cd /home/vagrant/tp
+
+export TELEPRESENCE_VERSION
+TELEPRESENCE_VERSION="$(cat build-output/version.txt)"
+export TELEPRESENCE_REGISTRY=local
+export RTEST_REGISTRY=local
+export RTEST_CONTEXT=minikube
+
+minikube status >/dev/null 2>&1 || minikube start \
+    --driver=docker \
+    --container-runtime=containerd \
+    --kubernetes-version=v1.33.5 \
+    --cpus=6 \
+    --memory=10g
+
+# "telepresence connect --docker" runs the client as a container on the
+# local docker daemon, so the images must be present there as well as in
+# the cluster.
+for image in tel2-image client-image routecontroller-image; do
+    docker load -i "build-output/${image}.tar"
+    minikube image load "build-output/${image}.tar"
+done
+
+exec make check-regression "SHARD=${SHARD}"

--- a/build-aux/vagrant-rtest/run-shards.sh
+++ b/build-aux/vagrant-rtest/run-shards.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Host orchestrator for the parallel Vagrant regression shards: builds
+# and saves the images once on the host, brings up the three shard VMs,
+# runs one regression shard per VM concurrently, and collects logs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR" && git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+"$SCRIPT_DIR/preflight.sh"
+
+export TELEPRESENCE_REGISTRY=local
+make build save-tel2-image save-client-image save-routecontroller-image
+
+export VAGRANT_CWD="$SCRIPT_DIR"
+vagrant up --parallel --provision
+vagrant rsync
+
+LOG_DIR="build-output/vagrant-rtest"
+mkdir -p "$LOG_DIR"
+
+declare -A pids
+for n in 1 2 3; do
+    vagrant ssh "shard${n}" \
+        -c "/home/vagrant/tp/build-aux/vagrant-rtest/run-shard.sh ${n}" -- -T \
+        >"${LOG_DIR}/shard-${n}.log" 2>&1 &
+    pids[$n]=$!
+done
+
+declare -A statuses
+for n in 1 2 3; do
+    if wait "${pids[$n]}"; then
+        statuses[$n]=0
+    else
+        statuses[$n]=$?
+    fi
+done
+
+# The directory may not exist if a shard failed before any test ran, so
+# a missing tar is not itself a failure.
+for n in 1 2 3; do
+    vagrant ssh "shard${n}" \
+        -c "tar czf - -C /home/vagrant/tp/build-output rtest/logs" -- -T \
+        >"${LOG_DIR}/shard-${n}-rtest-logs.tgz" 2>/dev/null || true
+done
+
+echo ""
+echo "Regression shard results:"
+overall=0
+for n in 1 2 3; do
+    if [ "${statuses[$n]}" -eq 0 ]; then
+        result="PASS"
+    else
+        result="FAIL"
+        overall=1
+    fi
+    printf '  shard%d: %-4s  log: %s\n' "$n" "$result" "${LOG_DIR}/shard-${n}.log"
+done
+
+exit "$overall"

--- a/regression_test/README.md
+++ b/regression_test/README.md
@@ -39,6 +39,24 @@ The client binary must be rebuilt (`make build`) after changing client code
 **or the chart** — the chart is embedded in the binary. The manager image
 must be rebuilt and re-loaded after changing `cmd/traffic` code.
 
+## Parallel shards in Vagrant VMs
+
+The three area shards can run concurrently on a single dev box, each in
+its own VirtualBox VM with its own minikube cluster, instead of serially
+against one cluster:
+
+```bash
+make check-regression-vagrant
+```
+
+This needs `vagrant` and VirtualBox, plus roughly 50G of free RAM and,
+on the first run, 60G of free disk (subsequent runs reuse the VMs and
+need only 25G). Per-shard output lands in `build-output/vagrant-rtest/`
+(`shard-N.log` and `shard-N-rtest-logs.tgz`). To free RAM between
+sessions without losing the VMs: `VAGRANT_CWD=build-aux/vagrant-rtest
+vagrant halt`. To reclaim the disk entirely:
+`VAGRANT_CWD=build-aux/vagrant-rtest vagrant destroy -f`.
+
 ## Environment
 
 The shell environment always wins; there is no config file.


### PR DESCRIPTION
The regression suite runs as three shards on three CI runners, but locally
it could only run serially: a host can only run one telepresence client at
a time, since the root daemon, TUN device and DNS override are per-OS.

`make check-regression-vagrant` now runs all three shards concurrently on
one dev box. Each shard gets a VirtualBox VM with its own minikube cluster,
so the whole suite finishes in about the time of its slowest shard -- ~20
minutes here, against ~45 serially.

The client and images are built once on the host and shipped into the VMs
as tars, so the VMs never build anything. A preflight script refuses to
start without enough free RAM and disk, or while KVM guests hold the CPU
virtualization extensions, and per-shard logs land in
`build-output/vagrant-rtest/`.

See `regression_test/README.md` for requirements and cleanup commands.

Verified with a full green run: 146 tests passed across the three shards.
