### PR TITLE
Give the Regression Tests workflow sole ownership of its required context

### DIFF
--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 End-to-end driver for releasing Telepresence. Picks up where `prepare-release` left off and carries the change through:
 
-1. Telepresence release PR (CI green + `ok to test` + `regression` green)
+1. Telepresence release PR (CI green + `regression` green)
 2. Docs PR in `../telepresence.io`
 3. Tag push, Releases workflow, merge of both PRs.
 
@@ -59,17 +59,11 @@ Filter out the rows whose name is exactly `regression` or `node_agent_docker_run
 
 **Polling cadence:** these checks (lint, unit tests, license, image-scan) typically finish in 5-15 min. Use `ScheduleWakeup` with `delaySeconds=180` while any check is still running. Do not tight-loop with sleeps.
 
-### 1.3 Trigger `regression`
+### 1.3 Wait for `regression` to be green
 
-Once every non-`regression` check is green:
-
-```
-gh pr edit "$tp_branch" --add-label "ok to test"
-```
-
-Confirm the label is set: `gh pr view "$tp_branch" --json labels`.
-
-### 1.4 Wait for `regression` to be green
+`regression` starts automatically with the push (the release branch lives in
+this repository); there is nothing to trigger. If it needs another attempt,
+use "Re-run all jobs" on its workflow run (`gh run rerun <run-id>`).
 
 The regression suite runs as three parallel shards (~30 min including cluster setup), summed into the single `regression` context; the node-agent job runs beside them. Use `ScheduleWakeup` with `delaySeconds` around **900**. Poll with the same `gh pr checks` query, looking at the `regression` and `node_agent_docker_runtime` rows.
 
@@ -235,7 +229,7 @@ Verify each merged: `gh pr view "$tp_branch" --json state` should report `MERGED
 
 - Anything under 5 min → don't sleep; just poll once.
 - 5-30 min waits (Phase 1.2 non-regression checks) → `ScheduleWakeup` with `delaySeconds=180`.
-- 30-60 min waits (Phase 1.4 `regression`) → `ScheduleWakeup` with `delaySeconds=1200`.
+- 30-60 min waits (Phase 1.3 `regression`) → `ScheduleWakeup` with `delaySeconds=1200`.
 - Hours-to-overnight (Phase 3.2 macOS signing approval) → `ScheduleWakeup` with `delaySeconds=1800` or longer.
 
 Each wake-up: re-fetch state, decide green/red/still-waiting, schedule the next wake or advance.
@@ -253,6 +247,6 @@ Each wake-up: re-fetch state, decide green/red/still-waiting, schedule the next 
 - Push tags before all required PR checks are green (Phase 1 must complete first).
 - Merge the release PR or the docs PR for a pre-release (`-test.*`/`-rc.*`) version — both stay open until GA (see 3.3).
 - Merge PRs as squash or rebase — both repos require merge commits.
-- Skip `ok to test` and try to trigger `regression` some other way.
+- Trigger `regression` by any means other than the push itself or a re-run of its workflow run.
 - Approve the `macos-signing` environment programmatically — that requires a human reviewer.
 - Force-push or delete the release branch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,6 @@ A few sentences describing the overall goals of the pull request's commits.
  - [ ] I made sure to add any documentation changes required for my change.
  - [ ] My change is adequately tested.
  - [ ] I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.
