### PR TITLE
Carry verified verdicts over docs-only pushes

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -54,6 +54,8 @@ jobs:
       docs_only: ${{ steps.decide.outputs.docs_only }}
       vouched: ${{ steps.decide.outputs.vouched }}
       draft: ${{ steps.decide.outputs.draft }}
+      inherited: ${{ steps.decide.outputs.inherited }}
+      inherited_from: ${{ steps.decide.outputs.inherited_from }}
     steps:
       - name: Decide whether the shards run
         id: decide
@@ -63,6 +65,9 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           ATTEMPT: ${{ github.run_attempt }}
+          ACTION: ${{ github.event.action }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
         run: |
           set -euo pipefail
           # A pull request whose head branch lives in this repository is
@@ -77,14 +82,26 @@ jobs:
           # Live pull-request state, not the frozen event payload, so a
           # re-run of an existing attempt sees the current draft flag.
           draft=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .draft)
+          # Succeeds when every filename on stdin is one the test suites
+          # cannot exercise.
+          docs_only_paths() {
+            local f
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              case "$f" in
+                docs/* | *.md | CHANGELOG.yml) ;;
+                *)
+                  echo "not a docs-only change: $f"
+                  return 1
+                  ;;
+              esac
+            done
+            return 0
+          }
           # docs_only=true when every file this pull request changes is one
           # the regression suite cannot exercise. It is a property of the
-          # whole pull request, deliberately not of the commits since some
-          # earlier successful run of this workflow: an incremental answer
-          # has to trust that run to have covered the code, and a run here
-          # can conclude successfully having tested nothing at all. Asking
-          # about the pull request as a whole cannot borrow a verdict from
-          # anything.
+          # whole pull request: there is then no code the shards could
+          # verify, so no verdict needs borrowing from anywhere.
           #
           # Anything unreadable or unexpected fails this job, so the
           # fail-safe direction stays a blocked merge.
@@ -93,24 +110,46 @@ jobs:
           if [ -z "$files" ]; then
             echo "no files reported for this pull request; running everything"
             docs_only=false
+          elif ! docs_only_paths <<<"$files"; then
+            docs_only=false
           fi
-          while IFS= read -r f; do
-            [ -n "$f" ] || continue
-            case "$f" in
-              docs/* | *.md | CHANGELOG.yml) ;;
-              *)
-                echo "not a docs-only change: $f"
-                docs_only=false
-                break
-                ;;
-            esac
-          done <<<"$files"
+          # A push whose commits change only docs cannot alter what the
+          # shards verify, so the previous head's verdict carries over --
+          # provided it was earned. Every run of this workflow reports the
+          # "regression" context truthfully (a run that tested nothing
+          # fails rather than passing vacuously), so a completed success on
+          # the previous head is proof that this exact code content was
+          # verified. The compare status must be "ahead": a force-push
+          # diverges, and the new head is then not the verified content
+          # plus docs. An API hiccup or a truncated file list (the compare
+          # endpoint caps at 300 files) falls back to a full run.
+          inherited=false
+          inherited_from=''
+          if [ "$ACTION" = synchronize ] && [ "$docs_only" != true ] &&
+             [ -n "$BEFORE" ] && [ -n "$AFTER" ]; then
+            cmp=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE...$AFTER" 2>/dev/null) || cmp=''
+            if [ -n "$cmp" ] &&
+               [ "$(jq -r .status <<<"$cmp")" = ahead ] &&
+               [ "$(jq -r '.files | length' <<<"$cmp")" -lt 300 ] &&
+               docs_only_paths < <(jq -r '.files[].filename' <<<"$cmp"); then
+              reg=$(gh api "repos/$GITHUB_REPOSITORY/commits/$BEFORE/check-runs?check_name=regression" \
+                --jq '[.check_runs[] | select(.name == "regression")] | sort_by(.started_at) | map("\(.status)/\(.conclusion)") | last // ""' 2>/dev/null) || reg=''
+              if [ "$reg" = completed/success ]; then
+                echo "docs-only push onto $BEFORE, whose regression verdict is green"
+                inherited=true
+                inherited_from=$BEFORE
+              else
+                echo "docs-only push, but no green regression on $BEFORE (found '$reg')"
+              fi
+            fi
+          fi
           run_shards=false
-          if [ "$vouched" = true ] && [ "$draft" != true ] && [ "$docs_only" != true ]; then
+          if [ "$vouched" = true ] && [ "$draft" != true ] &&
+             [ "$docs_only" != true ] && [ "$inherited" != true ]; then
             run_shards=true
           fi
-          printf 'vouched=%s\ndraft=%s\ndocs_only=%s\nrun_shards=%s\n' \
-            "$vouched" "$draft" "$docs_only" "$run_shards" | tee -a "$GITHUB_OUTPUT"
+          printf 'vouched=%s\ndraft=%s\ndocs_only=%s\ninherited=%s\ninherited_from=%s\nrun_shards=%s\n' \
+            "$vouched" "$draft" "$docs_only" "$inherited" "$inherited_from" "$run_shards" | tee -a "$GITHUB_OUTPUT"
       # The list is the branch protection's required contexts minus this
       # workflow's own regression; reading it from the API would need
       # admin scope the GITHUB_TOKEN does not have, so it is spelled out
@@ -136,16 +175,6 @@ jobs:
             pending=()
             for name in "${required[@]}"; do
               row=$(jq -r --arg n "$name" '.[] | select(.name == $n) | "\(.status)/\(.conclusion)"' <<<"$runs")
-              # A matrix job skipped before expansion (docs-only change)
-              # reports one bare context named for the job, not the
-              # per-matrix names; accept the bare context in that case.
-              if [ -z "$row" ] && [[ "$name" == *' ('* ]]; then
-                bare=${name%% (*}
-                barerow=$(jq -r --arg n "$bare" '.[] | select(.name == $n) | "\(.status)/\(.conclusion)"' <<<"$runs")
-                if [ "$barerow" = completed/skipped ]; then
-                  continue
-                fi
-              fi
               case "$row" in
                 completed/success|completed/neutral|completed/skipped) ;;
                 completed/*)
@@ -269,10 +298,11 @@ jobs:
           path: build-output/rtest/logs/
 
   # The single required "regression" context: green exactly when every
-  # shard is, or when the shards were legitimately not run because the
-  # change is docs-only. Any other skip is reported as a failure naming
-  # the reason, so the merge box always shows a verdict rather than an
-  # unreported context.
+  # shard is, when the shards were legitimately not run because the change
+  # is docs-only, or when a docs-only push carries over the verdict the
+  # previous head already earned. Any other skip is reported as a failure
+  # naming the reason, so the merge box always shows a verdict rather than
+  # an unreported context.
   regression:
     needs: [preflight, regression_shard]
     if: ${{ !cancelled() }}
@@ -285,6 +315,8 @@ jobs:
           DOCS_ONLY: ${{ needs.preflight.outputs.docs_only }}
           DRAFT: ${{ needs.preflight.outputs.draft }}
           VOUCHED: ${{ needs.preflight.outputs.vouched }}
+          INHERITED: ${{ needs.preflight.outputs.inherited }}
+          INHERITED_FROM: ${{ needs.preflight.outputs.inherited_from }}
         run: |
           set -eu
           echo "preflight: $PREFLIGHT, regression_shard: $SHARDS"
@@ -302,6 +334,10 @@ jobs:
           esac
           if [ "$DOCS_ONLY" = true ]; then
             echo "docs-only change; the shards have nothing to exercise"
+            exit 0
+          fi
+          if [ "$INHERITED" = true ]; then
+            echo "docs-only push; regression verdict inherited from $INHERITED_FROM"
             exit 0
           fi
           if [ "$DRAFT" = true ]; then

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -6,25 +6,108 @@ env:
 permissions:
   contents: read
   actions: read
+  checks: read
+  pull-requests: read
 jobs:
-  # Reports docs_only=true when every change since the last successful run of
-  # this workflow matches paths_ignore. The unit matrix is skipped in that
-  # case; a job skipped through its if-condition still satisfies its required
-  # status check. When no prior successful run can be found the answer is
-  # docs_only=false, so the fail-safe direction is to run the tests.
+  # Decides whether the unit matrix actually executes. Two cases let it
+  # not to: the pull request as a whole changes nothing the tests can
+  # exercise, or a docs-only push arrives on a head whose per-OS unit
+  # checks are already green -- the code content is then identical to what
+  # those checks verified. The decision is computed from the pull
+  # request's own state, never by trusting an earlier run of this
+  # workflow to have tested anything.
   changes:
     runs-on: ubuntu-latest
     outputs:
-      docs_only: ${{ steps.skip.outputs.should_skip }}
+      run_units: ${{ steps.decide.outputs.run_units }}
+      inherited_from: ${{ steps.decide.outputs.inherited_from }}
     steps:
-      - id: skip
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: false
-          paths_ignore: '["docs/**", "**.md", "CHANGELOG.yml"]'
+      - name: Decide whether the tests run
+        id: decide
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          # Succeeds when every filename on stdin is one the tests cannot
+          # exercise.
+          docs_only_paths() {
+            local f
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              case "$f" in
+                docs/* | *.md | CHANGELOG.yml) ;;
+                *)
+                  echo "not a docs-only change: $f"
+                  return 1
+                  ;;
+              esac
+            done
+            return 0
+          }
+          # Anything unreadable or unexpected fails this job, so the
+          # fail-safe direction stays a blocked merge.
+          files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR/files" --jq '.[].filename')
+          docs_only=true
+          if [ -z "$files" ]; then
+            echo "no files reported for this pull request; running everything"
+            docs_only=false
+          elif ! docs_only_paths <<<"$files"; then
+            docs_only=false
+          fi
+          # Verdict inheritance for a docs-only push: the compare status
+          # must be "ahead" (a force-push diverges, and the new head is
+          # then not the verified content plus docs), and every per-OS
+          # unit check on the previous head must have concluded success --
+          # a bare skipped "unit" context is not a verdict. An API hiccup
+          # or a truncated file list (the compare endpoint caps at 300
+          # files) falls back to a full run.
+          inherited=false
+          inherited_from=''
+          if [ "$ACTION" = synchronize ] && [ "$docs_only" != true ] &&
+             [ -n "$BEFORE" ] && [ -n "$AFTER" ]; then
+            cmp=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE...$AFTER" 2>/dev/null) || cmp=''
+            if [ -n "$cmp" ] &&
+               [ "$(jq -r .status <<<"$cmp")" = ahead ] &&
+               [ "$(jq -r '.files | length' <<<"$cmp")" -lt 300 ] &&
+               docs_only_paths < <(jq -r '.files[].filename' <<<"$cmp"); then
+              runs=$(gh api "repos/$GITHUB_REPOSITORY/commits/$BEFORE/check-runs?per_page=100" \
+                --jq '[.check_runs[] | {name, status, conclusion, started_at}]' 2>/dev/null) || runs='[]'
+              inherited=true
+              # Keep this list in sync with the unit job's matrix.
+              for u in 'unit (ubuntu-latest)' 'unit (macos-latest)' 'unit (windows-latest)'; do
+                row=$(jq -r --arg n "$u" \
+                  '[.[] | select(.name == $n)] | sort_by(.started_at) | map("\(.status)/\(.conclusion)") | last // ""' <<<"$runs")
+                if [ "$row" != completed/success ]; then
+                  echo "docs-only push, but no green '$u' on $BEFORE (found '$row')"
+                  inherited=false
+                  break
+                fi
+              done
+              if [ "$inherited" = true ]; then
+                echo "docs-only push onto $BEFORE, whose unit verdicts are green"
+                inherited_from=$BEFORE
+              fi
+            fi
+          fi
+          run_units=true
+          if [ "$docs_only" = true ] || [ "$inherited" = true ]; then
+            run_units=false
+          fi
+          printf 'docs_only=%s\ninherited=%s\ninherited_from=%s\nrun_units=%s\n' \
+            "$docs_only" "$inherited" "$inherited_from" "$run_units" | tee -a "$GITHUB_OUTPUT"
+  # The matrix never skips at the job level: a matrix job skipped before
+  # expansion reports one bare "unit" context instead of the per-OS names
+  # branch protection requires, leaving those contexts unreported and the
+  # merge blocked as "expected". When there is nothing to test, the jobs
+  # run with every step skipped and report their required contexts as
+  # successful in seconds.
   unit:
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -35,31 +118,36 @@ jobs:
     runs-on: ${{ matrix.runners }}
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.run_units == 'true'
         with:
           fetch-depth: 0
           ref: "${{ github.event.pull_request.head.sha }}"
       - name: install dependencies
+        if: needs.changes.outputs.run_units == 'true'
         uses: ./.github/actions/install-dependencies
       - name: install build dependencies
+        if: needs.changes.outputs.run_units == 'true'
         run: make build-deps
       - name: Lint
-        if: ${{ runner.os != 'Windows' }}
+        if: needs.changes.outputs.run_units == 'true' && runner.os != 'Windows'
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout 8m ./...
       - name: Lint (limited on windows)
-        if: ${{ runner.os == 'Windows' }}
         # Windows builds cgofuse without CGO (it drives winfsp through its DLL),
         # so lint with CGO disabled too; otherwise the type-checker pulls in
         # cgofuse's host_cgo.go, which needs winfsp's fuse_common.h header.
+        if: needs.changes.outputs.run_units == 'true' && runner.os == 'Windows'
         env:
           CGO_ENABLED: "0"
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout 8m ./cmd/telepresence/... ./pkg/...
       - name: Build
+        if: needs.changes.outputs.run_units == 'true'
         run: make build
       - name: Run tests
+        if: needs.changes.outputs.run_units == 'true'
         uses: nick-fields/retry/@v4
         with:
           max_attempts: 3


### PR DESCRIPTION
A docs-only push on a pull request no longer re-runs the regression shards or the unit tests. Preflight and the unit workflow's `changes` job compare the previous head with the new one: when the previous head is an ancestor, the diff is docs-only, and the required verdicts on it concluded success, those verdicts carry over. This is sound now because since #4273 every gate run reports its required contexts truthfully — a green verdict on the previous head proves the identical code content was verified. A force-push, a mixed push, a truncated compare, or any API hiccup falls back to a full run.

This also fixes a latent blocker: the unit matrix used to skip at the job level for docs-only changes, reporting one bare `unit` context instead of the per-OS names branch protection requires, which left those required contexts unreported and the merge box waiting forever. The matrix jobs now always run and short-circuit their steps when there is nothing to test, so `unit (ubuntu-latest)` and friends are always reported. The `fkirc/skip-duplicate-actions` dependency is gone with it.