- - [ ] Once my PR is ready to have integration tests ran, I posted the PR in #telepresence-oss channel on the
-       [CNCF Slack](https://slack.cncf.io/) so that the "ok to test" label can be applied.
+ - [ ] If my PR comes from a fork: once it is ready to have integration tests ran, I posted the PR in the
+       #telepresence-oss channel on the [CNCF Slack](https://slack.cncf.io/) so that a maintainer can start
+       them by re-running the "Regression Tests" workflow run.

--- a/.github/workflows/compat.yaml
+++ b/.github/workflows/compat.yaml
@@ -1,0 +1,100 @@
+name: "Compatibility Tests"
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TELEPRESENCE_REGISTRY: local
+
+concurrency:
+  group: "regression-compat-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+# Bidirectional compatibility of the compat-core subset: the labeled tests
+# collectively cover most of the manager.Manager RPC surface (guarded by
+# regression_test/framework/compat's manifest test). The counterpart
+# version is the latest release tag, not a hand-pinned literal.
+#
+# This lives in its own workflow so that the "compatibility test" label
+# never starts the Regression Tests workflow: the merge box resolves the
+# required "regression" context against that workflow's newest check
+# suite, and a suite this label created could never report it. Nothing
+# here is a required check, so a label-created suite of this workflow is
+# harmless -- including the skipped runs every other label produces,
+# since a trigger cannot filter labels by name.
+jobs:
+  regression_compat:
+    if: github.event.label.name == 'compatibility test'
+    runs-on: ubuntu-latest
+    steps:
+      # The label is a one-shot request: remove it so a maintainer can
+      # re-add it for another run. For PRs from a fork the GITHUB_TOKEN is
+      # read-only and this call fails; continue-on-error keeps that from
+      # aborting the job (the maintainer removes the label by hand
+      # instead). The label name and PR number are passed via env (not
+      # interpolated into the script) to avoid command injection.
+      - name: Remove triggering label
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          LABEL: ${{ github.event.label.name }}
+        run: gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL"
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: "${{ github.event.pull_request.head.sha }}"
+      - name: install dependencies
+        uses: ./.github/actions/install-dependencies
+      - name: Get Telepresence Version
+        run: |
+          v=$(go run build-aux/genversion/main.go ${{github.run_id}})
+          echo "TELEPRESENCE_VERSION=$v" >> "$GITHUB_ENV"
+          echo "TELEPRESENCE_SEMVER=${v#v}" >> "$GITHUB_ENV"
+      - name: Determine counterpart version
+        run: |
+          git fetch --tags --quiet
+          c=$(git tag --sort=-v:refname | grep -E '^v2\.[0-9]+\.[0-9]+$' | head -1)
+          echo "COMPAT_VERSION=${c#v}" >> "$GITHUB_ENV"
+          echo "counterpart version: $c"
+      - name: Start minikube
+        uses: medyagh/setup-minikube@latest
+        with:
+          kubernetes-version: v1.33.5
+          container-runtime: containerd
+      - name: Build client
+        run: make build
+      - name: Build images
+        run: make tel2-image client-image
+      - name: Load images into minikube
+        run: minikube image load ${{env.TELEPRESENCE_REGISTRY}}/tel2:${{env.TELEPRESENCE_SEMVER}}
+      - name: Compat-core against the released manager
+        timeout-minutes: 30
+        shell: bash
+        env:
+          RTEST_REGISTRY: local
+          RTEST_MANAGER_VERSION: ${{ env.COMPAT_VERSION }}
+          RTEST_LABELS: compat-core
+        run: |
+          set -ex
+          make check-regression
+      - name: Compat-core with the released client
+        timeout-minutes: 30
+        shell: bash
+        env:
+          RTEST_REGISTRY: local
+          RTEST_CLIENT_VERSION: ${{ env.COMPAT_VERSION }}
+          RTEST_LABELS: compat-core
+        run: |
+          set -ex
+          make check-regression
+      - uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: regression-compat-logs-${{ runner.os }}-${{ runner.arch }}
+          path: build-output/rtest/logs/

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -6,101 +6,94 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - labeled
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   actions: read
   checks: read
 
 env:
   TELEPRESENCE_REGISTRY: local
 
-# A new push cancels the still-running jobs of the previous push. The label
-# name is part of the group so that a push does not cancel an in-flight
-# labeled run of a different kind (e.g. "compatibility test").
+# A new push cancels the still-running jobs of the previous push.
 concurrency:
-  group: "regression-${{ github.event.pull_request.number }}-${{ github.event.label.name || 'push' }}"
+  group: "regression-${{ github.event.pull_request.number }}"
   cancel-in-progress: true
 
-# regression runs without a label for non-draft PRs whose head branch is
-# in this repository; the "ok to test"/"compatibility test" labels remain the
-# gate for PRs from forks. The jobs below repeat that condition because
-# workflow files cannot share expressions.
+# The merge box resolves the required "regression" context against the most
+# recently created check suite of this workflow; once a newer suite exists,
+# nothing an older suite reports counts. Two invariants keep that sound:
 #
-# Required-status-check semantics shape this workflow. GitHub counts a
-# "skipped" job as a satisfied required check, and evaluates a job's name
-# expression only when the job actually runs -- a job skipped by its if is
-# reported under the raw, unevaluated expression text. The regression
-# aggregate therefore always runs and decides in its steps, and its name
-# decides whether this run claims the required "regression" context at all:
-# a run that skips the shards by design (a label this workflow acts on for
-# some other purpose) or that no maintainer has vouched for (an unlabeled
-# fork PR) reports under a different name, leaving the context unreported
-# and the merge blocked as "expected".
+#  - Only pushes (and ready_for_review) trigger this workflow. In
+#    particular no label events: a trigger cannot filter labels by name,
+#    so any label would create a suite that either misstates the gate or
+#    leaves it unreported, blocking the merge as "expected" with no
+#    recovery short of a new push.
+#  - Every run reports the context under the literal name "regression",
+#    with a truthful verdict for its commit. The aggregate job therefore
+#    decides in its steps: a job skipped by its if reports under the raw,
+#    unevaluated name expression instead of its name.
+#
+# Job conditions consult github.event only for identities fixed for the
+# lifetime of the pull request: the event payload is frozen across
+# re-runs, and a re-run must be able to reach a different verdict. Gating
+# lives in preflight steps that read live state, plus github.run_attempt:
+# GitHub restricts re-running to users with write access, so a full
+# re-run ("Re-run all jobs") is how a maintainer vouches for a pull
+# request from a fork.
 jobs:
-  # Gatekeeper for the expensive jobs: removes the triggering label so a
-  # maintainer can re-add it, decides whether the change is docs-only, and
+  # Gatekeeper for the expensive jobs: decides whether the shards run, and
   # waits for the other required checks so a DCO or unit-test failure is
   # never followed by a pointless integration run.
   preflight:
-    # A labeled run enters only for the two labels this workflow acts on.
-    # Without that test every label added to an in-repository pull request
-    # would start this workflow and have the label stripped again by the
-    # step below.
-    if: >-
-      (github.event.action != 'labeled' &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       !github.event.pull_request.draft) ||
-      github.event.label.name == 'ok to test' ||
-      github.event.label.name == 'compatibility test'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
-      docs_only: ${{ steps.skip.outputs.docs_only }}
+      run_shards: ${{ steps.decide.outputs.run_shards }}
+      docs_only: ${{ steps.decide.outputs.docs_only }}
+      vouched: ${{ steps.decide.outputs.vouched }}
+      draft: ${{ steps.decide.outputs.draft }}
     steps:
-      # For PRs from a fork the GITHUB_TOKEN is read-only and this call
-      # fails; continue-on-error keeps that from aborting the job (the
-      # maintainer removes the label by hand instead). The label name and PR
-      # number are passed via env (not interpolated into the script) to
-      # avoid command injection.
-      - name: Remove triggering label
-        if: github.event.action == 'labeled'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          LABEL: ${{ github.event.label.name }}
-        run: gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL"
-      # docs_only=true when every file this pull request changes is one the
-      # regression suite cannot exercise. It is a property of the whole pull
-      # request, deliberately not of the commits since some earlier
-      # successful run of this workflow: an incremental answer has to trust
-      # that run to have covered the code, and a run here can conclude
-      # successfully having tested nothing at all -- an unlabeled fork pull
-      # request skips every job. A docs-only commit pushed on top of
-      # untested code would then inherit that verdict and take the required
-      # regression context green for code no shard ever ran. Asking about
-      # the pull request as a whole cannot borrow a verdict from anything.
-      #
-      # Anything unreadable or unexpected leaves docs_only unset, so the
-      # fail-safe direction stays a full run.
-      - name: Check for a docs-only change
-        id: skip
+      - name: Decide whether the shards run
+        id: decide
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
+          SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+          # A pull request whose head branch lives in this repository is
+          # vouched for by its author's write access. One from a fork runs
+          # the shards only on attempt two or later: re-running all jobs
+          # is how a maintainer vouches for it, and a new push starts over
+          # at attempt one.
+          vouched=false
+          if [ "$SAME_REPO" = true ] || [ "$ATTEMPT" -gt 1 ]; then
+            vouched=true
+          fi
+          # Live pull-request state, not the frozen event payload, so a
+          # re-run of an existing attempt sees the current draft flag.
+          draft=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .draft)
+          # docs_only=true when every file this pull request changes is one
+          # the regression suite cannot exercise. It is a property of the
+          # whole pull request, deliberately not of the commits since some
+          # earlier successful run of this workflow: an incremental answer
+          # has to trust that run to have covered the code, and a run here
+          # can conclude successfully having tested nothing at all. Asking
+          # about the pull request as a whole cannot borrow a verdict from
+          # anything.
+          #
+          # Anything unreadable or unexpected fails this job, so the
+          # fail-safe direction stays a blocked merge.
           files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR/files" --jq '.[].filename')
+          docs_only=true
           if [ -z "$files" ]; then
             echo "no files reported for this pull request; running everything"
-            echo "docs_only=false" >>"$GITHUB_OUTPUT"
-            exit 0
+            docs_only=false
           fi
-          docs_only=true
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
@@ -112,13 +105,18 @@ jobs:
                 ;;
             esac
           done <<<"$files"
-          echo "docs_only=$docs_only"
-          echo "docs_only=$docs_only" >>"$GITHUB_OUTPUT"
+          run_shards=false
+          if [ "$vouched" = true ] && [ "$draft" != true ] && [ "$docs_only" != true ]; then
+            run_shards=true
+          fi
+          printf 'vouched=%s\ndraft=%s\ndocs_only=%s\nrun_shards=%s\n' \
+            "$vouched" "$draft" "$docs_only" "$run_shards" | tee -a "$GITHUB_OUTPUT"
       # The list is the branch protection's required contexts minus this
-      # workflow's own build_and_test; reading it from the API would need
+      # workflow's own regression; reading it from the API would need
       # admin scope the GITHUB_TOKEN does not have, so it is spelled out
       # here. Keep it in sync with the branch protection settings.
       - name: Wait for the other required checks
+        if: steps.decide.outputs.run_shards == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -182,8 +180,7 @@ jobs:
     needs: preflight
     if: >-
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.docs_only != 'true' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ok to test')
+      needs.preflight.outputs.run_shards == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -230,8 +227,7 @@ jobs:
     needs: preflight
     if: >-
       needs.preflight.result == 'success' &&
-      needs.preflight.outputs.docs_only != 'true' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ok to test')
+      needs.preflight.outputs.run_shards == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -274,39 +270,21 @@ jobs:
 
   # The single required "regression" context: green exactly when every
   # shard is, or when the shards were legitimately not run because the
-  # change is docs-only.
-  #
-  # This job decides in its steps rather than its if. A skipped job never
-  # evaluates its name expression -- GitHub reports the raw expression text
-  # as the check name -- so gating with if would publish the verdict under a
-  # name that is not "regression", leaving the required context unreported
-  # for a docs-only change instead of satisfying it.
-  #
-  # Only a run that is actually responsible for the regression gate takes
-  # the required name. A run this workflow starts for some other purpose
-  # skips the shards by design, and must not then report the gate green on
-  # the strength of that skip: a maintainer labelling for the compatibility
-  # tests while a push run's shards are still going would otherwise publish
-  # a passing "regression" before the shards that decide it have finished,
-  # and the shards carry no required context of their own. An unlabeled fork
-  # PR is excluded for the original reason: the gate stays unreported until
-  # a maintainer vouches for the code with "ok to test".
+  # change is docs-only. Any other skip is reported as a failure naming
+  # the reason, so the merge box always shows a verdict rather than an
+  # unreported context.
   regression:
     needs: [preflight, regression_shard]
     if: ${{ !cancelled() }}
-    name: >-
-      ${{ (((github.event.action != 'labeled') &&
-             github.event.pull_request.head.repo.full_name == github.repository &&
-             !github.event.pull_request.draft) ||
-            github.event.label.name == 'ok to test')
-          && 'regression'
-          || 'regression (not requested)' }}
     runs-on: ubuntu-latest
     steps:
       - name: All shards green
         env:
           PREFLIGHT: ${{ needs.preflight.result }}
           SHARDS: ${{ needs.regression_shard.result }}
+          DOCS_ONLY: ${{ needs.preflight.outputs.docs_only }}
+          DRAFT: ${{ needs.preflight.outputs.draft }}
+          VOUCHED: ${{ needs.preflight.outputs.vouched }}
         run: |
           set -eu
           echo "preflight: $PREFLIGHT, regression_shard: $SHARDS"
@@ -314,83 +292,23 @@ jobs:
           # own required context, so the merge was already blocked; saying so
           # here as well beats a green "regression" that ran nothing.
           case "$PREFLIGHT" in
-            success | skipped) ;;
+            success) ;;
             *) echo "preflight did not succeed"; exit 1 ;;
           esac
           case "$SHARDS" in
-            success | skipped) ;;
+            success) exit 0 ;;
+            skipped) ;;
             *) echo "one or more regression shards did not succeed"; exit 1 ;;
           esac
-
-  # Bidirectional compatibility of the compat-core subset: the labeled tests
-  # collectively cover most of the manager.Manager RPC surface (guarded by
-  # regression_test/framework/compat's manifest test). The counterpart
-  # version is the latest release tag, not a hand-pinned literal.
-  #
-  # The label is an explicit request, so it does not consult docs_only.
-  # That output answers "is everything since the last successful run of this
-  # workflow ignorable", which the action decides by backtracking over
-  # paths_ignore: a docs-only commit on top of a revision whose regression
-  # run passed makes it true, even though no compatibility run has ever
-  # covered that revision. The two runs are not interchangeable, and asking
-  # for one by hand should not be answered with the other's result.
-  regression_compat:
-    needs: preflight
-    if: >-
-      needs.preflight.result == 'success' &&
-      github.event.label.name == 'compatibility test'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: "${{ github.event.pull_request.head.sha }}"
-      - name: install dependencies
-        uses: ./.github/actions/install-dependencies
-      - name: Get Telepresence Version
-        run: |
-          v=$(go run build-aux/genversion/main.go ${{github.run_id}})
-          echo "TELEPRESENCE_VERSION=$v" >> "$GITHUB_ENV"
-          echo "TELEPRESENCE_SEMVER=${v#v}" >> "$GITHUB_ENV"
-      - name: Determine counterpart version
-        run: |
-          git fetch --tags --quiet
-          c=$(git tag --sort=-v:refname | grep -E '^v2\.[0-9]+\.[0-9]+$' | head -1)
-          echo "COMPAT_VERSION=${c#v}" >> "$GITHUB_ENV"
-          echo "counterpart version: $c"
-      - name: Start minikube
-        uses: medyagh/setup-minikube@latest
-        with:
-          kubernetes-version: v1.33.5
-          container-runtime: containerd
-      - name: Build client
-        run: make build
-      - name: Build images
-        run: make tel2-image client-image
-      - name: Load images into minikube
-        run: minikube image load ${{env.TELEPRESENCE_REGISTRY}}/tel2:${{env.TELEPRESENCE_SEMVER}}
-      - name: Compat-core against the released manager
-        timeout-minutes: 30
-        shell: bash
-        env:
-          RTEST_REGISTRY: local
-          RTEST_MANAGER_VERSION: ${{ env.COMPAT_VERSION }}
-          RTEST_LABELS: compat-core
-        run: |
-          set -ex
-          make check-regression
-      - name: Compat-core with the released client
-        timeout-minutes: 30
-        shell: bash
-        env:
-          RTEST_REGISTRY: local
-          RTEST_CLIENT_VERSION: ${{ env.COMPAT_VERSION }}
-          RTEST_LABELS: compat-core
-        run: |
-          set -ex
-          make check-regression
-      - uses: actions/upload-artifact@v7
-        if: ${{ always() }}
-        with:
-          name: regression-compat-logs-${{ runner.os }}-${{ runner.arch }}
-          path: build-output/rtest/logs/
+          if [ "$DOCS_ONLY" = true ]; then
+            echo "docs-only change; the shards have nothing to exercise"
+            exit 0
+          fi
+          if [ "$DRAFT" = true ]; then
+            echo "draft pull request; the shards run when it is marked ready for review"
+          elif [ "$VOUCHED" != true ]; then
+            echo "pull request from a fork; a maintainer vouches for it by re-running all jobs of this run"
+          else
+            echo "the shards were skipped for no known reason"
+          fi
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,7 @@ kubectl config use-context telepresence-test-developer
 
 To create a release, set `TELEPRESENCE_VERSION` and run `make prepare-release`. This creates two annotated tags (`vX.Y.Z` and `rpc/vX.Y.Z`) and a commit updating go.mod references. Pushing the tags and branch triggers the release workflow.
 
-**Important:** A tag push publishes the release and cannot be taken back. Never push the tags directly after `make prepare-release`. Push only the branch, open a PR for it, and follow `/ship-release` (`.claude/skills/ship-release`), which drives the release PR's CI (including `ok to test` and `regression`), creates the docs PR in the telepresence.io repository, and pushes the tags only after everything is green. The command blocks below show the mechanics, not the order.
+**Important:** A tag push publishes the release and cannot be taken back. Never push the tags directly after `make prepare-release`. Push only the branch, open a PR for it, and follow `/ship-release` (`.claude/skills/ship-release`), which drives the release PR's CI (including the required `regression` gate), creates the docs PR in the telepresence.io repository, and pushes the tags only after everything is green. The command blocks below show the mechanics, not the order.
 
 ```bash
 # Test release (marked as pre-release, not promoted to latest)


### PR DESCRIPTION
Adding a label to a pull request no longer disturbs the required `regression` check.

GitHub resolves a required status check against the most recently created check suite of the workflow that reports it: once a newer suite of that workflow exists, older suites cannot satisfy the context, and re-running one is ignored. Any label event therefore poisoned the merge box — it started a new Regression Tests run whose aggregate reported under a different name, leaving `regression` at "Expected — waiting for status to be reported" with no recovery short of a new push. This was verified experimentally against a ruleset-required check in a scratch repository, along with the mechanics the fix relies on.

Regression Tests now runs only for pushes and ready-for-review, and every run reports `regression` truthfully:

- The compatibility tests move to their own workflow, still triggered by the `compatibility test` label. None of its contexts are required, so its suites cannot affect the merge box.
- The `ok to test` label retires. A maintainer vouches for a pull request from a fork by re-running all jobs of its Regression Tests run: GitHub restricts re-runs to write access, and the gating reads live state per attempt, so the re-run executes the shards.
- Fork PRs and drafts show a red `regression` naming the reason instead of an eternally pending "Expected".